### PR TITLE
bug: CBR Conversion Can Move XML to New Location

### DIFF
--- a/cbz_ops/convert.py
+++ b/cbz_ops/convert.py
@@ -7,6 +7,7 @@ import time
 from core.app_logging import app_logger
 from core.config import config, load_config
 from helpers import is_hidden, extract_rar_with_unar
+from cbz_ops.single_file import _flatten_single_wrapper_dir
 
 load_config()
 
@@ -85,7 +86,10 @@ def convert_single_rar_file(rar_path, zip_path, temp_extraction_dir):
         if not extraction_success:
             app_logger.error(f"Failed to extract any files from {os.path.basename(rar_path)}")
             return False
-        
+
+        # Flatten wrapper directory so ComicInfo.xml stays at archive root
+        _flatten_single_wrapper_dir(temp_extraction_dir)
+
         # Step 2: Count extracted files for progress tracking
         extracted_files = []
         for root, dirs, files in os.walk(temp_extraction_dir):

--- a/cbz_ops/single_file.py
+++ b/cbz_ops/single_file.py
@@ -10,6 +10,24 @@ from helpers import extract_rar_with_unar
 
 load_config()
 
+
+def _flatten_single_wrapper_dir(extraction_dir):
+    """
+    If extraction produced a single top-level directory containing all files,
+    move its contents up to extraction_dir so the CBZ archive has no wrapper folder.
+    This preserves ComicInfo.xml at the archive root where comic readers expect it.
+    """
+    entries = os.listdir(extraction_dir)
+    if len(entries) == 1:
+        single_entry = os.path.join(extraction_dir, entries[0])
+        if os.path.isdir(single_entry):
+            for item in os.listdir(single_entry):
+                src = os.path.join(single_entry, item)
+                dst = os.path.join(extraction_dir, item)
+                shutil.move(src, dst)
+            os.rmdir(single_entry)
+
+
 # Large file threshold (configurable)
 LARGE_FILE_THRESHOLD = config.getint("SETTINGS", "LARGE_FILE_THRESHOLD", fallback=500) * 1024 * 1024  # Convert MB to bytes
 
@@ -50,7 +68,10 @@ def convert_single_rar_file(rar_path, cbz_path, temp_extraction_dir):
         if not extraction_success:
             app_logger.error(f"Failed to extract any files from {os.path.basename(rar_path)}")
             return False
-        
+
+        # Flatten wrapper directory so ComicInfo.xml stays at archive root
+        _flatten_single_wrapper_dir(temp_extraction_dir)
+
         # Step 2: Count extracted files for progress tracking
         extracted_files = []
         for root, dirs, files in os.walk(temp_extraction_dir):

--- a/tests/mocked/test_single_file.py
+++ b/tests/mocked/test_single_file.py
@@ -101,6 +101,99 @@ class TestHandleCbzFile:
         mock_rebuild.assert_called_once_with(str(cbz))
 
 
+class TestFlattenSingleWrapperDir:
+
+    @patch("cbz_ops.single_file.get_db_connection", create=True, return_value=None)
+    @patch("cbz_ops.single_file.extract_rar_with_unar")
+    def test_flattens_wrapper_directory(self, mock_extract, mock_db, tmp_path):
+        from cbz_ops.single_file import convert_single_rar_file
+
+        rar_path = str(tmp_path / "comic.rar")
+        cbz_path = str(tmp_path / "comic.cbz")
+        temp_dir = str(tmp_path / "temp_comic")
+
+        def fake_extract(rar, dest):
+            os.makedirs(dest, exist_ok=True)
+            wrapper = os.path.join(dest, "ComicVolume")
+            os.makedirs(wrapper, exist_ok=True)
+            for i in range(3):
+                with open(os.path.join(wrapper, f"page{i}.jpg"), "w") as f:
+                    f.write("fake image data")
+            with open(os.path.join(wrapper, "ComicInfo.xml"), "w") as f:
+                f.write("<ComicInfo/>")
+            return True
+
+        mock_extract.side_effect = fake_extract
+
+        result = convert_single_rar_file(rar_path, cbz_path, temp_dir)
+        assert result is True
+        with zipfile.ZipFile(cbz_path, 'r') as zf:
+            names = zf.namelist()
+            # All files should be at root, no wrapper directory prefix
+            assert "ComicInfo.xml" in names
+            for name in names:
+                assert "/" not in name and "\\" not in name
+
+    @patch("cbz_ops.single_file.get_db_connection", create=True, return_value=None)
+    @patch("cbz_ops.single_file.extract_rar_with_unar")
+    def test_preserves_flat_structure(self, mock_extract, mock_db, tmp_path):
+        from cbz_ops.single_file import convert_single_rar_file
+
+        rar_path = str(tmp_path / "comic.rar")
+        cbz_path = str(tmp_path / "comic.cbz")
+        temp_dir = str(tmp_path / "temp_comic")
+
+        def fake_extract(rar, dest):
+            os.makedirs(dest, exist_ok=True)
+            for i in range(3):
+                with open(os.path.join(dest, f"page{i}.jpg"), "w") as f:
+                    f.write("fake image data")
+            with open(os.path.join(dest, "ComicInfo.xml"), "w") as f:
+                f.write("<ComicInfo/>")
+            return True
+
+        mock_extract.side_effect = fake_extract
+
+        result = convert_single_rar_file(rar_path, cbz_path, temp_dir)
+        assert result is True
+        with zipfile.ZipFile(cbz_path, 'r') as zf:
+            names = zf.namelist()
+            assert "ComicInfo.xml" in names
+            assert len(names) == 4
+
+    @patch("cbz_ops.single_file.get_db_connection", create=True, return_value=None)
+    @patch("cbz_ops.single_file.extract_rar_with_unar")
+    def test_preserves_multi_directory_structure(self, mock_extract, mock_db, tmp_path):
+        from cbz_ops.single_file import convert_single_rar_file
+
+        rar_path = str(tmp_path / "comic.rar")
+        cbz_path = str(tmp_path / "comic.cbz")
+        temp_dir = str(tmp_path / "temp_comic")
+
+        def fake_extract(rar, dest):
+            os.makedirs(dest, exist_ok=True)
+            dir_a = os.path.join(dest, "DirA")
+            dir_b = os.path.join(dest, "DirB")
+            os.makedirs(dir_a, exist_ok=True)
+            os.makedirs(dir_b, exist_ok=True)
+            with open(os.path.join(dir_a, "page1.jpg"), "w") as f:
+                f.write("fake image data")
+            with open(os.path.join(dir_b, "page2.jpg"), "w") as f:
+                f.write("fake image data")
+            return True
+
+        mock_extract.side_effect = fake_extract
+
+        result = convert_single_rar_file(rar_path, cbz_path, temp_dir)
+        assert result is True
+        with zipfile.ZipFile(cbz_path, 'r') as zf:
+            names = zf.namelist()
+            # Multi-directory structure should be preserved (not flattened)
+            dir_prefixes = {name.split("/")[0] for name in names if "/" in name}
+            assert "DirA" in dir_prefixes
+            assert "DirB" in dir_prefixes
+
+
 class TestConvertToCbz:
 
     def test_nonexistent_file(self):


### PR DESCRIPTION
## 📝 Description
Root cause: unrar-free x preserves the archive's internal directory tree. The CBZ creation step uses        
os.path.relpath(file_path, temp_extraction_dir) which faithfully reproduces that tree — including the wrapper 
directory.                                                                                                                                                                                               

Fix: Flatten single wrapper directory after extraction    

Closes #219 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass