### PR TITLE
refactor: Reduce Metron Credentials Check

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -61,7 +61,8 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "Bash(awk:*)",
       "Bash(Select-String \"passed\")",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(pip:*)"
     ],
     "deny": [],
     "ask": []

--- a/app.py
+++ b/app.py
@@ -451,18 +451,10 @@ def scheduled_series_sync():
         start_time = time.time()
 
         # Get Metron API with credentials from config
-        metron_username = app.config.get("METRON_USERNAME", "").strip()
-        metron_password = app.config.get("METRON_PASSWORD", "").strip()
-        if not metron_username or not metron_password:
-            app_logger.warning(
-                "Metron credentials not configured, skipping scheduled sync"
-            )
-            return
-
-        api = metron.get_api(metron_username, metron_password)
+        api = metron.get_flask_api(app)
         if not api:
             app_logger.warning(
-                "Failed to initialize Metron API, skipping scheduled sync"
+                "Metron API not configured or unavailable, skipping scheduled sync"
             )
             return
 
@@ -3346,7 +3338,8 @@ def auto_fetch_metron_metadata(destination_path):
     """
     try:
         from models.metron import (
-            get_api,
+            get_flask_api,
+            is_metron_configured,
             get_series_id,
             get_issue_metadata,
             map_to_comicinfo,
@@ -3357,9 +3350,7 @@ def auto_fetch_metron_metadata(destination_path):
         from cbz_ops.rename import rename_comic_from_metadata
 
         # Check 1: Are Metron credentials configured?
-        username = app.config.get("METRON_USERNAME", "")
-        password = app.config.get("METRON_PASSWORD", "")
-        if not username or not password:
+        if not is_metron_configured(app):
             app_logger.debug(
                 "Metron credentials not configured, skipping Metron metadata"
             )
@@ -3397,7 +3388,7 @@ def auto_fetch_metron_metadata(destination_path):
             return destination_path
 
         # Initialize Metron API
-        api = get_api(username, password)
+        api = get_flask_api(app)
         if not api:
             app_logger.warning("Failed to initialize Metron API")
             return destination_path
@@ -3909,13 +3900,10 @@ def api_mark_comic_read():
 
     # Scrobble to Metron if configured (non-blocking — local read already saved)
     try:
-        metron_username = app.config.get("METRON_USERNAME", "").strip()
-        metron_password = app.config.get("METRON_PASSWORD", "").strip()
-        if metron_username and metron_password:
-            from models import metron as metron_module
+        from models import metron as metron_module
 
-            api = metron_module.get_api(metron_username, metron_password)
-            if api:
+        api = metron_module.get_flask_api(app)
+        if api:
                 metron_issue_id = metron_module.resolve_metron_issue_id(
                     api, comic_path, comic_info.get("Number") if comic_info else None
                 )
@@ -5505,17 +5493,11 @@ def save_download_api_config():
         config["SETTINGS"]["COMICVINE_API_KEY"] = sanitize_config_value(
             data.get("comicvineApiKey", "")
         )
-        config["SETTINGS"]["METRON_USERNAME"] = sanitize_config_value(
-            data.get("metronUsername", "")
-        )
-        config["SETTINGS"]["METRON_PASSWORD"] = sanitize_config_value(
-            data.get("metronPassword", "")
-        )
         config["SETTINGS"]["DOWNLOAD_PROVIDER_PRIORITY"] = data.get(
             "downloadProviderPriority", "pixeldrain,download_now,mega"
         )
 
-        # Also save API credentials to DB (provider_credentials)
+        # Save API credentials to DB (provider_credentials)
         try:
             from database import save_provider_credentials
 
@@ -5794,14 +5776,7 @@ def config_page():
         config["SETTINGS"]["COMICVINE_API_KEY"] = sanitize_config_value(
             request.form.get("comicvineApiKey", "")
         )
-        config["SETTINGS"]["METRON_USERNAME"] = sanitize_config_value(
-            request.form.get("metronUsername", "")
-        )
-        config["SETTINGS"]["METRON_PASSWORD"] = sanitize_config_value(
-            request.form.get("metronPassword", "")
-        )
-
-        # Also save API credentials to DB (provider_credentials)
+        # Save API credentials to DB (provider_credentials)
         try:
             from database import save_provider_credentials
 
@@ -5925,10 +5900,8 @@ def config_page():
         pixeldrainApiKey=settings.get("PIXELDRAIN_API_KEY", ""),
         comicvineApiKey=(_cv_creds.get("api_key", "") if _cv_creds else "")
         or settings.get("COMICVINE_API_KEY", ""),
-        metronUsername=(_metron_creds.get("username", "") if _metron_creds else "")
-        or settings.get("METRON_USERNAME", ""),
-        metronPassword=(_metron_creds.get("password", "") if _metron_creds else "")
-        or settings.get("METRON_PASSWORD", ""),
+        metronUsername=_metron_creds.get("username", "") if _metron_creds else "",
+        metronPassword=_metron_creds.get("password", "") if _metron_creds else "",
         enableCustomRename=settings.get("ENABLE_CUSTOM_RENAME", "False") == "True",
         customRenamePattern=settings.get("CUSTOM_RENAME_PATTERN", ""),
         enableAutoRename=settings.get("ENABLE_AUTO_RENAME", "False") == "True",

--- a/config.py
+++ b/config.py
@@ -52,8 +52,6 @@ def load_config():
         "PIXELDRAIN_API_KEY": "",
         "GCD_METADATA_LANGUAGES": "en",
         "COMICVINE_API_KEY": "",
-        "METRON_USERNAME": "",
-        "METRON_PASSWORD": "",
         "ENABLE_CUSTOM_RENAME": "False",
         "CUSTOM_RENAME_PATTERN": "",
         "ENABLE_AUTO_RENAME": "False",
@@ -135,11 +133,10 @@ def load_flask_config(app, logger=None):
     app.config["PIXELDRAIN_API_KEY"] = settings.get("PIXELDRAIN_API_KEY", "")
     app.config["GCD_METADATA_LANGUAGES"] = settings.get("GCD_METADATA_LANGUAGES", "en")
     app.config["COMICVINE_API_KEY"] = settings.get("COMICVINE_API_KEY", "")
-    app.config["METRON_USERNAME"] = settings.get("METRON_USERNAME", "")
-    app.config["METRON_PASSWORD"] = settings.get("METRON_PASSWORD", "")
+    app.config["METRON_USERNAME"] = ""
+    app.config["METRON_PASSWORD"] = ""
 
-    # Override API credentials from DB (provider_credentials table) if available
-    # DB credentials take precedence over config.ini values
+    # Load API credentials from DB (provider_credentials table)
     try:
         from database import get_provider_credentials
         metron_creds = get_provider_credentials('metron')

--- a/models/metron.py
+++ b/models/metron.py
@@ -110,6 +110,46 @@ def get_api(username: str, password: str):
         return None
 
 
+def get_flask_api(app=None):
+    """Get Metron API client using Flask app config credentials.
+
+    Args:
+        app: Flask app instance. If None, uses current_app (requires app context).
+
+    Returns:
+        Mokkari Session client or None if credentials missing/invalid.
+    """
+    if app is None:
+        from flask import current_app
+        config = current_app.config
+    else:
+        config = app.config
+    username = config.get("METRON_USERNAME", "").strip()
+    password = config.get("METRON_PASSWORD", "").strip()
+    if not username or not password:
+        return None
+    return get_api(username, password)
+
+
+def is_metron_configured(app=None):
+    """Check if Metron credentials are present in Flask app config.
+
+    Args:
+        app: Flask app instance. If None, uses current_app (requires app context).
+
+    Returns:
+        True if both username and password are configured.
+    """
+    if app is None:
+        from flask import current_app
+        config = current_app.config
+    else:
+        config = app.config
+    username = config.get("METRON_USERNAME", "").strip()
+    password = config.get("METRON_PASSWORD", "").strip()
+    return bool(username and password)
+
+
 def parse_cvinfo_for_metron_id(cvinfo_path: str) -> Optional[int]:
     """
     Parse a cvinfo file for series_id.

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -903,8 +903,6 @@ def batch_metadata():
 
         # Always load API credentials (needed for provider initialization)
         comicvine_api_key = current_app.config.get('COMICVINE_API_KEY', '')
-        metron_username = current_app.config.get('METRON_USERNAME', '')
-        metron_password = current_app.config.get('METRON_PASSWORD', '')
 
         # Determine provider availability
         # If library_id is provided, use library-specific providers
@@ -922,7 +920,7 @@ def batch_metadata():
         else:
             # Fallback to global API credential availability checks
             comicvine_available = bool(comicvine_api_key and comicvine_api_key.strip())
-            metron_available = bool(metron_password and metron_password.strip())
+            metron_available = metron.is_metron_configured()
             gcd_available = gcd.is_mysql_available() and gcd.check_mysql_status().get('gcd_mysql_available', False)
             anilist_available = False
             bedetheque_available = False
@@ -931,9 +929,7 @@ def batch_metadata():
         app_logger.info(f"Batch metadata: CV={comicvine_available}, Metron={metron_available}, GCD={gcd_available}, AniList={anilist_available}, MangaDex={mangadex_available}")
 
         # Initialize Metron API early (needed for cvinfo creation)
-        metron_api = None
-        if metron_available:
-            metron_api = metron.get_api(metron_username, metron_password)
+        metron_api = metron.get_flask_api() if metron_available else None
 
         # Step 1: Get list of comic files (needed for year extraction)
         comic_files = []
@@ -2637,13 +2633,10 @@ def _try_metron_single(cvinfo_path, issue_number):
     """Try Metron provider for a single file. Returns (metadata_dict, image_url) or (None, None)."""
     try:
         series_id = metron.parse_cvinfo_for_metron_id(cvinfo_path)
-        metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-        metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-
-        if not (series_id and metron_username and metron_password):
+        if not series_id:
             return None, None
 
-        metron_api = metron.get_api(metron_username, metron_password)
+        metron_api = metron.get_flask_api()
         if not metron_api:
             return None, None
 
@@ -2928,7 +2921,7 @@ def search_metadata():
         else:
             # Fallback: try all available providers in default order
             provider_order = []
-            if current_app.config.get("METRON_PASSWORD", "").strip():
+            if metron.is_metron_configured():
                 provider_order.append('metron')
             if current_app.config.get("COMICVINE_API_KEY", "").strip():
                 provider_order.append('comicvine')

--- a/routes/series.py
+++ b/routes/series.py
@@ -45,12 +45,7 @@ def releases():
     # Get tracked series lookup for highlighting
     tracked_lookup = get_tracked_series_lookup()
 
-    api = None
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-    if metron_username and metron_password:
-        api = metron.get_api(metron_username, metron_password)
-
+    api = metron.get_flask_api()
     if not api:
         return render_template('releases.html',
                              releases=[],
@@ -239,9 +234,7 @@ def series_search():
     """
     Series Search page - search Metron database for series.
     """
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-    metron_configured = bool(metron_username and metron_password)
+    metron_configured = metron.is_metron_configured()
 
     return render_template('series_search.html',
                           metron_configured=metron_configured)
@@ -287,12 +280,7 @@ def issue_view(slug):
             return redirect(url_for('.series_view', slug=series_slug))
 
     # 2. Not cached — call api.issue() to resolve series_id
-    api = None
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-    if metron_username and metron_password:
-        api = metron.get_api(metron_username, metron_password)
-
+    api = metron.get_flask_api()
     if not api:
         flash("Metron API not configured", "error")
         return redirect(url_for('.releases'))
@@ -357,11 +345,7 @@ def series_view(slug):
 
     api = None
     if not use_cache:
-        metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-        metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-        if metron_username and metron_password:
-            api = metron.get_api(metron_username, metron_password)
-
+        api = metron.get_flask_api()
         if not api:
             if cached_series:
                 app_logger.warning(f"API not available, using stale cache for series {series_id}")
@@ -560,16 +544,10 @@ def api_search_series():
     if not query:
         return jsonify({"success": False, "error": "Search query required"}), 400
 
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-
-    if not metron_username or not metron_password:
-        return jsonify({"success": False, "error": "Metron credentials not configured"}), 400
-
     try:
-        api = metron.get_api(metron_username, metron_password)
+        api = metron.get_flask_api()
         if not api:
-            return jsonify({"success": False, "error": "Failed to connect to Metron API"}), 500
+            return jsonify({"success": False, "error": "Metron credentials not configured or API unavailable"}), 400
 
         results = api.series_list({'name': query})
 
@@ -760,12 +738,7 @@ def check_series_collection(series_id):
             series_info = cached_series
             all_issues = cached_issues
         else:
-            api = None
-            metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-            metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-            if metron_username and metron_password:
-                api = metron.get_api(metron_username, metron_password)
-
+            api = metron.get_flask_api()
             if not api:
                 return jsonify({'error': 'Metron API not configured and no cached data'}), 500
 
@@ -894,14 +867,9 @@ def sync_series(series_id):
     """Force sync a specific series from Metron API"""
     from database import clear_wanted_cache_for_series, get_series_mapping, update_series_desc
 
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-    if not metron_username or not metron_password:
-        return jsonify({'error': 'Metron credentials not configured'}), 500
-
-    api = metron.get_api(metron_username, metron_password)
+    api = metron.get_flask_api()
     if not api:
-        return jsonify({'error': 'Failed to initialize Metron API'}), 500
+        return jsonify({'error': 'Metron credentials not configured or API unavailable'}), 500
 
     try:
         series_mapping = get_series_by_id(series_id)
@@ -957,14 +925,9 @@ def sync_series(series_id):
 @series_bp.route('/api/sync/all', methods=['POST'])
 def sync_all_series():
     """Sync all mapped series that need updating"""
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-    if not metron_username or not metron_password:
-        return jsonify({'error': 'Metron credentials not configured'}), 500
-
-    api = metron.get_api(metron_username, metron_password)
+    api = metron.get_flask_api()
     if not api:
-        return jsonify({'error': 'Failed to initialize Metron API'}), 500
+        return jsonify({'error': 'Metron credentials not configured or API unavailable'}), 500
 
     try:
         hours = request.json.get('hours', 24) if request.is_json else 24
@@ -1348,16 +1311,10 @@ def api_search_publishers():
     if not query:
         return jsonify({"success": False, "error": "Search query required"}), 400
 
-    metron_username = current_app.config.get("METRON_USERNAME", "").strip()
-    metron_password = current_app.config.get("METRON_PASSWORD", "").strip()
-
-    if not metron_username or not metron_password:
-        return jsonify({"success": False, "error": "Metron credentials not configured"}), 400
-
     try:
-        api = metron.get_api(metron_username, metron_password)
+        api = metron.get_flask_api()
         if not api:
-            return jsonify({"success": False, "error": "Failed to connect to Metron API"}), 500
+            return jsonify({"success": False, "error": "Metron credentials not configured or API unavailable"}), 400
 
         results = api.publishers_list({'name': query})
 

--- a/sync.py
+++ b/sync.py
@@ -17,7 +17,6 @@ import sys
 from datetime import datetime
 from app_logging import app_logger
 from models import metron
-from config import config
 from database import (
     init_db, get_series_needing_sync, get_all_mapped_series, get_series_by_id,
     save_issues_bulk, update_series_sync_time, delete_issues_for_series,
@@ -26,15 +25,15 @@ from database import (
 
 
 def get_metron_api():
-    """Get Metron API client using credentials from config."""
-    metron_username = config.get("METRON", "USERNAME", fallback="").strip()
-    metron_password = config.get("METRON", "PASSWORD", fallback="").strip()
+    """Get Metron API client using credentials from DB."""
+    from database import get_provider_credentials
 
-    if not metron_username or not metron_password:
-        app_logger.error("Metron credentials not configured in config.ini")
+    creds = get_provider_credentials('metron')
+    if not creds or not creds.get('username') or not creds.get('password'):
+        app_logger.error("Metron credentials not configured")
         return None
 
-    return metron.get_api(metron_username, metron_password)
+    return metron.get_api(creds['username'], creds['password'])
 
 
 def sync_series_from_api(api, series_id: int) -> dict:

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -340,3 +340,129 @@ class TestGetReleases:
     def test_no_api(self):
         from models.metron import get_releases
         assert get_releases(None, "2024-01-01") == []
+
+
+class TestGetFlaskApi:
+
+    @patch("models.metron.MokkariSession")
+    def test_with_explicit_app(self, mock_session_class):
+        from models.metron import get_flask_api
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "user",
+            "METRON_PASSWORD": "pass",
+        }
+        mock_session_class.return_value = MagicMock()
+
+        api = get_flask_api(mock_app)
+        assert api is not None
+        mock_session_class.assert_called_once()
+
+    @patch("models.metron.MokkariSession")
+    def test_with_current_app(self, mock_session_class):
+        from flask import Flask
+        from models.metron import get_flask_api
+
+        test_app = Flask(__name__)
+        test_app.config["METRON_USERNAME"] = "user"
+        test_app.config["METRON_PASSWORD"] = "pass"
+        mock_session_class.return_value = MagicMock()
+
+        with test_app.app_context():
+            api = get_flask_api()
+            assert api is not None
+
+    def test_missing_credentials(self):
+        from models.metron import get_flask_api
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "",
+            "METRON_PASSWORD": "",
+        }
+        assert get_flask_api(mock_app) is None
+
+    def test_whitespace_only_credentials(self):
+        from models.metron import get_flask_api
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "  ",
+            "METRON_PASSWORD": "  ",
+        }
+        assert get_flask_api(mock_app) is None
+
+    def test_missing_username_only(self):
+        from models.metron import get_flask_api
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "",
+            "METRON_PASSWORD": "pass",
+        }
+        assert get_flask_api(mock_app) is None
+
+
+class TestIsMetronConfigured:
+
+    def test_both_credentials_present(self):
+        from models.metron import is_metron_configured
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "user",
+            "METRON_PASSWORD": "pass",
+        }
+        assert is_metron_configured(mock_app) is True
+
+    def test_no_credentials(self):
+        from models.metron import is_metron_configured
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "",
+            "METRON_PASSWORD": "",
+        }
+        assert is_metron_configured(mock_app) is False
+
+    def test_only_password(self):
+        from models.metron import is_metron_configured
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "",
+            "METRON_PASSWORD": "pass",
+        }
+        assert is_metron_configured(mock_app) is False
+
+    def test_only_username(self):
+        from models.metron import is_metron_configured
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "user",
+            "METRON_PASSWORD": "",
+        }
+        assert is_metron_configured(mock_app) is False
+
+    def test_whitespace_stripping(self):
+        from models.metron import is_metron_configured
+
+        mock_app = MagicMock()
+        mock_app.config = {
+            "METRON_USERNAME": "  user  ",
+            "METRON_PASSWORD": "  pass  ",
+        }
+        assert is_metron_configured(mock_app) is True
+
+    def test_with_current_app(self):
+        from flask import Flask
+        from models.metron import is_metron_configured
+
+        test_app = Flask(__name__)
+        test_app.config["METRON_USERNAME"] = "user"
+        test_app.config["METRON_PASSWORD"] = "pass"
+
+        with test_app.app_context():
+            assert is_metron_configured() is True

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -32,7 +32,7 @@ class TestSeriesSearch:
 
         mock_api = MagicMock()
         mock_api.series_list.return_value = [mock_series]
-        mock_metron.get_api.return_value = mock_api
+        mock_metron.get_flask_api.return_value = mock_api
         mock_metron.is_connection_error.return_value = False
 
         mock_app = MagicMock()


### PR DESCRIPTION
## 📝 Reduce Metron Credentials Check

27 functions were checking for Metron Username and Password - replaced these multi-line calls with a one line reference

## 🛠️ Changes Made
- [ ] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass