### PR TITLE
Files incorrectly renamed on move

### DIFF
--- a/app.py
+++ b/app.py
@@ -1058,7 +1058,7 @@ def scheduled_getcomics_download():
                         )
                 else:
                     app_logger.debug(
-                        f"No good match found for {series_name} #{issue_num} (best score: {best_score}) {search_context}"
+                        f"No good match found for {series_name} #{issue_num} {search_context}"
                     )
 
         # Update last run timestamp

--- a/app.py
+++ b/app.py
@@ -796,15 +796,19 @@ def process_incoming_wanted_issues():
                     moved_count += 1
                     affected_series.add(issue["series_id"])
 
-                    # Now rename using get_renamed_filename
-                    from cbz_ops.rename import get_renamed_filename
-
-                    new_filename = get_renamed_filename(filename, file_path=temp_dest)
+                    # Only rename if AUTO_RENAME_MONITOR is enabled
+                    auto_rename_monitor = config.getboolean(
+                        "SETTINGS", "AUTO_RENAME_MONITOR", fallback=True
+                    )
                     final_path = temp_dest
-                    if new_filename and new_filename != filename:
-                        final_path = os.path.join(dest_dir, new_filename)
-                        os.rename(temp_dest, final_path)
-                        app_logger.info(f"Renamed: {filename} -> {new_filename}")
+                    if auto_rename_monitor:
+                        from cbz_ops.rename import get_renamed_filename
+
+                        new_filename = get_renamed_filename(filename, file_path=temp_dest)
+                        if new_filename and new_filename != filename:
+                            final_path = os.path.join(dest_dir, new_filename)
+                            os.rename(temp_dest, final_path)
+                            app_logger.info(f"Renamed: {filename} -> {new_filename}")
 
                     # Auto-fetch metadata (try Metron first, then ComicVine as fallback)
                     app_logger.info(f"Auto-fetching metadata for: {final_path}")

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -2,6 +2,8 @@
 GetComics.org search and download functionality.
 Uses cloudscraper to bypass Cloudflare protection.
 """
+import re
+
 import cloudscraper
 from bs4 import BeautifulSoup
 import logging
@@ -152,6 +154,22 @@ ACCEPT_THRESHOLD = 40   # score >= this → ACCEPT
 FALLBACK_MIN     = 0    # range fallback requires score >= this
 
 
+def _normalize_separators(s):
+    """Normalize colons/en-dashes/em-dashes to ' - ' for series matching.
+
+    Handles cases where databases store series names with colons
+    (e.g. "Adventures of Superman: The Book of El") but GetComics uses
+    en-dashes (e.g. "Adventures of Superman – Book of El").
+    Also strips optional "The" after the separator.
+    Safe for hyphenated names like "Spider-Man" (no spaces around the hyphen).
+    """
+    s = re.sub(r'\s*:\s*', ' - ', s)
+    s = re.sub(r'\s*[\u2013\u2014]\s*', ' - ', s)
+    s = re.sub(r' - the ', ' - ', s, flags=re.IGNORECASE)
+    s = re.sub(r'\s+', ' ', s).strip()
+    return s
+
+
 def score_getcomics_result(
     result_title: str,
     series_name: str,
@@ -212,11 +230,14 @@ def score_getcomics_result(
     """
     if accept_variants is None:
         accept_variants = []
-    import re
 
     score = 0
     title_lower = result_title.lower()
     series_lower = series_name.lower()
+
+    # Normalize separators so "Series: The Sub" matches "Series – Sub"
+    series_norm = _normalize_separators(series_lower)
+    title_norm = _normalize_separators(title_lower)
 
     # Normalise issue number — strip leading zeros, preserve dot notation
     issue_str = str(issue_number)
@@ -253,11 +274,12 @@ def score_getcomics_result(
                     break
 
     # ── SERIES NAME MATCH (+30) ──────────────────────────────────────────────
-    series_starts = [series_lower]
-    if series_lower.startswith('the '):
-        series_starts.append(series_lower[4:])
+    # Use normalized strings so "Series: The Sub" matches "Series – Sub"
+    series_starts = [series_norm]
+    if series_norm.startswith('the '):
+        series_starts.append(series_norm[4:])
     else:
-        series_starts.append('the ' + series_lower)
+        series_starts.append('the ' + series_norm)
 
     # Known variant type keywords - these are publication variants, not arc/story sub-series
     # These can be accepted via SEARCH_VARIANTS config
@@ -282,13 +304,13 @@ def score_getcomics_result(
     detected_variant = None  # Store which specific variant was detected
     used_the_swap = False  # Track if we matched using "The " prefix swap
     for start in series_starts:
-        if title_lower.startswith(start):
-            remaining = title_lower[len(start):].strip()
+        if title_norm.startswith(start):
+            remaining = title_norm[len(start):].strip()
             # Track if we matched using the swapped "the " version
             # This helps detect different series like "The Flash Gordon" vs "Flash Gordon"
             # If search is "The Flash Gordon" but result matches "Flash Gordon" (without "The"),
             # that's a different series, not the same series with swapped prefix
-            if series_lower.startswith('the ') and start == series_lower[4:]:
+            if series_norm.startswith('the ') and start == series_norm[4:]:
                 used_the_swap = True
             # Sub-series with dash: "Series - Quarterly", "Series – Arc Name"
             if remaining.startswith(('-', '\u2013', '\u2014')):
@@ -532,7 +554,7 @@ def score_getcomics_result(
             logger.debug(f"Wrong year in title: -20")
 
     # ── COLLECTED EDITION PENALTY (-30) ──────────────────────────────────────
-    title_remainder = title_lower.replace(series_lower, '', 1)
+    title_remainder = title_norm.replace(series_norm, '', 1)
     collected_keywords = [
         r'\bomnibus\b',
         r'\btpb\b',
@@ -665,8 +687,6 @@ def find_latest_weekly_pack_url():
         Tuple of (pack_url, pack_date) or (None, None) if not found
         pack_date is in format "YYYY.MM.DD"
     """
-    import re
-
     base_url = "https://getcomics.org"
 
     try:
@@ -781,8 +801,6 @@ def parse_weekly_pack_page(pack_url: str, format_preference: str, publishers: li
         Dict mapping publisher to pixeldrain URL: {publisher: url}
         Returns empty dict if links not yet available
     """
-    import re
-
     result = {}
 
     try:

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -763,6 +763,80 @@ class TestScoreGetcomicsResult:
         assert score < ACCEPT_THRESHOLD
         assert decision == "REJECT"
 
+    # ===================================================================
+    # Separator normalization — colon vs en-dash/em-dash (Issue #241)
+    # ===================================================================
+
+    def test_colon_to_endash_series_match(self):
+        """Series with colon should match result with en-dash.
+
+        Database stores 'Adventures of Superman: The Book of El' but
+        GetComics lists 'Adventures of Superman – Book of El #7 (2026)'.
+        """
+        from models.getcomics import score_getcomics_result, accept_result
+        score, range_hit, series_match = score_getcomics_result(
+            "Adventures of Superman \u2013 Book of El #7 (2026)",
+            "Adventures of Superman: The Book of El",
+            "7",
+            2026,
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert series_match is True
+        assert score >= 90
+        assert decision == "ACCEPT"
+
+    def test_colon_to_emdash_series_match(self):
+        """Series with colon should match result with em-dash."""
+        from models.getcomics import score_getcomics_result, accept_result
+        score, range_hit, series_match = score_getcomics_result(
+            "Adventures of Superman \u2014 Book of El #7 (2026)",
+            "Adventures of Superman: The Book of El",
+            "7",
+            2026,
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert series_match is True
+        assert score >= 90
+        assert decision == "ACCEPT"
+
+    def test_hyphenated_name_unaffected_by_normalization(self):
+        """Hyphenated names like Spider-Man should not be affected by separator normalization."""
+        from models.getcomics import score_getcomics_result
+        score, _, _ = score_getcomics_result(
+            "Spider-Man #5 (2025)", "Spider-Man", "5", 2025
+        )
+        assert score == 95
+
+    def test_multiple_colons_match_dashes(self):
+        """Series with multiple colons should match result with dashes."""
+        from models.getcomics import score_getcomics_result, accept_result
+        score, range_hit, series_match = score_getcomics_result(
+            "Batman - Arkham Knight - Genesis #1 (2020)",
+            "Batman: Arkham Knight: Genesis",
+            "1",
+            2020,
+        )
+        decision = accept_result(score, range_hit, series_match)
+        assert series_match is True
+        assert decision == "ACCEPT"
+
+    def test_normalize_separators_function(self):
+        """Unit test for _normalize_separators helper."""
+        from models.getcomics import _normalize_separators
+        # Colon with "The" stripped
+        assert _normalize_separators("adventures of superman: the book of el") == \
+            "adventures of superman - book of el"
+        # Hyphenated name unchanged
+        assert _normalize_separators("spider-man #5") == "spider-man #5"
+        # En-dash normalized
+        assert _normalize_separators("batman \u2013 court of owls") == \
+            "batman - court of owls"
+        # Em-dash normalized
+        assert _normalize_separators("batman \u2014 court of owls") == \
+            "batman - court of owls"
+        # No separator, unchanged
+        assert _normalize_separators("the flash") == "the flash"
+
 
 # ===================================================================
 # get_weekly_pack_url_for_date (pure function)


### PR DESCRIPTION
## 📝 Description
Files incorrectly renamed on move - related to a previous bug where settings were not properly applied. Files were being renamed when moved for a subscription. The previous fix applied to only moving from TEMP to TARGET folders.

Closes #244 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass