### PR TITLE
feature: Grand Comics DB API Support

### DIFF
--- a/models/gcd_api.py
+++ b/models/gcd_api.py
@@ -1,0 +1,91 @@
+"""
+GCD REST API client for comics.org.
+
+Provides HTTP client for the Grand Comics Database REST API,
+separate from the MySQL-based GCD integration in gcd.py.
+"""
+import requests
+from requests.auth import HTTPBasicAuth
+from urllib.parse import urlparse, parse_qs, quote
+from typing import Optional, Dict, Any, List
+from core.app_logging import app_logger
+
+
+BASE_URL = "https://www.comics.org/api"
+
+
+class GCDApiClient:
+    """HTTP client for the GCD REST API at comics.org."""
+
+    def __init__(self, username: str, password: str):
+        self.session = requests.Session()
+        self.session.auth = HTTPBasicAuth(username, password)
+        self.session.headers.update({"Accept": "application/json"})
+
+    def _get(self, path: str, params: dict = None) -> Optional[Dict]:
+        """Make authenticated GET request to the GCD API."""
+        url = f"{BASE_URL}{path}"
+        try:
+            resp = self.session.get(url, params=params or {}, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.exceptions.HTTPError as e:
+            app_logger.error(f"GCD API HTTP error for {path}: {e}")
+            raise
+        except requests.exceptions.Timeout:
+            app_logger.error(f"GCD API timeout for {path}")
+            raise
+        except requests.exceptions.RequestException as e:
+            app_logger.error(f"GCD API request error for {path}: {e}")
+            raise
+
+    def search_series(self, name: str, year: int = None) -> List[Dict]:
+        """Search series by name, optionally filtered by year."""
+        encoded_name = quote(name, safe="")
+        if year:
+            path = f"/series/name/{encoded_name}/year/{year}/"
+        else:
+            path = f"/series/name/{encoded_name}/"
+        return self._get_all_pages(path)
+
+    def get_series(self, series_id: int) -> Optional[Dict]:
+        """Get series details by ID, including issue list."""
+        return self._get(f"/series/{series_id}/")
+
+    def get_issue(self, issue_id: int) -> Optional[Dict]:
+        """Get full issue details including stories and credits."""
+        return self._get(f"/issue/{issue_id}/")
+
+    def search_issue(self, series_name: str, issue_number: str, year: int = None) -> List[Dict]:
+        """Search for an issue by series name and issue number."""
+        encoded_name = quote(series_name, safe="")
+        encoded_number = quote(str(issue_number), safe="")
+        if year:
+            path = f"/series/name/{encoded_name}/issue/{encoded_number}/year/{year}/"
+        else:
+            path = f"/series/name/{encoded_name}/issue/{encoded_number}/"
+        return self._get_all_pages(path)
+
+    def get_publisher(self, publisher_id: int) -> Optional[Dict]:
+        """Get publisher details by ID."""
+        return self._get(f"/publisher/{publisher_id}/")
+
+    def _get_all_pages(self, path: str, max_pages: int = 5) -> List[Dict]:
+        """Fetch paginated results up to max_pages."""
+        results = []
+        params = {}
+        for _ in range(max_pages):
+            data = self._get(path, params)
+            if not data:
+                break
+            results.extend(data.get("results", []))
+            next_url = data.get("next")
+            if not next_url:
+                break
+            parsed = parse_qs(urlparse(next_url).query)
+            page = parsed.get("page", [None])[0]
+            if page:
+                params["page"] = page
+            else:
+                break
+        return results

--- a/models/providers/__init__.py
+++ b/models/providers/__init__.py
@@ -154,6 +154,7 @@ def get_provider_class(provider_type: ProviderType) -> Optional[Type[BaseProvide
 from .metron_provider import MetronProvider
 from .comicvine_provider import ComicVineProvider
 from .gcd_provider import GCDProvider
+from .gcd_api_provider import GCDApiProvider
 from .anilist_provider import AniListProvider
 from .bedetheque_provider import BedethequeProvider
 from .mangadex_provider import MangaDexProvider
@@ -181,6 +182,7 @@ __all__ = [
     'MetronProvider',
     'ComicVineProvider',
     'GCDProvider',
+    'GCDApiProvider',
     'AniListProvider',
     'BedethequeProvider',
     'MangaDexProvider',

--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -17,6 +17,7 @@ class ProviderType(Enum):
     METRON = "metron"
     COMICVINE = "comicvine"
     GCD = "gcd"
+    GCD_API = "gcd_api"
     ANILIST = "anilist"
     BEDETHEQUE = "bedetheque"
     MANGADEX = "mangadex"

--- a/models/providers/gcd_api_provider.py
+++ b/models/providers/gcd_api_provider.py
@@ -1,0 +1,533 @@
+"""
+GCD REST API Provider Adapter.
+
+Uses the GCD REST API at comics.org to provide metadata,
+separate from the MySQL-based GCD provider.
+"""
+import re
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+
+from core.app_logging import app_logger
+from .base import BaseProvider, ProviderType, ProviderCredentials, SearchResult, IssueResult
+from . import register_provider
+
+
+def _extract_id_from_url(api_url: str) -> Optional[str]:
+    """Extract numeric ID from a GCD API URL like 'https://www.comics.org/api/series/12345/'."""
+    if not api_url:
+        return None
+    match = re.search(r'/(\d+)/?$', api_url)
+    return match.group(1) if match else None
+
+
+def _clean_issue_number(descriptor: str) -> str:
+    """Clean a GCD descriptor like '3 [Jorge Jiménez Cover]' to just '3'."""
+    if not descriptor:
+        return ''
+    # Remove bracketed content: [Variant Cover], [Jorge Jiménez Cover], etc.
+    cleaned = re.sub(r'\s*\[.*?\]\s*', '', str(descriptor)).strip()
+    # Also remove trailing parenthetical variant info: (2nd printing), etc.
+    cleaned = re.sub(r'\s*\(.*?\)\s*$', '', cleaned).strip()
+    return cleaned
+
+
+def _parse_credits_text(credits_text: str) -> List[str]:
+    """Parse a GCD credits string like 'John Doe; Jane Smith' into a list of names."""
+    if not credits_text or credits_text.strip() in ('?', 'None', ''):
+        return []
+    # GCD separates multiple creators with semicolons
+    names = []
+    for name in re.split(r'[;]', credits_text):
+        name = name.strip()
+        # Remove parenthetical notes like "(as Bob Kane)"
+        name = re.sub(r'\s*\([^)]*\)\s*', '', name).strip()
+        # Strip trailing "?" — GCD uses this to mark uncertain credits
+        name = re.sub(r'\s*\?\s*$', '', name).strip()
+        if name and name != '?':
+            names.append(name)
+    return names
+
+
+@register_provider
+class GCDApiProvider(BaseProvider):
+    """GCD metadata provider using the REST API at comics.org."""
+
+    provider_type = ProviderType.GCD_API
+    display_name = "Grand Comics Database (API)"
+    requires_auth = True
+    auth_fields = ["username", "password"]
+    rate_limit = 30
+
+    def __init__(self, credentials: Optional[ProviderCredentials] = None):
+        super().__init__(credentials)
+        self._client_instance = None
+
+    def _get_client(self):
+        """Get or create the GCD API client."""
+        if self._client_instance is not None:
+            return self._client_instance
+
+        username = None
+        password = None
+
+        # Try passed credentials first
+        if self.credentials and self.credentials.username and self.credentials.password:
+            username = self.credentials.username
+            password = self.credentials.password
+        else:
+            # Try saved credentials from DB
+            try:
+                from core.database import get_provider_credentials
+                saved = get_provider_credentials('gcd_api')
+                if saved:
+                    username = saved.get('username')
+                    password = saved.get('password')
+            except Exception:
+                pass
+
+        if not username or not password:
+            return None
+
+        from models.gcd_api import GCDApiClient
+        self._client_instance = GCDApiClient(username, password)
+        return self._client_instance
+
+    def test_connection(self) -> bool:
+        """Test connection to GCD REST API."""
+        try:
+            client = self._get_client()
+            if not client:
+                return False
+            results = client.search_series("Batman")
+            return len(results) > 0
+        except Exception as e:
+            app_logger.error(f"GCD API connection test failed: {e}")
+            return False
+
+    def search_series(self, query: str, year: Optional[int] = None) -> List[SearchResult]:
+        """Search for series using the GCD REST API."""
+        try:
+            client = self._get_client()
+            if not client:
+                return []
+
+            raw_results = client.search_series(query, year)
+            if not raw_results:
+                return []
+
+            results = []
+            for series in raw_results:
+                series_id = _extract_id_from_url(series.get('api_url')) or str(series.get('id', ''))
+                publisher_name = None
+                publisher_url = series.get('publisher')
+                if isinstance(publisher_url, dict):
+                    publisher_name = publisher_url.get('name')
+                elif isinstance(publisher_url, str) and publisher_url:
+                    # Publisher might be a URL; we could fetch it, but for search results
+                    # just extract what we have
+                    publisher_name = None
+
+                results.append(SearchResult(
+                    provider=self.provider_type,
+                    id=series_id,
+                    title=series.get('name', series.get('series_name', '')),
+                    year=series.get('year_began'),
+                    publisher=publisher_name,
+                    issue_count=series.get('issue_count'),
+                    cover_url=None,
+                    description=series.get('notes')
+                ))
+
+            return results
+        except Exception as e:
+            app_logger.error(f"GCD API search_series failed: {e}")
+            return []
+
+    def get_series(self, series_id: str) -> Optional[SearchResult]:
+        """Get series details by GCD series ID."""
+        try:
+            client = self._get_client()
+            if not client:
+                return None
+
+            series = client.get_series(int(series_id))
+            if not series:
+                return None
+
+            publisher_name = None
+            publisher_data = series.get('publisher')
+            if isinstance(publisher_data, dict):
+                publisher_name = publisher_data.get('name')
+
+            return SearchResult(
+                provider=self.provider_type,
+                id=series_id,
+                title=series.get('name', ''),
+                year=series.get('year_began'),
+                publisher=publisher_name,
+                issue_count=series.get('issue_count'),
+                cover_url=None,
+                description=series.get('notes')
+            )
+        except Exception as e:
+            app_logger.error(f"GCD API get_series failed: {e}")
+            return None
+
+    def get_issues(self, series_id: str) -> List[IssueResult]:
+        """Get all issues for a series from the GCD API."""
+        try:
+            client = self._get_client()
+            if not client:
+                return []
+
+            series = client.get_series(int(series_id))
+            if not series:
+                return []
+
+            results = []
+            # Series response has parallel arrays: active_issues (URLs) and issue_descriptors (labels)
+            active_issues = series.get('active_issues', [])
+            issue_descriptors = series.get('issue_descriptors', [])
+
+            for i, issue_url in enumerate(active_issues):
+                issue_id = _extract_id_from_url(issue_url) if isinstance(issue_url, str) else None
+                descriptor = issue_descriptors[i] if i < len(issue_descriptors) else ''
+
+                if issue_id:
+                    results.append(IssueResult(
+                        provider=self.provider_type,
+                        id=issue_id,
+                        series_id=series_id,
+                        issue_number=_clean_issue_number(descriptor),
+                        title=None,
+                        cover_date=None,
+                        store_date=None,
+                        cover_url=None,
+                        summary=None
+                    ))
+
+            return results
+        except Exception as e:
+            app_logger.error(f"GCD API get_issues failed: {e}")
+            return []
+
+    def get_issue(self, issue_id: str) -> Optional[IssueResult]:
+        """Get full issue details by GCD issue ID."""
+        try:
+            client = self._get_client()
+            if not client:
+                return None
+
+            issue = client.get_issue(int(issue_id))
+            if not issue:
+                return None
+
+            series_url = issue.get('series')
+            series_id = ''
+            if isinstance(series_url, dict):
+                series_id = _extract_id_from_url(series_url.get('api_url')) or ''
+            elif isinstance(series_url, str):
+                series_id = _extract_id_from_url(series_url) or ''
+
+            cover_url = issue.get('cover')
+            if not cover_url:
+                # Try to extract from story with sequence_number 0 (cover)
+                stories = issue.get('story_set', issue.get('stories', []))
+                for story in stories:
+                    if isinstance(story, dict) and story.get('sequence_number') == 0:
+                        cover_url = story.get('cover') or story.get('image')
+                        break
+
+            return IssueResult(
+                provider=self.provider_type,
+                id=issue_id,
+                series_id=series_id,
+                issue_number=_clean_issue_number(issue.get('descriptor', issue.get('number', ''))),
+                title=issue.get('title'),
+                cover_date=issue.get('publication_date', issue.get('key_date')),
+                store_date=issue.get('on_sale_date'),
+                cover_url=cover_url,
+                summary=None
+            )
+        except Exception as e:
+            app_logger.error(f"GCD API get_issue failed: {e}")
+            return None
+
+    def get_issue_metadata(self, series_id: str, issue_number: str) -> Optional[Dict[str, Any]]:
+        """
+        Get full issue metadata suitable for ComicInfo.xml.
+
+        Uses the series name + issue number search endpoint to find the issue,
+        then fetches full details with credits.
+        """
+        try:
+            client = self._get_client()
+            if not client:
+                return None
+
+            # Get series info
+            series = client.get_series(int(series_id))
+            if not series:
+                return None
+
+            series_name = series.get('name', '')
+            start_year = series.get('year_began')
+
+            # Find the issue using the search_issue endpoint (more reliable than
+            # parsing the parallel active_issues/issue_descriptors arrays, which
+            # contain variant descriptors like "3 [Jim Lee Cover]")
+            target_issue_id = None
+
+            # Try with year filter first for precision, then without
+            for search_year in ([start_year, None] if start_year else [None]):
+                issue_results = client.search_issue(series_name, issue_number, year=search_year)
+                if issue_results:
+                    # Find the main printing (not a variant) — prefer entries without variant_of
+                    for ir in issue_results:
+                        if not ir.get('variant_of'):
+                            # Check it belongs to our series
+                            ir_series_url = ir.get('series', '')
+                            ir_series_id = _extract_id_from_url(ir_series_url)
+                            if ir_series_id == series_id:
+                                target_issue_id = _extract_id_from_url(ir.get('api_url'))
+                                break
+
+                    # Fallback: take first result matching our series
+                    if not target_issue_id:
+                        for ir in issue_results:
+                            ir_series_url = ir.get('series', '')
+                            ir_series_id = _extract_id_from_url(ir_series_url)
+                            if ir_series_id == series_id:
+                                target_issue_id = _extract_id_from_url(ir.get('api_url'))
+                                break
+
+                if target_issue_id:
+                    break
+
+            # Last resort: match from parallel arrays in series detail
+            if not target_issue_id:
+                active_issues = series.get('active_issues', [])
+                issue_descriptors = series.get('issue_descriptors', [])
+                issue_num_stripped = issue_number.lstrip('0') or '0'
+                for i, descriptor in enumerate(issue_descriptors):
+                    # Descriptor may be "3" or "3 [Variant Cover]" — match the number part
+                    desc_num = str(descriptor).split('[')[0].split('(')[0].strip()
+                    if desc_num == issue_number or desc_num.lstrip('0') == issue_num_stripped:
+                        if i < len(active_issues):
+                            target_issue_id = _extract_id_from_url(active_issues[i])
+                            break
+
+            if not target_issue_id:
+                app_logger.info(f"GCD API: Issue #{issue_number} not found in series {series_id} ({series_name})")
+                return None
+
+            # Fetch full issue details
+            issue = client.get_issue(int(target_issue_id))
+            if not issue:
+                return None
+
+            return self._build_comicinfo_from_api(issue, series)
+        except Exception as e:
+            app_logger.error(f"GCD API get_issue_metadata failed: {e}")
+            return None
+
+    def _build_comicinfo_from_api(self, issue: Dict, series: Dict) -> Dict[str, Any]:
+        """Build ComicInfo-compatible dict from API issue and series responses."""
+        writers = []
+        pencillers = []
+        inkers = []
+        colorists = []
+        letterers = []
+        editors = []
+        cover_artists = []
+        characters_set = set()
+        genres_set = set()
+        title = None
+        summary = None
+
+        stories = issue.get('story_set', issue.get('stories', []))
+        for story in stories:
+            if not isinstance(story, dict):
+                continue
+
+            seq = story.get('sequence_number')
+
+            # Collect credits from all stories
+            for name in _parse_credits_text(story.get('script', '')):
+                if name not in writers:
+                    writers.append(name)
+            for name in _parse_credits_text(story.get('pencils', '')):
+                if name not in pencillers:
+                    pencillers.append(name)
+            for name in _parse_credits_text(story.get('inks', '')):
+                if name not in inkers:
+                    inkers.append(name)
+            for name in _parse_credits_text(story.get('colors', '')):
+                if name not in colorists:
+                    colorists.append(name)
+            for name in _parse_credits_text(story.get('letters', '')):
+                if name not in letterers:
+                    letterers.append(name)
+            for name in _parse_credits_text(story.get('editing', '')):
+                if name not in editors:
+                    editors.append(name)
+
+            # Characters and genre (GCD uses "None" string for empty values)
+            chars = story.get('characters', '')
+            if chars and chars not in ('?', 'None', ''):
+                for c in re.split(r'[;]', chars):
+                    c = c.strip()
+                    if c and c != 'None':
+                        characters_set.add(c)
+
+            genre = story.get('genre', '')
+            if genre and genre not in ('?', 'None', ''):
+                for g in re.split(r'[;,]', genre):
+                    g = g.strip()
+                    if g and g != 'None':
+                        genres_set.add(g)
+
+            # Cover story (sequence 0) - get cover artists
+            if seq == 0:
+                for name in _parse_credits_text(story.get('pencils', '')):
+                    if name not in cover_artists:
+                        cover_artists.append(name)
+            else:
+                # Use first non-cover story title and synopsis
+                if not title:
+                    t = story.get('title', '')
+                    if t and t.strip() and t.strip() != 'None':
+                        title = t.strip()
+                if not summary:
+                    s = story.get('synopsis', '') or story.get('notes', '')
+                    if s and s.strip() and s.strip() != 'None':
+                        summary = s.strip()
+
+        # Parse date fields — prefer key_date (ISO format "YYYY-MM-DD")
+        # over publication_date (human format "June 2016")
+        key_date = issue.get('key_date', '')
+        pub_date = issue.get('publication_date', '')
+        year = None
+        month = None
+        # Try key_date first (ISO format)
+        if key_date and len(str(key_date)) >= 4:
+            try:
+                year = int(str(key_date)[:4])
+            except ValueError:
+                pass
+            if len(str(key_date)) >= 7:
+                try:
+                    month = int(str(key_date)[5:7])
+                except ValueError:
+                    pass
+        # Fallback: parse publication_date like "June 2016"
+        if not year and pub_date:
+            import calendar
+            parts = str(pub_date).strip().split()
+            for part in parts:
+                try:
+                    y = int(part)
+                    if 1900 <= y <= 2100:
+                        year = y
+                        break
+                except ValueError:
+                    continue
+            if not month:
+                month_names = {name.lower(): num for num, name in enumerate(calendar.month_name) if num}
+                month_abbrs = {name.lower(): num for num, name in enumerate(calendar.month_abbr) if num}
+                for part in parts:
+                    m = month_names.get(part.lower()) or month_abbrs.get(part.lower().rstrip('.'))
+                    if m:
+                        month = m
+                        break
+
+        # Publisher
+        publisher_name = None
+        publisher_data = series.get('publisher')
+        if isinstance(publisher_data, dict):
+            publisher_name = publisher_data.get('name')
+
+        # Cover URL
+        cover_url = issue.get('cover')
+
+        current_date = datetime.now().strftime('%Y-%m-%d')
+
+        metadata = {
+            'Series': series.get('name', ''),
+            'Number': _clean_issue_number(issue.get('descriptor', issue.get('number', ''))),
+            'Volume': series.get('year_began'),
+            'Title': title,
+            'Summary': summary,
+            'Publisher': publisher_name,
+            'Year': year,
+            'Month': month,
+            'Writer': ', '.join(writers) if writers else None,
+            'Penciller': ', '.join(pencillers) if pencillers else None,
+            'Inker': ', '.join(inkers) if inkers else None,
+            'Colorist': ', '.join(colorists) if colorists else None,
+            'Letterer': ', '.join(letterers) if letterers else None,
+            'Editor': ', '.join(editors) if editors else None,
+            'CoverArtist': ', '.join(cover_artists) if cover_artists else None,
+            'Characters': '; '.join(sorted(characters_set)) if characters_set else None,
+            'Genre': ', '.join(sorted(genres_set)) if genres_set else None,
+            'PageCount': issue.get('page_count'),
+            'LanguageISO': 'en',
+            'Web': f"https://www.comics.org/issue/{issue.get('id', '')}/",
+            'Notes': f'Metadata from GCD REST API. Issue ID: {issue.get("id", "")} — retrieved {current_date}.',
+        }
+
+        if cover_url:
+            metadata['_cover_url'] = cover_url
+
+        # GCD uses "?" for unknown/uncertain values — strip these out
+        def _is_valid(v):
+            if v is None:
+                return False
+            if isinstance(v, str) and v.strip() in ('?', 'None', ''):
+                return False
+            return True
+
+        return {k: v for k, v in metadata.items() if _is_valid(v)}
+
+    def to_comicinfo(self, issue: IssueResult, series: Optional[SearchResult] = None) -> Dict[str, Any]:
+        """Convert GCD API issue data to ComicInfo.xml fields."""
+        try:
+            # Try full metadata fetch
+            if issue.series_id and issue.issue_number:
+                metadata = self.get_issue_metadata(issue.series_id, issue.issue_number)
+                if metadata:
+                    return metadata
+
+            # Fallback: try fetching full issue by ID
+            client = self._get_client()
+            if client and issue.id:
+                full_issue = client.get_issue(int(issue.id))
+                if full_issue:
+                    series_data = {}
+                    if issue.series_id:
+                        series_data = client.get_series(int(issue.series_id)) or {}
+                    return self._build_comicinfo_from_api(full_issue, series_data)
+
+            # Minimal fallback from IssueResult
+            comicinfo = {
+                'Series': series.title if series else None,
+                'Number': issue.issue_number,
+                'Title': issue.title,
+                'Notes': f'Metadata from GCD REST API. Issue ID: {issue.id}',
+            }
+
+            if series:
+                comicinfo['Publisher'] = series.publisher
+                comicinfo['Volume'] = series.year
+
+            if issue.cover_date and len(issue.cover_date) >= 4:
+                try:
+                    comicinfo['Year'] = int(issue.cover_date[:4])
+                except ValueError:
+                    pass
+
+            return {k: v for k, v in comicinfo.items() if v is not None}
+        except Exception as e:
+            app_logger.error(f"GCD API to_comicinfo failed: {e}")
+            return {}

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -120,7 +120,7 @@ def generate_comicinfo_xml(issue_data, series_data=None):
 
     # Page count (integer)
     if issue_data.get("PageCount") not in (None, ""):
-        add("PageCount", str(int(issue_data["PageCount"])))
+        add("PageCount", str(int(float(issue_data["PageCount"]))))
 
     # Manga flag: ComicRack expects "Yes", "No", or "YesAndRightToLeft"
     add("Manga", issue_data.get("Manga") or "No")
@@ -1448,11 +1448,69 @@ def batch_metadata():
                             app_logger.warning(f"MangaUpdates lookup failed for {filename}: {e}")
                         return False
 
+                    # Helper function for GCD API lookup
+                    def try_gcd_api():
+                        nonlocal metadata, source
+                        try:
+                            from models.providers.gcd_api_provider import GCDApiProvider
+                            gcd_api_prov = GCDApiProvider()
+                            gcd_api_client = gcd_api_prov._get_client()
+                            if not gcd_api_client:
+                                return False
+
+                            gcd_api_series_name = os.path.basename(directory)
+                            gcd_api_series_name = re.sub(r'\s*\(\d{4}\).*$', '', gcd_api_series_name)
+                            gcd_api_series_name = re.sub(r'\s*v\d+.*$', '', gcd_api_series_name).strip()
+
+                            # If directory name was just "v2004", series name is empty — use parent
+                            if not gcd_api_series_name:
+                                parent_dir = os.path.dirname(directory)
+                                gcd_api_series_name = os.path.basename(parent_dir)
+                                gcd_api_series_name = re.sub(r'\s*\(\d{4}\).*$', '', gcd_api_series_name)
+                                gcd_api_series_name = re.sub(r'\s*v\d+.*$', '', gcd_api_series_name).strip()
+
+                            if not gcd_api_series_name:
+                                return False
+
+                            # Resolve start year from folder context
+                            start_yr = _resolve_gcd_api_start_year(file_path, gcd_api_series_name) if file_path else None
+
+                            # Search with start year if available, else without
+                            results = None
+                            if start_yr:
+                                results = gcd_api_prov.search_series(gcd_api_series_name, start_yr)
+                            if not results:
+                                results = gcd_api_prov.search_series(gcd_api_series_name)
+                            if not results:
+                                return False
+
+                            # For batch, require a single exact title match
+                            search_lower = gcd_api_series_name.lower().strip()
+                            exact = [r for r in results if r.title.lower().strip() == search_lower]
+                            if len(exact) == 1:
+                                match = exact[0]
+                            elif len(results) == 1:
+                                match = results[0]
+                            else:
+                                app_logger.info(f"GCD API: {len(results)} results for '{gcd_api_series_name}', skipping batch auto-select")
+                                return False
+
+                            metadata = gcd_api_prov.get_issue_metadata(match.id, issue_number)
+                            if metadata:
+                                metadata.pop('_cover_url', None)
+                                source = 'GCD API'
+                                app_logger.info(f"Found metadata from GCD API for {filename}")
+                                return True
+                        except Exception as e:
+                            app_logger.warning(f"GCD API lookup failed for {filename}: {e}")
+                        return False
+
                     # Use providers in library-configured priority order
                     provider_try_fns = {
                         'metron': try_metron,
                         'comicvine': try_comicvine,
                         'gcd': try_gcd,
+                        'gcd_api': try_gcd_api,
                         'anilist': try_anilist,
                         'mangadex': try_mangadex,
                         'mangaupdates': try_mangaupdates,
@@ -2907,6 +2965,178 @@ def _try_gcd_single(series_name, issue_number, year):
         return None, None, None
 
 
+def _resolve_gcd_api_start_year(file_path, series_name):
+    """Try to find the series start year from folder name or sibling ComicInfo.xml.
+
+    The GCD API year filter matches the year the series *started*, which is
+    different from the issue publication year that typically appears in filenames.
+
+    Resolution order:
+    1. Parent folder name patterns: "v2025", "Batman (2025)", "(2025)"
+    2. Volume field in a sibling CBZ's ComicInfo.xml (Volume = series start year)
+    """
+    import glob
+
+    folder_path = os.path.dirname(file_path) if file_path else None
+    if not folder_path:
+        return None
+
+    # 1. Check parent folder name for year patterns
+    folder_name = os.path.basename(folder_path)
+    # Match "v2025", "Batman (2025)", etc.
+    folder_year_match = re.search(r'\bv(\d{4})\b', folder_name, re.IGNORECASE)
+    if not folder_year_match:
+        folder_year_match = re.search(r'\((\d{4})\)', folder_name)
+    if folder_year_match:
+        candidate = int(folder_year_match.group(1))
+        if 1900 <= candidate <= 2100:
+            app_logger.info(f"[gcd-api] Resolved start year {candidate} from folder '{folder_name}'")
+            return candidate
+
+    # 2. Check sibling CBZ files for Volume field in ComicInfo.xml
+    #    Skip this in WATCH/TARGET directories — those are temp locations
+    #    where siblings are unrelated files from different series.
+    try:
+        from flask import current_app
+        watch_dir = os.path.realpath(current_app.config.get("WATCH", ""))
+        target_dir = os.path.realpath(current_app.config.get("TARGET", ""))
+        real_folder = os.path.realpath(folder_path)
+        if real_folder == watch_dir or real_folder == target_dir or \
+           real_folder.startswith(watch_dir + os.sep) or real_folder.startswith(target_dir + os.sep):
+            app_logger.debug(f"[gcd-api] Skipping sibling check in temp directory: {folder_path}")
+            return None
+    except RuntimeError:
+        pass  # Outside app context
+
+    try:
+        from core.comicinfo import read_comicinfo_from_zip
+        sibling_cbzs = glob.glob(os.path.join(folder_path, '*.cbz'))
+        for sibling in sibling_cbzs[:5]:  # Check up to 5 siblings
+            if os.path.realpath(sibling) == os.path.realpath(file_path):
+                continue
+            try:
+                info = read_comicinfo_from_zip(sibling)
+                volume = info.get('Volume')
+                if volume:
+                    vol_int = int(volume)
+                    if 1900 <= vol_int <= 2100:
+                        app_logger.info(f"[gcd-api] Resolved start year {vol_int} from sibling '{os.path.basename(sibling)}' Volume field")
+                        return vol_int
+            except Exception:
+                continue
+    except Exception as e:
+        app_logger.debug(f"[gcd-api] Error checking siblings for start year: {e}")
+
+    return None
+
+
+def _try_gcd_api_single(series_name, issue_number, year, file_path=None, user_start_year=None):
+    """Try GCD REST API provider for a single file.
+    Returns (metadata_dict, img_url, None) on success,
+    or (None, None, selection_data) when user selection is needed,
+    or (None, None, None) when nothing found.
+
+    The GCD API year filter matches the series start year, not the issue
+    publication year. This function resolves the start year from folder names
+    and sibling ComicInfo.xml before falling back to searching without year.
+
+    Args:
+        user_start_year: Optional user-provided series start year (from prompt).
+    """
+    try:
+        from models.providers.gcd_api_provider import GCDApiProvider
+        provider = GCDApiProvider()
+        client = provider._get_client()
+        if not client:
+            return None, None, None
+
+        if not series_name:
+            return None, None, None
+
+        # Use user-provided start year first, then try to resolve from context
+        start_year = user_start_year
+        if not start_year:
+            start_year = _resolve_gcd_api_start_year(file_path, series_name)
+        if start_year:
+            app_logger.info(f"[gcd-api] Using start year: {start_year}")
+
+        # Search strategy:
+        # 1. Try with resolved start year (if found)
+        # 2. Try without year filter
+        # 3. If no results at all, give up
+        # Use the client directly to get raw API data (country, language fields)
+        from models.providers.gcd_api_provider import _extract_id_from_url
+        raw_results = None
+        if start_year:
+            raw_results = client.search_series(series_name, start_year)
+
+        if not raw_results:
+            # Search without year filter
+            raw_results = client.search_series(series_name)
+
+        if not raw_results:
+            # No results at all — prompt user for start year
+            return None, None, {
+                "requires_selection": True,
+                "requires_start_year": True,
+                "provider": "gcd_api",
+                "possible_matches": [],
+                "message": f"No series found for '{series_name}'. Try providing the series start year.",
+            }
+
+        # Check for confident match: only auto-accept when there is exactly
+        # ONE exact title match with start_year known (from folder/user).
+        # Without a year, multiple series may share the same name across
+        # different years (e.g. "Sherlock Holmes" 1955 vs 1976).
+        search_lower = series_name.lower().strip()
+        exact_matches = [r for r in raw_results if (r.get('name', '') or '').lower().strip() == search_lower]
+
+        if len(exact_matches) == 1 and start_year:
+            match_id = _extract_id_from_url(exact_matches[0].get('api_url'))
+            if match_id:
+                metadata = provider.get_issue_metadata(match_id, issue_number)
+                if metadata:
+                    img_url = metadata.pop('_cover_url', None)
+                    return metadata, img_url, None
+
+        if len(raw_results) == 1 and start_year:
+            match_id = _extract_id_from_url(raw_results[0].get('api_url'))
+            if match_id:
+                metadata = provider.get_issue_metadata(match_id, issue_number)
+                if metadata:
+                    img_url = metadata.pop('_cover_url', None)
+                    return metadata, img_url, None
+
+        # Multiple results or no year confidence — prompt user to select
+        possible_matches = []
+        for r in raw_results:
+            possible_matches.append({
+                "id": _extract_id_from_url(r.get('api_url')) or '',
+                "name": r.get('name', ''),
+                "start_year": r.get('year_began'),
+                "publisher_name": r.get('publisher_name', ''),
+                "image_url": None,
+                "description": r.get('notes', ''),
+                "count_of_issues": r.get('issue_count'),
+                "country": r.get('country', ''),
+                "language": r.get('language', ''),
+            })
+        selection_data = {
+            "requires_selection": True,
+            "provider": "gcd_api",
+            "possible_matches": possible_matches,
+        }
+        return None, None, selection_data
+        if metadata:
+            img_url = metadata.pop('_cover_url', None)
+            return metadata, img_url, None
+
+        return None, None, None
+    except Exception as e:
+        app_logger.warning(f"[search-metadata] GCD API lookup failed: {e}")
+        return None, None, None
+
+
 @metadata_bp.route('/api/search-metadata', methods=['POST'])
 def search_metadata():
     """
@@ -2925,6 +3155,7 @@ def search_metadata():
         library_id = data.get('library_id')
         selected_match = data.get('selected_match')
         search_term_override = data.get('search_term')
+        gcd_api_start_year = data.get('gcd_api_start_year')  # User-provided series start year for GCD API
 
         if not file_path or not file_name:
             return jsonify({"success": False, "error": "Missing file_path or file_name"}), 400
@@ -3021,6 +3252,16 @@ def search_metadata():
                 if series_id:
                     metadata = gcd.get_issue_metadata(series_id, issue_number)
 
+            elif provider == 'gcd_api':
+                series_id = selected_match.get('series_id')
+                if series_id:
+                    from models.providers.gcd_api_provider import GCDApiProvider
+                    gcd_api_prov = GCDApiProvider()
+                    api_metadata = gcd_api_prov.get_issue_metadata(series_id, issue_number)
+                    if api_metadata:
+                        img_url = api_metadata.pop('_cover_url', None)
+                        metadata = api_metadata
+
             elif provider in ('anilist', 'mangadex', 'mangaupdates'):
                 series_id = selected_match.get('series_id')
                 preferred_title = selected_match.get('preferred_title')
@@ -3095,6 +3336,14 @@ def search_metadata():
                 provider_order.append('comicvine')
             if gcd.is_mysql_available() and gcd.check_mysql_status().get('gcd_mysql_available', False):
                 provider_order.append('gcd')
+            # Check if GCD API credentials are configured
+            try:
+                from core.database import get_provider_credentials
+                gcd_api_creds = get_provider_credentials('gcd_api')
+                if gcd_api_creds and gcd_api_creds.get('username'):
+                    provider_order.append('gcd_api')
+            except Exception:
+                pass
 
         app_logger.info(f"[search-metadata] Provider order: {provider_order}")
 
@@ -3127,6 +3376,20 @@ def search_metadata():
 
             elif provider_type == 'gcd':
                 metadata, _, selection_data = _try_gcd_single(series_name, issue_number, year)
+                if selection_data:
+                    selection_data["parsed_filename"] = {
+                        "series_name": series_name,
+                        "issue_number": issue_number,
+                        "year": year
+                    }
+                    app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
+                    return jsonify(selection_data)
+
+            elif provider_type == 'gcd_api':
+                metadata, img_url, selection_data = _try_gcd_api_single(
+                    series_name, issue_number, year, file_path,
+                    user_start_year=int(gcd_api_start_year) if gcd_api_start_year else None
+                )
                 if selection_data:
                     selection_data["parsed_filename"] = {
                         "series_name": series_name,

--- a/static/js/clu-metadata.js
+++ b/static/js/clu-metadata.js
@@ -161,6 +161,7 @@
   var _cvClickHandler = null;
   var _cvSortNameAsc = true;
   var _cvSortYearAsc = true;
+  var _cvFilterFn = null;  // Override for custom filtering (e.g., GCD API language filter)
 
   function _renderCVVolumeList(volumes) {
     var volumeList = document.getElementById('cvVolumeList');
@@ -180,6 +181,9 @@
         '<img src="' + volume.image_url + '" class="img-thumbnail me-3" style="width: 80px; height: 120px; object-fit: cover;" alt="' + CLU.escapeHtml(volume.name) + ' cover">' :
         '<div class="me-3 d-flex align-items-center justify-content-center bg-secondary text-white" style="width: 80px; height: 120px; font-size: 10px;">No Cover</div>';
 
+      var langBadge = volume.language ?
+        '<span class="badge bg-info rounded-pill ms-1">' + CLU.escapeHtml((volume.language || '').toUpperCase()) + '</span>' : '';
+
       volumeItem.innerHTML =
         thumbnailHtml +
         '<div class="flex-grow-1 d-flex justify-content-between align-items-start">' +
@@ -188,7 +192,10 @@
             '<small class="text-muted">Publisher: ' + CLU.escapeHtml(volume.publisher_name || 'Unknown') + '<br>Issues: ' + issueCount + '</small>' +
             descriptionPreview +
           '</div>' +
-          '<span class="badge bg-success rounded-pill">' + yearDisplay + '</span>' +
+          '<div class="text-end">' +
+            '<span class="badge bg-success rounded-pill">' + yearDisplay + '</span>' +
+            langBadge +
+          '</div>' +
         '</div>';
 
       volumeItem.addEventListener('click', function () {
@@ -242,7 +249,7 @@
         otherBtn.className = 'btn btn-outline-secondary btn-sm';
         otherBtn.querySelector('i').className = 'bi bi-sort-numeric-down me-1';
         _cvSortYearAsc = true;
-        _renderCVVolumeList(_getFilteredVolumes());
+        _renderCVVolumeList((_cvFilterFn || _getFilteredVolumes)());
       });
     }
     if (yearBtn) {
@@ -260,21 +267,29 @@
         otherBtn.className = 'btn btn-outline-secondary btn-sm';
         otherBtn.querySelector('i').className = 'bi bi-sort-alpha-down me-1';
         _cvSortNameAsc = true;
-        _renderCVVolumeList(_getFilteredVolumes());
+        _renderCVVolumeList((_cvFilterFn || _getFilteredVolumes)());
       });
     }
     if (filterInput) {
       var newFilterInput = filterInput.cloneNode(true);
       filterInput.parentNode.replaceChild(newFilterInput, filterInput);
       newFilterInput.addEventListener('input', function () {
-        _renderCVVolumeList(_getFilteredVolumes());
+        _renderCVVolumeList((_cvFilterFn || _getFilteredVolumes)());
       });
     }
   }
 
   // ── ComicVine volume modal (single-file context) ──────────────────────
 
+  function _removeGCDApiLangFilter() {
+    var el = document.getElementById('gcdApiLangFilter');
+    if (el) el.parentNode.removeChild(el);
+    _cvFilterFn = null;
+    _gcdApiLangFilter = '';
+  }
+
   function _showCVVolumeModal(data, filePath, fileName) {
+    _removeGCDApiLangFilter();
     // Show the inline refine row for single-file context
     var refineRow = document.getElementById('cvRefineSearchRow');
     if (refineRow) refineRow.style.display = '';
@@ -364,9 +379,230 @@
     modal.show();
   }
 
+  // ── GCD API series modal (reuses ComicVine volume modal UI) ───────────
+
+  // Track active GCD API language/country filter
+  var _gcdApiLangFilter = '';
+
+  function _showGCDApiVolumeModal(data, filePath, fileName) {
+    // Hide the inline refine row (not applicable for GCD API)
+    var refineRow = document.getElementById('cvRefineSearchRow');
+    if (refineRow) refineRow.style.display = 'none';
+
+    // Populate parsed info
+    var cvSeries = document.getElementById('cvParsedSeries');
+    var cvIssue = document.getElementById('cvParsedIssue');
+    var cvYear = document.getElementById('cvParsedYear');
+    if (cvSeries && data.parsed_filename) cvSeries.textContent = data.parsed_filename.series_name || '';
+    if (cvIssue && data.parsed_filename) cvIssue.textContent = data.parsed_filename.issue_number || '';
+    if (cvYear && data.parsed_filename) cvYear.textContent = data.parsed_filename.year || 'Unknown';
+
+    // Store volumes and set click handler
+    _cvVolumes = data.possible_matches.slice();
+    _gcdApiLangFilter = '';
+    _cvClickHandler = function (volume) {
+      var modal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+      if (modal) modal.hide();
+
+      CLU.searchMetadataWithSelection(filePath, fileName, {
+        provider: 'gcd_api',
+        series_id: volume.id
+      });
+    };
+
+    // Set custom filter function for GCD API (includes language filtering)
+    _cvFilterFn = _getGCDApiFilteredVolumes;
+
+    _wireCVSortAndFilter();
+
+    // Build unique language/country values for the filter dropdown
+    var langSet = {};
+    _cvVolumes.forEach(function (v) {
+      var lang = (v.language || '').toUpperCase();
+      var country = (v.country || '').toUpperCase();
+      var key = lang || country || '';
+      if (key) langSet[key] = (langSet[key] || 0) + 1;
+    });
+
+    // Insert language filter dropdown after the existing filter controls
+    var existingLangFilter = document.getElementById('gcdApiLangFilter');
+    if (existingLangFilter) existingLangFilter.parentNode.removeChild(existingLangFilter);
+
+    if (Object.keys(langSet).length > 1) {
+      var filterContainer = document.getElementById('cvFilterInput');
+      if (filterContainer && filterContainer.parentNode) {
+        var selectEl = document.createElement('select');
+        selectEl.id = 'gcdApiLangFilter';
+        selectEl.className = 'form-select form-select-sm';
+        selectEl.style.width = '120px';
+        selectEl.innerHTML = '<option value="">All languages</option>';
+        Object.keys(langSet).sort().forEach(function (key) {
+          selectEl.innerHTML += '<option value="' + key + '">' + key + ' (' + langSet[key] + ')</option>';
+        });
+        filterContainer.parentNode.insertBefore(selectEl, filterContainer);
+
+        selectEl.addEventListener('change', function () {
+          _gcdApiLangFilter = selectEl.value;
+          _renderCVVolumeList(_getGCDApiFilteredVolumes());
+        });
+      }
+    }
+
+    // Update title with count
+    var modalTitle = document.getElementById('comicVineVolumeModalLabel');
+    if (modalTitle) {
+      modalTitle.textContent = 'Select correct match (via GCD API) — ' + data.possible_matches.length + ' Series';
+    }
+
+    _renderCVVolumeList(_cvVolumes);
+
+    var modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
+    modal.show();
+  }
+
+  function _getGCDApiFilteredVolumes() {
+    // Apply text filter
+    var filtered = _getFilteredVolumes();
+    // Apply language/country filter
+    if (_gcdApiLangFilter) {
+      var f = _gcdApiLangFilter.toLowerCase();
+      filtered = filtered.filter(function (v) {
+        return (v.language || '').toLowerCase() === f || (v.country || '').toLowerCase() === f;
+      });
+    }
+    return filtered;
+  }
+
+  // ── GCD API start year prompt ─────────────────────────────────────────
+
+  function _showGCDApiStartYearPrompt(data, filePath, fileName) {
+    var seriesName = (data.parsed_filename && data.parsed_filename.series_name) || 'Unknown';
+    var message = data.message || ('No series found for "' + seriesName + '". Enter the year the series started.');
+
+    // Reuse the ComicVine volume modal as a start year prompt
+    var modalTitle = document.getElementById('comicVineVolumeModalLabel');
+    if (modalTitle) {
+      modalTitle.textContent = 'GCD API - Series Start Year Required';
+    }
+
+    var cvSeries = document.getElementById('cvParsedSeries');
+    var cvIssue = document.getElementById('cvParsedIssue');
+    var cvYear = document.getElementById('cvParsedYear');
+    if (cvSeries) cvSeries.textContent = seriesName;
+    if (cvIssue && data.parsed_filename) cvIssue.textContent = data.parsed_filename.issue_number || '';
+    if (cvYear && data.parsed_filename) cvYear.textContent = data.parsed_filename.year || 'Unknown';
+
+    // Hide refine search row
+    var refineRow = document.getElementById('cvRefineSearchRow');
+    if (refineRow) refineRow.style.display = 'none';
+
+    var volumeList = document.getElementById('cvVolumeList');
+    volumeList.innerHTML =
+      '<div class="p-3">' +
+        '<p class="text-muted">' + CLU.escapeHtml(message) + '</p>' +
+        '<p class="text-muted small">The GCD API filters by the year a series <strong>started</strong>, ' +
+          'not the issue publication year. For example, a 2026 issue may belong to a series that started in 2025.</p>' +
+        '<div class="input-group mb-2">' +
+          '<input type="number" id="gcdApiStartYearInput" class="form-control" placeholder="e.g. 2025" min="1900" max="2100">' +
+          '<button class="btn btn-primary" type="button" id="gcdApiStartYearSearchBtn">' +
+            '<i class="bi bi-search me-1"></i>Search' +
+          '</button>' +
+        '</div>' +
+        '<button class="btn btn-outline-secondary btn-sm" type="button" id="gcdApiNoYearSearchBtn">' +
+          'Search without year filter' +
+        '</button>' +
+      '</div>';
+
+    // Wire up search with year
+    var searchBtn = document.getElementById('gcdApiStartYearSearchBtn');
+    var yearInput = document.getElementById('gcdApiStartYearInput');
+    var noYearBtn = document.getElementById('gcdApiNoYearSearchBtn');
+
+    function doSearch(startYear) {
+      searchBtn.disabled = true;
+      noYearBtn.disabled = true;
+      searchBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Searching...';
+
+      var requestBody = {
+        file_path: filePath,
+        file_name: fileName,
+        search_term: seriesName,
+        gcd_api_start_year: startYear || null
+      };
+      var libraryId = _getLibraryId();
+      if (libraryId) requestBody.library_id = libraryId;
+
+      fetch('/api/search-metadata', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody)
+      })
+        .then(function (response) { return response.json(); })
+        .then(function (newData) {
+          searchBtn.disabled = false;
+          noYearBtn.disabled = false;
+          searchBtn.innerHTML = '<i class="bi bi-search me-1"></i>Search';
+
+          if (newData.requires_selection && newData.provider === 'gcd_api' && !newData.requires_start_year) {
+            // Got results — close and show selection modal
+            var cvModal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+            if (cvModal) cvModal.hide();
+            _showGCDApiVolumeModal(newData, filePath, fileName);
+          } else if (newData.success) {
+            var cvModal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+            if (cvModal) cvModal.hide();
+            CLU.showToast('Metadata Found', 'Metadata found via ' + newData.source, 'success');
+            var contract = _getContract();
+            if (typeof contract.onMetadataFound === 'function') {
+              contract.onMetadataFound(filePath, newData);
+            }
+          } else if (newData.requires_start_year) {
+            CLU.showToast('No Results', 'No series found with that year. Try a different year.', 'warning');
+          } else {
+            CLU.showToast('No Results', newData.error || 'No metadata found', 'warning');
+          }
+        })
+        .catch(function (error) {
+          searchBtn.disabled = false;
+          noYearBtn.disabled = false;
+          searchBtn.innerHTML = '<i class="bi bi-search me-1"></i>Search';
+          CLU.showToast('Search Error', error.message || 'Search failed', 'error');
+        });
+    }
+
+    searchBtn.addEventListener('click', function () {
+      var yr = parseInt(yearInput.value, 10);
+      if (!yr || yr < 1900 || yr > 2100) {
+        CLU.showToast('Invalid Year', 'Please enter a valid year (1900-2100)', 'warning');
+        return;
+      }
+      doSearch(yr);
+    });
+
+    yearInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        searchBtn.click();
+      }
+    });
+
+    noYearBtn.addEventListener('click', function () {
+      doSearch(null);
+    });
+
+    var modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
+    modal.show();
+
+    // Focus the year input after modal is shown
+    document.getElementById('comicVineVolumeModal').addEventListener('shown.bs.modal', function handler() {
+      yearInput.focus();
+      document.getElementById('comicVineVolumeModal').removeEventListener('shown.bs.modal', handler);
+    });
+  }
+
   // ── ComicVine volume modal (batch/directory context) ──────────────────
 
   function _showBatchCVVolumeModal(data, dirPath, dirName) {
+    _removeGCDApiLangFilter();
     // Hide refine row for batch context
     var refineRow = document.getElementById('cvRefineSearchRow');
     if (refineRow) refineRow.style.display = 'none';
@@ -446,6 +682,12 @@
               window._cascadeGCDSelection = { filePath: filePath, fileName: fileName, libraryId: libraryId };
             } else {
               CLU.showToast('GCD Selection', 'GCD series selection requires the Files page', 'warning');
+            }
+          } else if (data.provider === 'gcd_api') {
+            if (data.requires_start_year) {
+              _showGCDApiStartYearPrompt(data, filePath, fileName);
+            } else {
+              _showGCDApiVolumeModal(data, filePath, fileName);
             }
           } else if (['mangadex', 'mangaupdates', 'anilist'].indexOf(data.provider) !== -1) {
             if (typeof showMangaSeriesSelectionModal === 'function') {

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -5119,6 +5119,12 @@ function searchComicVineMetadata(filePath, fileName) {
         // Show selection modal based on provider
         if (['mangadex', 'mangaupdates', 'anilist'].indexOf(data.provider) !== -1) {
           showMangaSeriesSelectionModal(data, filePath, fileName);
+        } else if (data.provider === 'gcd_api') {
+          if (data.requires_start_year) {
+            showGCDApiStartYearPrompt(data, filePath, fileName);
+          } else {
+            showGCDApiSeriesSelectionModal(data, filePath, fileName);
+          }
         } else {
           showComicVineVolumeSelectionModal(data, filePath, fileName);
         }
@@ -5256,6 +5262,246 @@ function showComicVineVolumeSelectionModal(data, filePath, fileName) {
   // Show the modal
   const modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
   modal.show();
+}
+
+function showGCDApiSeriesSelectionModal(data, filePath, fileName) {
+  console.log('Showing GCD API series selection modal', data);
+
+  // Reuse the ComicVine volume modal UI
+  document.getElementById('cvParsedSeries').textContent = data.parsed_filename.series_name;
+  document.getElementById('cvParsedIssue').textContent = data.parsed_filename.issue_number;
+  document.getElementById('cvParsedYear').textContent = data.parsed_filename.year || 'Unknown';
+
+  const modalTitle = document.getElementById('comicVineVolumeModalLabel');
+  if (modalTitle) {
+    modalTitle.textContent = `Found ${data.possible_matches.length} Series (via GCD API) — Select Correct One`;
+  }
+
+  // Hide refine search row
+  const refineRow = document.getElementById('cvRefineSearchRow');
+  if (refineRow) refineRow.style.display = 'none';
+
+  // Build language/country filter dropdown
+  const allMatches = data.possible_matches;
+  const langSet = {};
+  allMatches.forEach(v => {
+    const key = (v.language || v.country || '').toUpperCase();
+    if (key) langSet[key] = (langSet[key] || 0) + 1;
+  });
+
+  // Remove old language filter if present
+  const oldLangFilter = document.getElementById('gcdApiLangFilterFiles');
+  if (oldLangFilter) oldLangFilter.parentNode.removeChild(oldLangFilter);
+
+  let activeLangFilter = '';
+
+  function renderFilteredList() {
+    const volumeList = document.getElementById('cvVolumeList');
+    volumeList.innerHTML = '';
+
+    const filtered = activeLangFilter
+      ? allMatches.filter(v => (v.language || '').toUpperCase() === activeLangFilter || (v.country || '').toUpperCase() === activeLangFilter)
+      : allMatches;
+
+    filtered.forEach(volume => {
+      const volumeItem = document.createElement('div');
+      volumeItem.className = 'list-group-item list-group-item-action d-flex align-items-start';
+      volumeItem.style.cursor = 'pointer';
+
+      const yearDisplay = volume.start_year || 'Unknown';
+      const langDisplay = (volume.language || '').toUpperCase();
+      const descriptionPreview = volume.description ?
+        `<small class="text-muted d-block mt-1">${volume.description}</small>` : '';
+
+      const thumbnailHtml = volume.image_url ?
+        `<img src="${volume.image_url}" class="img-thumbnail me-3" style="width: 80px; height: 120px; object-fit: cover;" alt="${volume.name} cover">` :
+        `<div class="me-3 d-flex align-items-center justify-content-center bg-secondary text-white" style="width: 80px; height: 120px; font-size: 10px;">No Cover</div>`;
+
+      volumeItem.innerHTML = `
+        ${thumbnailHtml}
+        <div class="flex-grow-1 d-flex justify-content-between align-items-start">
+          <div class="me-2">
+            <div class="fw-bold">${volume.name}</div>
+            <small class="text-muted">Publisher: ${volume.publisher_name || 'Unknown'}<br>Issues: ${volume.count_of_issues || 'Unknown'}</small>
+            ${descriptionPreview}
+          </div>
+          <div class="text-end">
+            <span class="badge bg-success rounded-pill">${yearDisplay}</span>
+            ${langDisplay ? `<span class="badge bg-info rounded-pill ms-1">${langDisplay}</span>` : ''}
+          </div>
+        </div>
+      `;
+
+      volumeItem.addEventListener('click', () => {
+        volumeList.querySelectorAll('.list-group-item').forEach(item => item.classList.remove('active'));
+        volumeItem.classList.add('active');
+
+        const modal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+        if (modal) modal.hide();
+
+        CLU.showToast('GCD API', 'Retrieving metadata...', 'info');
+        fetch('/api/search-metadata', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            file_path: filePath,
+            file_name: fileName,
+            selected_match: { provider: 'gcd_api', series_id: volume.id }
+          })
+        })
+          .then(response => response.json())
+          .then(result => {
+            if (result.success) {
+              CLU.showToast('Metadata Found', 'Metadata applied via GCD API', 'success');
+              if (typeof window.refreshCurrentPage === 'function') window.refreshCurrentPage();
+            } else {
+              CLU.showToast('Metadata Error', result.error || 'No metadata found for selection', 'error');
+            }
+          })
+          .catch(error => {
+            CLU.showToast('Metadata Error', error.message || 'Failed to apply metadata', 'error');
+          });
+      });
+
+      volumeList.appendChild(volumeItem);
+    });
+  }
+
+  // Add language filter if multiple languages present
+  if (Object.keys(langSet).length > 1) {
+    const filterContainer = document.getElementById('cvFilterInput');
+    if (filterContainer && filterContainer.parentNode) {
+      const selectEl = document.createElement('select');
+      selectEl.id = 'gcdApiLangFilterFiles';
+      selectEl.className = 'form-select form-select-sm';
+      selectEl.style.width = '120px';
+      selectEl.innerHTML = '<option value="">All languages</option>';
+      Object.keys(langSet).sort().forEach(key => {
+        selectEl.innerHTML += `<option value="${key}">${key} (${langSet[key]})</option>`;
+      });
+      filterContainer.parentNode.insertBefore(selectEl, filterContainer);
+      selectEl.addEventListener('change', () => {
+        activeLangFilter = selectEl.value;
+        renderFilteredList();
+      });
+    }
+  }
+
+  renderFilteredList();
+
+  const modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
+  modal.show();
+}
+
+function showGCDApiStartYearPrompt(data, filePath, fileName) {
+  console.log('Showing GCD API start year prompt', data);
+
+  const seriesName = (data.parsed_filename && data.parsed_filename.series_name) || 'Unknown';
+  const message = data.message || `No series found for "${seriesName}". Enter the year the series started.`;
+
+  // Reuse the ComicVine volume modal
+  const modalTitle = document.getElementById('comicVineVolumeModalLabel');
+  if (modalTitle) {
+    modalTitle.textContent = 'GCD API - Series Start Year Required';
+  }
+
+  document.getElementById('cvParsedSeries').textContent = seriesName;
+  document.getElementById('cvParsedIssue').textContent = data.parsed_filename.issue_number || '';
+  document.getElementById('cvParsedYear').textContent = data.parsed_filename.year || 'Unknown';
+
+  const refineRow = document.getElementById('cvRefineSearchRow');
+  if (refineRow) refineRow.style.display = 'none';
+
+  const volumeList = document.getElementById('cvVolumeList');
+  volumeList.innerHTML = `
+    <div class="p-3">
+      <p class="text-muted">${message}</p>
+      <p class="text-muted small">The GCD API filters by the year a series <strong>started</strong>,
+        not the issue publication year. For example, a 2026 issue may belong to a series that started in 2025.</p>
+      <div class="input-group mb-2">
+        <input type="number" id="gcdApiStartYearInput" class="form-control" placeholder="e.g. 2025" min="1900" max="2100">
+        <button class="btn btn-primary" type="button" id="gcdApiStartYearSearchBtn">
+          <i class="bi bi-search me-1"></i>Search
+        </button>
+      </div>
+      <button class="btn btn-outline-secondary btn-sm" type="button" id="gcdApiNoYearSearchBtn">
+        Search without year filter
+      </button>
+    </div>
+  `;
+
+  const searchBtn = document.getElementById('gcdApiStartYearSearchBtn');
+  const yearInput = document.getElementById('gcdApiStartYearInput');
+  const noYearBtn = document.getElementById('gcdApiNoYearSearchBtn');
+
+  function doSearch(startYear) {
+    searchBtn.disabled = true;
+    noYearBtn.disabled = true;
+    searchBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Searching...';
+
+    fetch('/api/search-metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        file_path: filePath,
+        file_name: fileName,
+        search_term: seriesName,
+        gcd_api_start_year: startYear || null
+      })
+    })
+      .then(response => response.json())
+      .then(result => {
+        searchBtn.disabled = false;
+        noYearBtn.disabled = false;
+        searchBtn.innerHTML = '<i class="bi bi-search me-1"></i>Search';
+
+        if (result.requires_selection && result.provider === 'gcd_api' && !result.requires_start_year) {
+          const cvModal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+          if (cvModal) cvModal.hide();
+          showGCDApiSeriesSelectionModal(result, filePath, fileName);
+        } else if (result.success) {
+          const cvModal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+          if (cvModal) cvModal.hide();
+          CLU.showToast('Metadata Found', 'Metadata applied via GCD API', 'success');
+          if (typeof window.refreshCurrentPage === 'function') {
+            window.refreshCurrentPage();
+          }
+        } else if (result.requires_start_year) {
+          CLU.showToast('No Results', 'No series found with that year. Try a different year.', 'warning');
+        } else {
+          CLU.showToast('No Results', result.error || 'No metadata found', 'warning');
+        }
+      })
+      .catch(error => {
+        searchBtn.disabled = false;
+        noYearBtn.disabled = false;
+        searchBtn.innerHTML = '<i class="bi bi-search me-1"></i>Search';
+        CLU.showToast('Search Error', error.message || 'Search failed', 'error');
+      });
+  }
+
+  searchBtn.addEventListener('click', () => {
+    const yr = parseInt(yearInput.value, 10);
+    if (!yr || yr < 1900 || yr > 2100) {
+      CLU.showToast('Invalid Year', 'Please enter a valid year (1900-2100)', 'warning');
+      return;
+    }
+    doSearch(yr);
+  });
+
+  yearInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') searchBtn.click();
+  });
+
+  noYearBtn.addEventListener('click', () => doSearch(null));
+
+  const modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
+  modal.show();
+
+  document.getElementById('comicVineVolumeModal').addEventListener('shown.bs.modal', function handler() {
+    yearInput.focus();
+    document.getElementById('comicVineVolumeModal').removeEventListener('shown.bs.modal', handler);
+  });
 }
 
 // showBatchVolumeSelectionModal, fetchAllMetadataWithVolume – delegated to clu-metadata.js

--- a/tests/mocked/test_gcd_api_provider.py
+++ b/tests/mocked/test_gcd_api_provider.py
@@ -1,0 +1,360 @@
+"""Tests for the GCD REST API provider adapter (models/providers/gcd_api_provider.py)."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# Sample API responses for mocking
+# Sample data matching the real GCD API response structure
+SAMPLE_SERIES = {
+    "api_url": "https://www.comics.org/api/series/70876/",
+    "name": "Batman",
+    "year_began": 2016,
+    "publisher": "https://www.comics.org/api/publisher/10/",
+    "notes": "The Dark Knight",
+    "active_issues": [
+        "https://www.comics.org/api/issue/100001/",
+        "https://www.comics.org/api/issue/100002/",
+    ],
+    "issue_descriptors": [
+        "1",
+        "2",
+    ],
+}
+
+# Search results have publisher as dict with name in some contexts
+SAMPLE_SEARCH_SERIES = {
+    "api_url": "https://www.comics.org/api/series/70876/",
+    "name": "Batman",
+    "year_began": 2016,
+    "publisher": "https://www.comics.org/api/publisher/10/",
+    "notes": "The Dark Knight",
+}
+
+# Issue search result (IssueOnly format from /series/name/{name}/issue/{number}/)
+SAMPLE_ISSUE_SEARCH_RESULT = {
+    "api_url": "https://www.comics.org/api/issue/100001/",
+    "series_name": "Batman",
+    "descriptor": "1",
+    "publication_date": "June 2016",
+    "price": "2.99 USD",
+    "page_count": "32",
+    "variant_of": None,
+    "series": "https://www.comics.org/api/series/70876/",
+}
+
+SAMPLE_ISSUE = {
+    "id": 100001,
+    "api_url": "https://www.comics.org/api/issue/100001/",
+    "descriptor": "1",
+    "series_name": "Batman",
+    "series": "https://www.comics.org/api/series/70876/",
+    "publication_date": "June 2016",
+    "key_date": "2016-06-15",
+    "on_sale_date": "2016-06-01",
+    "page_count": "32",
+    "cover": "https://www.comics.org/issue/100001/cover/4/",
+    "story_set": [
+        {
+            "type": "cover",
+            "sequence_number": 0,
+            "title": "None",
+            "pencils": "David Finch",
+            "inks": "Matt Banning",
+            "colors": "Jordie Bellaire",
+            "script": "None",
+            "letters": "None",
+            "editing": "None",
+            "characters": "None",
+            "genre": "",
+            "synopsis": "None",
+        },
+        {
+            "type": "story",
+            "sequence_number": 1,
+            "title": "I Am Gotham Part One",
+            "script": "Tom King",
+            "pencils": "David Finch",
+            "inks": "Matt Banning",
+            "colors": "Jordie Bellaire",
+            "letters": "John Workman",
+            "editing": "James Tynion IV",
+            "characters": "Batman [Bruce Wayne]; Alfred Pennyworth; Commissioner Gordon",
+            "genre": "superhero",
+            "synopsis": "Batman saves a crashing plane.",
+        },
+    ],
+}
+
+
+class TestGCDApiProvider:
+
+    def _make_provider(self):
+        from models.providers.gcd_api_provider import GCDApiProvider
+        from models.providers.base import ProviderCredentials
+        creds = ProviderCredentials(username="testuser", password="testpass")
+        return GCDApiProvider(credentials=creds)
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_search_series_maps_to_search_result(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.search_series.return_value = [SAMPLE_SEARCH_SERIES]
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        results = provider.search_series("Batman")
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.title == "Batman"
+        assert r.year == 2016
+        assert r.id == "70876"
+        assert r.provider.value == "gcd_api"
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_search_series_with_year(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.search_series.return_value = [SAMPLE_SERIES]
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        provider.search_series("Batman", year=2016)
+        mock_client.search_series.assert_called_once_with("Batman", 2016)
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_search_series_empty_results(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.search_series.return_value = []
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        results = provider.search_series("NonexistentComic")
+        assert results == []
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_get_series_maps_correctly(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.get_series.return_value = SAMPLE_SERIES
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        result = provider.get_series("70876")
+        assert result.title == "Batman"
+        assert result.year == 2016
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_get_series_not_found(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.get_series.return_value = None
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        result = provider.get_series("99999999")
+        assert result is None
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_get_issue_maps_with_cover_url(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.get_issue.return_value = SAMPLE_ISSUE
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        result = provider.get_issue("100001")
+        assert result.id == "100001"
+        assert result.issue_number == "1"
+        assert result.cover_url == "https://www.comics.org/issue/100001/cover/4/"
+        assert result.series_id == "70876"
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_get_issues_from_series(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.get_series.return_value = SAMPLE_SERIES
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        results = provider.get_issues("70876")
+        assert len(results) == 2
+        assert results[0].issue_number == "1"
+        assert results[1].issue_number == "2"
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_get_issue_metadata_builds_comicinfo(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.get_series.return_value = SAMPLE_SERIES
+        mock_client.get_issue.return_value = SAMPLE_ISSUE
+        # search_issue returns the IssueOnly result matching our series
+        mock_client.search_issue.return_value = [SAMPLE_ISSUE_SEARCH_RESULT]
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        metadata = provider.get_issue_metadata("70876", "1")
+        assert metadata is not None
+        assert metadata["Series"] == "Batman"
+        assert metadata["Number"] == "1"
+        assert metadata["Writer"] == "Tom King"
+        assert metadata["Penciller"] == "David Finch"
+        assert metadata["Inker"] == "Matt Banning"
+        assert metadata["Colorist"] == "Jordie Bellaire"
+        assert metadata["Letterer"] == "John Workman"
+        assert metadata["Title"] == "I Am Gotham Part One"
+        assert metadata["Summary"] == "Batman saves a crashing plane."
+        assert "Batman [Bruce Wayne]" in metadata["Characters"]
+        assert metadata["Genre"] == "superhero"
+        assert metadata["PageCount"] == "32"
+        assert metadata["Year"] == 2016
+        assert "_cover_url" in metadata
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_to_comicinfo_uses_full_metadata(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.get_series.return_value = SAMPLE_SERIES
+        mock_client.get_issue.return_value = SAMPLE_ISSUE
+        mock_client.search_issue.return_value = [SAMPLE_ISSUE_SEARCH_RESULT]
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        from models.providers.base import IssueResult, ProviderType
+        issue_result = IssueResult(
+            provider=ProviderType.GCD_API,
+            id="100001",
+            series_id="70876",
+            issue_number="1",
+        )
+        result = provider.to_comicinfo(issue_result)
+        assert result["Series"] == "Batman"
+        assert result["Writer"] == "Tom King"
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_to_comicinfo_fallback_minimal(self, mock_client_cls):
+        """When API calls fail, falls back to minimal IssueResult data."""
+        mock_client = MagicMock()
+        mock_client.get_series.return_value = None
+        mock_client.get_issue.return_value = None
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        from models.providers.base import IssueResult, SearchResult, ProviderType
+        issue_result = IssueResult(
+            provider=ProviderType.GCD_API,
+            id="100001",
+            series_id="70876",
+            issue_number="1",
+            cover_date="2016-06-15",
+        )
+        series_result = SearchResult(
+            provider=ProviderType.GCD_API,
+            id="70876",
+            title="Batman",
+            year=2016,
+            publisher="DC",
+        )
+        result = provider.to_comicinfo(issue_result, series_result)
+        assert result["Series"] == "Batman"
+        assert result["Number"] == "1"
+        assert result["Publisher"] == "DC"
+        assert result["Year"] == 2016
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_test_connection_success(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.search_series.return_value = [SAMPLE_SERIES]
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        assert provider.test_connection() is True
+
+    @patch("models.gcd_api.GCDApiClient")
+    def test_test_connection_failure(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.search_series.side_effect = Exception("Connection refused")
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        assert provider.test_connection() is False
+
+    def test_test_connection_no_credentials(self):
+        from models.providers.gcd_api_provider import GCDApiProvider
+        provider = GCDApiProvider()
+        # No credentials and no saved creds - mock the DB call
+        with patch("core.database.get_provider_credentials", return_value=None):
+            assert provider.test_connection() is False
+
+
+class TestHelperFunctions:
+
+    def test_clean_issue_number(self):
+        from models.providers.gcd_api_provider import _clean_issue_number
+        assert _clean_issue_number("3") == "3"
+        assert _clean_issue_number("3 [Jorge Jiménez Cover]") == "3"
+        assert _clean_issue_number("1 [Jim Lee & Scott Williams Cardstock Variant Cover]") == "1"
+        assert _clean_issue_number("12 (2nd printing)") == "12"
+        assert _clean_issue_number("3 [Variant] (2nd printing)") == "3"
+        assert _clean_issue_number("") == ""
+        assert _clean_issue_number(None) == ""
+        assert _clean_issue_number("1/2") == "1/2"
+
+    def test_extract_id_from_url(self):
+        from models.providers.gcd_api_provider import _extract_id_from_url
+        assert _extract_id_from_url("https://www.comics.org/api/series/70876/") == "70876"
+        assert _extract_id_from_url("https://www.comics.org/api/issue/100001/") == "100001"
+        assert _extract_id_from_url(None) is None
+        assert _extract_id_from_url("") is None
+
+    def test_parse_credits_text(self):
+        from models.providers.gcd_api_provider import _parse_credits_text
+        assert _parse_credits_text("Tom King") == ["Tom King"]
+        assert _parse_credits_text("Tom King; Scott Snyder") == ["Tom King", "Scott Snyder"]
+        assert _parse_credits_text("?") == []
+        assert _parse_credits_text("") == []
+        assert _parse_credits_text(None) == []
+        assert _parse_credits_text("None") == []
+
+    def test_parse_credits_text_strips_parenthetical(self):
+        from models.providers.gcd_api_provider import _parse_credits_text
+        result = _parse_credits_text("Bob Kane (as Bob Kane); Bill Finger")
+        assert result == ["Bob Kane", "Bill Finger"]
+
+    def test_parse_credits_text_strips_trailing_question_mark(self):
+        from models.providers.gcd_api_provider import _parse_credits_text
+        assert _parse_credits_text("Mike Royer ?") == ["Mike Royer"]
+        assert _parse_credits_text("John Doe ?; Jane Smith") == ["John Doe", "Jane Smith"]
+        assert _parse_credits_text("Tom King ?; Scott Snyder ?") == ["Tom King", "Scott Snyder"]
+
+    def test_provider_type_is_gcd_api(self):
+        from models.providers.gcd_api_provider import GCDApiProvider
+        from models.providers.base import ProviderType
+        assert GCDApiProvider.provider_type == ProviderType.GCD_API
+        assert GCDApiProvider.provider_type.value == "gcd_api"
+
+    def test_provider_auth_fields(self):
+        from models.providers.gcd_api_provider import GCDApiProvider
+        assert GCDApiProvider.auth_fields == ["username", "password"]
+        assert GCDApiProvider.requires_auth is True
+
+    def test_provider_display_name(self):
+        from models.providers.gcd_api_provider import GCDApiProvider
+        assert "API" in GCDApiProvider.display_name
+        assert "Grand Comics Database" in GCDApiProvider.display_name

--- a/tests/unit/test_gcd_api.py
+++ b/tests/unit/test_gcd_api.py
@@ -1,0 +1,229 @@
+"""Tests for the GCD REST API client (models/gcd_api.py)."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestGCDApiClient:
+
+    def _make_client(self):
+        from models.gcd_api import GCDApiClient
+        return GCDApiClient("testuser", "testpass")
+
+    def test_init_sets_auth(self):
+        client = self._make_client()
+        assert client.session.auth is not None
+
+    @patch("models.gcd_api.requests.Session")
+    def test_search_series_url_no_year(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"count": 1, "next": None, "results": [{"name": "Batman"}]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        results = client.search_series("Batman")
+
+        call_args = mock_session.get.call_args
+        assert "/series/name/Batman/" in call_args[0][0]
+        assert len(results) == 1
+        assert results[0]["name"] == "Batman"
+
+    @patch("models.gcd_api.requests.Session")
+    def test_search_series_url_with_year(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        client.search_series("Batman", year=2016)
+
+        call_args = mock_session.get.call_args
+        assert "/series/name/Batman/year/2016/" in call_args[0][0]
+
+    @patch("models.gcd_api.requests.Session")
+    def test_get_series_url(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"id": 123, "name": "Batman"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        result = client.get_series(123)
+
+        call_args = mock_session.get.call_args
+        assert "/series/123/" in call_args[0][0]
+        assert result["name"] == "Batman"
+
+    @patch("models.gcd_api.requests.Session")
+    def test_get_issue_url(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"id": 456, "descriptor": "1"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        result = client.get_issue(456)
+
+        call_args = mock_session.get.call_args
+        assert "/issue/456/" in call_args[0][0]
+        assert result["descriptor"] == "1"
+
+    @patch("models.gcd_api.requests.Session")
+    def test_search_issue_url(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        client.search_issue("Batman", "42")
+
+        call_args = mock_session.get.call_args
+        assert "/series/name/Batman/issue/42/" in call_args[0][0]
+
+    @patch("models.gcd_api.requests.Session")
+    def test_search_issue_url_with_year(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        client.search_issue("Batman", "42", year=2016)
+
+        call_args = mock_session.get.call_args
+        assert "/series/name/Batman/issue/42/year/2016/" in call_args[0][0]
+
+    @patch("models.gcd_api.requests.Session")
+    def test_pagination_follows_next(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+
+        page1 = MagicMock()
+        page1.json.return_value = {
+            "count": 2,
+            "next": "https://www.comics.org/api/series/name/Batman/?page=2",
+            "results": [{"name": "Batman (1940)"}]
+        }
+        page1.raise_for_status = MagicMock()
+
+        page2 = MagicMock()
+        page2.json.return_value = {
+            "count": 2,
+            "next": None,
+            "results": [{"name": "Batman (2016)"}]
+        }
+        page2.raise_for_status = MagicMock()
+
+        mock_session.get.side_effect = [page1, page2]
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        results = client.search_series("Batman")
+
+        assert len(results) == 2
+        assert results[0]["name"] == "Batman (1940)"
+        assert results[1]["name"] == "Batman (2016)"
+        assert mock_session.get.call_count == 2
+
+    @patch("models.gcd_api.requests.Session")
+    def test_pagination_stops_at_max_pages(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+
+        # Always return a next page
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "count": 100,
+            "next": "https://www.comics.org/api/series/name/X/?page=99",
+            "results": [{"name": "X"}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        results = client._get_all_pages("/series/name/X/", max_pages=3)
+
+        assert mock_session.get.call_count == 3
+        assert len(results) == 3
+
+    @patch("models.gcd_api.requests.Session")
+    def test_http_error_raises(self, mock_session_cls):
+        import requests as req
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = req.exceptions.HTTPError("401 Unauthorized")
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        with pytest.raises(req.exceptions.HTTPError):
+            client.get_series(1)
+
+    @patch("models.gcd_api.requests.Session")
+    def test_timeout_raises(self, mock_session_cls):
+        import requests as req
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_session.get.side_effect = req.exceptions.Timeout("timed out")
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        with pytest.raises(req.exceptions.Timeout):
+            client.get_issue(1)
+
+    @patch("models.gcd_api.requests.Session")
+    def test_series_name_url_encoded(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        client.search_series("Spider-Man / Deadpool")
+
+        call_args = mock_session.get.call_args
+        # Spaces and slashes should be encoded
+        assert "Spider" in call_args[0][0]
+        assert " " not in call_args[0][0].split("/api/")[-1].split("/series/name/")[-1].split("/")[0]
+
+    @patch("models.gcd_api.requests.Session")
+    def test_get_publisher_url(self, mock_session_cls):
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"id": 10, "name": "Marvel"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        result = client.get_publisher(10)
+
+        call_args = mock_session.get.call_args
+        assert "/publisher/10/" in call_args[0][0]
+        assert result["name"] == "Marvel"

--- a/tests/unit/test_gcd_api_year_resolution.py
+++ b/tests/unit/test_gcd_api_year_resolution.py
@@ -1,0 +1,83 @@
+"""Tests for GCD API start year resolution logic."""
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+
+
+class TestResolveGCDApiStartYear:
+    """Test _resolve_gcd_api_start_year from routes/metadata.py."""
+
+    def _resolve(self, file_path, series_name="Batman"):
+        from routes.metadata import _resolve_gcd_api_start_year
+        return _resolve_gcd_api_start_year(file_path, series_name)
+
+    def test_folder_name_v_year(self, tmp_path):
+        folder = tmp_path / "Batman v2025"
+        folder.mkdir()
+        cbz = folder / "Batman 001.cbz"
+        cbz.write_text("")
+        assert self._resolve(str(cbz)) == 2025
+
+    def test_folder_name_parenthetical_year(self, tmp_path):
+        folder = tmp_path / "Batman (2025)"
+        folder.mkdir()
+        cbz = folder / "Batman 001.cbz"
+        cbz.write_text("")
+        assert self._resolve(str(cbz)) == 2025
+
+    def test_folder_name_no_year(self, tmp_path):
+        folder = tmp_path / "Batman"
+        folder.mkdir()
+        cbz = folder / "Batman 001.cbz"
+        cbz.write_text("")
+        # No year in folder name and no sibling CBZs with Volume field
+        assert self._resolve(str(cbz)) is None
+
+    def test_no_file_path(self):
+        assert self._resolve(None) is None
+
+    def test_sibling_xml_volume_field(self, tmp_path):
+        """When folder name has no year, check sibling CBZ Volume field."""
+        folder = tmp_path / "Batman"
+        folder.mkdir()
+        target = folder / "Batman 003.cbz"
+        target.write_text("")
+        sibling = folder / "Batman 001.cbz"
+
+        # Create a real CBZ with ComicInfo.xml containing Volume=2025
+        import zipfile
+        with zipfile.ZipFile(str(sibling), 'w') as zf:
+            zf.writestr("ComicInfo.xml", '<?xml version="1.0"?><ComicInfo><Volume>2025</Volume></ComicInfo>')
+
+        result = self._resolve(str(target))
+        assert result == 2025
+
+    def test_sibling_xml_no_volume(self, tmp_path):
+        """Sibling CBZ without Volume field returns None."""
+        folder = tmp_path / "Batman"
+        folder.mkdir()
+        target = folder / "Batman 003.cbz"
+        target.write_text("")
+        sibling = folder / "Batman 001.cbz"
+
+        import zipfile
+        with zipfile.ZipFile(str(sibling), 'w') as zf:
+            zf.writestr("ComicInfo.xml", '<?xml version="1.0"?><ComicInfo><Series>Batman</Series></ComicInfo>')
+
+        result = self._resolve(str(target))
+        assert result is None
+
+    def test_folder_v_year_case_insensitive(self, tmp_path):
+        folder = tmp_path / "Batman V2025"
+        folder.mkdir()
+        cbz = folder / "Batman 001.cbz"
+        cbz.write_text("")
+        assert self._resolve(str(cbz)) == 2025
+
+    def test_invalid_year_ignored(self, tmp_path):
+        folder = tmp_path / "Batman (1800)"
+        folder.mkdir()
+        cbz = folder / "Batman 001.cbz"
+        cbz.write_text("")
+        # 1800 is outside valid range (1900-2100), no siblings either
+        assert self._resolve(str(cbz)) is None


### PR DESCRIPTION
## 📝 Description
Adding Grand Comics Database (Comics.org) API Support. The API is currently very limited in endpoints, but basic search by `Series Name`, `Start Year` and `Issue Number` is available. Updated the Search confirmation modal to allow filtering by language to eliminate results when matching is uncertain. There's no way to limit API results by language currently, so doing it on the front end made the most sense.

Closes #207 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="791" height="536" alt="image" src="https://github.com/user-attachments/assets/cf229b69-ddcb-4e89-95df-5272be0ed6bb" />
<img width="779" height="634" alt="image" src="https://github.com/user-attachments/assets/8f579a74-9765-4585-8aad-ec9ceae99f0f" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass