### PR TITLE
Revise CBL Reading Lists to Use Metadata First

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 from flask import (
-    Flask,
     render_template,
     request,
     Response,
@@ -8,11 +7,8 @@ from flask import (
     redirect,
     jsonify,
     url_for,
-    stream_with_context,
-    render_template_string,
     flash,
 )
-from werkzeug.utils import secure_filename
 from werkzeug.routing import IntegerConverter
 import subprocess
 import io
@@ -27,37 +23,23 @@ import logging
 import signal
 import select
 import random
-from models import comicvine
 from datetime import datetime, timedelta
-import time as time_module
 from PIL import Image, ImageFilter, ImageDraw
 
 try:
     import pwd
 except ImportError:
     pwd = None
-from functools import lru_cache
 import hashlib
 import re
-import xml.etree.ElementTree as ET
 import heapq
 import zipfile
 import rarfile
 import traceback
-import mysql.connector
-import base64
-from io import BytesIO
 from api import app
 import app_state
 from favorites import favorites_bp
 
-
-# Custom URL converter for signed integers (supports negative IDs)
-class SignedIntConverter(IntegerConverter):
-    regex = r"-?\d+"
-
-
-app.url_map.converters["signed"] = SignedIntConverter
 from opds import opds_bp
 from models import gcd
 from models import metron
@@ -65,21 +47,13 @@ from config import config, load_flask_config, write_config, load_config
 from cbz_ops.edit import (
     get_edit_modal,
     save_cbz,
-    cropCenter,
-    cropLeft,
-    cropRight,
-    cropFreeForm,
-    get_image_data_url,
-    modal_body_template,
 )
 from memory_utils import (
     initialize_memory_management,
-    cleanup_on_exit,
     memory_context,
     get_global_monitor,
 )
 from app_logging import app_logger, APP_LOG, MONITOR_LOG
-from helpers import is_hidden
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections import OrderedDict
 from version import __version__
@@ -88,7 +62,6 @@ from packaging import version as pkg_version
 from database import (
     init_db,
     get_db_connection,
-    get_recent_files,
     log_recent_file,
     invalidate_browse_cache,
     get_file_index_from_db,
@@ -96,30 +69,18 @@ from database import (
     update_file_index_entry,
     add_file_index_entry,
     delete_file_index_entry,
-    clear_file_index_from_db,
     sync_file_index_incremental,
-    search_file_index,
     get_rebuild_schedule,
     save_rebuild_schedule as db_save_rebuild_schedule,
     update_last_rebuild,
-    get_sync_schedule,
-    save_sync_schedule as db_save_sync_schedule,
-    update_last_sync,
-    get_path_counts_batch,
-    get_directory_children,
     clear_stats_cache,
     clear_stats_cache_keys,
     mark_issue_read,
     get_issues_read,
     get_recent_read_issues,
     save_issues_bulk,
-    get_issues_for_series,
     update_series_sync_time,
-    get_wanted_issues,
-    delete_issues_for_series,
-    get_series_needing_sync,
     get_all_mapped_series,
-    get_series_by_id,
     get_continue_reading_items,
     get_provider_credentials,
 )
@@ -136,10 +97,16 @@ from models.stats import (
 from models.timeline import get_reading_timeline
 
 # Add URL encoding support for template filters
-from urllib.parse import quote_plus
 from file_watcher import FileWatcher
-from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+
+
+# Custom URL converter for signed integers (supports negative IDs)
+class SignedIntConverter(IntegerConverter):
+    regex = r"-?\d+"
+
+
+app.url_map.converters["signed"] = SignedIntConverter
 
 
 # Register custom Jinja2 template filters
@@ -398,8 +365,8 @@ def configure_schedule(schedule_name):
         ]
 
         # Add jitter for sync/getcomics to reduce API thundering herd
-        jitter_seconds = 1800 if schedule_name in ('sync', 'getcomics') else 0
-        jitter_kwargs = {'jitter': jitter_seconds} if jitter_seconds else {}
+        jitter_seconds = 1800 if schedule_name in ("sync", "getcomics") else 0
+        jitter_kwargs = {"jitter": jitter_seconds} if jitter_seconds else {}
 
         if schedule["frequency"] == "daily":
             trigger = CronTrigger(hour=hour, minute=minute)
@@ -3897,12 +3864,12 @@ def api_mark_comic_read():
 
         api = metron_module.get_flask_api(app)
         if api:
-                metron_issue_id = metron_module.resolve_metron_issue_id(
-                    api, comic_path, comic_info.get("Number") if comic_info else None
-                )
-                if metron_issue_id:
-                    metron_module.scrobble_issue(api, metron_issue_id, read_at)
-                    app_logger.info(f"Scrobbled to Metron: issue {metron_issue_id}")
+            metron_issue_id = metron_module.resolve_metron_issue_id(
+                api, comic_path, comic_info.get("Number") if comic_info else None
+            )
+            if metron_issue_id:
+                metron_module.scrobble_issue(api, metron_issue_id, read_at)
+                app_logger.info(f"Scrobbled to Metron: issue {metron_issue_id}")
     except Exception as e:
         app_logger.warning(f"Metron scrobble failed (non-blocking): {e}")
 
@@ -5555,7 +5522,9 @@ def save_system_perf_config():
         config["SETTINGS"]["LARGE_FILE_THRESHOLD"] = data.get(
             "largeFileThreshold", "500"
         )
-        set_user_preference("timezone", data.get("timezone", "UTC"), category="personalization")
+        set_user_preference(
+            "timezone", data.get("timezone", "UTC"), category="personalization"
+        )
         config["SETTINGS"]["REBUILD_FREQUENCY"] = data.get(
             "rebuildFrequency", "disabled"
         )
@@ -5809,7 +5778,9 @@ def config_page():
         config["SETTINGS"]["ENABLE_DEBUG_LOGGING"] = str(
             request.form.get("enableDebugLogging") == "on"
         )
-        set_user_preference("timezone", request.form.get("timezone", "UTC"), category="personalization")
+        set_user_preference(
+            "timezone", request.form.get("timezone", "UTC"), category="personalization"
+        )
 
         # Styling and Recommendations are saved to user_preferences DB
         set_user_preference(

--- a/database.py
+++ b/database.py
@@ -2035,6 +2035,69 @@ def search_file_index(query, limit=100):
         return []
 
 
+def search_by_comic_metadata(series, number, volume=None, year=None, publisher=None, limit=20):
+    """
+    Search file_index using ComicInfo.xml metadata columns.
+
+    Matches on ci_series (LIKE) and ci_number (numeric or text equality).
+    Returns list of dicts with name, path, type, parent, size, and ci_* fields.
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+
+        c = conn.cursor()
+
+        # Clean series: replace ':' and '-' with spaces, remove special chars,
+        # then collapse whitespace so "Batman - Legends" / "Batman: Legends"
+        # both match "Batman Legends" in metadata
+        series_cleaned = re.sub(r'[^\w\s]', '', series.replace(':', ' ').replace('-', ' '))
+        series_normalized = re.sub(r'\s+', ' ', series_cleaned).strip()
+
+        c.execute(
+            """
+            SELECT name, path, type, size, parent,
+                   ci_series, ci_number, ci_volume, ci_year, ci_publisher
+            FROM file_index
+            WHERE has_comicinfo = 1
+              AND type = 'file'
+              AND LOWER(REPLACE(REPLACE(ci_series, ':', ' '), '-', ' ')) LIKE LOWER(?)
+              AND (
+                  (CAST(ci_number AS REAL) = CAST(? AS REAL) AND ci_number GLOB '[0-9]*')
+                  OR LOWER(TRIM(ci_number)) = LOWER(TRIM(?))
+              )
+            ORDER BY name ASC
+            LIMIT ?
+        """,
+            (f"%{series_normalized}%", number, number, limit),
+        )
+
+        rows = c.fetchall()
+        conn.close()
+
+        results = []
+        for row in rows:
+            results.append({
+                "name": row["name"],
+                "path": row["path"],
+                "type": row["type"],
+                "parent": row["parent"],
+                "size": row["size"],
+                "ci_series": row["ci_series"],
+                "ci_number": row["ci_number"],
+                "ci_volume": row["ci_volume"],
+                "ci_year": row["ci_year"],
+                "ci_publisher": row["ci_publisher"],
+            })
+
+        return results
+
+    except Exception as e:
+        app_logger.error(f"Failed to search file index by metadata: {e}")
+        return []
+
+
 # ============================================
 # File Index Metadata Scanning Functions
 # ============================================

--- a/models/cbl.py
+++ b/models/cbl.py
@@ -1,7 +1,7 @@
 import defusedxml.ElementTree as SafeET
 import re
 import os
-from database import search_file_index
+from database import search_file_index, search_by_comic_metadata
 from app_logging import app_logger
 
 class CBLLoader:
@@ -79,15 +79,76 @@ class CBLLoader:
         """
         Attempt to match a book to a file in the library.
         Strategy:
-        1. Search by filename using rename pattern format
-        2. Filter results by expected path structure:
-           - /Publisher/Series/vVolume/  (subfolder format)
-           - /Publisher/Series (Volume)/  (year in folder name)
-        3. REQUIRE issue number to match in filename
+        1. Try metadata-first matching using ComicInfo.xml fields
+        2. Fall back to filename pattern matching
         """
         if not series or not number:
             return None
 
+        match = self._match_by_metadata(series, number, volume, year)
+        if match:
+            return match
+        return self._match_by_filename(series, number, volume, year)
+
+    def _match_by_metadata(self, series, number, volume, year):
+        """Match using ComicInfo.xml metadata columns in file_index."""
+        results = search_by_comic_metadata(
+            series, number, volume=volume, year=year,
+            publisher=self.publisher
+        )
+
+        if not results:
+            return None
+
+        best_match = None
+        best_score = 0
+
+        for res in results:
+            score = 10  # Base score for series + number match
+
+            ci_series = (res.get('ci_series') or '').lower()
+            ci_volume = res.get('ci_volume') or ''
+            ci_year = res.get('ci_year') or ''
+            ci_publisher = (res.get('ci_publisher') or '').lower()
+            path = (res.get('path') or '').lower().replace('\\', '/')
+
+            # Normalize colons and dashes for comparison so
+            # "Batman: Legends" / "Batman - Legends" match "Batman Legends"
+            ci_series_norm = ' '.join(ci_series.replace(':', ' ').replace('-', ' ').split())
+            series_norm = ' '.join(series.lower().replace(':', ' ').replace('-', ' ').split())
+
+            # Exact series name match (dash-normalized)
+            if ci_series_norm == series_norm:
+                score += 15
+            elif series_norm in ci_series_norm:
+                score += 5
+
+            # Volume match
+            if volume and ci_volume:
+                if ci_volume == volume:
+                    score += 15
+                elif year and ci_volume == year:
+                    score += 10
+
+            # Year match
+            if year and ci_year == year:
+                score += 10
+
+            # Publisher match via metadata
+            if self.publisher and ci_publisher and self.publisher.lower() in ci_publisher:
+                score += 10
+            # Publisher match via path
+            elif self.publisher and self.publisher.lower() in path:
+                score += 5
+
+            if score > best_score:
+                best_score = score
+                best_match = res['path']
+
+        return best_match
+
+    def _match_by_filename(self, series, number, volume, year):
+        """Match using filename patterns and path scoring (fallback)."""
         # Clean series name for search - replace ':' with ' -'
         series_cleaned = series.replace(':', ' -')
         clean_series = re.sub(r'[^\w\s-]', '', series_cleaned)
@@ -109,6 +170,14 @@ class CBLLoader:
             f"{clean_series} #{padded_3}",        # "Avengers #018"
             f"{clean_series} #{number}",          # "Avengers #18"
         ])
+
+        # Dash-stripped patterns for cases like "Batman - Legends" -> "Batman Legends"
+        no_dash_series = re.sub(r'\s+', ' ', clean_series.replace('-', ' ')).strip()
+        if no_dash_series != clean_series:
+            search_patterns.extend([
+                f"{no_dash_series} {padded_3}",
+                f"{no_dash_series} {number}",
+            ])
 
         # Remove duplicates while preserving order
         search_patterns = list(dict.fromkeys(search_patterns))
@@ -148,11 +217,8 @@ class CBLLoader:
             filename = res['name'].lower()
 
             # REQUIRED: Check issue number in filename (avoid matching #1 in #10, or 19 in 2019)
-            # Pattern: must be preceded by non-digit (space, #, or start), then optional zeros, then the number
-            # Followed by non-digit (space, dot, paren, or end)
             padded_2 = number.zfill(2)
             padded_3 = number.zfill(3)
-            # Match patterns like: #19, #019, " 19", " 019", "_019" etc.
             issue_pattern = rf'(?:^|[^\d])#?\s*(?:0*{re.escape(number)}|{re.escape(padded_2)}|{re.escape(padded_3)})(?:[^\d]|$)'
             if not re.search(issue_pattern, filename):
                 continue  # Skip files that don't have the correct issue number

--- a/reading_lists.py
+++ b/reading_lists.py
@@ -19,6 +19,7 @@ from database import (
 )
 from models.cbl import CBLLoader
 from app_logging import app_logger
+import app_state
 
 reading_lists_bp = Blueprint('reading_lists', __name__)
 
@@ -48,6 +49,7 @@ def view_list(list_id):
 
 def process_cbl_import(task_id, content, filename, source, rename_pattern=None):
     """Background worker to process CBL import."""
+    op_id = None
     try:
         app_logger.info(f"[Import {task_id[:8]}] Starting import for: {filename}")
         import_tasks[task_id]['status'] = 'processing'
@@ -58,6 +60,13 @@ def process_cbl_import(task_id, content, filename, source, rename_pattern=None):
         # Parse entries first (fast - just XML parsing)
         entries = loader.parse_entries()
         total = len(entries)
+
+        # Extract clean display name from filename
+        display_name = filename
+        if display_name.endswith('.cbl'):
+            display_name = display_name[:-4]
+
+        op_id = app_state.register_operation("import", f"Import: {display_name}", total=total)
 
         app_logger.info(f"[Import {task_id[:8]}] Parsed {total} entries from CBL")
         import_tasks[task_id]['message'] = f'Matching {total} issues to library...'
@@ -70,6 +79,8 @@ def process_cbl_import(task_id, content, filename, source, rename_pattern=None):
             app_logger.error(f"[Import {task_id[:8]}] Failed to create reading list")
             import_tasks[task_id]['status'] = 'error'
             import_tasks[task_id]['message'] = 'Failed to create reading list'
+            if op_id:
+                app_state.complete_operation(op_id, error=True)
             return
 
         app_logger.info(f"[Import {task_id[:8]}] Created reading list: {loader.name} (id={list_id})")
@@ -85,6 +96,10 @@ def process_cbl_import(task_id, content, filename, source, rename_pattern=None):
 
             # Update progress
             import_tasks[task_id]['processed'] = i + 1
+            app_state.update_operation(
+                op_id, current=i + 1,
+                detail=f"{entry.get('series', '')} #{entry.get('issue_number', '')}"
+            )
             if (i + 1) % 10 == 0:
                 app_logger.info(f"[Import {task_id[:8]}] Progress: {i + 1}/{total} issues")
 
@@ -92,12 +107,15 @@ def process_cbl_import(task_id, content, filename, source, rename_pattern=None):
         import_tasks[task_id]['message'] = f'Imported {total} issues'
         import_tasks[task_id]['list_id'] = list_id
         import_tasks[task_id]['list_name'] = loader.name
+        app_state.complete_operation(op_id)
         app_logger.info(f"[Import {task_id[:8]}] Complete: {total} issues imported to '{loader.name}'")
 
     except Exception as e:
         app_logger.error(f"[Import {task_id[:8]}] Error: {str(e)}")
         import_tasks[task_id]['status'] = 'error'
         import_tasks[task_id]['message'] = str(e)
+        if op_id:
+            app_state.complete_operation(op_id, error=True)
 
 
 @reading_lists_bp.route('/api/reading-lists/upload', methods=['POST'])

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -143,49 +143,38 @@ function hideProgressToast() {
     }
 }
 
-// Poll for import task completion
+// Poll for import task completion (progress is shown in the navbar ops-indicator)
 function pollImportStatus(taskId, filename) {
     console.log(`[Poll] Starting to poll for task: ${taskId}`);
-    const pollInterval = 500; // Check every 500ms for more responsive updates
+    const pollInterval = 2000;
 
     function checkStatus() {
         fetch(`/api/reading-lists/import-status/${taskId}`)
             .then(response => response.json())
             .then(data => {
-                console.log(`[Poll] Status: ${data.status}, processed: ${data.processed}/${data.total}, message: ${data.message}`);
-
                 if (!data.success) {
-                    hideProgressToast();
                     showToast('Import task not found', 'error');
                     return;
                 }
 
                 if (data.status === 'complete') {
-                    hideProgressToast();
                     showToast(`Imported "${data.list_name}" (${data.processed} issues)`, 'success', 8000);
-                    // Reload page to show the new list
-                    setTimeout(() => window.location.reload(), 2000);
+                    // Reload if still on the reading lists page
+                    if (window.location.pathname === '/reading-lists') {
+                        setTimeout(() => window.location.reload(), 2000);
+                    }
                 } else if (data.status === 'error') {
-                    hideProgressToast();
                     showToast(`Import failed: ${data.message}`, 'error', 10000);
                 } else {
-                    // Still processing, update progress toast
-                    if (data.total > 0) {
-                        showProgressToast(`Importing "${filename}"... ${data.processed}/${data.total} issues`);
-                    } else {
-                        showProgressToast(`Importing "${filename}"...`);
-                    }
                     setTimeout(checkStatus, pollInterval);
                 }
             })
             .catch(error => {
                 console.error('Error checking import status:', error);
-                setTimeout(checkStatus, pollInterval * 2); // Retry with longer delay
+                setTimeout(checkStatus, pollInterval * 2);
             });
     }
 
-    // Show initial progress toast
-    showProgressToast(`Starting import of "${filename}"...`);
     checkStatus();
 }
 
@@ -233,9 +222,10 @@ function uploadCBL() {
             console.log('Upload response:', data);
             if (data.success) {
                 if (data.background && data.task_id) {
-                    // Close modal and start polling
+                    // Close modal — progress shown in navbar ops-indicator
                     const modal = bootstrap.Modal.getInstance(document.getElementById('uploadCBLModal'));
                     if (modal) modal.hide();
+                    showToast(`Importing "${listName}" — track progress in the navbar`, 'info', 5000);
                     pollImportStatus(data.task_id, listName);
                 } else {
                     window.location.reload();
@@ -308,9 +298,10 @@ function importGithub() {
             console.log('Import response:', data);
             if (data.success) {
                 if (data.background && data.task_id) {
-                    // Close modal and start polling
+                    // Close modal — progress shown in navbar ops-indicator
                     const modal = bootstrap.Modal.getInstance(document.getElementById('importGithubModal'));
                     if (modal) modal.hide();
+                    showToast(`Importing "${filename}" — track progress in the navbar`, 'info', 5000);
                     pollImportStatus(data.task_id, filename);
                 } else {
                     window.location.reload();
@@ -333,24 +324,68 @@ function importGithub() {
 }
 
 function deleteReadingList(id) {
-    if (!confirm('Are you sure you want to delete this reading list?')) {
-        return;
-    }
+    // Show confirmation toast instead of JS alert
+    const toastContainer = getToastContainer();
 
+    const toast = document.createElement('div');
+    toast.className = 'toast align-items-center text-white bg-danger border-0 show';
+    toast.setAttribute('role', 'alert');
+    toast.innerHTML = `
+        <div class="toast-body">
+            <div class="mb-2">Delete this reading list?</div>
+            <div class="d-flex gap-2">
+                <button class="btn btn-warning btn-sm confirm-delete-btn">Delete</button>
+                <button class="btn btn-light btn-sm cancel-delete-btn">Cancel</button>
+            </div>
+        </div>
+    `;
+
+    toast.querySelector('.cancel-delete-btn').addEventListener('click', function () {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+    });
+
+    toast.querySelector('.confirm-delete-btn').addEventListener('click', function () {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+        confirmDelete(id);
+    });
+
+    toastContainer.appendChild(toast);
+}
+
+function dismissToast(toastId) {
+    const el = document.getElementById(toastId);
+    if (el) {
+        el.classList.remove('show');
+        setTimeout(() => el.remove(), 300);
+    }
+}
+
+function confirmDelete(id) {
     fetch(`/api/reading-lists/${id}`, {
         method: 'DELETE'
     })
         .then(response => response.json())
         .then(data => {
             if (data.success) {
-                window.location.reload();
+                // Animate the card out then reload
+                const card = document.querySelector(`.reading-list-card[onclick*="list_id=${id}"]`);
+                if (card) {
+                    card.style.transition = 'opacity 0.3s, transform 0.3s';
+                    card.style.opacity = '0';
+                    card.style.transform = 'scale(0.95)';
+                    setTimeout(() => window.location.reload(), 400);
+                } else {
+                    window.location.reload();
+                }
             } else {
-                alert('Error: ' + data.message);
+                showToast('Error: ' + data.message, 'error');
             }
         })
         .catch(error => {
             console.error('Error:', error);
-            alert('An error occurred');
+            showToast('An error occurred while deleting', 'error');
         });
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -171,7 +171,7 @@
             return b.started_at - a.started_at;
           });
 
-          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer' };
+          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload' };
           let html = '';
           ops.forEach(op => {
             const icon = iconMap[op.op_type] || 'bi-gear';

--- a/tests/unit/test_cbl.py
+++ b/tests/unit/test_cbl.py
@@ -26,7 +26,8 @@ EMPTY_CBL = """\
 @pytest.fixture(autouse=True)
 def _mock_cbl_deps():
     """Mock database search so CBL doesn't try to hit real DB."""
-    with patch("models.cbl.search_file_index", return_value=[]):
+    with patch("models.cbl.search_file_index", return_value=[]), \
+         patch("models.cbl.search_by_comic_metadata", return_value=[]):
         yield
 
 
@@ -179,3 +180,146 @@ class TestMatchFile:
             result = loader.match_file("Batman", "1", None, None)
             assert result is not None
             assert "/DC/" in result
+
+
+class TestMatchByMetadata:
+
+    def _meta_result(self, path, name, ci_series, ci_number,
+                     ci_volume="", ci_year="", ci_publisher=""):
+        return {
+            "path": path, "name": name, "type": "file", "parent": "/data",
+            "size": 1000, "ci_series": ci_series, "ci_number": ci_number,
+            "ci_volume": ci_volume, "ci_year": ci_year,
+            "ci_publisher": ci_publisher,
+        }
+
+    def test_metadata_match_returns_path(self):
+        from models.cbl import CBLLoader
+        results = [self._meta_result(
+            "/data/DC/Batman/Batman 001.cbz", "Batman 001.cbz",
+            "Batman", "1", ci_volume="2020", ci_year="2020"
+        )]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            result = loader.match_file("Batman", "1", "2020", "2020")
+            assert result == "/data/DC/Batman/Batman 001.cbz"
+
+    def test_metadata_prefers_exact_series(self):
+        from models.cbl import CBLLoader
+        results = [
+            self._meta_result(
+                "/data/DC/Batman White Knight/BWK 001.cbz", "BWK 001.cbz",
+                "Batman: White Knight", "1"
+            ),
+            self._meta_result(
+                "/data/DC/Batman/Batman 001.cbz", "Batman 001.cbz",
+                "Batman", "1"
+            ),
+        ]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            result = loader.match_file("Batman", "1", None, None)
+            assert result == "/data/DC/Batman/Batman 001.cbz"
+
+    def test_metadata_prefers_volume_match(self):
+        from models.cbl import CBLLoader
+        results = [
+            self._meta_result(
+                "/data/DC/Batman/v2016/Batman 001.cbz", "Batman 001.cbz",
+                "Batman", "1", ci_volume="2016", ci_year="2016"
+            ),
+            self._meta_result(
+                "/data/DC/Batman/v2020/Batman 001.cbz", "Batman 001.cbz",
+                "Batman", "1", ci_volume="2020", ci_year="2020"
+            ),
+        ]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            result = loader.match_file("Batman", "1", "2020", "2020")
+            assert "v2020" in result
+
+    def test_metadata_prefers_year_match(self):
+        from models.cbl import CBLLoader
+        results = [
+            self._meta_result(
+                "/data/DC/Batman/Batman 005 (2016).cbz", "Batman 005 (2016).cbz",
+                "Batman", "5", ci_year="2016"
+            ),
+            self._meta_result(
+                "/data/DC/Batman/Batman 005 (2018).cbz", "Batman 005 (2018).cbz",
+                "Batman", "5", ci_year="2018"
+            ),
+        ]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            result = loader.match_file("Batman", "5", None, "2018")
+            assert "2018" in result
+
+    def test_metadata_publisher_boost(self):
+        from models.cbl import CBLLoader
+        results = [
+            self._meta_result(
+                "/data/Image/Batman/Batman 001.cbz", "Batman 001.cbz",
+                "Batman", "1", ci_publisher="Image"
+            ),
+            self._meta_result(
+                "/data/DC/Batman/Batman 001.cbz", "Batman 001.cbz",
+                "Batman", "1", ci_publisher="DC Comics"
+            ),
+        ]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL, filename="[DC] Batman.cbl")
+            result = loader.match_file("Batman", "1", None, None)
+            assert result == "/data/DC/Batman/Batman 001.cbz"
+
+    def test_metadata_no_results_falls_to_filename(self):
+        from models.cbl import CBLLoader
+        filename_results = [
+            {"path": "/data/DC/Batman/Batman 001.cbz", "name": "Batman 001.cbz"},
+        ]
+        with patch("models.cbl.search_by_comic_metadata", return_value=[]), \
+             patch("models.cbl.search_file_index", return_value=filename_results):
+            loader = CBLLoader(SAMPLE_CBL)
+            result = loader.match_file("Batman", "1", None, None)
+            assert result == "/data/DC/Batman/Batman 001.cbz"
+
+    def test_metadata_partial_series_match(self):
+        from models.cbl import CBLLoader
+        results = [self._meta_result(
+            "/data/DC/Batman - The Dark Knight/BTDK 001.cbz", "BTDK 001.cbz",
+            "Batman - The Dark Knight", "1"
+        )]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            # Search for "Batman: The Dark Knight" should match "Batman - The Dark Knight"
+            result = loader.match_file("Batman: The Dark Knight", "1", None, None)
+            assert result is not None
+
+    def test_metadata_dash_in_series_name(self):
+        from models.cbl import CBLLoader
+        results = [self._meta_result(
+            "/data/DC/BLODK/Batman Legends of the Dark Knight 060.cbz",
+            "Batman Legends of the Dark Knight 060.cbz",
+            "Batman: Legends of the Dark Knight", "60", ci_year="1994"
+        )]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            # CBL has dash, metadata has colon — both should normalize
+            result = loader.match_file(
+                "Batman - Legends of the Dark Knight", "60", None, "1994"
+            )
+            assert result is not None
+            # Should get exact match score (colon/dash-normalized comparison)
+            assert "060" in result
+
+    def test_metadata_number_zero_padding(self):
+        from models.cbl import CBLLoader
+        results = [self._meta_result(
+            "/data/DC/Batman/Batman 001.cbz", "Batman 001.cbz",
+            "Batman", "001"
+        )]
+        with patch("models.cbl.search_by_comic_metadata", return_value=results):
+            loader = CBLLoader(SAMPLE_CBL)
+            # Searching for "1" should match metadata with "001" (handled by DB query CAST)
+            result = loader.match_file("Batman", "1", None, None)
+            assert result == "/data/DC/Batman/Batman 001.cbz"


### PR DESCRIPTION
## 📝 Description
- Revised to use Metadata in the 'file_index' table with old file logic as a fall back if no metadata exists in a file.
- Moved progress in the header - so user can navigate away and continue monitoring.
- Updated logic to look for `Batman: Legends...` and `Batman Legends...` and `Batman - Legends...` if one doesn't exist.

Closes #162 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="406" height="194" alt="Screenshot 2026-03-06 095323" src="https://github.com/user-attachments/assets/7b078b06-a821-49d0-9b88-cb9db49f77b1" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass