### PR TITLE
feature: Allow Users to Hide or Exclude Directories

### DIFF
--- a/app.py
+++ b/app.py
@@ -1866,6 +1866,7 @@ from helpers.collection import (
     extract_comicinfo,
     match_issues_to_collection,
 )
+from helpers import is_hidden
 
 
 # app = Flask(__name__)
@@ -2160,10 +2161,9 @@ def get_directory_listing(path):
                 _is_trash = None
 
             for entry in entries:
-                if entry.startswith((".", "_")):
-                    continue
-
                 full_path = os.path.join(path, entry)
+                if is_hidden(full_path):
+                    continue
 
                 # Hide the trash directory from listings
                 if _is_trash and _is_trash(full_path):
@@ -2338,8 +2338,7 @@ def warmup_cache():
                     d
                     for d in os.listdir(base_path)
                     if os.path.isdir(os.path.join(base_path, d))
-                    and not d.startswith(".")
-                    and not d.startswith("_")
+                    and not is_hidden(os.path.join(base_path, d))
                 ]
                 # Add first few subdirectories to warmup
                 for subdir in subdirs[:5]:
@@ -2774,7 +2773,7 @@ def build_file_index():
             for root, dirs, files in os.walk(library_root):
                 # Skip hidden directories
                 dirs[:] = [
-                    d for d in dirs if not d.startswith(".") and not d.startswith("_")
+                    d for d in dirs if not is_hidden(os.path.join(root, d))
                 ]
 
                 # Index directories
@@ -2946,8 +2945,7 @@ def scan_filesystem_for_sync():
                 dirs[:] = [
                     d
                     for d in dirs
-                    if not d.startswith(".")
-                    and not d.startswith("_")
+                    if not is_hidden(os.path.join(root, d))
                     and not is_in_target_dir(os.path.join(root, d))
                 ]
 
@@ -3256,7 +3254,7 @@ def update_index_on_create(path):
                     dirs[:] = [
                         d
                         for d in dirs
-                        if not d.startswith(".") and not d.startswith("_")
+                        if not is_hidden(os.path.join(root, d))
                     ]
 
                     # Index subdirectories
@@ -5614,6 +5612,20 @@ def save_file_processing_config():
         )
         config["SETTINGS"]["SKIPPED_FILES"] = data.get("skippedFiles", "")
         config["SETTINGS"]["DELETED_FILES"] = data.get("deletedFiles", "")
+
+        # Save hidden directories preference
+        hidden_dirs_raw = data.get("hiddenDirectories", ["@eaDir"])
+        if isinstance(hidden_dirs_raw, str):
+            hidden_dirs_list = [d.strip() for d in hidden_dirs_raw.split(",") if d.strip()]
+        elif isinstance(hidden_dirs_raw, list):
+            hidden_dirs_list = [d.strip() for d in hidden_dirs_raw if isinstance(d, str) and d.strip()]
+        else:
+            hidden_dirs_list = ["@eaDir"]
+        from core.database import set_user_preference as _set_pref_hd
+        _set_pref_hd("hidden_directories", hidden_dirs_list, category="file_processing")
+        from helpers import reload_hidden_directories
+        reload_hidden_directories()
+
         config["SETTINGS"]["ENABLE_CUSTOM_RENAME"] = str(
             data.get("enableCustomRename", False)
         )
@@ -5946,6 +5958,13 @@ def config_page():
         set_user_preference("custom_headers", request.form.get("customHeaders", ""), category="downloads")
         config["SETTINGS"]["SKIPPED_FILES"] = request.form.get("skippedFiles", "")
         config["SETTINGS"]["DELETED_FILES"] = request.form.get("deletedFiles", "")
+
+        # Save hidden directories preference
+        hidden_dirs_str = request.form.get("hiddenDirectories", "@eaDir")
+        hidden_dirs_list = [d.strip() for d in hidden_dirs_str.split(",") if d.strip()]
+        set_user_preference("hidden_directories", hidden_dirs_list, category="file_processing")
+        from helpers import reload_hidden_directories
+        reload_hidden_directories()
         config["SETTINGS"]["OPERATION_TIMEOUT"] = request.form.get(
             "operationTimeout", "3600"
         )
@@ -6081,6 +6100,7 @@ def config_page():
         trashMaxSizeMb=settings.get("TRASH_MAX_SIZE_MB", "1024"),
         skippedFiles=settings.get("SKIPPED_FILES", ""),
         deletedFiles=settings.get("DELETED_FILES", ""),
+        hiddenDirectories=get_user_preference("hidden_directories", ["@eaDir"]),
         customHeaders=get_user_preference("custom_headers", ""),
         operationTimeout=settings.get("OPERATION_TIMEOUT", "3600"),
         largeFileThreshold=settings.get("LARGE_FILE_THRESHOLD", "500"),

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -18,6 +18,29 @@ from contextlib import contextmanager
 # Hidden File Handling  #
 #########################
 
+_hidden_directories = None
+
+def _get_hidden_directories():
+    global _hidden_directories
+    if _hidden_directories is None:
+        reload_hidden_directories()
+    return _hidden_directories
+
+def reload_hidden_directories():
+    """Reload hidden directories from user_preferences. Call after preference changes."""
+    global _hidden_directories
+    try:
+        from core.database import get_user_preference
+        dirs = get_user_preference("hidden_directories", default=["@eaDir"])
+        if isinstance(dirs, list):
+            _hidden_directories = set(d.strip() for d in dirs if d.strip())
+        elif isinstance(dirs, str):
+            _hidden_directories = set(d.strip() for d in dirs.split(",") if d.strip())
+        else:
+            _hidden_directories = {"@eaDir"}
+    except Exception:
+        _hidden_directories = {"@eaDir"}
+
 def is_hidden(filepath):
     """
     Returns True if the file or directory is considered hidden.
@@ -27,6 +50,9 @@ def is_hidden(filepath):
     name = os.path.basename(filepath)
     # Check for names starting with '.' or '_'
     if name.startswith('.') or name.startswith('_'):
+        return True
+    # Check against user-configured hidden directory names
+    if name in _get_hidden_directories():
         return True
     # For Windows, check the hidden attribute
     if os.name == 'nt':

--- a/templates/config.html
+++ b/templates/config.html
@@ -331,6 +331,19 @@
                         </div>
                     </div>
 
+                    <div class="row mt-3">
+                        <div class="col-md-6">
+                            <label for="hiddenDirectories" class="form-label">HIDDEN DIRECTORIES:</label>
+                            <input type="text" name="hiddenDirectories" id="hiddenDirectories"
+                                value="{{ hiddenDirectories | join(', ') }}" class="form-control">
+                            <small class="form-text text-muted">
+                                Comma-separated list of directory names to hide from all views
+                                (e.g., @eaDir). Common NAS system directories like @eaDir are
+                                hidden by default.
+                            </small>
+                        </div>
+                    </div>
+
                 </div>
 
                 <!-- Custom Rename Pattern Configuration -->
@@ -1534,7 +1547,8 @@
             customMovePattern: document.getElementById('customMovePattern')?.value || '',
             trashEnabled: document.getElementById('trashEnabled')?.checked || false,
             trashDir: document.getElementById('trashDir')?.value || '',
-            trashMaxSizeMb: document.getElementById('trashMaxSizeMb')?.value || '1024'
+            trashMaxSizeMb: document.getElementById('trashMaxSizeMb')?.value || '1024',
+            hiddenDirectories: document.getElementById('hiddenDirectories')?.value || '@eaDir'
         };
 
         try {

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -43,6 +43,34 @@ class TestIsHidden:
         from helpers import is_hidden
         assert is_hidden("/path/_MACOSX") is True
 
+    def test_at_eadir_hidden_by_default(self):
+        import helpers
+        helpers._hidden_directories = None  # Reset cache
+        with patch("core.database.get_user_preference", return_value=["@eaDir"]):
+            helpers.reload_hidden_directories()
+            assert helpers.is_hidden("/path/@eaDir") is True
+
+    def test_custom_hidden_directory(self, tmp_path):
+        import helpers
+        # Create a real dir so Windows os.stat doesn't fail
+        normal_dir = tmp_path / "comics"
+        normal_dir.mkdir()
+        with patch("core.database.get_user_preference", return_value=["@eaDir", "Thumbs.db", ".sync"]):
+            helpers.reload_hidden_directories()
+            assert helpers.is_hidden("/path/Thumbs.db") is True
+            assert helpers.is_hidden("/path/@eaDir") is True
+            assert helpers.is_hidden(str(normal_dir)) is False
+
+    def test_reload_clears_cache(self):
+        import helpers
+        with patch("core.database.get_user_preference", return_value=["@eaDir"]):
+            helpers.reload_hidden_directories()
+            assert "@eaDir" in helpers._hidden_directories
+        with patch("core.database.get_user_preference", return_value=["customDir"]):
+            helpers.reload_hidden_directories()
+            assert "customDir" in helpers._hidden_directories
+            assert "@eaDir" not in helpers._hidden_directories
+
 
 # ===== apply_gamma =====
 


### PR DESCRIPTION
## 📝 Description
Allow Users to Hide or Exclude Directories. Default hides `@eaDir` NAS directories. Can configure others to be excluded from views by adding to config

Closes #199 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="670" height="160" alt="image" src="https://github.com/user-attachments/assets/0d9871c7-a3e3-4440-b45a-527c80194263" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass