### PR TITLE
bug:Unable to Add Additional Library

### DIFF
--- a/routes/series.py
+++ b/routes/series.py
@@ -1112,7 +1112,7 @@ def api_get_libraries():
 def api_add_library():
     """Add a new library."""
     from database import add_library
-    from app import invalidate_file_index, scan_filesystem_for_sync
+    from app import scan_filesystem_for_sync
     from database import sync_file_index_incremental, invalidate_browse_cache
 
     data = request.get_json() or {}


### PR DESCRIPTION
## 📝 Unable to Add Additional Library
Removed dead import of invalidate_file_index from routes/series.py 

Closes #109 

## 🛠️ Changes Made
- [ ] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass