### PR TITLE
bug: DB Lock on Clean Install of Large Library

### DIFF
--- a/app.py
+++ b/app.py
@@ -2553,6 +2553,15 @@ file_index = []
 index_built = False
 
 
+def sanitize_filename(name):
+    """Remove surrogate characters from filenames that have invalid UTF-8 encoding."""
+    try:
+        name.encode('utf-8')
+        return name
+    except UnicodeEncodeError:
+        return name.encode('utf-8', errors='surrogateescape').decode('utf-8', errors='replace')
+
+
 def build_file_index():
     """Build an in-memory index of all files and directories for fast searching"""
     global file_index, index_built
@@ -2640,10 +2649,10 @@ def build_file_index():
                         )
                         file_index.append(
                             {
-                                "name": name,
-                                "path": dir_path,
+                                "name": sanitize_filename(name),
+                                "path": sanitize_filename(dir_path),
                                 "type": "directory",
-                                "parent": parent_path,
+                                "parent": sanitize_filename(parent_path),
                                 "has_thumbnail": check_has_thumbnail(full_dir_path),
                             }
                         )
@@ -2684,11 +2693,11 @@ def build_file_index():
 
                         file_index.append(
                             {
-                                "name": name,
-                                "path": file_path,
+                                "name": sanitize_filename(name),
+                                "path": sanitize_filename(file_path),
                                 "type": "file",
                                 "size": file_size,
-                                "parent": parent_path,
+                                "parent": sanitize_filename(parent_path),
                                 "modified_at": mtime,
                             }
                         )

--- a/core/database.py
+++ b/core/database.py
@@ -1478,6 +1478,9 @@ def save_file_index_to_db(file_index):
     """
     Save the entire file index to the database (batch operation).
 
+    Uses chunked inserts to avoid holding a write lock for too long,
+    which prevents "database is locked" errors from concurrent threads.
+
     Args:
         file_index: List of dictionaries with keys: name, path, type, size, parent, has_thumbnail
 
@@ -1494,38 +1497,43 @@ def save_file_index_to_db(file_index):
 
         # Clear existing index
         c.execute("DELETE FROM file_index")
+        conn.commit()
 
-        # Prepare batch insert
         import time
 
         current_time = time.time()
-        records = [
-            (
-                entry["name"],
-                entry["path"],
-                entry["type"],
-                entry.get("size"),
-                entry["parent"],
-                entry.get("has_thumbnail", 0),
-                entry.get("modified_at"),
-                current_time,  # first_indexed_at
+        CHUNK_SIZE = 5000
+        total_saved = 0
+
+        for i in range(0, len(file_index), CHUNK_SIZE):
+            chunk = file_index[i:i + CHUNK_SIZE]
+            records = []
+            for entry in chunk:
+                try:
+                    records.append((
+                        entry["name"],
+                        entry["path"],
+                        entry["type"],
+                        entry.get("size"),
+                        entry["parent"],
+                        entry.get("has_thumbnail", 0),
+                        entry.get("modified_at"),
+                        current_time,
+                    ))
+                except Exception:
+                    continue
+
+            c.executemany(
+                """INSERT INTO file_index (name, path, type, size, parent, has_thumbnail, modified_at, first_indexed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                records,
             )
-            for entry in file_index
-        ]
+            conn.commit()
+            total_saved += len(records)
 
-        # Batch insert
-        c.executemany(
-            """
-            INSERT INTO file_index (name, path, type, size, parent, has_thumbnail, modified_at, first_indexed_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-            records,
-        )
-
-        conn.commit()
         conn.close()
 
-        app_logger.info(f"Saved {len(records)} entries to file index database")
+        app_logger.info(f"Saved {total_saved} entries to file index database")
         return True
 
     except Exception as e:


### PR DESCRIPTION
## 📝 DB Lock on Clean Install of Large Library
Closes #190 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass