### PR TITLE
Revise Metadata to Use Rename Pattern

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -397,6 +397,199 @@ def load_custom_rename_config():
         return False, ""
 
 
+# -------------------------------------------------------------------
+#  Token → regex mapping for custom rename patterns
+# -------------------------------------------------------------------
+_TOKEN_REGEX = {
+    "series_name": r"(?P<series_name>.+?)",
+    "issue_number": r"(?P<issue_number>\d{1,4}(?:\.\w+)?)",
+    "volume_number": r"(?P<volume_number>\d{1,4})",
+    "year": r"(?P<year>\d{4})",
+    "issue_title": r"(?P<issue_title>.+?)",
+}
+
+# Regex to find {token_name} in a pattern string
+_TOKEN_RE = re.compile(r"\{(" + "|".join(_TOKEN_REGEX.keys()) + r")\}")
+
+
+def reverse_parse_pattern(filename, pattern):
+    """Reverse-parse a filename using a custom rename pattern.
+
+    Converts pattern like '{series_name} #{issue_number} V{volume_number} ({year})'
+    into a regex and extracts named groups.
+
+    Returns dict with series_name, issue_number, volume_number, year, issue_title
+    or None if pattern doesn't match.
+    """
+    if not pattern or not filename:
+        return None
+
+    # Split the pattern into literal parts and tokens
+    # We'll build a regex by escaping literals and replacing tokens
+    parts = _TOKEN_RE.split(pattern)
+    regex_parts = []
+
+    for i, part in enumerate(parts):
+        if part in _TOKEN_REGEX:
+            # This is a token name — insert the named capture group
+            regex_parts.append(_TOKEN_REGEX[part])
+        else:
+            # Literal text — escape it, then replace escaped spaces with \s+
+            escaped = re.escape(part)
+            escaped = escaped.replace(r"\ ", r"\s+")
+            regex_parts.append(escaped)
+
+    full_regex = "^" + "".join(regex_parts) + "$"
+
+    try:
+        compiled = re.compile(full_regex, re.IGNORECASE)
+    except re.error:
+        app_logger.warning(f"Failed to compile reverse-parse regex: {full_regex}")
+        return None
+
+    match = compiled.match(filename)
+    if not match:
+        return None
+
+    result = {
+        "series_name": "",
+        "issue_number": "",
+        "volume_number": "",
+        "year": "",
+        "issue_title": "",
+    }
+    for key in result:
+        val = match.groupdict().get(key)
+        if val is not None:
+            result[key] = val.strip()
+
+    return result
+
+
+def parse_comic_filename(filename, custom_pattern=None):
+    """Parse comic filename into series, issue, volume, year.
+
+    Tries in order:
+    1. Custom rename pattern (if provided)
+    2. extract_comic_values() (30+ patterns)
+    3. Minimal fallback (filename as series)
+
+    Returns dict: {series_name, issue_number, year, volume_number}
+    - issue_number is a plain string (e.g., "1", "700.1"), not zero-padded
+    - year is int or None
+    """
+    # Strip extension for parsing
+    name_without_ext = filename
+    for ext in ('.cbz', '.cbr', '.zip'):
+        if name_without_ext.lower().endswith(ext):
+            name_without_ext = name_without_ext[:-len(ext)]
+            break
+
+    result = {
+        "series_name": "",
+        "issue_number": "",
+        "year": None,
+        "volume_number": "",
+    }
+
+    # Step 1: Try custom pattern
+    if custom_pattern:
+        parsed = reverse_parse_pattern(name_without_ext, custom_pattern)
+        if parsed and parsed.get("series_name"):
+            result["series_name"] = parsed["series_name"]
+            result["volume_number"] = parsed.get("volume_number", "")
+            if parsed.get("issue_number"):
+                # Strip leading zeros for search: "001" -> "1"
+                issue = parsed["issue_number"]
+                if "." in issue:
+                    parts = issue.split(".", 1)
+                    try:
+                        result["issue_number"] = str(int(parts[0])) + "." + parts[1]
+                    except ValueError:
+                        result["issue_number"] = issue
+                else:
+                    try:
+                        result["issue_number"] = str(int(issue))
+                    except ValueError:
+                        result["issue_number"] = issue
+            if parsed.get("year"):
+                try:
+                    result["year"] = int(parsed["year"])
+                except ValueError:
+                    pass
+            app_logger.debug(
+                f"parse_comic_filename: custom pattern matched - "
+                f"series='{result['series_name']}', issue='{result['issue_number']}', "
+                f"year={result['year']}"
+            )
+            return result
+
+    # Step 2: Try extract_comic_values()
+    values = extract_comic_values(filename)
+    if values.get("series_name"):
+        result["series_name"] = values["series_name"]
+        result["volume_number"] = values.get("volume_number", "")
+        if values.get("issue_number"):
+            # Strip leading zeros for search: "001" -> "1", "012.1" -> "12.1"
+            issue = values["issue_number"]
+            if "." in issue:
+                parts = issue.split(".", 1)
+                try:
+                    result["issue_number"] = str(int(parts[0])) + "." + parts[1]
+                except ValueError:
+                    result["issue_number"] = issue
+            else:
+                try:
+                    result["issue_number"] = str(int(issue))
+                except ValueError:
+                    result["issue_number"] = issue
+        if values.get("year"):
+            try:
+                result["year"] = int(values["year"])
+            except ValueError:
+                pass
+        app_logger.debug(
+            f"parse_comic_filename: extract_comic_values matched - "
+            f"series='{result['series_name']}', issue='{result['issue_number']}', "
+            f"year={result['year']}"
+        )
+        return result
+
+    # Step 2b: Additional patterns not covered by extract_comic_values
+    # These handle edge cases like "Series vNN" (manga volumes) and
+    # "Series #NN (YYYY)" where extract_comic_values may miss the series name
+    additional_patterns = [
+        (r'^(.+?)\s+v(\d+)\s*\((\d{4})\)', True),    # "Series v1 (2020)" - volume as issue
+        (r'^(.+?)\s+v(\d+)$', True),                   # "Series v01" - volume as issue
+        (r'^(.+?)\s+#(\d{1,4})\s*\((\d{4})\)', False), # "Series #42 (2020)"
+        (r'^(.+?)\s+(\d{1,4})\s+\(of\s+\d+\)\s+\((\d{4})\)', False),  # "Series 05 (of 12) (2020)"
+    ]
+
+    for pattern, is_volume_as_issue in additional_patterns:
+        match = re.match(pattern, name_without_ext, re.IGNORECASE)
+        if match:
+            result["series_name"] = match.group(1).strip()
+            result["issue_number"] = str(int(match.group(2)))
+            if is_volume_as_issue:
+                result["volume_number"] = "v" + match.group(2)
+            if len(match.groups()) >= 3:
+                try:
+                    result["year"] = int(match.group(3))
+                except ValueError:
+                    pass
+            app_logger.debug(
+                f"parse_comic_filename: additional pattern matched - "
+                f"series='{result['series_name']}', issue='{result['issue_number']}', "
+                f"year={result['year']}"
+            )
+            return result
+
+    # Step 3: Minimal fallback
+    result["series_name"] = name_without_ext.strip()
+    app_logger.debug(f"parse_comic_filename: fallback - series='{result['series_name']}'")
+    return result
+
+
 def extract_comic_values(filename):
     """
     Extract comic values from filename using existing regex patterns.
@@ -700,6 +893,8 @@ def extract_comic_values(filename):
             series_part = filename[:issue_pos].strip()
             # Clean up the series name
             series_part = re.sub(r"[\(\)\[\]]", "", series_part).strip()
+            # Strip trailing # (from #NNN patterns) and trailing - or whitespace
+            series_part = re.sub(r'[#\-\s]+$', '', series_part).strip()
             values["series_name"] = series_part
         else:
             # If we can't find the issue number position, try a different approach

--- a/config.ini
+++ b/config.ini
@@ -39,4 +39,5 @@ AUTO_RENAME_MONITOR = True
 TRASH_ENABLED = True
 TRASH_DIR = 
 TRASH_MAX_SIZE_MB = 1024
+SEARCH_VARIANTS = annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery,absolute
 

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -1714,45 +1714,31 @@ def search_gcd_metadata():
                 issue_number = 1  # Ultimate fallback
                 app_logger.debug(f"DEBUG: Could not parse issue number from filename, defaulting to 1")
         else:
-            # Pattern matching for common comic filename formats
-            patterns = [
-                r'^(.+?)\s+(\d{3,4})\s+\((\d{4})\)',  # "Series 001 (2020)"
-                r'^(.+?)\s+#?(\d{1,4})\s*\((\d{4})\)', # "Series #1 (2020)" or "Series 1 (2020)"
-                r'^(.+?)\s+v\d+\s+(\d{1,4})\s*\((\d{4})\)', # "Series v1 001 (2020)"
-                r'^(.+?)\s+(\d{1,4})\s+\(of\s+\d+\)\s+\((\d{4})\)', # "Series 05 (of 12) (2020)"
-                r'^(.+?)\s+#?(\d{1,4})$',  # "Series 169" or "Series #169" (no year)
-            ]
+            # Use consolidated parser for comic filename formats
+            from cbz_ops.rename import parse_comic_filename
+            custom_pattern = current_app.config.get("CUSTOM_RENAME_PATTERN", "")
+            parsed = parse_comic_filename(file_name, custom_pattern=custom_pattern or None)
+            series_name = parsed['series_name'] or None
+            year = parsed['year']
+            if parsed['issue_number']:
+                try:
+                    issue_number = int(float(parsed['issue_number'].split('.')[0]))
+                except (ValueError, IndexError):
+                    issue_number = None
+                app_logger.debug(f"DEBUG: File parsed - series_name={series_name}, issue_number={issue_number}, year={year}")
+            else:
+                issue_number = None
 
-            for pattern in patterns:
-                match = re.match(pattern, name_without_ext, re.IGNORECASE)
-                if match:
-                    series_name = match.group(1).strip()
-                    issue_number = int(match.group(2))  # Handles '0', '00', '000' -> 0
-                    year = int(match.group(3)) if len(match.groups()) >= 3 else None
-                    if issue_number == 0:
-                        app_logger.debug(f"DEBUG: File parsed - series_name={series_name}, issue_number={issue_number} (zero/variant issue), year={year}")
-                    else:
-                        app_logger.debug(f"DEBUG: File parsed - series_name={series_name}, issue_number={issue_number}, year={year}")
-                    break
-
-            # If no pattern matched, try to parse as single-issue/graphic novel with just year
-            if not series_name:
-                # Pattern for single-issue series: "Series Name (2020)" or "Series Name: Subtitle (2020)"
-                single_issue_pattern = r'^(.+?)\s*\((\d{4})\)$'
-                match = re.match(single_issue_pattern, name_without_ext, re.IGNORECASE)
-                if match:
-                    series_name = match.group(1).strip()
-                    year = int(match.group(2))
-                    issue_number = 1  # Default to issue 1 for single-issue series/graphic novels
-                    issue_number_was_defaulted = True  # Mark that we defaulted this
-                    app_logger.debug(f"DEBUG: Single-issue/graphic novel parsed - series_name={series_name}, year={year}, issue_number={issue_number} (defaulted)")
-
-            # Ultimate fallback: if still no series_name, use the entire filename as series name
+            # If no series_name, use the entire filename as series name
             if not series_name:
                 series_name = name_without_ext.strip()
                 issue_number = 1  # Default to issue 1
                 issue_number_was_defaulted = True
                 app_logger.debug(f"DEBUG: Fallback parsing - using entire filename as series_name={series_name}, issue_number={issue_number} (defaulted)")
+            elif issue_number is None:
+                issue_number = 1
+                issue_number_was_defaulted = True
+                app_logger.debug(f"DEBUG: No issue number found, defaulting to 1")
 
         if not series_name or (not is_directory_search and issue_number is None):
             app_logger.debug(f"DEBUG: Failed to parse: {name_without_ext}")
@@ -3163,50 +3149,21 @@ def search_metadata():
         app_logger.info(f"[search-metadata] Starting search for {file_name}")
 
         # Parse filename - extract series name, issue number, year
-        name_without_ext = file_name
-        for ext in ('.cbz', '.cbr', '.zip'):
-            name_without_ext = name_without_ext.replace(ext, '')
+        from cbz_ops.rename import parse_comic_filename
+        custom_pattern = current_app.config.get("CUSTOM_RENAME_PATTERN", "")
+        parsed = parse_comic_filename(file_name, custom_pattern=custom_pattern or None)
+        series_name = parsed['series_name'] or None
+        issue_number = parsed['issue_number'] or None
+        issue_from_pattern = bool(issue_number)
+        year = parsed['year']
 
-        series_name = None
-        issue_number = None
-        issue_from_pattern = False  # Track if issue number came from a regex match
-        year = None
-
-        patterns = [
-            r'^(.+?)\s+(\d{3,4})\s+\((\d{4})\)',
-            r'^(.+?)\s+#?(\d{1,4})\s*\((\d{4})\)',
-            r'^(.+?)\s+v\d+\s+(\d{1,4})\s*\((\d{4})\)',
-            r'^(.+?)\s+v(\d+)\s*\((\d{4})\)',
-            r'^(.+?)\s+(\d{1,4})\s+\(of\s+\d+\)\s+\((\d{4})\)',
-            r'^(.+?)\s+v(\d+)$',
-            r'^(.+?)\s+#?(\d{1,4})$',
-        ]
-
-        for pattern in patterns:
-            match = re.match(pattern, name_without_ext, re.IGNORECASE)
-            if match:
-                series_name = match.group(1).strip()
-                issue_number = str(int(match.group(2)))
-                issue_from_pattern = True
-                year = int(match.group(3)) if len(match.groups()) >= 3 else None
-                break
-
-        if not series_name:
-            single_issue_pattern = r'^(.+?)\s*\((\d{4})\)$'
-            match = re.match(single_issue_pattern, name_without_ext, re.IGNORECASE)
-            if match:
-                series_name = match.group(1).strip()
-                year = int(match.group(2))
-                issue_number = "1"
-
-        if not series_name:
-            series_name = name_without_ext.strip()
+        if not issue_number:
             issue_number = "1"
 
         # Also extract issue number via the provider base utility
         # Only use fallback when no pattern matched an issue number (avoid
         # overriding a valid match, e.g. "Spider-Man 2099 001" where 001 is correct)
-        if not issue_number or (issue_number == "1" and not issue_from_pattern):
+        if not issue_from_pattern:
             extracted = comicvine.extract_issue_number(file_name)
             if extracted:
                 issue_number = extracted

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -583,3 +583,188 @@ class TestRenameComicFromMetadata:
         assert was_renamed is True
         assert os.path.basename(result_path) == "Dinosaur Sanctuary v01 (2021).cbz"
         assert os.path.exists(result_path)
+
+
+# ===== reverse_parse_pattern =====
+
+class TestReverseParsePattern:
+
+    def test_standard_pattern(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Batman #001 V2021 (2021)",
+            "{series_name} #{issue_number} V{volume_number} ({year})"
+        )
+        assert result is not None
+        assert result["series_name"] == "Batman"
+        assert result["issue_number"] == "001"
+        assert result["volume_number"] == "2021"
+        assert result["year"] == "2021"
+
+    def test_problematic_filename(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Miskatonic - Even Death May Die #001 V2021 (2021)",
+            "{series_name} #{issue_number} V{volume_number} ({year})"
+        )
+        assert result is not None
+        assert result["series_name"] == "Miskatonic - Even Death May Die"
+        assert result["issue_number"] == "001"
+        assert result["volume_number"] == "2021"
+        assert result["year"] == "2021"
+
+    def test_simple_pattern(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Batman 042 (2020)",
+            "{series_name} {issue_number} ({year})"
+        )
+        assert result is not None
+        assert result["series_name"] == "Batman"
+        assert result["issue_number"] == "042"
+        assert result["year"] == "2020"
+
+    def test_pattern_with_issue_title(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Batman 042 - Court of Owls (2020)",
+            "{series_name} {issue_number} - {issue_title} ({year})"
+        )
+        assert result is not None
+        assert result["series_name"] == "Batman"
+        assert result["issue_number"] == "042"
+        assert result["issue_title"] == "Court of Owls"
+        assert result["year"] == "2020"
+
+    def test_no_match_returns_none(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "totally different format",
+            "{series_name} #{issue_number} ({year})"
+        )
+        assert result is None
+
+    def test_none_pattern_returns_none(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        assert reverse_parse_pattern("filename", None) is None
+
+    def test_empty_pattern_returns_none(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        assert reverse_parse_pattern("filename", "") is None
+
+    def test_empty_filename_returns_none(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        assert reverse_parse_pattern("", "{series_name}") is None
+
+    def test_flexible_whitespace(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Batman  042  (2020)",
+            "{series_name} {issue_number} ({year})"
+        )
+        assert result is not None
+        assert result["series_name"] == "Batman"
+        assert result["issue_number"] == "042"
+
+    def test_case_insensitive(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Batman #001 v2021 (2021)",
+            "{series_name} #{issue_number} V{volume_number} ({year})"
+        )
+        assert result is not None
+        assert result["issue_number"] == "001"
+
+    def test_decimal_issue(self):
+        from cbz_ops.rename import reverse_parse_pattern
+        result = reverse_parse_pattern(
+            "Avengers 012.1 (2011)",
+            "{series_name} {issue_number} ({year})"
+        )
+        assert result is not None
+        assert result["issue_number"] == "012.1"
+
+
+# ===== parse_comic_filename =====
+
+class TestParseComicFilename:
+
+    def test_custom_pattern_match(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename(
+            "Miskatonic - Even Death May Die #001 V2021 (2021).cbz",
+            custom_pattern="{series_name} #{issue_number} V{volume_number} ({year})"
+        )
+        assert result["series_name"] == "Miskatonic - Even Death May Die"
+        assert result["issue_number"] == "1"  # Stripped leading zeros
+        assert result["volume_number"] == "2021"
+        assert result["year"] == 2021
+
+    def test_fallback_to_extract_comic_values(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename("Batman 001 (2020).cbz")
+        assert result["series_name"]  # Should have a series name
+        assert result["issue_number"] == "1"
+        assert result["year"] == 2020
+
+    def test_no_custom_pattern_uses_extract(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename(
+            "The Amazing Spider-Man (2018) Issue 080.BEY.cbz"
+        )
+        assert result["series_name"] == "The Amazing Spider-Man"
+        assert "80" in result["issue_number"]
+        assert result["year"] == 2018
+
+    def test_custom_pattern_no_match_falls_back(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename(
+            "Batman 001 (2020).cbz",
+            custom_pattern="{series_name} #{issue_number} V{volume_number} ({year})"
+        )
+        # Custom pattern won't match "Batman 001 (2020)" (missing #, V), falls back
+        assert result["series_name"]
+        assert result["issue_number"] == "1"
+        assert result["year"] == 2020
+
+    def test_ultimate_fallback(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename("random-file.cbz")
+        assert result["series_name"] == "random-file"
+        assert result["issue_number"] == ""
+        assert result["year"] is None
+
+    def test_issue_number_stripped_of_leading_zeros(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename(
+            "Batman #042 (2020).cbz",
+            custom_pattern="{series_name} #{issue_number} ({year})"
+        )
+        assert result["issue_number"] == "42"
+
+    def test_decimal_issue_preserved(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename(
+            "Avengers 012.1 (2011).cbz",
+            custom_pattern="{series_name} {issue_number} ({year})"
+        )
+        assert result["issue_number"] == "12.1"
+
+    def test_standard_filenames_still_parse(self):
+        """Regression test — common formats should still work without custom pattern."""
+        from cbz_ops.rename import parse_comic_filename
+        # Standard "Series 001 (YYYY)" format
+        r1 = parse_comic_filename("Batman 001 (2020).cbz")
+        assert r1["series_name"]
+        assert r1["year"] == 2020
+
+        # Volume + Issue format
+        r2 = parse_comic_filename("Comic Name v3 051 (2018).cbz")
+        assert r2["series_name"]
+        assert r2["year"] == 2018
+
+    def test_no_extension(self):
+        from cbz_ops.rename import parse_comic_filename
+        result = parse_comic_filename("Batman 001 (2020)")
+        # Should still attempt parsing even without recognized extension
+        assert result["series_name"]


### PR DESCRIPTION
## 📝 Description
Revise Metadata Search to Use Custom Rename Pattern to determine `series`, `issue` and `year`

If you have CLU setup rename your files like this `{comic_name} {issue_number} {volume} ({publish_year})` it will attempt that pattern first when trying to extract series, year and issue for metadata fetch.

Closes #223 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass