### PR TITLE
Import Story Arcs from Metron

### DIFF
--- a/models/metron.py
+++ b/models/metron.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime, timedelta
 from core.version import __version__
 
+import requests as requests_lib
 import requests.exceptions as requests_exceptions
 from mokkari.session import Session as MokkariSession
 from mokkari.exceptions import ApiError, RateLimitError
@@ -1139,6 +1140,134 @@ def fetch_reading_list_items(api, list_id):
     results = _api_call(
         lambda: api.reading_list_items(list_id),
         f"fetching items for reading list {list_id}",
+        default=[],
+    )
+    if not results:
+        return []
+    return [_to_dict(item) for item in results]
+
+
+def fetch_arcs(api, params=None):
+    """Fetch story arcs from Metron.
+
+    Args:
+        api: Mokkari API client
+        params: Optional dict of query parameters (e.g. {"name": "..."})
+
+    Returns:
+        List of arc dicts
+    """
+    if not api:
+        return []
+
+    results = _api_call(
+        lambda: api.arcs_list(params or {}),
+        "fetching story arcs",
+        default=[],
+    )
+    if not results:
+        return []
+    return [_to_dict(item) for item in results]
+
+
+def fetch_arcs_page(api, params=None, page=1):
+    """Fetch a single page of story arcs from Metron (no auto-pagination).
+
+    Bypasses Mokkari's auto-pagination by making a direct HTTP request,
+    returning only the requested page of results.
+
+    Args:
+        api: Mokkari API client (used for credentials and user-agent)
+        params: Optional dict of query parameters (e.g. {"name": "..."})
+        page: Page number to fetch (default 1)
+
+    Returns:
+        dict with keys: results (list of dicts), has_next (bool), count (int), page (int)
+    """
+    if not api:
+        return {"results": [], "has_next": False, "count": 0, "page": page}
+
+    url = "https://metron.cloud/api/arc/"
+    query_params = {"page": page}
+    if params:
+        query_params.update(params)
+
+    headers = getattr(api, "header", {})
+    auth = (api.username, api.passwd)
+
+    for attempt in range(_RATE_LIMIT_MAX_RETRIES):
+        try:
+            resp = requests_lib.get(
+                url, params=query_params, auth=auth, headers=headers, timeout=30
+            )
+            if resp.status_code == 429:
+                retry_after = int(resp.headers.get("Retry-After", _RATE_LIMIT_DEFAULT_WAIT))
+                if retry_after > _DAILY_RATE_LIMIT_THRESHOLD:
+                    app_logger.info(
+                        f"Metron daily rate limit exceeded fetching arcs page {page}"
+                    )
+                    break
+                if attempt < _RATE_LIMIT_MAX_RETRIES - 1:
+                    app_logger.info(
+                        f"Metron rate limit hit fetching arcs page {page}: "
+                        f"waiting {retry_after}s (attempt {attempt + 1}/{_RATE_LIMIT_MAX_RETRIES})"
+                    )
+                    time.sleep(retry_after)
+                    continue
+                break
+            resp.raise_for_status()
+            data = resp.json()
+            return {
+                "results": data.get("results", []),
+                "has_next": data.get("next") is not None,
+                "count": data.get("count", 0),
+                "page": page,
+            }
+        except requests_lib.exceptions.RequestException as e:
+            app_logger.error(f"Error fetching arcs page {page}: {e}")
+            break
+
+    return {"results": [], "has_next": False, "count": 0, "page": page}
+
+
+def fetch_arc_detail(api, arc_id):
+    """Fetch full detail for a single Metron story arc.
+
+    Args:
+        api: Mokkari API client
+        arc_id: Metron story arc ID
+
+    Returns:
+        Dict with arc detail, or None
+    """
+    if not api:
+        return None
+
+    result = _api_call(
+        lambda: api.arc(arc_id),
+        f"fetching story arc {arc_id}",
+    )
+    if not result:
+        return None
+    return _to_dict(result)
+
+
+def fetch_arc_issues(api, arc_id):
+    """Fetch issues for a Metron story arc.
+
+    Args:
+        api: Mokkari API client
+        arc_id: Metron story arc ID
+
+    Returns:
+        List of issue dicts
+    """
+    if not api:
+        return []
+
+    results = _api_call(
+        lambda: api.arc_issues_list(arc_id),
+        f"fetching issues for story arc {arc_id}",
         default=[],
     )
     if not results:

--- a/routes/reading_lists.py
+++ b/routes/reading_lists.py
@@ -35,6 +35,10 @@ from models.metron import (
     fetch_reading_lists,
     fetch_reading_list_detail,
     fetch_reading_list_items,
+    fetch_arcs,
+    fetch_arcs_page,
+    fetch_arc_detail,
+    fetch_arc_issues,
 )
 from core.app_logging import app_logger
 import core.app_state as app_state
@@ -826,6 +830,187 @@ def process_metron_import(task_id, api, list_id, rename_pattern):
 
     except Exception as e:
         app_logger.error(f"[Metron import {task_id[:8]}] Error: {str(e)}")
+        import_tasks[task_id]['status'] = 'error'
+        import_tasks[task_id]['message'] = str(e)
+        if op_id:
+            app_state.complete_operation(op_id, error=True)
+
+
+@reading_lists_bp.route('/api/reading-lists/metron-browse-arcs')
+def metron_browse_arcs():
+    """Browse story arcs from Metron API."""
+    if not is_metron_configured():
+        return jsonify({
+            'success': False,
+            'message': 'Metron credentials not configured. Go to Settings to add your Metron username and password.'
+        })
+
+    api = get_flask_api()
+    if not api:
+        return jsonify({'success': False, 'message': 'Failed to connect to Metron API'})
+
+    search = request.args.get('search', '').strip()
+    page = request.args.get('page', 1, type=int)
+    params = {"name": search} if search else None
+
+    result = fetch_arcs_page(api, params, page=page)
+    return jsonify({'success': True, **result})
+
+
+@reading_lists_bp.route('/api/reading-lists/metron-import-arcs', methods=['POST'])
+def metron_import_arcs():
+    """Import story arcs from Metron API as reading lists."""
+    if not is_metron_configured():
+        return jsonify({
+            'success': False,
+            'message': 'Metron credentials not configured.'
+        })
+
+    data = request.json
+    arc_ids = data.get('arc_ids', []) if data else []
+
+    if not arc_ids:
+        return jsonify({'success': False, 'message': 'No arcs selected'})
+
+    rename_pattern = current_app.config.get('CUSTOM_RENAME_PATTERN', '{series_name} {issue_number}')
+    app = current_app._get_current_object()
+    tasks = []
+
+    for arc_id in arc_ids:
+        task_id = str(uuid.uuid4())
+        import_tasks[task_id] = {
+            'status': 'pending',
+            'message': 'Queued...',
+            'processed': 0,
+            'total': 0,
+        }
+
+        thread = threading.Thread(
+            target=_metron_arc_import_worker,
+            args=(task_id, arc_id, rename_pattern, app),
+        )
+        thread.daemon = True
+        thread.start()
+
+        tasks.append({'task_id': task_id, 'arc_id': arc_id})
+
+    return jsonify({'success': True, 'tasks': tasks})
+
+
+def _metron_arc_import_worker(task_id, arc_id, rename_pattern, app):
+    """Worker that acquires semaphore then imports a Metron story arc."""
+    _import_semaphore.acquire()
+    try:
+        with app.app_context():
+            api = get_flask_api(app)
+            if not api:
+                import_tasks[task_id]['status'] = 'error'
+                import_tasks[task_id]['message'] = 'Failed to connect to Metron API'
+                return
+            process_metron_arc_import(task_id, api, arc_id, rename_pattern)
+    except Exception as e:
+        app_logger.error(f"[Metron arc import {task_id[:8]}] Error: {e}")
+        import_tasks[task_id]['status'] = 'error'
+        import_tasks[task_id]['message'] = str(e)
+    finally:
+        _import_semaphore.release()
+
+
+def process_metron_arc_import(task_id, api, arc_id, rename_pattern):
+    """Background worker to import a story arc from Metron."""
+    op_id = None
+    try:
+        app_logger.info(f"[Metron arc import {task_id[:8]}] Starting import for arc {arc_id}")
+        import_tasks[task_id]['status'] = 'processing'
+        import_tasks[task_id]['message'] = 'Fetching story arc details...'
+
+        # Fetch arc detail
+        detail = fetch_arc_detail(api, arc_id)
+        if not detail:
+            import_tasks[task_id]['status'] = 'error'
+            import_tasks[task_id]['message'] = f'Failed to fetch story arc {arc_id}'
+            return
+
+        arc_name = detail.get('name', f'Metron Arc {arc_id}')
+
+        # Fetch issues
+        import_tasks[task_id]['message'] = 'Fetching story arc issues...'
+        issues = fetch_arc_issues(api, arc_id)
+
+        total = len(issues)
+        op_id = app_state.register_operation("import", f"Import: {arc_name}", total=total)
+
+        import_tasks[task_id]['message'] = f'Matching {total} issues to library...'
+        import_tasks[task_id]['total'] = total
+        import_tasks[task_id]['processed'] = 0
+
+        # Create reading list
+        source = f"metron://arc/{arc_id}"
+        db_list_id = create_reading_list(arc_name, source=source)
+        if not db_list_id:
+            app_logger.error(f"[Metron arc import {task_id[:8]}] Failed to create reading list")
+            import_tasks[task_id]['status'] = 'error'
+            import_tasks[task_id]['message'] = 'Failed to create reading list'
+            if op_id:
+                app_state.complete_operation(op_id, error=True)
+            return
+
+        app_logger.info(f"[Metron arc import {task_id[:8]}] Created reading list: {arc_name} (id={db_list_id})")
+
+        # Store description if available
+        description = detail.get('desc') or detail.get('description')
+        if description:
+            update_reading_list_description(db_list_id, description)
+
+        # Create a CBLLoader for match_file() reuse
+        loader = CBLLoader(
+            "<ReadingList><Name>x</Name><Books/></ReadingList>",
+            rename_pattern=rename_pattern,
+        )
+
+        # Match and add entries — arc issues are BaseIssue objects directly
+        for i, issue in enumerate(issues):
+            series_info = issue.get('series', {}) or {}
+
+            series_name = series_info.get('display_name') or series_info.get('name', '')
+            issue_number = str(issue.get('number', '') or '')
+            volume = series_info.get('volume')
+            year = series_info.get('year_began')
+
+            # match_file expects string arguments
+            vol_str = str(volume) if volume is not None else None
+            year_str = str(year) if year is not None else None
+
+            # Match to local file
+            matched_path = loader.match_file(series_name, issue_number, vol_str, year_str)
+
+            entry_data = {
+                'series': series_name,
+                'issue_number': str(issue_number) if issue_number else '',
+                'volume': str(volume) if volume else None,
+                'year': str(year) if year else None,
+                'matched_file_path': matched_path,
+            }
+
+            add_reading_list_entry(db_list_id, entry_data)
+
+            import_tasks[task_id]['processed'] = i + 1
+            app_state.update_operation(
+                op_id, current=i + 1,
+                detail=f"{series_name} #{issue_number}"
+            )
+            if (i + 1) % 10 == 0:
+                app_logger.info(f"[Metron arc import {task_id[:8]}] Progress: {i + 1}/{total} issues")
+
+        import_tasks[task_id]['status'] = 'complete'
+        import_tasks[task_id]['message'] = f'Imported {total} issues'
+        import_tasks[task_id]['list_id'] = db_list_id
+        import_tasks[task_id]['list_name'] = arc_name
+        app_state.complete_operation(op_id)
+        app_logger.info(f"[Metron arc import {task_id[:8]}] Complete: {total} issues imported to '{arc_name}'")
+
+    except Exception as e:
+        app_logger.error(f"[Metron arc import {task_id[:8]}] Error: {str(e)}")
         import_tasks[task_id]['status'] = 'error'
         import_tasks[task_id]['message'] = str(e)
         if op_id:

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -2334,6 +2334,280 @@ function importSelectedMetronLists() {
 }
 
 // ==========================================
+// Metron Story Arc Browser
+// ==========================================
+
+let _metronArcsPage = 0;       // current page loaded (0 = none yet)
+let _metronArcsHasNext = false;
+let _metronArcsSearchQuery = '';
+let _metronArcsLoaded = false;  // true after first successful load
+let _metronArcsTotalCount = 0;
+let _metronArcsDisplayed = 0;
+let _metronArcSearchTimeout = null;
+let _metronArcsFetching = false;
+let _metronArcsObserver = null;
+
+function activateMetronTab(tab) {
+    const rlTab = document.getElementById('metronRLTab');
+    const arcTab = document.getElementById('metronArcTab');
+    const importMetronBtn = document.getElementById('importMetronBtn');
+    const importMetronArcBtn = document.getElementById('importMetronArcBtn');
+
+    if (tab === 'story-arcs' && arcTab) {
+        const bsTab = new bootstrap.Tab(arcTab);
+        bsTab.show();
+        if (importMetronBtn) importMetronBtn.classList.add('d-none');
+        if (importMetronArcBtn) importMetronArcBtn.classList.remove('d-none');
+    } else if (rlTab) {
+        const bsTab = new bootstrap.Tab(rlTab);
+        bsTab.show();
+        if (importMetronBtn) importMetronBtn.classList.remove('d-none');
+        if (importMetronArcBtn) importMetronArcBtn.classList.add('d-none');
+    }
+}
+
+function loadMetronArcs() {
+    if (_metronArcsLoaded && !_metronArcsSearchQuery) {
+        return; // already showing browse results
+    }
+    _metronArcsSearchQuery = '';
+    _metronArcsPage = 0;
+    _metronArcsDisplayed = 0;
+    fetchMetronArcsPage(1);
+}
+
+function searchMetronArcs() {
+    clearTimeout(_metronArcSearchTimeout);
+    _metronArcSearchTimeout = setTimeout(() => {
+        const query = document.getElementById('metronArcSearchInput').value.trim();
+        _metronArcsSearchQuery = query;
+        _metronArcsPage = 0;
+        _metronArcsDisplayed = 0;
+        if (!query) {
+            _metronArcsLoaded = false; // allow browse reload
+        }
+        fetchMetronArcsPage(1);
+    }, 300);
+}
+
+function fetchMetronArcsPage(page) {
+    if (_metronArcsFetching) return;
+    _metronArcsFetching = true;
+
+    const loading = document.getElementById('metronArcListLoading');
+    const content = document.getElementById('metronArcListContent');
+    const error = document.getElementById('metronArcListError');
+    const empty = document.getElementById('metronArcListEmpty');
+    const notConfigured = document.getElementById('metronArcNotConfigured');
+    const sentinel = document.getElementById('metronArcScrollSentinel');
+    const sentinelSpinner = document.getElementById('metronArcSentinelSpinner');
+    const pageInfo = document.getElementById('metronArcPageInfo');
+
+    if (!loading) { _metronArcsFetching = false; return; }
+
+    const append = page > 1;
+
+    if (!append) {
+        loading.classList.remove('d-none');
+        content.classList.add('d-none');
+        error.classList.add('d-none');
+        empty.classList.add('d-none');
+        notConfigured.classList.add('d-none');
+        if (sentinel) sentinel.classList.add('d-none');
+        if (pageInfo) pageInfo.classList.add('d-none');
+    } else {
+        // Show the spinner inside the sentinel while fetching
+        if (sentinelSpinner) sentinelSpinner.classList.remove('d-none');
+    }
+
+    let url = `/api/reading-lists/metron-browse-arcs?page=${page}`;
+    if (_metronArcsSearchQuery) {
+        url += `&search=${encodeURIComponent(_metronArcsSearchQuery)}`;
+    }
+
+    fetch(url)
+        .then(r => r.json())
+        .then(data => {
+            loading.classList.add('d-none');
+            _metronArcsFetching = false;
+            if (data.success) {
+                _metronArcsPage = data.page;
+                _metronArcsHasNext = data.has_next;
+                _metronArcsTotalCount = data.count;
+
+                if (data.results.length === 0 && !append) {
+                    empty.classList.remove('d-none');
+                    if (sentinel) sentinel.classList.add('d-none');
+                } else {
+                    renderMetronArcs(data.results, append);
+                    _metronArcsDisplayed += data.results.length;
+                    content.classList.remove('d-none');
+                    if (!_metronArcsSearchQuery) _metronArcsLoaded = true;
+
+                    // Keep sentinel visible inside scroll container when more pages exist
+                    // Hide spinner text until next fetch triggers
+                    if (sentinelSpinner) sentinelSpinner.classList.add('d-none');
+                    if (_metronArcsHasNext) {
+                        if (sentinel) sentinel.classList.remove('d-none');
+                        _setupArcScrollObserver();
+                    } else {
+                        if (sentinel) sentinel.classList.add('d-none');
+                        if (_metronArcsObserver) {
+                            _metronArcsObserver.disconnect();
+                            _metronArcsObserver = null;
+                        }
+                    }
+
+                    if (pageInfo) {
+                        pageInfo.textContent = `Showing ${_metronArcsDisplayed} of ${_metronArcsTotalCount} arcs`;
+                        pageInfo.classList.remove('d-none');
+                    }
+                }
+            } else {
+                if (data.message && data.message.includes('not configured')) {
+                    notConfigured.classList.remove('d-none');
+                } else {
+                    error.classList.remove('d-none');
+                    error.textContent = data.message || 'Failed to load';
+                }
+                if (sentinel) sentinel.classList.add('d-none');
+            }
+        })
+        .catch(err => {
+            loading.classList.add('d-none');
+            _metronArcsFetching = false;
+            error.classList.remove('d-none');
+            error.textContent = 'Failed to load story arcs: ' + err.message;
+            if (sentinel) sentinel.classList.add('d-none');
+        });
+}
+
+function _setupArcScrollObserver() {
+    // Clean up previous observer
+    if (_metronArcsObserver) {
+        _metronArcsObserver.disconnect();
+        _metronArcsObserver = null;
+    }
+    if (!_metronArcsHasNext) return;
+
+    const sentinel = document.getElementById('metronArcScrollSentinel');
+    const scrollContainer = document.getElementById('metronArcListContainer');
+    if (!sentinel || !scrollContainer) return;
+
+    _metronArcsObserver = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && _metronArcsHasNext && !_metronArcsFetching) {
+            fetchMetronArcsPage(_metronArcsPage + 1);
+        }
+    }, {
+        root: scrollContainer,
+        rootMargin: '200px',
+    });
+    _metronArcsObserver.observe(sentinel);
+}
+
+function renderMetronArcs(arcs, append) {
+    const container = document.getElementById('metronArcListContent');
+    if (!container) return;
+
+    if (!append) container.innerHTML = '';
+
+    arcs.forEach(arc => {
+        const div = document.createElement('div');
+        div.className = 'metron-arc-item d-flex align-items-center px-3 py-2';
+        div.style.borderBottom = '1px solid #dee2e6';
+
+        const name = arc.name || 'Unnamed Arc';
+        const desc = arc.desc || arc.description || '';
+        const arcId = arc.id;
+
+        let descHtml = '';
+        if (desc) {
+            const snippet = desc.length > 80 ? desc.substring(0, 80) + '...' : desc;
+            descHtml = `<span class="text-muted ms-2 small">${snippet}</span>`;
+        }
+
+        div.innerHTML = `
+            <div class="form-check mb-0 flex-grow-1">
+                <input class="form-check-input metron-arc-check" type="checkbox" value="${arcId}" id="metron-arc-chk-${arcId}" onchange="updateMetronArcSelectedCount()">
+                <label class="form-check-label w-100" for="metron-arc-chk-${arcId}">
+                    <strong>${name}</strong>
+                    ${descHtml}
+                </label>
+            </div>
+        `;
+        container.appendChild(div);
+    });
+}
+
+function getSelectedMetronArcs() {
+    const checks = document.querySelectorAll('.metron-arc-check:checked');
+    return Array.from(checks).map(c => parseInt(c.value));
+}
+
+function updateMetronArcSelectedCount() {
+    const count = document.querySelectorAll('.metron-arc-check:checked').length;
+    const el = document.getElementById('metronArcSelectedCount');
+    if (el) el.textContent = `${count} arc${count !== 1 ? 's' : ''} selected`;
+}
+
+function selectAllMetronArcsVisible() {
+    document.querySelectorAll('.metron-arc-item').forEach(item => {
+        if (item.style.display !== 'none') {
+            const cb = item.querySelector('.metron-arc-check');
+            if (cb) cb.checked = true;
+        }
+    });
+    updateMetronArcSelectedCount();
+}
+
+function deselectAllMetronArcs() {
+    document.querySelectorAll('.metron-arc-check').forEach(cb => cb.checked = false);
+    updateMetronArcSelectedCount();
+}
+
+function importSelectedMetronArcs() {
+    const arcIds = getSelectedMetronArcs();
+    if (arcIds.length === 0) {
+        showToast('No arcs selected', 'error');
+        return;
+    }
+
+    const btn = document.getElementById('importMetronArcBtn');
+    btn.disabled = true;
+    btn.querySelector('.btn-text').classList.add('d-none');
+    btn.querySelector('.btn-loading').classList.remove('d-none');
+
+    fetch('/api/reading-lists/metron-import-arcs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ arc_ids: arcIds })
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                const modal = bootstrap.Modal.getInstance(document.getElementById('importMetronModal'));
+                if (modal) modal.hide();
+
+                showToast(`Importing ${data.tasks.length} arc(s) -- track progress in the navbar`, 'info', 5000);
+
+                data.tasks.forEach(task => {
+                    pollImportStatus(task.task_id, `Metron arc ${task.arc_id}`);
+                });
+            } else {
+                showToast('Error: ' + data.message, 'error');
+            }
+        })
+        .catch(err => {
+            showToast('Import failed: ' + err.message, 'error');
+        })
+        .finally(() => {
+            btn.disabled = false;
+            btn.querySelector('.btn-text').classList.remove('d-none');
+            btn.querySelector('.btn-loading').classList.add('d-none');
+        });
+}
+
+// ==========================================
 // Sync Reading List
 // ==========================================
 

--- a/templates/reading_lists.html
+++ b/templates/reading_lists.html
@@ -29,11 +29,22 @@
                 <i class="bi bi-github"></i>
                 <span>GitHub Import</span>
             </button>
-            <button class="btn btn-outline-info d-flex align-items-center gap-2" data-bs-toggle="modal"
-                data-bs-target="#importMetronModal">
-                <i class="bi bi-cloud-arrow-down"></i>
-                <span>Metron Import</span>
-            </button>
+            <div class="dropdown">
+                <button class="btn btn-outline-info d-flex align-items-center gap-2 dropdown-toggle" data-bs-toggle="dropdown">
+                    <i class="bi bi-cloud-arrow-down"></i>
+                    <span>Metron Import</span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#importMetronModal"
+                        onclick="activateMetronTab('reading-lists')">
+                        <i class="bi bi-journal-bookmark me-2"></i>Reading Lists
+                    </a></li>
+                    <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#importMetronModal"
+                        onclick="activateMetronTab('story-arcs')">
+                        <i class="bi bi-signpost-split me-2"></i>Story Arcs
+                    </a></li>
+                </ul>
+            </div>
         </div>
     </div>
 
@@ -299,36 +310,98 @@
                 <h5 class="modal-title fw-bold"><i class="bi bi-cloud-arrow-down me-2"></i>Import from Metron</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <div class="modal-body p-3">
-                <div class="mb-3">
-                    <div class="input-group">
-                        <span class="input-group-text"><i class="bi bi-search"></i></span>
-                        <input type="text" class="form-control" id="metronSearchInput" placeholder="Search reading lists..." oninput="searchMetronLists()">
+            <div class="modal-body p-0">
+                <!-- Tabs -->
+                <ul class="nav nav-tabs px-3 pt-3" id="metronTabs" role="tablist">
+                    <li class="nav-item">
+                        <button class="nav-link active" id="metronRLTab" data-bs-toggle="tab" data-bs-target="#metronRLPane" type="button" role="tab">
+                            <i class="bi bi-journal-bookmark me-1"></i>Reading Lists
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link" id="metronArcTab" data-bs-toggle="tab" data-bs-target="#metronArcPane" type="button" role="tab">
+                            <i class="bi bi-signpost-split me-1"></i>Story Arcs
+                        </button>
+                    </li>
+                </ul>
+
+                <div class="tab-content p-3">
+                    <!-- Tab 1: Reading Lists -->
+                    <div class="tab-pane fade show active" id="metronRLPane" role="tabpanel">
+                        <div class="mb-3">
+                            <div class="input-group">
+                                <span class="input-group-text"><i class="bi bi-search"></i></span>
+                                <input type="text" class="form-control" id="metronSearchInput" placeholder="Search reading lists..." oninput="searchMetronLists()">
+                            </div>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <div class="btn-group btn-group-sm">
+                                <button class="btn btn-outline-secondary" onclick="selectAllMetronVisible()">Select All</button>
+                                <button class="btn btn-outline-secondary" onclick="deselectAllMetron()">Deselect All</button>
+                            </div>
+                            <span class="text-muted small" id="metronSelectedCount">0 lists selected</span>
+                        </div>
+                        <div id="metronListContainer" style="max-height: 400px; overflow-y: auto; border: 1px solid #dee2e6; border-radius: 0.375rem;">
+                            <div class="text-center py-5 text-muted" id="metronListLoading">
+                                <span class="spinner-border spinner-border-sm me-2"></span>Loading reading lists...
+                            </div>
+                            <div id="metronListContent" class="d-none"></div>
+                            <div id="metronListError" class="text-center py-4 text-danger d-none"></div>
+                            <div id="metronListEmpty" class="text-center py-4 text-muted d-none">No reading lists found</div>
+                        </div>
+                        <div id="metronNotConfigured" class="alert alert-warning mt-3 d-none">
+                            <i class="bi bi-exclamation-triangle me-2"></i>
+                            Metron credentials not configured. <a href="/settings">Go to Settings</a> to add your Metron username and password.
+                        </div>
                     </div>
-                </div>
-                <div class="d-flex justify-content-between align-items-center mb-2">
-                    <div class="btn-group btn-group-sm">
-                        <button class="btn btn-outline-secondary" onclick="selectAllMetronVisible()">Select All</button>
-                        <button class="btn btn-outline-secondary" onclick="deselectAllMetron()">Deselect All</button>
+
+                    <!-- Tab 2: Story Arcs -->
+                    <div class="tab-pane fade" id="metronArcPane" role="tabpanel">
+                        <div class="mb-3">
+                            <div class="input-group">
+                                <span class="input-group-text"><i class="bi bi-search"></i></span>
+                                <input type="text" class="form-control" id="metronArcSearchInput" placeholder="Search story arcs..." oninput="searchMetronArcs()">
+                            </div>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <div class="btn-group btn-group-sm">
+                                <button class="btn btn-outline-secondary" onclick="selectAllMetronArcsVisible()">Select All</button>
+                                <button class="btn btn-outline-secondary" onclick="deselectAllMetronArcs()">Deselect All</button>
+                            </div>
+                            <span class="text-muted small" id="metronArcSelectedCount">0 arcs selected</span>
+                        </div>
+                        <div id="metronArcListContainer" style="max-height: 400px; overflow-y: auto; border: 1px solid #dee2e6; border-radius: 0.375rem;">
+                            <div class="text-center py-5 text-muted" id="metronArcListLoading">
+                                <span class="spinner-border spinner-border-sm me-2"></span>Loading story arcs...
+                            </div>
+                            <div id="metronArcListContent" class="d-none"></div>
+                            <div id="metronArcListError" class="text-center py-4 text-danger d-none"></div>
+                            <div id="metronArcListEmpty" class="text-center py-4 text-muted d-none">No story arcs found</div>
+                            <div id="metronArcScrollSentinel" class="d-none">
+                                <div class="text-center py-2" id="metronArcSentinelSpinner">
+                                    <span class="spinner-border spinner-border-sm me-1"></span>
+                                    <span class="text-muted small">Loading more arcs...</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="text-muted small text-center py-1 d-none" id="metronArcPageInfo"></div>
+                        <div id="metronArcNotConfigured" class="alert alert-warning mt-3 d-none">
+                            <i class="bi bi-exclamation-triangle me-2"></i>
+                            Metron credentials not configured. <a href="/settings">Go to Settings</a> to add your Metron username and password.
+                        </div>
                     </div>
-                    <span class="text-muted small" id="metronSelectedCount">0 lists selected</span>
-                </div>
-                <div id="metronListContainer" style="max-height: 400px; overflow-y: auto; border: 1px solid #dee2e6; border-radius: 0.375rem;">
-                    <div class="text-center py-5 text-muted" id="metronListLoading">
-                        <span class="spinner-border spinner-border-sm me-2"></span>Loading reading lists...
-                    </div>
-                    <div id="metronListContent" class="d-none"></div>
-                    <div id="metronListError" class="text-center py-4 text-danger d-none"></div>
-                    <div id="metronListEmpty" class="text-center py-4 text-muted d-none">No reading lists found</div>
-                </div>
-                <div id="metronNotConfigured" class="alert alert-warning mt-3 d-none">
-                    <i class="bi bi-exclamation-triangle me-2"></i>
-                    Metron credentials not configured. <a href="/settings">Go to Settings</a> to add your Metron username and password.
                 </div>
             </div>
             <div class="modal-footer bg-light">
                 <button type="button" class="btn btn-link text-decoration-none text-muted" data-bs-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-info px-4" onclick="importSelectedMetronLists()" id="importMetronBtn">
+                    <span class="btn-text">Import Selected</span>
+                    <span class="btn-loading d-none">
+                        <span class="spinner-border spinner-border-sm me-1"></span>
+                        Importing...
+                    </span>
+                </button>
+                <button type="button" class="btn btn-info px-4 d-none" onclick="importSelectedMetronArcs()" id="importMetronArcBtn">
                     <span class="btn-text">Import Selected</span>
                     <span class="btn-loading d-none">
                         <span class="spinner-border spinner-border-sm me-1"></span>
@@ -400,12 +473,37 @@
 {{ super() }}
 <script src="{{ url_for('static', filename='js/reading_list.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script>
-// Load Metron lists when modal opens
+// Load Metron data on tab shown
 document.addEventListener('DOMContentLoaded', function() {
+    const metronRLTab = document.getElementById('metronRLTab');
+    const metronArcTab = document.getElementById('metronArcTab');
+    const importMetronBtn = document.getElementById('importMetronBtn');
+    const importMetronArcBtn = document.getElementById('importMetronArcBtn');
+
+    if (metronRLTab) {
+        metronRLTab.addEventListener('shown.bs.tab', function() {
+            loadMetronLists();
+            importMetronBtn.classList.remove('d-none');
+            importMetronArcBtn.classList.add('d-none');
+        });
+    }
+    if (metronArcTab) {
+        metronArcTab.addEventListener('shown.bs.tab', function() {
+            loadMetronArcs();
+            importMetronBtn.classList.add('d-none');
+            importMetronArcBtn.classList.remove('d-none');
+        });
+    }
+
+    // Load data when modal first opens based on active tab
     const metronModal = document.getElementById('importMetronModal');
     if (metronModal) {
         metronModal.addEventListener('shown.bs.modal', function() {
-            loadMetronLists();
+            if (metronArcTab && metronArcTab.classList.contains('active')) {
+                loadMetronArcs();
+            } else {
+                loadMetronLists();
+            }
         });
     }
 });

--- a/tests/routes/test_reading_list_metron.py
+++ b/tests/routes/test_reading_list_metron.py
@@ -111,3 +111,150 @@ class TestMetronImport:
         )
         data = resp.get_json()
         assert data["success"] is False
+
+
+class TestMetronArcBrowse:
+
+    @patch("routes.reading_lists.is_metron_configured", return_value=False)
+    def test_arc_browse_not_configured(self, mock_configured, client):
+        resp = client.get("/api/reading-lists/metron-browse-arcs")
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "not configured" in data["message"]
+
+    @patch("routes.reading_lists.fetch_arcs_page")
+    @patch("routes.reading_lists.get_flask_api")
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_browse_returns_arcs(self, mock_configured, mock_api, mock_fetch, client):
+        mock_api.return_value = MagicMock()
+        mock_fetch.return_value = {
+            "results": [
+                {"id": 10, "name": "Knightfall"},
+                {"id": 20, "name": "No Man's Land"},
+            ],
+            "has_next": True,
+            "count": 100,
+            "page": 1,
+        }
+
+        resp = client.get("/api/reading-lists/metron-browse-arcs")
+        data = resp.get_json()
+        assert data["success"] is True
+        assert len(data["results"]) == 2
+        assert data["results"][0]["name"] == "Knightfall"
+        assert data["has_next"] is True
+        assert data["count"] == 100
+        assert data["page"] == 1
+
+    @patch("routes.reading_lists.fetch_arcs_page")
+    @patch("routes.reading_lists.get_flask_api")
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_browse_with_search(self, mock_configured, mock_api, mock_fetch, client):
+        mock_api.return_value = MagicMock()
+        mock_fetch.return_value = {
+            "results": [{"id": 10, "name": "Knightfall"}],
+            "has_next": False,
+            "count": 1,
+            "page": 1,
+        }
+
+        resp = client.get("/api/reading-lists/metron-browse-arcs?search=knight")
+        data = resp.get_json()
+        assert data["success"] is True
+
+        # Verify search param was forwarded
+        call_args = mock_fetch.call_args
+        assert call_args[0][1] == {"name": "knight"}
+
+    @patch("routes.reading_lists.fetch_arcs_page")
+    @patch("routes.reading_lists.get_flask_api")
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_browse_page_param(self, mock_configured, mock_api, mock_fetch, client):
+        mock_api.return_value = MagicMock()
+        mock_fetch.return_value = {
+            "results": [{"id": 30, "name": "War of the Realms"}],
+            "has_next": False,
+            "count": 50,
+            "page": 2,
+        }
+
+        resp = client.get("/api/reading-lists/metron-browse-arcs?page=2")
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["page"] == 2
+
+        # Verify page param was forwarded
+        call_args = mock_fetch.call_args
+        assert call_args[1]["page"] == 2
+
+    @patch("routes.reading_lists.fetch_arcs_page")
+    @patch("routes.reading_lists.get_flask_api")
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_browse_api_failure(self, mock_configured, mock_api, mock_fetch, client):
+        mock_api.return_value = MagicMock()
+        mock_fetch.return_value = {
+            "results": [],
+            "has_next": False,
+            "count": 0,
+            "page": 1,
+        }
+
+        resp = client.get("/api/reading-lists/metron-browse-arcs")
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["results"] == []
+
+    @patch("routes.reading_lists.get_flask_api", return_value=None)
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_browse_api_connect_failure(self, mock_configured, mock_api, client):
+        resp = client.get("/api/reading-lists/metron-browse-arcs")
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "Failed to connect" in data["message"]
+
+
+class TestMetronArcImport:
+
+    @patch("routes.reading_lists.threading.Thread")
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_import_creates_tasks(self, mock_configured, mock_thread, client):
+        resp = client.post(
+            "/api/reading-lists/metron-import-arcs",
+            json={"arc_ids": [10, 20, 30]},
+        )
+        data = resp.get_json()
+        assert data["success"] is True
+        assert len(data["tasks"]) == 3
+        assert data["tasks"][0]["arc_id"] == 10
+        assert data["tasks"][1]["arc_id"] == 20
+        assert data["tasks"][2]["arc_id"] == 30
+
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_import_no_arc_ids(self, mock_configured, client):
+        resp = client.post(
+            "/api/reading-lists/metron-import-arcs",
+            json={"arc_ids": []},
+        )
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "No arcs selected" in data["message"]
+
+    @patch("routes.reading_lists.is_metron_configured", return_value=False)
+    def test_arc_import_not_configured(self, mock_configured, client):
+        resp = client.post(
+            "/api/reading-lists/metron-import-arcs",
+            json={"arc_ids": [10]},
+        )
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "not configured" in data["message"]
+
+    @patch("routes.reading_lists.is_metron_configured", return_value=True)
+    def test_arc_import_no_body(self, mock_configured, client):
+        resp = client.post(
+            "/api/reading-lists/metron-import-arcs",
+            content_type="application/json",
+            data="{}",
+        )
+        data = resp.get_json()
+        assert data["success"] is False


### PR DESCRIPTION
## 📝 Description
Import Story Arcs from Metron. Modal loads 100 Story Arcs and as user scrolls, 100 more are loaded. Searching for an Arc will search Metron and load any relevant results.

Story Arcs are same idea and format as Reading Lists - but they are not user contributed, they are designated by the Publisher.

Closes #203 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="721" height="677" alt="image" src="https://github.com/user-attachments/assets/f37c9ed2-19a7-43cb-9d26-9766934f9a52" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass