### PR TITLE
Add Support for Illustrator Field

### DIFF
--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -264,7 +264,7 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
 
             if "writer" in role or "script" in role:
                 writers.append(name)
-            elif "pencil" in role:
+            elif "pencil" in role or "illustrat" in role:
                 pencillers.append(name)
             elif "ink" in role:
                 inkers.append(name)

--- a/models/gcd.py
+++ b/models/gcd.py
@@ -487,7 +487,7 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
             if 'script' in credit_type or 'writer' in credit_type or 'plot' in credit_type:
                 if name not in writers:
                     writers.append(name)
-            elif 'pencil' in credit_type:
+            elif 'pencil' in credit_type or 'illustrat' in credit_type:
                 if name not in pencillers:
                     pencillers.append(name)
             elif 'ink' in credit_type:

--- a/models/metron.py
+++ b/models/metron.py
@@ -495,7 +495,7 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
     # Extract credits
     credits = _get_attr(issue_data, "credits", []) or []
     writer = extract_credits_by_role(credits, ["Writer"])
-    penciller = extract_credits_by_role(credits, ["Penciller", "Artist"])
+    penciller = extract_credits_by_role(credits, ["Penciller", "Artist", "Illustrator"])
     inker = extract_credits_by_role(credits, ["Inker"])
     colorist = extract_credits_by_role(credits, ["Colorist"])
     letterer = extract_credits_by_role(credits, ["Letterer"])

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -2006,7 +2006,7 @@ def search_gcd_metadata():
                         if seq_num is None or seq_num != 0:
                             credits_dict['Writer'].add(name)
                     # Penciller
-                    elif 'pencil' in ct_lower or 'penc' in ct_lower:
+                    elif 'pencil' in ct_lower or 'penc' in ct_lower or 'illustrat' in ct_lower:
                         if seq_num is None or seq_num != 0:
                             credits_dict['Penciller'].add(name)
                     # Inker
@@ -2022,7 +2022,7 @@ def search_gcd_metadata():
                         if seq_num is None or seq_num != 0:
                             credits_dict['Letterer'].add(name)
                     # Cover Artist
-                    elif 'cover' in ct_lower or (seq_num == 0 and any(x in ct_lower for x in ['pencil', 'penc', 'ink', 'art'])):
+                    elif 'cover' in ct_lower or (seq_num == 0 and any(x in ct_lower for x in ['pencil', 'penc', 'ink', 'art', 'illustrat'])):
                         credits_dict['CoverArtist'].add(name)
 
                 # Convert sets to sorted comma-separated strings
@@ -2396,7 +2396,7 @@ def search_gcd_metadata_with_selection():
                       LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
                       WHERE s.issue_id = i.id
                         AND (s.sequence_number IS NULL OR s.sequence_number <> 0)
-                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%')
+                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'illustrat%')
                         AND (sc.deleted = 0 OR sc.deleted IS NULL)
                       UNION
                       SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
@@ -2404,7 +2404,7 @@ def search_gcd_metadata_with_selection():
                       JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
                       LEFT JOIN gcd_creator c ON c.id = ic.creator_id
                       WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%')
+                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'illustrat%')
                         AND (ic.deleted = 0 OR ic.deleted IS NULL)
                     ) x
                     WHERE NULLIF(name,'') IS NOT NULL
@@ -2488,7 +2488,7 @@ def search_gcd_metadata_with_selection():
                       LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
                       WHERE s.issue_id = i.id
                         AND (s.sequence_number = 0 OR ct.name LIKE 'cover%')
-                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'ink%' OR ct.name LIKE 'art%' OR ct.name LIKE 'cover%')
+                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'ink%' OR ct.name LIKE 'art%' OR ct.name LIKE 'cover%' OR ct.name LIKE 'illustrat%')
                         AND (sc.deleted = 0 OR sc.deleted IS NULL)
                       UNION
                       SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name


### PR DESCRIPTION
## 📝 Add Support for Illustrator Field
Some metadata will list "Illustrator" which is generally the penciller & inker. Added support to map this value to the 'ci_pencil' field in the database.

Closes #

## 🛠️ Changes Made
- [X] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [X] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [X] Manual test in `dev` container
- [X] Linting/Unit tests pass