### PR TITLE
bug: Filename Parsing Broken when Encounter Year in Title

### DIFF
--- a/app.py
+++ b/app.py
@@ -3041,7 +3041,7 @@ def auto_fetch_metron_metadata(destination_path):
         from models.providers.base import extract_issue_number
         from models.comicvine import generate_comicinfo_xml, add_comicinfo_to_archive
         from comicinfo import read_comicinfo_from_zip
-        from cbz_ops.rename import load_custom_rename_config
+        from cbz_ops.rename import load_custom_rename_config, smart_title_case
 
         # Check 1: Is Mokkari library available?
         if not is_mokkari_available():
@@ -3157,6 +3157,7 @@ def auto_fetch_metron_metadata(destination_path):
                         series = metadata.get('Series', '')
                         series = series.replace(':', ' -')
                         series = re.sub(r'[<>"/\\|?*]', '', series)
+                        series = smart_title_case(series)
                         issue_num_padded = str(metadata.get('Number', '')).zfill(3)
                         year = str(metadata.get('Year', ''))
 

--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -210,6 +210,13 @@ SERIES_NUMBER_ISSUE_YEAR_PATTERN = re.compile(
 )
 
 # ====== BEGIN: Rule Engine Helpers ======
+def _capitalize_word(word: str) -> str:
+    """Capitalize a word, handling hyphenated words like Spider-Man, X-Men."""
+    if '-' in word:
+        return '-'.join(part.capitalize() for part in word.split('-'))
+    return word.capitalize()
+
+
 def smart_title_case(text: str) -> str:
     """
     Convert text to title case with special handling for articles and conjunctions.
@@ -217,6 +224,7 @@ def smart_title_case(text: str) -> str:
     - Always capitalize the first word
     - Don't capitalize: a, an, and, of, if, the (unless they're the first word)
     - Capitalize all other words
+    - Capitalize each part of hyphenated words (e.g. Spider-Man, X-Men)
     """
     if not text:
         return text
@@ -232,13 +240,13 @@ def smart_title_case(text: str) -> str:
     for i, word in enumerate(words):
         # Always capitalize the first word
         if i == 0:
-            result.append(word.capitalize())
+            result.append(_capitalize_word(word))
         # Check if word (lowercase) is in our exceptions list
         elif word.lower() in lowercase_words:
             result.append(word.lower())
         # Capitalize all other words
         else:
-            result.append(word.capitalize())
+            result.append(_capitalize_word(word))
 
     return ' '.join(result)
 

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -2657,6 +2657,7 @@ def search_metadata():
 
         series_name = None
         issue_number = None
+        issue_from_pattern = False  # Track if issue number came from a regex match
         year = None
 
         patterns = [
@@ -2672,6 +2673,7 @@ def search_metadata():
             if match:
                 series_name = match.group(1).strip()
                 issue_number = str(int(match.group(2)))
+                issue_from_pattern = True
                 year = int(match.group(3)) if len(match.groups()) >= 3 else None
                 break
 
@@ -2688,7 +2690,9 @@ def search_metadata():
             issue_number = "1"
 
         # Also extract issue number via the provider base utility
-        if not issue_number or issue_number == "1":
+        # Only use fallback when no pattern matched an issue number (avoid
+        # overriding a valid match, e.g. "Spider-Man 2099 001" where 001 is correct)
+        if not issue_number or (issue_number == "1" and not issue_from_pattern):
             extracted = comicvine.extract_issue_number(file_name)
             if extracted:
                 issue_number = extracted


### PR DESCRIPTION
## 📝 Updating to handle '{issue_title} in naming and "Issue" in filenames broke parsing for "Years" in the filename.
Closes #95 

## 🛠️ Changes Made
- [X] Added new feature logic
- [X] Updated Docker/Config if necessary
- [X] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
## 🧪 Testing Performed
- [X] Manual test in `dev` container
- [ ] Linting/Unit tests pass