### PR TITLE
Header Value Whitespace & CBR Convert Race Condition

### DIFF
--- a/api.py
+++ b/api.py
@@ -51,7 +51,8 @@ download_progress = {}
 
 # Setup the download directory from config.
 watch = config.get("SETTINGS", "WATCH", fallback="watch")
-custom_headers_str = config.get("SETTINGS", "HEADERS", fallback="")
+from core.database import get_user_preference
+custom_headers_str = get_user_preference("custom_headers", "")
 
 DOWNLOAD_DIR = watch
 if not os.path.exists(DOWNLOAD_DIR):
@@ -70,6 +71,7 @@ if custom_headers_str:
     try:
         custom_headers = json.loads(custom_headers_str)
         if isinstance(custom_headers, dict):
+            custom_headers = {k.strip(): v.strip() for k, v in custom_headers.items()}
             default_headers.update(custom_headers)
             monitor_logger.info("Custom headers from settings applied.")
         else:
@@ -223,6 +225,50 @@ def process_download(task):
                 download_progress[download_id]['provider'] = 'getcomics'
                 monitor_logger.debug(f"Routing to: download_getcomics (fallback)")
                 file_path = download_getcomics(final_url, download_id, hdrs=use_headers)
+
+            # Auto-convert CBR/RAR to CBZ and move to TARGET after download
+            if file_path and file_path.lower().endswith(('.cbr', '.rar')):
+                _autoconvert = config.getboolean("SETTINGS", "AUTOCONVERT", fallback=False)
+                if _autoconvert:
+                    if not os.path.exists(file_path):
+                        monitor_logger.info(f"Downloaded file already moved by monitor, skipping api conversion: {file_path}")
+                    else:
+                        try:
+                            from cbz_ops.single_file import convert_to_cbz
+                            from cbz_ops.rename import rename_file
+
+                            # Rename before conversion
+                            renamed_path = rename_file(file_path)
+                            if renamed_path:
+                                monitor_logger.info(f"Renamed downloaded file: {renamed_path}")
+                                file_path = renamed_path
+
+                            # Convert CBR/RAR to CBZ
+                            monitor_logger.info(f"Auto-converting downloaded file: {file_path}")
+                            convert_to_cbz(file_path)
+                            cbz_path = os.path.splitext(file_path)[0] + '.cbz'
+                            if os.path.exists(cbz_path):
+                                file_path = cbz_path
+                                monitor_logger.info(f"Post-download conversion complete: {cbz_path}")
+
+                                # Move converted file to TARGET directory
+                                target_dir = config.get("SETTINGS", "TARGET", fallback="/processed")
+                                target_path = os.path.join(target_dir, os.path.basename(cbz_path))
+                                os.makedirs(target_dir, exist_ok=True)
+                                if os.path.abspath(cbz_path) != os.path.abspath(target_path):
+                                    if os.path.exists(target_path):
+                                        base, ext = os.path.splitext(target_path)
+                                        counter = 1
+                                        while os.path.exists(target_path):
+                                            target_path = f"{base} ({counter}){ext}"
+                                            counter += 1
+                                    shutil.move(cbz_path, target_path)
+                                    file_path = target_path
+                                    monitor_logger.info(f"Moved converted file to: {target_path}")
+                            else:
+                                monitor_logger.warning(f"Conversion did not produce expected file: {cbz_path}")
+                        except Exception as e:
+                            monitor_logger.error(f"Post-download auto-conversion failed for {file_path}: {e}")
 
             # Success
             download_progress[download_id]['filename'] = file_path

--- a/app.py
+++ b/app.py
@@ -213,6 +213,13 @@ if get_user_preference("rec_enabled") is None:
         "Migrated recommendation settings from config.ini to user_preferences DB"
     )
 
+# Migrate custom headers from config.ini to user_preferences DB
+if get_user_preference("custom_headers") is None:
+    _ini_headers = config.get("SETTINGS", "HEADERS", fallback="")
+    if _ini_headers:
+        set_user_preference("custom_headers", _ini_headers, category="downloads")
+        app_logger.info("Migrated custom headers from config.ini to user_preferences DB")
+
 # Backup database on startup (only if changed since last backup)
 from core.database import backup_database
 
@@ -5659,7 +5666,7 @@ def save_download_api_config():
             config["SETTINGS"] = {}
 
         # Update config values
-        config["SETTINGS"]["HEADERS"] = data.get("customHeaders", "")
+        set_user_preference("custom_headers", data.get("customHeaders", ""), category="downloads")
         config["SETTINGS"]["PIXELDRAIN_API_KEY"] = sanitize_config_value(
             data.get("pixeldrainApiKey", "")
         )
@@ -5936,7 +5943,7 @@ def config_page():
         config["SETTINGS"]["CLEANUP_INTERVAL_HOURS"] = request.form.get(
             "cleanupIntervalHours", "1"
         )
-        config["SETTINGS"]["HEADERS"] = request.form.get("customHeaders", "")
+        set_user_preference("custom_headers", request.form.get("customHeaders", ""), category="downloads")
         config["SETTINGS"]["SKIPPED_FILES"] = request.form.get("skippedFiles", "")
         config["SETTINGS"]["DELETED_FILES"] = request.form.get("deletedFiles", "")
         config["SETTINGS"]["OPERATION_TIMEOUT"] = request.form.get(
@@ -6074,7 +6081,7 @@ def config_page():
         trashMaxSizeMb=settings.get("TRASH_MAX_SIZE_MB", "1024"),
         skippedFiles=settings.get("SKIPPED_FILES", ""),
         deletedFiles=settings.get("DELETED_FILES", ""),
-        customHeaders=settings.get("HEADERS", ""),
+        customHeaders=get_user_preference("custom_headers", ""),
         operationTimeout=settings.get("OPERATION_TIMEOUT", "3600"),
         largeFileThreshold=settings.get("LARGE_FILE_THRESHOLD", "500"),
         pixeldrainApiKey=settings.get("PIXELDRAIN_API_KEY", ""),

--- a/cbz_ops/single_file.py
+++ b/cbz_ops/single_file.py
@@ -378,7 +378,9 @@ def convert_to_cbz(file_path):
         app_logger.info("Converting RAR/CBR to CBZ format")
 
         base_name = os.path.splitext(file_path)[0]  # Removes the extension
-        temp_extraction_dir = f"temp_{base_name}"
+        parent_dir = os.path.dirname(file_path)
+        base_only = os.path.splitext(os.path.basename(file_path))[0]
+        temp_extraction_dir = os.path.join(parent_dir, f"temp_{base_only}")
         cbz_file_path = base_name + '.cbz'
 
         # Get parent directory for cache invalidation

--- a/core/config.py
+++ b/core/config.py
@@ -47,7 +47,6 @@ def load_config():
         "AUTO_RENAME_MONITOR": "True",
         "SKIPPED_FILES": ".xml",
         "DELETED_FILES": ".nfo,.sfv,.db,.DS_Store",
-        "HEADERS": "",
         "DOWNLOAD_PROVIDER_PRIORITY": "pixeldrain,download_now,mega",
         "PIXELDRAIN_API_KEY": "",
         "GCD_METADATA_LANGUAGES": "en",

--- a/monitor.py
+++ b/monitor.py
@@ -424,20 +424,24 @@ class DownloadCompleteHandler(FileSystemEventHandler):
                 monitor_logger.info(f"Checking if '{target_path}' is a CBR file")
                 if target_path.lower().endswith('.cbr'):
                     if self.autoconvert:
-                        monitor_logger.info(f"Sending Convert Request for '{target_path}'")
-                        retries = 3
-                        for _ in range(retries):
-                            if os.path.exists(target_path):
-                                break
-                            time.sleep(0.5)
-                        try:
-                            convert_to_cbz(target_path)
-                            # After conversion, the file will be .cbz
-                            final_target_path = os.path.splitext(target_path)[0] + '.cbz'
-                            monitor_logger.info(f"Converted to: {final_target_path}")
-                        except Exception as e:
-                            monitor_logger.error(f"Conversion failed for '{target_path}': {e}")
-                            # If conversion failed, keep the original .cbr path
+                        # Check if already converted (e.g., by api.py post-download)
+                        expected_cbz = os.path.splitext(target_path)[0] + '.cbz'
+                        if os.path.exists(expected_cbz):
+                            monitor_logger.info(f"CBZ already exists, skipping conversion: {expected_cbz}")
+                            final_target_path = expected_cbz
+                        elif os.path.getsize(target_path) == 0:
+                            monitor_logger.warning(f"Skipping conversion — file is empty: {target_path}")
+                        else:
+                            monitor_logger.info(f"Sending Convert Request for '{target_path}'")
+                            try:
+                                convert_to_cbz(target_path)
+                                if os.path.exists(expected_cbz):
+                                    final_target_path = expected_cbz
+                                    monitor_logger.info(f"Converted to: {final_target_path}")
+                                else:
+                                    monitor_logger.error(f"Conversion did not produce expected file: {expected_cbz}")
+                            except Exception as e:
+                                monitor_logger.error(f"Conversion failed for '{target_path}': {e}")
                     else:
                         monitor_logger.info("Auto-conversion is disabled.")
                 else:


### PR DESCRIPTION
## 📝 Description

Closing 2 issues found internally. 

1. Moving Custom Header info to DB and placing a whitespace removal check to ensure headers are passed correctly if a user pastes them incorrectly.
2. Reorganized the MOVE and CONVERT logic to get rid of a race condition that could move a CBR that was slated to be converted to a CBZ before the process started.

Closes #

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass