### PR TITLE
fix: Improve GetComics search scoring for variants, arcs, and series matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,58 @@ CBZ processing in `edit.py` (`process_cbz_file`):
 3. Skip/delete files based on configured extensions
 4. Normalize image filenames with zero-padded numbering
 
+## GetComics Search Scoring System
+
+The GetComics download detection uses a scoring system in `models/getcomics.py` (`score_getcomics_result`) to match search results against wanted issues.
+
+### Scoring Components
+
+| Component | Points | Description |
+|-----------|--------|-------------|
+| Series match | +30 | Series name matches |
+| Issue match | +30 | Issue number found explicitly (e.g., `#1`) |
+| Standalone issue | +20 | Issue number found without `#` prefix |
+| Year match | +20 | Year matches exactly |
+| Title tightness | +15/-10 | Bonus for title closely matching series |
+| Different series | -30 | Remaining text indicates different series |
+| Arc sub-series | -30 | Story arc sub-series (not variant) |
+| Variant sub-series | -30 | Publication variant without acceptance |
+| Issue mismatch | -40 | Explicit issue number found but wrong |
+| Wrong year | -20 | Year present but doesn't match |
+| Range ends on target | -100 | Range pack ending on target issue |
+
+### Variant Keywords
+
+Variants are publication types that can be optionally accepted via `SEARCH_VARIANTS` config:
+
+```
+annual, quarterly, tpB, oneshot, one-shot, o.s., os, OS,
+trade paperback, trade-paperback, omni, omnibus, omb,
+hardcover, deluxe, prestige, gallery, absolute
+```
+
+### Sub-series Detection
+
+1. **Variants** (Annual, TPB, Quarterly, etc.): Publication variants, penalized unless the variant keyword is in `SEARCH_VARIANTS` config
+2. **Arcs** (Batman - Court of Owls): Story arcs with dash notation, always penalized - arc issue numbering is different from main series
+3. **Different Series** (Batman Inc, Flash Gordon): Series with remaining text that isn't variant or arc, penalized
+
+### "The" Prefix Handling
+
+The swap logic allows matching "The Flash" with "Flash" for series flexibility. However, if a search uses "The " prefix and the result doesn't (or vice versa), it's treated as a different series to prevent false matches.
+
+### Decision Thresholds
+
+- `ACCEPT`: Score >= 40, strong match
+- `FALLBACK`: Score positive but < 40, range pack containing target issue
+- `REJECT`: Score <= 0 or explicitly disqualified
+
+### Edge Cases
+
+- Range packs (e.g., `#1-5`) containing target issue are accepted as FALLBACK
+- Different arcs (e.g., "Court of Owls" vs "Darkest Knight") do NOT match
+- Series with "The " prefix are treated as different from same series without
+
 ## Docker Environment
 
 - Base: `python:3.11-slim-bookworm`

--- a/app.py
+++ b/app.py
@@ -930,17 +930,36 @@ def scheduled_getcomics_download():
                 # Get year from store_date or series (used in query and scoring)
                 issue_year = int(store_date[:4]) if store_date else series_year
 
+                # Get variant search preferences
+                search_variants_str = config.get("SETTINGS", "SEARCH_VARIANTS", fallback="")
+                search_variants = [v.strip().lower() for v in search_variants_str.split(",") if v.strip()]
+
                 query = (
                     f"{series_name} {issue_num} {issue_year}"
                     if issue_year
                     else f"{series_name} {issue_num}"
                 )
-                app_logger.info(f"🔍 Searching GetComics for: {query}")
+                search_context = f"[{series_name} #{issue_num}" + (f", {issue_year}]" if issue_year else "]")
+                app_logger.info(f"🔍 Searching GetComics for: {query} {search_context}")
 
                 # Rate limit - avoid hammering GetComics
                 time.sleep(2)
 
                 results = search_getcomics(query, max_pages=1)
+
+                # Fallback: if main search finds nothing and variants are configured, retry with variants
+                if not results and search_variants:
+                    variant_query = (
+                        f"{series_name} {' '.join(search_variants)} {issue_num} {issue_year}"
+                        if issue_year
+                        else f"{series_name} {' '.join(search_variants)} {issue_num}"
+                    )
+                    app_logger.info(f"🔍 Main search found nothing, retrying with variants: {variant_query}")
+                    time.sleep(2)  # Rate limit
+                    results = search_getcomics(variant_query, max_pages=1)
+                    if results:
+                        app_logger.info(f"✅ Found {len(results)} results with variant search")
+
                 if not results:
                     app_logger.debug(f"No results found for: {query}")
                     continue
@@ -952,8 +971,10 @@ def scheduled_getcomics_download():
                 single_found  = False
 
                 for result in results:
+                    # When searching with variants, accept those variants without penalty
                     score, is_range, series_match = score_getcomics_result(
-                        result["title"], series_name, issue_num, issue_year
+                        result["title"], series_name, issue_num, issue_year,
+                        accept_variants=search_variants
                     )
                     decision = accept_result(
                         score, is_range, series_match,
@@ -971,7 +992,7 @@ def scheduled_getcomics_download():
                     best_result, best_score = chosen
                     tier = "direct match" if best_accept else "range fallback"
                     app_logger.info(
-                        f"✅ Found match ({tier}, score={best_score}): {best_result['title']}"
+                        f"✅ Found match for {series_name} #{issue_num} ({tier}, score={best_score}): {best_result['title']} {search_context}"
                     )
 
                     # Get download links
@@ -1021,14 +1042,14 @@ def scheduled_getcomics_download():
                         download_queue.put(task)
 
                         download_count += 1
-                        app_logger.info(f"📥 Queued download: {filename}")
+                        app_logger.info(f"📥 Queued download for {series_name} #{issue_num}: {filename} {search_context}")
                     else:
                         app_logger.warning(
-                            f"No download link found for: {best_result['title']}"
+                            f"No download link found for: {best_result['title']} {search_context}"
                         )
                 else:
                     app_logger.debug(
-                        f"No good match found for {series_name} #{issue_num} (best score: {best_score})"
+                        f"No good match found for {series_name} #{issue_num} (best score: {best_score}) {search_context}"
                     )
 
         # Update last run timestamp

--- a/core/config.py
+++ b/core/config.py
@@ -63,7 +63,8 @@ def load_config():
         "METADATA_SCAN_THREADS": "2",
         "TRASH_ENABLED": "True",
         "TRASH_DIR": "",
-        "TRASH_MAX_SIZE_MB": "1024"
+        "TRASH_MAX_SIZE_MB": "1024",
+        "SEARCH_VARIANTS": "annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery,absolute"
     }
 
     if not os.path.exists(CONFIG_FILE):

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -157,9 +157,19 @@ def score_getcomics_result(
     series_name: str,
     issue_number: str,
     year: int,
+    accept_variants: list = None,
 ) -> tuple:
     """
     Score a GetComics search result against a wanted issue.
+
+    Args:
+        result_title: Title from GetComics search result
+        series_name: Series name to match
+        issue_number: Issue number to match
+        year: Year to match
+        accept_variants: Optional list of variant types to accept without penalty.
+                        E.g., ['annual'] - if Annual is detected but user searched for it,
+                        don't penalize as sub-series. Maps to global SEARCH_VARIANTS config.
 
     Returns:
         (score, range_contains_target, series_match)
@@ -176,17 +186,32 @@ def score_getcomics_result(
 
     Penalties:
         -10  Title tightness (1+ extra words)
-        -20  Sub-series detected (dash after series name)
+        -30  Sub-series detected (dash after series name OR variant keyword)
+        -30  Different series (remaining text indicates different series)
+        -30  "The" prefix swap used but remaining doesn't match (e.g., "The Flash Gordon" vs "Flash Gordon")
         -20  Wrong year explicitly present in title
         -30  Collected edition keyword (omnibus, TPB, hardcover, etc.)
         -40  Confirmed issue mismatch (#N present but points to wrong number)
+
+    Sub-series handling:
+        - Variants (Annual, TPB, Quarterly, etc.): Penalized unless variant keyword in accept_variants
+        - Arcs (Batman - Court of Owls): ALWAYS penalized - arc issue numbering differs from main series
+        - Different Series (Batman Inc, Flash Gordon): Penalized - not the same series
+
+    "The" prefix handling:
+        The swap logic allows "The Flash" to match "Flash" for series flexibility.
+        However, if the search uses "The " but result doesn't (or vice versa),
+        the match is penalized as a different series.
 
     Range fallback logic:
         When a range like "#1-12" contains the target issue,
         range_contains_target=True is returned and the score is capped below
         ACCEPT_THRESHOLD. Use accept_result() to decide whether to use it.
-        FALLBACK requires series_match=True — sub-series arc packs are rejected.
+        FALLBACK requires series_match=True — arc sub-series range packs ARE allowed
+        (arcs are often bundled in packs).
     """
+    if accept_variants is None:
+        accept_variants = []
     import re
 
     score = 0
@@ -234,15 +259,63 @@ def score_getcomics_result(
     else:
         series_starts.append('the ' + series_lower)
 
+    # Known variant type keywords - these are publication variants, not arc/story sub-series
+    # These can be accepted via SEARCH_VARIANTS config
+    VARIANT_KEYWORDS = [
+        'annual',
+        'tpb', 'tpb',  # Trade Paperback
+        'trade paperback', 'trade-paperback',
+        'oneshot', 'one-shot',  # One-shot
+        'o.s.', 'os',  # Original Series (same as oneshot)
+        'quarterly',
+        'omni', 'omnibus', 'omb',  # Omnibus
+        'hardcover',  # Hardcover edition
+        'deluxe', 'deluxe edition',
+        'absolute',
+        'prestige',
+        'gallery',
+    ]
+
     series_match = False
-    sub_series_detected = False
+    sub_series_type = None  # 'variant' (annual, tpB, etc.), 'arc' (story arc), or None
+    remaining = ""  # Initialize for scope
+    detected_variant = None  # Store which specific variant was detected
+    used_the_swap = False  # Track if we matched using "The " prefix swap
     for start in series_starts:
         if title_lower.startswith(start):
             remaining = title_lower[len(start):].strip()
+            # Track if we matched using the swapped "the " version
+            # This helps detect different series like "The Flash Gordon" vs "Flash Gordon"
+            # If search is "The Flash Gordon" but result matches "Flash Gordon" (without "The"),
+            # that's a different series, not the same series with swapped prefix
+            if series_lower.startswith('the ') and start == series_lower[4:]:
+                used_the_swap = True
+            # Sub-series with dash: "Series - Quarterly", "Series – Arc Name"
             if remaining.startswith(('-', '\u2013', '\u2014')):
                 if re.match(r'[-\u2013\u2014]\s*\w+', remaining):
-                    sub_series_detected = True
-                    continue
+                    # Check if dash sub-series matches a known variant keyword
+                    dash_part = remaining.lstrip('-\u2013\u2014').strip().lower()
+                    variant_found = False
+                    for keyword in VARIANT_KEYWORDS:
+                        # Match whole word anywhere in dash_part to catch variants like "one-shot"
+                        # that don't appear at the start. \b ensures we match whole words only.
+                        if re.search(rf'\b{re.escape(keyword)}\b', dash_part, re.IGNORECASE):
+                            sub_series_type = 'variant'
+                            detected_variant = keyword
+                            variant_found = True
+                            break
+                    # If no variant keyword matched, treat as story arc (not a publication variant)
+                    if not variant_found:
+                        sub_series_type = 'arc'
+            # Sub-series with variant keyword (even without dash):
+            # "Absolute Batman 2025 Annual #1" or "Batman Annual #1"
+            # "Annual" is a publication variant, not the main series
+            else:
+                for keyword in VARIANT_KEYWORDS:
+                    if re.search(rf'\b{re.escape(keyword)}\b', remaining, re.IGNORECASE):
+                        sub_series_type = 'variant'
+                        detected_variant = keyword
+                        break
             series_match = True
             break
 
@@ -253,9 +326,50 @@ def score_getcomics_result(
     # Sub-series penalty — skip when range already flagged so arc packs
     # (e.g. "Batman – Court of Owls #1-11") can still surface as FALLBACK
     # if series_match happens to be True.
-    if sub_series_detected and not range_contains_target:
-        score -= 20
-        logger.debug(f"Sub-series penalty: -20")
+    # Variant sub-series (Annual, TPB, Quarterly, etc.) are publication variants,
+    # not story arcs. They are penalized unless explicitly accepted via SEARCH_VARIANTS.
+    # Arc sub-series (story arcs with dash) are also penalized but for different reasons.
+
+    # Check if any accept_variants keyword matches the detected variant
+    # Accept if:
+    #   1. detected_variant is in accept_variants, OR
+    #   2. any accept_variants keyword matches the remaining, OR
+    #   3. the search series_name itself contains the variant keyword (e.g., searching for
+    #      "Flash Gordon - Quarterly" should not penalize "Flash Gordon - Quarterly #5")
+    variant_accepted = False
+    if sub_series_type in ('variant', 'arc'):
+        # Normalize remaining text for matching (remove hyphens to handle "one-shot" = "oneshot")
+        remaining_normalized = remaining.replace('-', '').replace('\u2013', '').replace('\u2014', '').lower()
+        # Normalize series_name for checking if variant is in the search series name
+        series_name_normalized = series_lower.replace('-', '').replace('\u2013', '').replace('\u2014', '').lower()
+
+        for keyword in accept_variants:
+            keyword_normalized = keyword.replace('-', '').lower()
+            # Check exact match or normalized match (remove hyphens for comparison)
+            # e.g., 'one-shot' normalized = 'oneshot' matches 'oneshot' normalized = 'oneshot'
+            if (detected_variant and keyword == detected_variant) or \
+               (detected_variant and keyword_normalized == detected_variant.replace('-', '').lower()) or \
+               keyword_normalized in remaining_normalized or \
+               (detected_variant and detected_variant in series_name_normalized):
+                variant_accepted = True
+                break
+
+    # For variants, we don't penalize if variant_accepted is True (user explicitly searched for variants)
+    # But for ARCS, we ALWAYS penalize because arc issue numbering is different from main series numbering
+    should_penalize_subseries = (
+        sub_series_type is not None and
+        not variant_accepted and
+        not range_contains_target
+    )
+    # Arcs are ALWAYS penalized because "Batman - Court of Owls #1" is NOT "Batman #1"
+    # Even if user accepts the arc keyword, the arc issue numbering is different
+    if sub_series_type == 'arc':
+        should_penalize_subseries = True
+
+    if should_penalize_subseries:
+        score -= 30
+        penalty_type = detected_variant if detected_variant else sub_series_type
+        logger.debug(f"Sub-series penalty ({penalty_type}): -30")
 
     # ── TITLE TIGHTNESS (+15 / -10) ──────────────────────────────────────────
     noise_words = {
@@ -286,45 +400,118 @@ def score_getcomics_result(
         logger.debug(f"Title tightness penalty ({extra_count} extra words): -10")
 
     # ── ISSUE NUMBER MATCH (+30 / +20) ───────────────────────────────────────
+    # Cross-series fix: issue matching only counts when series_match is True.
+    # If series doesn't match, finding #N in a different series is meaningless.
+    # Variant sub-series fix: when a variant (Annual, TPB, Quarterly, etc.) is detected,
+    # the issue number is for that variant, not the main series, so don't count unless variant_accepted.
+    # Different series fix: when remaining text exists but wasn't classified as variant or arc,
+    # it's a DIFFERENT series (e.g., "Batman Inc #1" is not "Batman #1"), so don't count issue.
     issue_matched = False
 
-    if is_dot_issue:
-        dot_patterns = [
-            rf'#0*{re.escape(issue_num)}\b',
-            rf'issue\s*0*{re.escape(issue_num)}\b',
-            rf'\b0*{re.escape(issue_num)}\b',
-        ]
-        for pattern in dot_patterns:
-            if re.search(pattern, title_lower, re.IGNORECASE):
-                score += 30
-                issue_matched = True
-                logger.debug(f"Dot-issue match: +30")
-                break
-    else:
-        explicit_patterns = [
-            rf'#0*{re.escape(issue_num)}\b',
-            rf'issue\s*0*{re.escape(issue_num)}\b',
-        ]
-        for pattern in explicit_patterns:
-            if re.search(pattern, title_lower, re.IGNORECASE):
-                score += 30
-                issue_matched = True
-                logger.debug(f"Issue match ({pattern}): +30")
-                break
+    # Check if remaining text indicates a different series (not variant, not arc)
+    remaining_is_different_series = False
+    if remaining and sub_series_type is None:
+        # Check if remaining is primarily a range pattern (digits, dashes, spaces, parens)
+        # These are NOT different series - they're issue ranges for the same series
+        remaining_cleaned = remaining.strip().replace('-', '').replace('\u2013', '').replace('\u2014', '').replace(' ', '').replace('#', '').replace('(', '').replace(')', '')
+        is_purely_range = bool(remaining_cleaned) and all(c.isdigit() or c == '.' for c in remaining_cleaned)
 
-        if not issue_matched:
-            standalone = re.search(rf'\b0*{re.escape(issue_num)}\b', title_lower)
-            if standalone:
-                match_start = standalone.start()
-                prefix = result_title[max(0, match_start - 10):match_start].lower()
-                if (not re.search(r'[-\u2013\u2014]\s*$', prefix) and
-                        not re.search(r'\bvol(?:ume)?\.?\s*$', prefix)):
-                    score += 20
+        # First check: does remaining START with an issue number? If so, NOT different series
+        # (remaining would be "#1 2025" or "1 2025" which is just the issue number)
+        starts_with_issue = re.match(r'^#?\d', remaining.strip())
+
+        # Also check if remaining starts with "Issue" (issue as a word) - e.g., "Batman Issue 7"
+        # This is NOT a different series, just the issue number written as a word
+        starts_with_issue_word = re.match(r'^issue\s*\d', remaining.strip(), re.IGNORECASE)
+
+        # If we matched using the "The " swap but result doesn't have "The ", treat as different series
+        # e.g., searching "The Flash Gordon" should NOT match "Flash Gordon"
+        # This must be checked BEFORE is_purely_range because "#1" would be range but should still
+        # be treated as different series when swap was used
+        if used_the_swap:
+            remaining_is_different_series = True
+        # Ranges like "#1-5" that don't use swap are NOT different series
+        elif is_purely_range:
+            remaining_is_different_series = False
+        elif not starts_with_issue and not starts_with_issue_word:
+            # Remaining doesn't start with issue number or "issue" word - might be different series
+            # Check if remaining starts with a dash (would be arc - handled above)
+            if not remaining.startswith(('-', '\u2013', '\u2014')):
+                # Doesn't start with dash either - check for variant keywords
+                has_variant_keyword = False
+                remaining_check = remaining.replace('-', '').replace('\u2013', '').replace('\u2014', '').lower()
+                for kw in VARIANT_KEYWORDS:
+                    if re.search(rf'\b{re.escape(kw)}\b', remaining_check, re.IGNORECASE):
+                        has_variant_keyword = True
+                        break
+                if not has_variant_keyword:
+                    remaining_is_different_series = True
+
+    # Apply different-series penalty: when remaining text indicates a different series
+    # (e.g., "Batman Inc #1" is not "Batman #1", "Batman Adventures #1" is not "Batman #1")
+    if remaining_is_different_series:
+        score -= 30
+        logger.debug(f"Different series penalty: -30 (remaining: '{remaining[:30]}...')")
+
+    # Determine if we should allow issue matching based on variant_accepted
+    # Allow issue matching if:
+    #   1. no sub-series AND remaining text is empty (clean match), OR
+    #   2. variant was accepted (but NOT for arcs - arc issue numbers are arc-internal)
+    # DON'T allow issue matching for arcs - "Batman - Court of Owls #1" is NOT the same as "Batman #1"
+    # Arcs have their own issue numbering within the arc, separate from the main series
+    # DON'T allow if remaining text indicates a different series
+    allow_issue_match = series_match and (
+        (sub_series_type is None and not remaining_is_different_series) or
+        (variant_accepted and sub_series_type != 'arc')
+    )
+
+    if is_dot_issue:
+        if allow_issue_match:
+            dot_patterns = [
+                rf'#0*{re.escape(issue_num)}\b',
+                rf'issue\s*0*{re.escape(issue_num)}\b',
+                rf'\b0*{re.escape(issue_num)}\b',
+            ]
+            for pattern in dot_patterns:
+                if re.search(pattern, title_lower, re.IGNORECASE):
+                    score += 30
                     issue_matched = True
-                    logger.debug(f"Issue match (standalone): +20")
+                    variant_note = f", accepted variant ({detected_variant})" if variant_accepted else ", not sub-series"
+                    logger.debug(f"Dot-issue match (series confirmed{variant_note}): +30")
+                    break
+    else:
+        if allow_issue_match:
+            explicit_patterns = [
+                rf'#0*{re.escape(issue_num)}\b',
+                rf'issue\s*0*{re.escape(issue_num)}\b',
+            ]
+            for pattern in explicit_patterns:
+                if re.search(pattern, title_lower, re.IGNORECASE):
+                    score += 30
+                    issue_matched = True
+                    variant_note = f", accepted variant ({detected_variant})" if variant_accepted else ""
+                    logger.debug(f"Issue match ({pattern}, series confirmed{variant_note}): +30")
+                    break
+
+            if not issue_matched:
+                standalone = re.search(rf'\b0*{re.escape(issue_num)}\b', title_lower)
+                if standalone:
+                    match_start = standalone.start()
+                    prefix = result_title[max(0, match_start - 10):match_start].lower()
+                    if (not re.search(r'[-\u2013\u2014]\s*$', prefix) and
+                            not re.search(r'\bvol(?:ume)?\.?\s*$', prefix)):
+                        score += 20
+                        issue_matched = True
+                        variant_note = f", accepted variant ({detected_variant})" if variant_accepted else ""
+                        logger.debug(f"Issue match (standalone, series confirmed{variant_note}): +20")
+        elif series_match and sub_series_type is not None and not variant_accepted:
+            logger.debug(f"Skipping issue match - sub-series detected ({detected_variant or sub_series_type}), not in accept_variants")
+        elif not series_match:
+            logger.debug(f"Skipping issue match - series does not match")
 
     # Confirmed mismatch — explicit #N found but it's the wrong number
-    if not issue_matched:
+    # Only penalize when series matches but issue number is different
+    if not issue_matched and series_match:
         explicit = re.search(
             rf'(?:#|issue\s)0*(\d+(?:\.\d+)?)\b', title_lower, re.IGNORECASE
         )
@@ -355,8 +542,14 @@ def score_getcomics_result(
         r'\bcomplete\s+collection\b',
         r'\blibrary\s+edition\b',
         r'\bbook\s+\d+\b',
-        r'\bannual\b',
     ]
+    # Skip "annual" penalty if already detected as variant sub-series (Issue #193)
+    # Annual and Quarterly are publication frequencies, not collected editions
+    # So we only penalize them once via sub-series penalty
+    # But TPB, Hardcover, Omnibus etc. can be both variants AND collected editions,
+    # so they get double-penalized (which is correct - TPB with issue # is weird)
+    if sub_series_type is None:
+        collected_keywords.extend([r'\bannual\b', r'\bquarterly\b'])
     for kw in collected_keywords:
         if re.search(kw, title_remainder):
             score -= 30

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -403,6 +403,366 @@ class TestScoreGetcomicsResult:
         score, _, _ = score_getcomics_result("Batman #1", "Batman", "001", 0)
         assert score >= 60  # series(30) + issue(30)
 
+    def test_annual_as_sub_series_penalty(self):
+        """Annual variant should be penalized as sub-series (Issue #193)."""
+        from models.getcomics import score_getcomics_result
+        # Main series "Batman #1 (2020)" should score higher than "Batman Annual #1 (2020)"
+        main_score, _, _ = score_getcomics_result("Batman #1 (2020)", "Batman", "1", 2020)
+        annual_score, _, _ = score_getcomics_result("Batman Annual #1 (2020)", "Batman", "1", 2020)
+        # Annual has -30 sub-series penalty but still has series + issue + year match
+        assert main_score > annual_score
+        # Annual should be penalized by at least 30 points (increased from -20 to -30)
+        assert main_score - annual_score >= 30
+
+    def test_annual_keyword_detected_as_sub_series(self):
+        """Annual keyword should be detected as sub-series without dash (Issue #193)."""
+        from models.getcomics import score_getcomics_result
+        # "Absolute Batman 2025 Annual #1" - Annual appears after year but should be detected
+        score, _, _ = score_getcomics_result(
+            "Absolute Batman 2025 Annual #1 (2025)", "Absolute Batman", "1", 2025
+        )
+        # Should have sub-series penalty of -30
+        # Issue match is NOT counted for Annual (Annual #N is not main series #N)
+        # Score breakdown: series(30) - sub-series(30) + title_tightness(-10) + year(20) = 10
+        assert score == 10
+
+    def test_quarterly_sub_series_penalty_increased(self):
+        """Quarterly sub-series penalty increased from -20 to -30 (Issue #193)."""
+        from models.getcomics import score_getcomics_result
+        # "Flash Gordon - Quarterly #5" vs main series
+        quarterly_score, _, _ = score_getcomics_result(
+            "Flash Gordon - Quarterly (2025) Issue 5", "Flash Gordon", "5", 2025
+        )
+        main_score, _, _ = score_getcomics_result(
+            "Flash Gordon #5 (2025)", "Flash Gordon", "5", 2025
+        )
+        # Main series should be at least 30 points higher (increased penalty)
+        assert main_score - quarterly_score >= 30
+
+    def test_flash_gordon_quarterly_issue_matching(self):
+        """Flash Gordon Quarterly Issue 5 should not incorrectly match base series (Issue #193)."""
+        from models.getcomics import score_getcomics_result
+        # When searching for Flash Gordon #5, Quarterly variant should score lower
+        quarterly_score, _, _ = score_getcomics_result(
+            "Flash Gordon - Quarterly (2025) Issue 5", "Flash Gordon", "5", 2025
+        )
+        # With increased -30 sub-series penalty:
+        # series(30) - sub-series(30) + title_tightness(-10?) + issue(30) + year(20) = 40-ish
+        # Actually: series(30) - 30 + 15 + 30 + 20 = 65
+        assert quarterly_score < 70  # Should be significantly lower than main series
+
+    def test_cross_series_false_positive_batman_vs_superman(self):
+        """Searching for Batman #1 should not match Superman #1 (cross-series bug fix)."""
+        from models.getcomics import score_getcomics_result, ACCEPT_THRESHOLD
+        score, _, _ = score_getcomics_result(
+            "Superman #1 (2020)", "Batman", "1", 2020
+        )
+        # Score should be < ACCEPT_THRESHOLD (no series match, no issue match)
+        assert score < ACCEPT_THRESHOLD
+
+    def test_cross_series_false_positive_flash_gordon_vs_the_flash(self):
+        """Searching for Flash Gordon #1 should not match The Flash #1."""
+        from models.getcomics import score_getcomics_result, ACCEPT_THRESHOLD
+        score, _, _ = score_getcomics_result(
+            "The Flash #1 (2020)", "Flash Gordon", "1", 2020
+        )
+        # Score should be < ACCEPT_THRESHOLD
+        assert score < ACCEPT_THRESHOLD
+
+    def test_cross_series_same_series_still_works(self):
+        """Batman #1 should still match when searching for Batman #1."""
+        from models.getcomics import score_getcomics_result, ACCEPT_THRESHOLD
+        score, _, _ = score_getcomics_result(
+            "Batman #1 (2020)", "Batman", "1", 2020
+        )
+        # Perfect match should score 95
+        assert score == 95
+
+    def test_cross_series_prefix_variation(self):
+        """The Batman should match Batman when series prefix is swapped."""
+        from models.getcomics import score_getcomics_result, ACCEPT_THRESHOLD
+        score, _, _ = score_getcomics_result(
+            "The Batman #1 (2020)", "Batman", "1", 2020
+        )
+        # Should still be a perfect match (95)
+        assert score == 95
+
+    # ===================================================================
+    # Variant Types - TPB, Quarterly, One-Shot, OS, Omni, Hardcover, etc.
+    # ===================================================================
+
+    def test_tpb_variant_penalty_and_acceptance(self):
+        """TPB (Trade Paperback) variant should be penalized unless accepted."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # Without accept_variants: TPB should be penalized
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - The Court of Owls TPB #1 (2020)", "Batman", "1", 2020
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Score: series(30) + sub-series variant(-30) + title_tightness(-10) + issue(30) + year(20) = 40
+        # But TPB is also collected edition, so -30 more = 10
+        # Actually: series(30) - variant(30) + tight(-10) + issue(30) + year(20) + collected(30) = -10
+        assert score < 0  # Heavily penalized due to collected edition keyword
+        assert decision == "REJECT"
+
+        # With accept_variants: TPB should be accepted
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - The Court of Owls TPB #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['tpb']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Score: series(30) + tight(-10) + issue(30) + year(20) + collected(-30) = 40
+        assert decision == "ACCEPT"
+
+    def test_quarterly_variant_acceptance(self):
+        """Quarterly variant should be accepted when 'quarterly' is in accept_variants."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # Without accept_variants: Quarterly should be rejected
+        score, range_hit, series_match = score_getcomics_result(
+            "Flash Gordon - Quarterly #5 (2025)", "Flash Gordon", "5", 2025
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Quarterly is detected as variant, issue match blocked, -30 sub-series penalty
+        # Score: series(30) - variant(30) + tight(-10) + year(20) = 10
+        assert decision == "REJECT"
+
+        # With accept_variants: Quarterly should be accepted
+        score, range_hit, series_match = score_getcomics_result(
+            "Flash Gordon - Quarterly #5 (2025)", "Flash Gordon", "5", 2025,
+            accept_variants=['quarterly']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Score: series(30) + tight(-10) + issue(30) + year(20) = 70
+        assert decision == "ACCEPT"
+
+    def test_oneshot_variant_acceptance(self):
+        """One-shot variant (o.s., os, oneshot) should be accepted when accepted."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Batman - Year One OS #1" - OS/One-Shot variant
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Year One OS #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['os']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Score: series(30) + tight(-10) + issue(30) + year(20) = 70
+        assert decision == "ACCEPT"
+
+        # "Batman - Year One One-Shot #1"
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Year One One-Shot #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['oneshot']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert decision == "ACCEPT"
+
+        # Without acceptance: should be rejected
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Year One OS #1 (2020)", "Batman", "1", 2020
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert decision == "REJECT"
+
+    def test_omnibus_variant_acceptance(self):
+        """Omnibus variant should be accepted when 'omni' or 'omnibus' is in accept_variants."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Batman - The Dark Knight Omnibus #1 (2020)"
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - The Dark Knight Omnibus #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['omni']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Score: series(30) + tight(-10) + issue(30) + year(20) = 70
+        assert decision == "ACCEPT"
+
+    def test_hardcover_variant_acceptance(self):
+        """Hardcover variant should be accepted when 'hardcover' is in accept_variants."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Batman - The Long Halloween Hardcover #1 (2020)"
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - The Long Halloween Hardcover #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['hardcover']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Score: series(30) + tight(-10) + issue(30) + year(20) = 70
+        assert decision == "ACCEPT"
+
+    def test_deluxe_variant_acceptance(self):
+        """Deluxe edition variant should be accepted when 'deluxe' is in accept_variants."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Batman - No Man's Land Deluxe #1 (2020)"
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - No Man's Land Deluxe #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['deluxe']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert decision == "ACCEPT"
+
+    def test_absolute_variant_detection(self):
+        """'Absolute' should be detected as a variant type."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Absolute Batman #1 (2025)" - Absolute is a variant designation
+        # This is actually the main series name "Absolute Batman", not a sub-series
+        score, range_hit, series_match = score_getcomics_result(
+            "Absolute Batman #1 (2025)", "Absolute Batman", "1", 2025
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Series name is "Absolute Batman", so it matches perfectly
+        assert decision == "ACCEPT"
+        assert score == 95
+
+    def test_arc_sub_series_not_variant(self):
+        """Story arcs like 'Court of Owls' should NOT get issue matching.
+
+        Arc sub-series like 'Batman - Court of Owls #1' are NOT the same issue as 'Batman #1'.
+        They have their own arc-internal issue numbering. So arc sub-series should be
+        penalized and NOT receive issue matching points.
+        """
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Batman - Court of Owls #1 (2020)" - this is a story arc, not the same as Batman #1
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Court of Owls #1 (2020)", "Batman", "1", 2020
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Arc sub-series gets -30 penalty, issue match is blocked
+        # Score: series(30) - arc(30) + tight(-10) + year(20) = 10
+        assert score == 10
+        assert decision == "REJECT"
+
+        # Even if someone accepts the arc keyword, issue matching should still be blocked
+        # because "Court of Owls #1" is not "Batman #1"
+        score_arc_accepted, range_hit, series_match = score_getcomics_result(
+            "Batman - Court of Owls #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['court']
+        )
+        # Issue matching is still blocked for arcs, even if variant_accepted is True
+        # Score: series(30) - arc(30) + tight(-10) + year(20) + issue blocked = 10
+        assert score_arc_accepted == 10
+        assert accept_result(score_arc_accepted, range_hit, series_match) == "REJECT"
+
+    def test_annual_with_year_in_different_position(self):
+        """Annual variant with year in different position should still be detected."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # "Batman 2025 Annual #1" - Annual after year
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman 2025 Annual #1 (2025)", "Batman", "1", 2025,
+            accept_variants=['annual']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert decision == "ACCEPT"
+
+    def test_trade_paperback_variant(self):
+        """Trade Paperback (full name) variant should be detected and accepted."""
+        from models.getcomics import score_getcomics_result, accept_result
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - The Killing Joke Trade Paperback #1 (2020)", "Batman", "1", 2020,
+            accept_variants=['trade paperback']
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert decision == "ACCEPT"
+
+    def test_series_name_contains_variant_keyword_not_penalized(self):
+        """When search series name contains variant keyword, result should not be penalized.
+
+        E.g., searching for 'Flash Gordon - Quarterly' (which IS a series that publishes
+        quarterly) should not penalize 'Flash Gordon - Quarterly #5' as a sub-series variant.
+        """
+        from models.getcomics import score_getcomics_result, accept_result, ACCEPT_THRESHOLD
+        # Searching for "Flash Gordon - Quarterly" series (series name contains Quarterly)
+        score, range_hit, series_match = score_getcomics_result(
+            "Flash Gordon - Quarterly #5 (2025)",  # Result
+            "Flash Gordon - Quarterly",  # Search series name contains "Quarterly"
+            "5",
+            2025
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Should be a perfect match - series name matches and issue matches
+        assert score == 95
+        assert decision == "ACCEPT"
+
+        # But searching for main "Flash Gordon" series should penalize the Quarterly variant
+        score2, range_hit2, series_match2 = score_getcomics_result(
+            "Flash Gordon - Quarterly #5 (2025)",
+            "Flash Gordon",  # Search series name does NOT contain "Quarterly"
+            "5",
+            2025
+        )
+        decision2 = accept_result(score2, range_hit2, series_match2)
+        # Should be penalized as sub-series
+        assert score2 < ACCEPT_THRESHOLD
+        assert decision2 == "REJECT"
+
+    def test_series_name_contains_annual_keyword(self):
+        """When search series name contains 'Annual', result should not be penalized.
+
+        E.g., searching for 'Batman Annual' (which could be a valid series name)
+        should match 'Batman Annual #1' without penalty.
+        """
+        from models.getcomics import score_getcomics_result, accept_result
+        # Searching for "Batman Annual" series (series name contains Annual)
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman Annual #1 (2025)",
+            "Batman Annual",
+            "1",
+            2025
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Should be a perfect match
+        assert score == 95
+        assert decision == "ACCEPT"
+
+    def test_different_arc_sub_series_not_match(self):
+        """Different arc sub-series should NOT match each other.
+
+        Batman - Darkest Knight is a DIFFERENT arc from Batman - Court of Owls.
+        Searching for 'Batman - Darkest Knight #1' should NOT match 'Batman - Court of Owls #1'.
+        """
+        from models.getcomics import score_getcomics_result, accept_result, ACCEPT_THRESHOLD
+        # Batman - Darkest Knight searching for issue, but result is Batman - Court of Owls
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Court of Owls #1 (2020)", "Batman - Darkest Knight", "1", 2020
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Series matches "Batman" but remaining is arc " - Court of Owls"
+        # Arc gets penalized and issue matching blocked
+        # Score is low, decision is REJECT - which is correct
+        assert score < ACCEPT_THRESHOLD
+        assert decision == "REJECT"
+
+    def test_arc_range_pack_accepted(self):
+        """Arc range pack containing target issue should be accepted.
+
+        Batman - Court of Owls #1-5 containing Batman - Court of Owls #2 should match.
+        Range packs for the same arc are valid because arcs are often bundled.
+        """
+        from models.getcomics import score_getcomics_result, accept_result, ACCEPT_THRESHOLD
+        # Batman - Court of Owls #1-5 when searching for Batman - Court of Owls #2
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Court of Owls #1-5 (2020)", "Batman - Court of Owls", "2", 2020
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Series matches, range contains target issue "2"
+        # Score is positive, decision is FALLBACK (not strong accept but usable)
+        assert score > 0
+        assert decision in ("ACCEPT", "FALLBACK")
+
+    def test_different_series_with_the_prefix(self):
+        """Series with 'The' prefix should not match same series without 'The'.
+
+        'The Flash Gordon' and 'Flash Gordon' are considered different series.
+        Searching for 'The Flash Gordon #1' should NOT match 'Flash Gordon #1'.
+        """
+        from models.getcomics import score_getcomics_result, accept_result, ACCEPT_THRESHOLD
+        # "Flash Gordon #1 (2024)" when searching for "The Flash Gordon #1"
+        # Result doesn't have "The" prefix, search does - should reject
+        score, range_hit, series_match = score_getcomics_result(
+            "Flash Gordon #1 (2024)", "The Flash Gordon", "1", 2024
+        )
+        decision = accept_result(score, range_hit, series_match)
+        # Result "Flash Gordon #1" doesn't match search "The Flash Gordon"
+        # Since result doesn't start with "the flash gordon", series doesn't match
+        assert score < ACCEPT_THRESHOLD
+        assert decision == "REJECT"
+
 
 # ===================================================================
 # get_weekly_pack_url_for_date (pure function)


### PR DESCRIPTION
## Summary

- Add `SEARCH_VARIANTS` config to globally accept variant types (annual, tpB, quarterly, etc.)
- Fix arc sub-series detection: "Batman - Court of Owls" treated as arc, not variant
- Block issue matching for arcs: arc # 1 ≠ main series # 1
- Fix "The" prefix matching: "The Flash Gordon" ≠ "Flash Gordon"
- Add different-series penalty for Batman Inc, Flash Gordon, vs Batman, Flash etc.
- Fix arc range pack detection: # 1-5 containing # 2 returns FALLBACK
- Add comprehensive scoring documentation in CLAUDE.md
- Add tests for edge cases: different arcs, arc range packs, and 'The' prefix

## Test plan

- [x] All 73 tests in `test_getcomics.py` pass
- [x] All 986 tests in full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) & MiniMax M2.7