### PR TITLE
Update Settings to Use Time Zone and Jitter Syncs

### DIFF
--- a/app.py
+++ b/app.py
@@ -397,6 +397,10 @@ def configure_schedule(schedule_name):
             "Sunday",
         ]
 
+        # Add jitter for sync/getcomics to reduce API thundering herd
+        jitter_seconds = 1800 if schedule_name in ('sync', 'getcomics') else 0
+        jitter_kwargs = {'jitter': jitter_seconds} if jitter_seconds else {}
+
         if schedule["frequency"] == "daily":
             trigger = CronTrigger(hour=hour, minute=minute)
             app_state.scheduler.add_job(
@@ -405,6 +409,7 @@ def configure_schedule(schedule_name):
                 id=job_id,
                 name=f"Daily {label}",
                 replace_existing=True,
+                **jitter_kwargs,
             )
             app_logger.info(f"📅 Scheduled daily {label} at {schedule['time']}")
 
@@ -417,6 +422,7 @@ def configure_schedule(schedule_name):
                 id=job_id,
                 name=f"Weekly {label}",
                 replace_existing=True,
+                **jitter_kwargs,
             )
             app_logger.info(
                 f"📅 Scheduled weekly {label} on {days[weekday]} at {schedule['time']}"
@@ -5549,7 +5555,7 @@ def save_system_perf_config():
         config["SETTINGS"]["LARGE_FILE_THRESHOLD"] = data.get(
             "largeFileThreshold", "500"
         )
-        config["SETTINGS"]["TIMEZONE"] = data.get("timezone", "UTC")
+        set_user_preference("timezone", data.get("timezone", "UTC"), category="personalization")
         config["SETTINGS"]["REBUILD_FREQUENCY"] = data.get(
             "rebuildFrequency", "disabled"
         )
@@ -5803,7 +5809,7 @@ def config_page():
         config["SETTINGS"]["ENABLE_DEBUG_LOGGING"] = str(
             request.form.get("enableDebugLogging") == "on"
         )
-        config["SETTINGS"]["TIMEZONE"] = request.form.get("timezone", "UTC")
+        set_user_preference("timezone", request.form.get("timezone", "UTC"), category="personalization")
 
         # Styling and Recommendations are saved to user_preferences DB
         set_user_preference(
@@ -5907,7 +5913,7 @@ def config_page():
         ),
         enableDebugLogging=settings.get("ENABLE_DEBUG_LOGGING", "False") == "True",
         bootstrapTheme=get_user_preference("bootstrap_theme", default="default"),
-        timezone=settings.get("TIMEZONE", "UTC"),
+        timezone=get_user_preference("timezone", default="UTC"),
         config=settings,  # Pass full settings dictionary
         rec_enabled=get_user_preference("rec_enabled", default=True),
         rec_provider=get_user_preference("rec_provider", default="gemini"),

--- a/config.py
+++ b/config.py
@@ -60,7 +60,6 @@ def load_config():
         "ENABLE_DEBUG_LOGGING": "False",
         "CACHE_DIR": "/cache",
         "BOOTSTRAP_THEME": "default",
-        "TIMEZONE": "UTC",
         "ENABLE_METADATA_SCAN": "True",
         "METADATA_SCAN_THREADS": "2",
         "TRASH_ENABLED": "True",

--- a/database.py
+++ b/database.py
@@ -2,6 +2,7 @@ import sqlite3
 import os
 import re
 import hashlib
+import random
 import zipfile
 from datetime import datetime
 from typing import Optional
@@ -783,9 +784,10 @@ def init_db():
                     ("sync", row[0], row[1], row[2], row[3]),
                 )
             else:
+                sync_time = f"{random.randint(0, 23):02d}:{random.randint(0, 59):02d}"
                 c.execute(
                     "INSERT INTO schedules (name, frequency, time, weekday) VALUES (?, ?, ?, ?)",
-                    ("sync", "disabled", "03:00", 0),
+                    ("sync", "disabled", sync_time, 0),
                 )
 
             # Migrate getcomics_schedule
@@ -799,9 +801,10 @@ def init_db():
                     ("getcomics", row[0], row[1], row[2], row[3]),
                 )
             else:
+                gc_time = f"{random.randint(0, 23):02d}:{random.randint(0, 59):02d}"
                 c.execute(
                     "INSERT INTO schedules (name, frequency, time, weekday) VALUES (?, ?, ?, ?)",
-                    ("getcomics", "disabled", "03:00", 0),
+                    ("getcomics", "disabled", gc_time, 0),
                 )
 
             # Migrate weekly_packs_config (map enabled -> frequency)
@@ -847,6 +850,18 @@ def init_db():
                 "Migrated schedule data from legacy tables to unified schedules table"
             )
 
+        # Migration: Randomize default schedule times to reduce API thundering herd
+        for sched_name, default_time in [('sync', '03:00'), ('getcomics', '03:00')]:
+            c.execute("SELECT time FROM schedules WHERE name = ?", (sched_name,))
+            row = c.fetchone()
+            if row and row[0] == default_time:
+                new_time = f"{random.randint(0, 23):02d}:{random.randint(0, 59):02d}"
+                c.execute("UPDATE schedules SET time = ? WHERE name = ?", (new_time, sched_name))
+                app_logger.info(
+                    f"Randomized {sched_name} schedule time from {default_time} to {new_time} "
+                    "(reduces API thundering herd)"
+                )
+
         # Migration: Auto-create default library if table is empty and /data exists
         c.execute("SELECT COUNT(*) FROM libraries")
         if c.fetchone()[0] == 0:
@@ -857,6 +872,28 @@ def init_db():
                     VALUES ('Library', '/data', 1)
                 """)
                 app_logger.info("Created default library with path /data")
+
+        # Migration: Move TIMEZONE from config.ini to user_preferences
+        try:
+            tz_value = config.get("SETTINGS", "TIMEZONE", fallback=None)
+            if tz_value is not None:
+                # Check if timezone is already in user_preferences
+                c.execute("SELECT value FROM user_preferences WHERE key = 'timezone'")
+                if not c.fetchone():
+                    import json
+                    c.execute(
+                        "INSERT OR REPLACE INTO user_preferences (key, value, category, updated_at) "
+                        "VALUES (?, ?, 'personalization', CURRENT_TIMESTAMP)",
+                        ("timezone", json.dumps(tz_value)),
+                    )
+                    app_logger.info(f"Migrated TIMEZONE '{tz_value}' from config.ini to user_preferences")
+                # Remove TIMEZONE from config.ini
+                config.remove_option("SETTINGS", "TIMEZONE")
+                from config import write_config
+                write_config()
+                app_logger.info("Removed TIMEZONE from config.ini")
+        except Exception as e:
+            app_logger.debug(f"TIMEZONE migration skipped or already done: {e}")
 
         conn.commit()
         conn.close()

--- a/models/stats.py
+++ b/models/stats.py
@@ -1,9 +1,8 @@
 import sqlite3
 import os
 import re
-from database import get_db_connection, get_db_path, get_cached_stats, save_cached_stats
+from database import get_db_connection, get_db_path, get_cached_stats, save_cached_stats, get_user_preference
 from app_logging import app_logger
-from config import config
 
 def get_library_stats():
     """
@@ -154,8 +153,8 @@ def get_reading_history_stats():
     Returns daily read counts for the last 3 months (~90 days).
     Applies timezone offset from config settings.
     """
-    # Get timezone offset from config
-    tz_offset = config['SETTINGS'].get('TIMEZONE', 'UTC') if 'SETTINGS' in config else 'UTC'
+    # Get timezone offset from user preferences
+    tz_offset = get_user_preference("timezone", default="UTC")
 
     # Build offset string for SQLite datetime()
     if tz_offset == 'UTC':

--- a/models/timeline.py
+++ b/models/timeline.py
@@ -1,9 +1,8 @@
 import sqlite3
 import os
-from database import get_db_connection
+from database import get_db_connection, get_user_preference
 from app_logging import app_logger
 from datetime import datetime, timedelta
-from config import config
 
 def get_reading_timeline(limit=100, offset=0, year=None, month=None):
     """
@@ -156,8 +155,8 @@ def get_reading_timeline(limit=100, offset=0, year=None, month=None):
         conn.close()
 
         # 3. Process and Group Data
-        # Get timezone offset from config
-        tz_offset = config['SETTINGS'].get('TIMEZONE', 'UTC') if 'SETTINGS' in config else 'UTC'
+        # Get timezone offset from user preferences
+        tz_offset = get_user_preference("timezone", default="UTC")
         tz_hours = 0
         if tz_offset != 'UTC':
             try:

--- a/templates/config.html
+++ b/templates/config.html
@@ -844,7 +844,7 @@
                             <label for="rebuildTime" class="form-label">Rebuild Time:</label>
                             <input type="time" class="form-control" id="rebuildTime" name="rebuildTime" value="02:00">
                             <small class="form-text text-muted">
-                                Time of day to run the rebuild (24-hour format).
+                                Time of day to run the rebuild (in your timezone).
                             </small>
                         </div>
 
@@ -897,7 +897,7 @@
                             <label for="syncTime" class="form-label">Sync Time:</label>
                             <input type="time" class="form-control" id="syncTime" name="syncTime" value="03:00">
                             <small class="form-text text-muted">
-                                Time of day to run the sync (24-hour format).
+                                Time of day to run the sync (in your timezone).
                             </small>
                         </div>
 
@@ -970,7 +970,7 @@
                             <input type="time" class="form-control" id="getcomicsTime" name="getcomicsTime"
                                 value="03:00">
                             <small class="form-text text-muted">
-                                Time of day to search and download (24-hour format).
+                                Time of day to search and download (in your timezone).
                             </small>
                         </div>
 
@@ -1404,6 +1404,29 @@
         return toast;
     }
 
+    // Timezone conversion helpers for schedule time inputs
+    function getTimezoneOffset() {
+        const tz = document.getElementById('timezone')?.value || 'UTC';
+        if (tz === 'UTC') return 0;
+        return parseFloat(tz) || 0;
+    }
+
+    function utcToLocal(timeStr, offsetHours) {
+        if (!timeStr || offsetHours === 0) return timeStr;
+        const [h, m] = timeStr.split(':').map(Number);
+        const fracMinutes = Math.round((offsetHours % 1) * 60);
+        let newM = m + fracMinutes;
+        let newH = Math.floor(h + offsetHours);
+        if (newM >= 60) { newM -= 60; newH++; }
+        if (newM < 0) { newM += 60; newH--; }
+        newH = ((newH % 24) + 24) % 24;
+        return String(newH).padStart(2, '0') + ':' + String(newM).padStart(2, '0');
+    }
+
+    function localToUtc(timeStr, offsetHours) {
+        return utcToLocal(timeStr, -offsetHours);
+    }
+
     function updateTrashSizeHint() {
         const input = document.getElementById('trashMaxSizeMb');
         const hint = document.getElementById('trashSizeHint');
@@ -1612,18 +1635,19 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
 
+        const offset = getTimezoneOffset();
         const data = {
             operationTimeout: document.getElementById('operationTimeout')?.value || '3600',
             largeFileThreshold: document.getElementById('largeFileThreshold')?.value || '500',
             timezone: document.getElementById('timezone')?.value || 'UTC',
             rebuildFrequency: document.getElementById('rebuildFrequency')?.value || 'disabled',
-            rebuildTime: document.getElementById('rebuildTime')?.value || '02:00',
+            rebuildTime: localToUtc(document.getElementById('rebuildTime')?.value || '02:00', offset),
             rebuildWeekday: document.getElementById('rebuildWeekday')?.value || '0',
             syncFrequency: document.getElementById('syncFrequency')?.value || 'disabled',
-            syncTime: document.getElementById('syncTime')?.value || '03:00',
+            syncTime: localToUtc(document.getElementById('syncTime')?.value || '03:00', offset),
             syncWeekday: document.getElementById('syncWeekday')?.value || '0',
             getcomicsFrequency: document.getElementById('getcomicsFrequency')?.value || 'disabled',
-            getcomicsTime: document.getElementById('getcomicsTime')?.value || '04:00',
+            getcomicsTime: localToUtc(document.getElementById('getcomicsTime')?.value || '04:00', offset),
             getcomicsWeekday: document.getElementById('getcomicsWeekday')?.value || '0',
             ignored_terms: document.getElementById('ignored_terms')?.value || '',
             ignored_files: document.getElementById('ignored_files')?.value || '',
@@ -1938,6 +1962,13 @@
         // Load getcomics schedule on page load
         loadGetcomicsSchedule();
 
+        // Re-convert displayed schedule times when timezone changes
+        document.getElementById('timezone').addEventListener('change', function() {
+            loadRebuildSchedule();
+            loadSyncSchedule();
+            loadGetcomicsSchedule();
+        });
+
         // Load Komga config on page load
         loadKomgaConfig();
 
@@ -2023,7 +2054,8 @@
                 if (data.success) {
                     const schedule = data.schedule;
                     document.getElementById('rebuildFrequency').value = schedule.frequency || 'disabled';
-                    document.getElementById('rebuildTime').value = schedule.time || '02:00';
+                    const offset = getTimezoneOffset();
+                    document.getElementById('rebuildTime').value = utcToLocal(schedule.time || '02:00', offset);
                     document.getElementById('rebuildWeekday').value = schedule.weekday || '0';
 
                     // Show weekday selector if weekly
@@ -2055,9 +2087,10 @@
         button.innerHTML = '<i class="bi bi-floppy spin"></i> Saving...';
         button.disabled = true;
 
+        const offset = getTimezoneOffset();
         const schedule = {
             frequency: document.getElementById('rebuildFrequency').value,
-            time: document.getElementById('rebuildTime').value,
+            time: localToUtc(document.getElementById('rebuildTime').value, offset),
             weekday: document.getElementById('rebuildWeekday').value
         };
 
@@ -2096,7 +2129,8 @@
                 if (data.success) {
                     const schedule = data.schedule;
                     document.getElementById('syncFrequency').value = schedule.frequency || 'disabled';
-                    document.getElementById('syncTime').value = schedule.time || '03:00';
+                    const offset = getTimezoneOffset();
+                    document.getElementById('syncTime').value = utcToLocal(schedule.time || '03:00', offset);
                     document.getElementById('syncWeekday').value = schedule.weekday || '0';
 
                     // Show weekday selector if weekly
@@ -2133,9 +2167,10 @@
         button.innerHTML = '<i class="bi bi-floppy spin"></i> Saving...';
         button.disabled = true;
 
+        const offset = getTimezoneOffset();
         const schedule = {
             frequency: document.getElementById('syncFrequency').value,
-            time: document.getElementById('syncTime').value,
+            time: localToUtc(document.getElementById('syncTime').value, offset),
             weekday: document.getElementById('syncWeekday').value
         };
 
@@ -2239,7 +2274,8 @@
                 if (data.success) {
                     const schedule = data.schedule;
                     document.getElementById('getcomicsFrequency').value = schedule.frequency || 'disabled';
-                    document.getElementById('getcomicsTime').value = schedule.time || '03:00';
+                    const offset = getTimezoneOffset();
+                    document.getElementById('getcomicsTime').value = utcToLocal(schedule.time || '03:00', offset);
                     document.getElementById('getcomicsWeekday').value = schedule.weekday || '0';
 
                     // Show weekday selector if weekly
@@ -2276,9 +2312,10 @@
         button.innerHTML = '<i class="bi bi-floppy spin"></i> Saving...';
         button.disabled = true;
 
+        const offset = getTimezoneOffset();
         const schedule = {
             frequency: document.getElementById('getcomicsFrequency').value,
-            time: document.getElementById('getcomicsTime').value,
+            time: localToUtc(document.getElementById('getcomicsTime').value, offset),
             weekday: document.getElementById('getcomicsWeekday').value
         };
 


### PR DESCRIPTION
## 📝  Update Settings to Use Time Zone and Jitter Syncs
Displays all time settings in config using the selected Time Zone. Inserts a randomized offset into Metron sync and randomizes default time to keep from sending all requests to Metron at the same time.


## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass