### PR TITLE
Potential fix for code scanning alert no. 60: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -6047,8 +6047,17 @@ def stream_logs(script_type):
                     script_type, os.path.basename(directory)
                 )
 
+            # Validate and normalize the directory argument before using it
+            base_dir = os.path.abspath("jobs")
+            requested_dir = os.path.abspath(os.path.join(base_dir, directory or ""))
+            if not requested_dir.startswith(base_dir + os.sep):
+                yield "data: ERROR: Invalid directory path.\n\n"
+                return
+
+            safe_directory = requested_dir
+
             process = subprocess.Popen(
-                ["python", "-u"] + script_cmd + [directory],
+                ["python", "-u"] + script_cmd + [safe_directory],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,


### PR DESCRIPTION
Potential fix for [https://github.com/allaboutduncan/clu-comics/security/code-scanning/60](https://github.com/allaboutduncan/clu-comics/security/code-scanning/60)

In general, to fix uncontrolled command-line usage when user input forms part of the argument vector, either (a) avoid passing user input entirely by using fixed, hard-coded arguments, or (b) strictly validate or map user input to a small allowlist of safe values (e.g., known directory names, IDs, or files). When dealing with filesystem paths, a common safe pattern is to restrict users to a specific base directory and then canonicalize and verify that the requested path is inside that base directory.

For this specific case, the vulnerable value is `directory` taken from `request.args.get("directory")` and appended as the final argument to `subprocess.Popen`. The least invasive fix that preserves functionality is to validate and normalize `directory` before it is used:

1. Define a base directory under which all operations are allowed (for example, read from config or an existing constant; since we cannot assume additional config here, we can use a neutral but explicit base directory name such as `"jobs"` or similar that the rest of the code is presumably using).  
2. Combine the user-provided `directory` with that base directory using `os.path.join`.
3. Canonicalize with `os.path.abspath` and check that the resulting path starts with the canonical base dir path (`os.path.commonpath` or a `startswith` pattern).
4. If the check fails, return a 400 response and do not spawn the subprocess.
5. If it passes, pass the validated, canonical path (`safe_directory`) into `subprocess.Popen` instead of the raw `directory`.

All changes must be in `app.py` within the snippet shown. We only need to (a) insert validation logic before `subprocess.Popen` is called in `generate_logs` and (b) change the argument list in the `Popen` call to use the validated path. Existing imports already include `os`, so no new imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
