### PR TITLE
Truncated Images in Some CBR Files When Reading

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -72,7 +72,13 @@
       "Bash(pip3 show:*)",
       "Bash(pip3.11 show:*)",
       "Bash(python3.11 -c \"import rarfile; print\\([x for x in dir\\(rarfile\\) if ''''TOOL'''' in x or ''''ALT'''' in x or ''''tool'''' in x.lower\\(\\)]\\)\")",
-      "Bash(^d \")"
+      "Bash(^d \")",
+      "Read(//c/Program Files/**)",
+      "Read(//c/Program Files \\(x86\\)/**)",
+      "Read(//c/Program Files/WinRAR//**)",
+      "Bash(\"/c/Program Files/WinRAR/UnRAR.exe\" e -y temp/Antananarivo.cbr 005.jpg temp/test_extract/)",
+      "Bash(docker run:*)",
+      "WebFetch(domain:www.rarlab.com)"
     ],
     "deny": [],
     "ask": []

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       unar \
+      p7zip-full \
       poppler-utils \
       tini \
       gosu \
@@ -82,6 +83,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       lsb-release \
       xdg-utils \
     && rm -rf /var/lib/apt/lists/*
+
+# Install RARLAB unrar for solid RAR archive support (free to use/redistribute for extraction)
+# Only the unrar binary is installed — the rar tool (commercial) is not included
+# Falls back to unar/7z if unavailable — see helpers.py extract_rar_with_unar()
+RUN wget -q https://www.rarlab.com/rar/rarlinux-x64-720.tar.gz -O /tmp/rar.tar.gz \
+    && tar xzf /tmp/rar.tar.gz -C /tmp \
+    && install -m 755 /tmp/rar/unrar /usr/local/bin/unrar \
+    && rm -rf /tmp/rar /tmp/rar.tar.gz
 
 WORKDIR /app
 

--- a/app.py
+++ b/app.py
@@ -38,8 +38,13 @@ import rarfile
 import tempfile
 import traceback
 
-# Use unar as the external tool to avoid rarfile's native 2MB buffer limit
-rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, force=True)
+# Prefer unrar (proprietary, handles solid archives) over unar
+# Fall back to unar if unrar is not installed
+try:
+    subprocess.run(["unrar"], capture_output=True, timeout=5)
+    rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, force=True)
+except FileNotFoundError:
+    rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, force=True)
 from api import app
 import core.app_state as app_state
 from routes.favorites import favorites_bp
@@ -3792,39 +3797,195 @@ def find_folder_thumbnails_batch(folder_paths):
     return results
 
 
-def _extract_single_rar_entry(rar_path, entry_name):
-    """Extract a single file from a RAR archive using unar subprocess."""
+# ---------------------------------------------------------------------------
+# RAR full-archive extraction cache
+# ---------------------------------------------------------------------------
+_rar_extract_cache = {}   # {rar_path: {"dir": str, "time": float}}
+_RAR_CACHE_MAX = 3
+
+
+def _cleanup_rar_cache():
+    """Remove all cached RAR extraction temp directories."""
+    for entry in _rar_extract_cache.values():
+        try:
+            shutil.rmtree(entry["dir"], ignore_errors=True)
+        except Exception:
+            pass
+    _rar_extract_cache.clear()
+
+
+import atexit
+atexit.register(_cleanup_rar_cache)
+
+
+def _find_extracted_file(directory, filename):
+    """Walk *directory* and return the path of the first file matching *filename* (case-insensitive)."""
+    target = filename.lower()
+    for root, _dirs, files in os.walk(directory):
+        for f in files:
+            if f.lower() == target:
+                full = os.path.join(root, f)
+                # Path traversal guard
+                if os.path.realpath(full).startswith(os.path.realpath(directory)):
+                    return full
+    return None
+
+
+def _is_valid_image_data(data):
+    """Check if image data appears complete (not truncated)."""
+    if not data or len(data) < 10:
+        return False
+    # JPEG: must start with FF D8 and end with FF D9
+    if data[:2] == b'\xff\xd8':
+        return data[-2:] == b'\xff\xd9'
+    # PNG: must start with PNG signature and end with IEND chunk
+    if data[:8] == b'\x89PNG\r\n\x1a\n':
+        return b'IEND' in data[-12:]
+    # Other formats — assume valid if non-empty
+    return True
+
+
+
+def _try_full_extraction(tool_cmd, rar_path, tmp_dir):
+    """Run a full-archive extraction with the given tool. Returns True if files were produced."""
     try:
-        rar_path = os.path.realpath(rar_path)
-        from helpers.library import is_allowed_path
-        if not is_allowed_path(rar_path):
-            app_logger.error(f"Path not in allowed directory: {rar_path}")
-            return None
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            result = subprocess.run(
-                ["unar", "-f", "-o", tmp_dir, rar_path, entry_name],
-                capture_output=True, timeout=60
-            )
+        result = subprocess.run(tool_cmd, capture_output=True, timeout=120)
+        has_files = any(os.scandir(tmp_dir))
+        if has_files:
+            tool_name = tool_cmd[0]
             if result.returncode != 0:
-                stderr_msg = result.stderr.decode("utf-8", errors="replace") if result.stderr else ""
-                app_logger.error(f"unar extraction failed: {stderr_msg}")
-                return None
-            safe_name = os.path.basename(entry_name)
-            if not safe_name:
-                app_logger.error(f"Invalid RAR entry name: {entry_name}")
-                return None
-            extracted = os.path.join(tmp_dir, safe_name)
-            # Verify the resolved path is still within tmp_dir (path traversal guard)
-            if not os.path.realpath(extracted).startswith(os.path.realpath(tmp_dir)):
-                app_logger.error(f"Path traversal detected in RAR entry: {entry_name}")
-                return None
-            if os.path.exists(extracted):
-                with open(extracted, "rb") as f:
-                    return f.read()
-        return None
+                app_logger.warning(
+                    f"{tool_name} full extraction partial success (rc={result.returncode}) for {rar_path}"
+                )
+            else:
+                app_logger.info(f"{tool_name} full extraction succeeded for {rar_path}")
+            return True
+    except FileNotFoundError:
+        pass  # tool not installed
     except Exception as e:
-        app_logger.error(f"Subprocess RAR extraction failed: {e}")
+        app_logger.warning(f"{tool_cmd[0]} full extraction failed for {rar_path}: {e}")
+    return False
+
+
+def _get_full_rar_extraction(rar_path):
+    """Return a directory containing the fully-extracted RAR, using a cache.
+
+    Tries unrar first (proprietary, best solid-archive support), then 7z, then unar.
+    Returns the directory path on success or None on total failure.
+    """
+    rar_path = os.path.realpath(rar_path)
+
+    # Return cached extraction if available
+    if rar_path in _rar_extract_cache:
+        cached = _rar_extract_cache[rar_path]
+        if os.path.isdir(cached["dir"]):
+            return cached["dir"]
+        del _rar_extract_cache[rar_path]
+
+    # Evict oldest entry if at capacity
+    if len(_rar_extract_cache) >= _RAR_CACHE_MAX:
+        oldest_key = min(_rar_extract_cache, key=lambda k: _rar_extract_cache[k]["time"])
+        old = _rar_extract_cache.pop(oldest_key)
+        shutil.rmtree(old["dir"], ignore_errors=True)
+
+    # Try each tool in order: unrar (proprietary) → 7z → unar
+    tools = [
+        ["unrar", "x", "-y", "-o+", rar_path],       # unrar x -y -o+ archive.rar tmp_dir/
+        ["7z", "x", f"-y", rar_path],                  # 7z x -y archive.rar -o{tmp_dir}
+        ["unar", "-f", "-o", None, rar_path],           # unar -f -o tmp_dir archive.rar
+    ]
+
+    for tool_cmd in tools:
+        tmp_dir = tempfile.mkdtemp(prefix="clu_rar_")
+        # Fix up output dir argument per tool
+        tool_name = tool_cmd[0]
+        if tool_name == "unrar":
+            cmd = tool_cmd + [tmp_dir + "/"]
+        elif tool_name == "7z":
+            cmd = tool_cmd[:2] + [f"-o{tmp_dir}"] + tool_cmd[2:]
+        else:  # unar
+            cmd = tool_cmd.copy()
+            cmd[3] = tmp_dir  # replace None placeholder
+
+        if _try_full_extraction(cmd, rar_path, tmp_dir):
+            _rar_extract_cache[rar_path] = {"dir": tmp_dir, "time": time.time()}
+            return tmp_dir
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    app_logger.error(f"All full extraction tools failed for {rar_path}")
+    return None
+
+
+def _extract_single_rar_entry(rar_path, entry_name):
+    """Extract a single file from a RAR archive.
+
+    Fallback chain:
+    1. unrar single-entry (proprietary, handles solid archives)
+    2. 7z single-entry
+    3. unar single-entry
+    4. Full-archive extraction (cached) + file lookup
+    Each step validates image completeness before returning.
+    """
+    rar_path = os.path.realpath(rar_path)
+    from helpers.library import is_allowed_path
+    if not is_allowed_path(rar_path):
+        app_logger.error(f"Path not in allowed directory: {rar_path}")
         return None
+
+    safe_name = os.path.basename(entry_name)
+    if not safe_name:
+        app_logger.error(f"Invalid RAR entry name: {entry_name}")
+        return None
+
+    # --- Attempts 1-3: single-entry extraction with each tool ---
+    single_tools = [
+        ["unrar", "e", "-y", "-o+"],  # unrar e -y -o+ archive entry dest/
+        ["7z", "e", "-y"],             # 7z e -y -o{dir} archive entry
+        ["unar", "-f", "-o"],          # unar -f -o dir archive entry
+    ]
+    for tool_cmd in single_tools:
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                tool_name = tool_cmd[0]
+                if tool_name == "unrar":
+                    cmd = tool_cmd + [rar_path, entry_name, tmp_dir + "/"]
+                elif tool_name == "7z":
+                    cmd = tool_cmd + [f"-o{tmp_dir}", rar_path, entry_name]
+                else:  # unar
+                    cmd = tool_cmd + [tmp_dir, rar_path, entry_name]
+
+                result = subprocess.run(cmd, capture_output=True, timeout=60)
+                found = _find_extracted_file(tmp_dir, safe_name)
+                if found:
+                    with open(found, "rb") as f:
+                        data = f.read()
+                    if _is_valid_image_data(data):
+                        return data
+                    app_logger.warning(f"{tool_name} extracted truncated data for {entry_name}")
+        except FileNotFoundError:
+            continue  # tool not installed
+        except Exception as e:
+            app_logger.warning(f"{tool_cmd[0]} single-entry extraction failed for {entry_name}: {e}")
+
+    # --- Attempt 4: full-archive extraction (cached) ---
+    app_logger.info(
+        f"Single-entry extraction failed for {entry_name}, trying full archive extraction"
+    )
+    cache_dir = _get_full_rar_extraction(rar_path)
+    if cache_dir:
+        found = _find_extracted_file(cache_dir, safe_name)
+        if found:
+            try:
+                with open(found, "rb") as f:
+                    data = f.read()
+                if _is_valid_image_data(data):
+                    return data
+                app_logger.warning(f"Full extraction produced truncated data for {entry_name}")
+            except Exception as e:
+                app_logger.error(f"Failed to read extracted file {found}: {e}")
+
+    app_logger.error(f"All extraction methods failed for {entry_name} in {rar_path}")
+    return None
 
 
 @app.route("/api/read/<path:comic_path>/page/<int:page_num>")
@@ -3881,18 +4042,34 @@ def read_comic_page(comic_path, page_num):
 
         # Read the requested page
         target_file = image_files[page_num]
-        try:
+        image_data = None
+        rar_read_failed = False
+
+        if ext == ".cbr":
+            try:
+                image_data = archive.read(target_file)
+                if not _is_valid_image_data(image_data):
+                    app_logger.warning(
+                        f"rarfile returned truncated data for {target_file} from {comic_path}"
+                    )
+                    image_data = None
+                    rar_read_failed = True
+            except Exception as exc:
+                app_logger.warning(
+                    f"rarfile failed to read {target_file} from {comic_path} "
+                    f"({type(exc).__name__}), falling back to subprocess extraction"
+                )
+                rar_read_failed = True
+
+            if rar_read_failed:
+                if archive:
+                    archive.close()
+                    archive = None
+                image_data = _extract_single_rar_entry(comic_path, target_file)
+                if image_data is None:
+                    return send_file("static/images/error.svg", mimetype="image/svg+xml")
+        else:
             image_data = archive.read(target_file)
-        except rarfile.BadRarFile:
-            app_logger.warning(
-                f"rarfile failed to read {target_file} from {comic_path}, "
-                "falling back to unrar-free subprocess"
-            )
-            archive.close()
-            archive = None
-            image_data = _extract_single_rar_entry(comic_path, target_file)
-            if image_data is None:
-                return send_file("static/images/error.svg", mimetype="image/svg+xml")
 
         # Close archive
         if archive:

--- a/cbz_ops/convert.py
+++ b/cbz_ops/convert.py
@@ -144,7 +144,7 @@ def convert_single_rar_file(rar_path, zip_path, temp_extraction_dir):
 def convert_rar_directory(directory):
     """
     Convert all RAR and CBR files in a directory (and optionally its subdirectories)
-    to CBZ files using unar for extraction, skipping hidden system files and directories.
+    to CBZ files, skipping hidden system files and directories.
 
     :param directory: Path to the directory containing RAR and CBR files.
     :return: List of successfully converted files (without extensions)

--- a/cbz_ops/rebuild.py
+++ b/cbz_ops/rebuild.py
@@ -282,7 +282,7 @@ def rebuild_single_cbz_file(cbz_path, directory):
 
 def convert_rar_to_zip_in_directory(directory, total_files=None, processed_files=None):
     """
-    Convert all RAR/CBR files in a directory to CBZ files using unar for extraction,
+    Convert all RAR/CBR files in a directory to CBZ files,
     skipping hidden system files and directories.
     
     :param directory: Path to the directory containing RAR/CBR files.

--- a/cbz_ops/single_file.py
+++ b/cbz_ops/single_file.py
@@ -389,7 +389,7 @@ def handle_cbz_file(file_path):
 
 def convert_to_cbz(file_path):
     """
-    Convert a single RAR or CBR file to a ZIP file using unar for extraction.
+    Convert a single RAR or CBR file to a ZIP file.
 
     :param file_path: Path to the RAR or CBR file.
     :return: None

--- a/helpers.py
+++ b/helpers.py
@@ -88,9 +88,31 @@ def _count_unar_failures(stdout_bytes):
         return 0
 
 
+def _try_extract_with_tool(tool_name, rar_path, output_dir):
+    """Attempt full extraction with a single tool.
+
+    Returns (returncode, has_files, failed_count) or raises FileNotFoundError if tool missing.
+    """
+    if tool_name == "unrar":
+        cmd = ["unrar", "x", "-y", "-o+", rar_path, output_dir + "/"]
+    elif tool_name == "7z":
+        cmd = ["7z", "x", f"-o{output_dir}", "-y", rar_path]
+    else:
+        cmd = ["unar", "-f", "-o", output_dir, rar_path]
+
+    result = subprocess.run(cmd, capture_output=True)
+    has_files = os.path.exists(output_dir) and any(os.listdir(output_dir))
+    failed_count = _count_unar_failures(result.stdout) if tool_name == "unar" and result.stdout else 0
+
+    return result.returncode, has_files, failed_count
+
+
 def extract_rar_with_unar(rar_path, output_dir):
     """
-    Extract a RAR file using unar.
+    Extract a RAR file, trying tools in order: unrar (proprietary) → 7z → unar.
+
+    The proprietary unrar handles all RAR features including solid archives.
+    7z and unar are used as fallbacks if unrar is not installed.
 
     :param rar_path: Path to the RAR file.
     :param output_dir: Directory to extract the contents into.
@@ -115,42 +137,54 @@ def extract_rar_with_unar(rar_path, output_dir):
 
         os.makedirs(output_dir, exist_ok=True)
 
-        # Verify unar is available
-        try:
-            subprocess.run(["unar", "--version"], capture_output=True)
-        except FileNotFoundError:
-            app_logger.error("unar not found. Please install it (apt-get install unar).")
-            raise RuntimeError("unar not found. Please install it (apt-get install unar).")
+        # Try each tool in order of capability
+        tools = ["unrar", "7z", "unar"]
+        last_error = None
 
-        app_logger.info(f"Extracting {rar_path} to {output_dir} using unar")
+        for tool_name in tools:
+            try:
+                app_logger.info(f"Extracting {rar_path} to {output_dir} using {tool_name}")
+                returncode, has_files, failed_count = _try_extract_with_tool(
+                    tool_name, rar_path, output_dir
+                )
 
-        result = subprocess.run(
-            ["unar", "-f", "-o", output_dir, rar_path],
-            capture_output=True
-        )
+                if returncode == 0 and has_files:
+                    app_logger.info(f"Extraction completed with {tool_name}. Output directory: {output_dir}")
+                    return True, 0
+                elif returncode != 0 and has_files:
+                    app_logger.warning(
+                        f"{tool_name} partial extraction (rc={returncode}), "
+                        f"continuing with extracted files"
+                    )
+                    return True, failed_count
+                else:
+                    app_logger.warning(f"{tool_name} produced no files (rc={returncode})")
+                    # Clean output_dir for next tool attempt
+                    import shutil
+                    shutil.rmtree(output_dir, ignore_errors=True)
+                    os.makedirs(output_dir, exist_ok=True)
 
-        has_files = os.path.exists(output_dir) and any(os.listdir(output_dir))
-        failed_count = _count_unar_failures(result.stdout) if result.stdout else 0
+            except FileNotFoundError:
+                app_logger.debug(f"{tool_name} not found, trying next tool")
+                continue
+            except Exception as e:
+                last_error = e
+                app_logger.warning(f"{tool_name} failed: {e}, trying next tool")
+                # Clean output_dir for next tool attempt
+                import shutil
+                shutil.rmtree(output_dir, ignore_errors=True)
+                os.makedirs(output_dir, exist_ok=True)
+                continue
 
-        if result.returncode == 0 and has_files:
-            app_logger.info(f"Extraction completed. Output directory: {output_dir}")
-            return True, 0
-        elif result.returncode != 0 and has_files:
-            # Partial extraction — some files failed but others succeeded (e.g., corrupt archive)
-            stdout_msg = result.stdout.decode("utf-8", errors="replace").strip() if result.stdout else ""
-            app_logger.warning(f"unar partial extraction (rc={result.returncode}), continuing with extracted files: {stdout_msg[-200:]}")
-            return True, failed_count
-        else:
-            stdout_msg = result.stdout.decode("utf-8", errors="replace").strip() if result.stdout else ""
-            stderr_msg = result.stderr.decode("utf-8", errors="replace").strip() if result.stderr else ""
-            combined = stderr_msg or stdout_msg
-            app_logger.error(f"unar extraction failed (rc={result.returncode}): {combined}")
-            return False, failed_count
+        # All tools failed
+        msg = f"No extraction tool could extract {rar_path}"
+        if last_error:
+            msg += f": {last_error}"
+        app_logger.error(msg)
+        return False, 0
 
-    except subprocess.CalledProcessError as e:
-        error_msg = e.stderr.decode("utf-8", errors="replace").strip() if e.stderr else "Unknown error"
-        app_logger.error(f"Failed to extract {rar_path}: {error_msg}")
-        raise RuntimeError(f"Failed to extract {rar_path}: {error_msg}")
+    except (ValueError, RuntimeError):
+        raise
     except Exception as e:
         app_logger.error(f"Unexpected error extracting {rar_path}: {str(e)}")
         raise RuntimeError(f"Unexpected error extracting {rar_path}: {str(e)}")

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -119,9 +119,31 @@ def _count_unar_failures(stdout_bytes):
         return 0
 
 
+def _try_extract_with_tool(tool_name, rar_path, output_dir):
+    """Attempt full extraction with a single tool.
+
+    Returns (has_files, failed_count) or raises FileNotFoundError if tool missing.
+    """
+    if tool_name == "unrar":
+        cmd = ["unrar", "x", "-y", "-o+", rar_path, output_dir + "/"]
+    elif tool_name == "7z":
+        cmd = ["7z", "x", f"-o{output_dir}", "-y", rar_path]
+    else:
+        cmd = ["unar", "-f", "-o", output_dir, rar_path]
+
+    result = subprocess.run(cmd, capture_output=True)
+    has_files = os.path.exists(output_dir) and any(os.listdir(output_dir))
+    failed_count = _count_unar_failures(result.stdout) if tool_name == "unar" and result.stdout else 0
+
+    return result.returncode, has_files, failed_count
+
+
 def extract_rar_with_unar(rar_path, output_dir):
     """
-    Extract a RAR file using unar.
+    Extract a RAR file, trying tools in order: unrar (proprietary) → 7z → unar.
+
+    The proprietary unrar handles all RAR features including solid archives.
+    7z and unar are used as fallbacks if unrar is not installed.
 
     :param rar_path: Path to the RAR file.
     :param output_dir: Directory to extract the contents into.
@@ -146,42 +168,54 @@ def extract_rar_with_unar(rar_path, output_dir):
 
         os.makedirs(output_dir, exist_ok=True)
 
-        # Verify unar is available
-        try:
-            subprocess.run(["unar", "--version"], capture_output=True)
-        except FileNotFoundError:
-            app_logger.error("unar not found. Please install it (apt-get install unar).")
-            raise RuntimeError("unar not found. Please install it (apt-get install unar).")
+        # Try each tool in order of capability
+        tools = ["unrar", "7z", "unar"]
+        last_error = None
 
-        app_logger.info(f"Extracting {rar_path} to {output_dir} using unar")
+        for tool_name in tools:
+            try:
+                app_logger.info(f"Extracting {rar_path} to {output_dir} using {tool_name}")
+                returncode, has_files, failed_count = _try_extract_with_tool(
+                    tool_name, rar_path, output_dir
+                )
 
-        result = subprocess.run(
-            ["unar", "-f", "-o", output_dir, rar_path],
-            capture_output=True
-        )
+                if returncode == 0 and has_files:
+                    app_logger.info(f"Extraction completed with {tool_name}. Output directory: {output_dir}")
+                    return True, 0
+                elif returncode != 0 and has_files:
+                    app_logger.warning(
+                        f"{tool_name} partial extraction (rc={returncode}), "
+                        f"continuing with extracted files"
+                    )
+                    return True, failed_count
+                else:
+                    app_logger.warning(f"{tool_name} produced no files (rc={returncode})")
+                    # Clean output_dir for next tool attempt
+                    import shutil
+                    shutil.rmtree(output_dir, ignore_errors=True)
+                    os.makedirs(output_dir, exist_ok=True)
 
-        has_files = os.path.exists(output_dir) and any(os.listdir(output_dir))
-        failed_count = _count_unar_failures(result.stdout) if result.stdout else 0
+            except FileNotFoundError:
+                app_logger.debug(f"{tool_name} not found, trying next tool")
+                continue
+            except Exception as e:
+                last_error = e
+                app_logger.warning(f"{tool_name} failed: {e}, trying next tool")
+                # Clean output_dir for next tool attempt
+                import shutil
+                shutil.rmtree(output_dir, ignore_errors=True)
+                os.makedirs(output_dir, exist_ok=True)
+                continue
 
-        if result.returncode == 0 and has_files:
-            app_logger.info(f"Extraction completed. Output directory: {output_dir}")
-            return True, 0
-        elif result.returncode != 0 and has_files:
-            # Partial extraction — some files failed but others succeeded (e.g., corrupt archive)
-            stdout_msg = result.stdout.decode("utf-8", errors="replace").strip() if result.stdout else ""
-            app_logger.warning(f"unar partial extraction (rc={result.returncode}), continuing with extracted files: {stdout_msg[-200:]}")
-            return True, failed_count
-        else:
-            stdout_msg = result.stdout.decode("utf-8", errors="replace").strip() if result.stdout else ""
-            stderr_msg = result.stderr.decode("utf-8", errors="replace").strip() if result.stderr else ""
-            combined = stderr_msg or stdout_msg
-            app_logger.error(f"unar extraction failed (rc={result.returncode}): {combined}")
-            return False, failed_count
+        # All tools failed
+        msg = f"No extraction tool could extract {rar_path}"
+        if last_error:
+            msg += f": {last_error}"
+        app_logger.error(msg)
+        return False, 0
 
-    except subprocess.CalledProcessError as e:
-        error_msg = e.stderr.decode("utf-8", errors="replace").strip() if e.stderr else "Unknown error"
-        app_logger.error(f"Failed to extract {rar_path}: {error_msg}")
-        raise RuntimeError(f"Failed to extract {rar_path}: {error_msg}")
+    except (ValueError, RuntimeError):
+        raise
     except Exception as e:
         app_logger.error(f"Unexpected error extracting {rar_path}: {str(e)}")
         raise RuntimeError(f"Unexpected error extracting {rar_path}: {str(e)}")

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,7 +1,7 @@
 <footer class="footer mt-auto py-3 bg-body-tertiary text-center">
   <div class="container">
     <span class="text-muted"><a href="https://github.com/allaboutduncan/clu-comics/releases" target="_blank"
-        class="text-decoration-none">Version {{ version }}</a></span> |
+        class="text-decoration-none">Version Beta {{ version }}</a></span> |
     <a href="https://discord.gg/ndDhpvrgBa" target="_blank" class="text-decoration-none">Help & Support</a>
   </div>
 </footer>


### PR DESCRIPTION
## 📝 Description
Truncated Images in Some CBR Files When Reading. Caused by libraries being used to extract RAR files. Updated to download rarlab UNRAR on install, which is a more complete RAR library. 

Previously, page in Screenshots below would not load

```
RUN wget -q https://www.rarlab.com/rar/rarlinux-x64-720.tar.gz -O /tmp/rar.tar.gz \
    && tar xzf /tmp/rar.tar.gz -C /tmp \
    && install -m 755 /tmp/rar/unrar /usr/local/bin/unrar \
    && rm -rf /tmp/rar /tmp/rar.tar.gz
```

Closes #210  

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="688" height="1076" alt="Image" src="https://github.com/user-attachments/assets/4beeac33-772e-47e5-94fd-8813b9352ca0" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass