### PR TITLE
Running Scan Files on Additional Libraries Fails

### DIFF
--- a/routes/collection.py
+++ b/routes/collection.py
@@ -336,17 +336,13 @@ def api_scan_directory():
     """
     Recursively scan a directory and update the file_index.
     """
-    from app import DATA_DIR
-
     data = request.get_json()
     path = data.get('path')
 
     if not path:
         return jsonify({"error": "Missing path parameter"}), 400
 
-    normalized_path = os.path.normpath(path)
-    normalized_data_dir = os.path.normpath(DATA_DIR)
-    if not normalized_path.startswith(normalized_data_dir):
+    if not is_valid_library_path(path):
         return jsonify({"error": "Access denied"}), 403
 
     if not os.path.exists(path):


### PR DESCRIPTION
## 📝 Running Scan Files on Additional Libraries Fails
Closes #176 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
**Fix:** The api_scan_directory endpoint was hardcoded to only allow paths under DATA_DIR (the default library). Replaced the DATA_DIR prefix check with is_valid_library_path(path), which validates against all configured libraries. This was already imported and used by other endpoints like list_directories.

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass