### PR TITLE
Delete Empty Folders without Moving to Trash

### DIFF
--- a/helpers/trash.py
+++ b/helpers/trash.py
@@ -150,6 +150,37 @@ def _get_item_size(source_path):
     return total
 
 
+def _cleanup_empty_parent(folder_path):
+    """Remove the parent folder if it's empty or only contains a cvinfo file."""
+    from flask import current_app
+
+    if not folder_path or not os.path.isdir(folder_path):
+        return
+
+    # Don't clean up DATA_DIR roots or the trash dir itself
+    data_dir = current_app.config.get("DATA_DIR", "/data")
+    normalized_folder = os.path.normpath(folder_path)
+    normalized_data = os.path.normpath(data_dir)
+    if normalized_folder == normalized_data:
+        return
+    if is_trash_path(folder_path):
+        return
+
+    try:
+        remaining = os.listdir(folder_path)
+        # Empty folder — remove it
+        if not remaining:
+            shutil.rmtree(folder_path)
+            app_logger.info(f"Removed empty folder after trash: {folder_path}")
+            return
+        # Only cvinfo file(s) remain — remove folder and contents
+        if all(item.lower() == 'cvinfo' for item in remaining):
+            shutil.rmtree(folder_path)
+            app_logger.info(f"Removed folder with only cvinfo after trash: {folder_path}")
+    except OSError as e:
+        app_logger.error(f"Error cleaning up empty parent folder {folder_path}: {e}")
+
+
 def move_to_trash(source_path):
     """
     Move a file or directory to the trash.
@@ -160,6 +191,17 @@ def move_to_trash(source_path):
 
     Falls back to permanent delete if trash is disabled.
     """
+    # If it's an empty directory or only contains cvinfo, just delete it directly
+    if os.path.isdir(source_path):
+        try:
+            contents = os.listdir(source_path)
+            if not contents or all(item.lower() == 'cvinfo' for item in contents):
+                shutil.rmtree(source_path)
+                app_logger.info(f"Deleted empty/cvinfo-only folder (not trashed): {source_path}")
+                return {"trashed": False, "path": source_path}
+        except OSError:
+            pass
+
     trash_dir = get_trash_dir()
 
     if trash_dir is None:
@@ -191,8 +233,10 @@ def move_to_trash(source_path):
             dest_path = os.path.join(trash_dir, f"{name}_{int(time.time())}{ext}")
 
     try:
+        parent_dir = os.path.dirname(source_path)
         shutil.move(source_path, dest_path)
         app_logger.info(f"Moved to trash: {source_path} -> {dest_path}")
+        _cleanup_empty_parent(parent_dir)
         return {"trashed": True, "path": dest_path}
     except Exception as e:
         # Fall back to permanent delete on move failure

--- a/tests/unit/test_trash.py
+++ b/tests/unit/test_trash.py
@@ -22,6 +22,7 @@ def app(trash_dir, tmp_path):
     flask_app.config["TRASH_DIR"] = str(trash_dir)
     flask_app.config["TRASH_MAX_SIZE_MB"] = 1024
     flask_app.config["CACHE_DIR"] = str(tmp_path / "cache")
+    flask_app.config["DATA_DIR"] = str(tmp_path / "data")
     return flask_app
 
 
@@ -120,6 +121,33 @@ class TestMoveToTrash:
         assert not source_dir.exists()
         assert os.path.isdir(os.path.join(str(trash_dir), "Batman"))
 
+    def test_empty_dir_deleted_not_trashed(self, app, trash_dir, tmp_path):
+        """Empty directories are deleted directly, not moved to trash."""
+        source_dir = tmp_path / "EmptySeries"
+        source_dir.mkdir()
+
+        with app.app_context():
+            from helpers.trash import move_to_trash
+            result = move_to_trash(str(source_dir))
+
+        assert result["trashed"] is False
+        assert not source_dir.exists()
+        assert not os.path.exists(os.path.join(str(trash_dir), "EmptySeries"))
+
+    def test_cvinfo_only_dir_deleted_not_trashed(self, app, trash_dir, tmp_path):
+        """Directories with only cvinfo are deleted directly, not trashed."""
+        source_dir = tmp_path / "CvinfoSeries"
+        source_dir.mkdir()
+        (source_dir / "cvinfo").write_text("https://comicvine.gamespot.com/test/4050-123/")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash
+            result = move_to_trash(str(source_dir))
+
+        assert result["trashed"] is False
+        assert not source_dir.exists()
+        assert not os.path.exists(os.path.join(str(trash_dir), "CvinfoSeries"))
+
 
 class TestEmptyTrash:
 
@@ -203,3 +231,60 @@ class TestGetTrashContents:
         assert contents[1]["name"] == "new.cbz"
         assert contents[0]["size"] == 3
         assert contents[1]["size"] == 10
+
+
+class TestCleanupEmptyParent:
+
+    def test_removes_empty_folder(self, app, trash_dir, tmp_path):
+        """Parent folder is removed when last file is trashed."""
+        series_dir = tmp_path / "data" / "publisher" / "Batman"
+        series_dir.mkdir(parents=True)
+        comic = series_dir / "issue1.cbz"
+        comic.write_bytes(b"data")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash
+            move_to_trash(str(comic))
+
+        assert not series_dir.exists()
+
+    def test_removes_folder_with_only_cvinfo(self, app, trash_dir, tmp_path):
+        """Parent folder is removed when only cvinfo remains."""
+        series_dir = tmp_path / "data" / "publisher" / "Batman"
+        series_dir.mkdir(parents=True)
+        (series_dir / "cvinfo").write_text("https://comicvine.gamespot.com/batman/4050-796/")
+        comic = series_dir / "issue1.cbz"
+        comic.write_bytes(b"data")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash
+            move_to_trash(str(comic))
+
+        assert not series_dir.exists()
+
+    def test_keeps_folder_with_other_files(self, app, trash_dir, tmp_path):
+        """Parent folder is kept when other comic files remain."""
+        series_dir = tmp_path / "data" / "publisher" / "Batman"
+        series_dir.mkdir(parents=True)
+        (series_dir / "issue1.cbz").write_bytes(b"data1")
+        (series_dir / "issue2.cbz").write_bytes(b"data2")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash
+            move_to_trash(str(series_dir / "issue1.cbz"))
+
+        assert series_dir.exists()
+        assert (series_dir / "issue2.cbz").exists()
+
+    def test_does_not_remove_data_dir(self, app, trash_dir, tmp_path):
+        """DATA_DIR root is never removed even if empty."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True)
+        comic = data_dir / "comic.cbz"
+        comic.write_bytes(b"data")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash
+            move_to_trash(str(comic))
+
+        assert data_dir.exists()


### PR DESCRIPTION
## 📝 Delete Empty Folders without Moving to Trash

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass