### PR TITLE
Fix getcomics_urls table not created in database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1355,8 +1355,11 @@ def scheduled_scrape_index_build(batch_size: int = 20):
     """
     try:
         from core.database import get_db_connection
-        from models.getcomics import _scrape_url_to_index as _scrape_url_for_index
+        from models.getcomics import _scrape_url_to_index as _scrape_url_for_index, _ensure_urls_table
         import time
+
+        # Ensure table exists before querying
+        _ensure_urls_table()
 
         app_logger.info(f"Starting scrape index build (batch={batch_size})...")
 
@@ -3134,6 +3137,10 @@ def api_scrape_index_count():
     """Return the current number of entries in the scrape index."""
     try:
         from core.database import get_db_connection
+        # Ensure table exists before querying
+        from models.getcomics import _ensure_urls_table
+        _ensure_urls_table()
+
         conn = get_db_connection()
         c = conn.execute("SELECT COUNT(*) FROM getcomics_urls WHERE scrape_status = 'success'")
         count = c.fetchone()[0]


### PR DESCRIPTION
## Summary

Fixes an error where `GET /api/scrape-index-count` would fail with "no such table: getcomics_urls" on a fresh or existing database.

The scrape index count API and scheduled builder were querying `getcomics_urls` without first calling `_ensure_urls_table()` to create it if missing.

## Fix

Call `_ensure_urls_table()` in both places before querying the table:

1. `api_scrape_index_count()` - the count API endpoint
2. `scheduled_scrape_index_build()` - the scheduled builder

## User Workaround (if deployed with bug)

None, wait for next release with this PR. That's my screw up. :(

Generated with MiniMax