### PR TITLE
Fix: ensure getcomics_urls table exists before querying

### DIFF
--- a/app.py
+++ b/app.py
@@ -1355,8 +1355,11 @@ def scheduled_scrape_index_build(batch_size: int = 20):
     """
     try:
         from core.database import get_db_connection
-        from models.getcomics import _scrape_url_to_index as _scrape_url_for_index
+        from models.getcomics import _scrape_url_to_index as _scrape_url_for_index, _ensure_urls_table
         import time
+
+        # Ensure table exists before querying
+        _ensure_urls_table()
 
         app_logger.info(f"Starting scrape index build (batch={batch_size})...")
 
@@ -3134,6 +3137,10 @@ def api_scrape_index_count():
     """Return the current number of entries in the scrape index."""
     try:
         from core.database import get_db_connection
+        # Ensure table exists before querying
+        from models.getcomics import _ensure_urls_table
+        _ensure_urls_table()
+
         conn = get_db_connection()
         c = conn.execute("SELECT COUNT(*) FROM getcomics_urls WHERE scrape_status = 'success'")
         count = c.fetchone()[0]

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -2088,6 +2088,9 @@ def lookup_series_urls(series_name: str) -> list[dict]:
     Returns:
         List of dicts with keys: series_norm, url_slug, full_url, category
     """
+    # Ensure table exists before querying (handles fresh databases)
+    _ensure_urls_table()
+
     # Resolve alias to canonical before looking up
     resolved = resolve_series_alias(series_name)
     series_norm, _ = normalize_series_name(resolved)
@@ -2136,6 +2139,9 @@ def build_sitemap_index(max_sitemaps: int | None = None, force_refresh: bool = F
     import xml.etree.ElementTree as ET
     from urllib.parse import urlparse
     from core.database import get_db_connection
+
+    # Ensure table exists before querying (handles fresh databases)
+    _ensure_urls_table()
 
     SITEMAP_INDEX = "https://getcomics.org/sitemap.xml"
     sitemap_urls = []
@@ -2544,6 +2550,25 @@ def _ensure_urls_table():
         conn.execute("UPDATE getcomics_urls SET scrape_status = 'success' WHERE download_url IS NOT NULL AND download_url != ''")
         conn.execute("UPDATE getcomics_urls SET scrape_status = 'empty' WHERE scrape_status = 'pending'")
         logger.info("Migrated scrape_status columns for existing getcomics_urls entries")
+
+    # Re-read columns after potential ALTER TABLE additions
+    existing_cols = {r[1] for r in conn.execute("PRAGMA table_info(getcomics_urls)").fetchall()}
+
+    # Migration: add search_aliases and series_norm_norm columns if missing.
+    # These were added to CREATE TABLE but had no ALTER TABLE migration.
+    if 'search_aliases' not in existing_cols:
+        conn.execute("ALTER TABLE getcomics_urls ADD COLUMN search_aliases TEXT")
+        logger.info("Migrated getcomics_urls: added search_aliases column")
+
+    if 'series_norm_norm' not in existing_cols:
+        conn.execute("ALTER TABLE getcomics_urls ADD COLUMN series_norm_norm TEXT")
+        # Backfill: pre-compute normalized series_norm for existing rows
+        conn.execute("""
+            UPDATE getcomics_urls
+            SET series_norm_norm = LOWER(REPLACE(REPLACE(REPLACE(series_norm, '-', ' '), '\\u2013', ' '), '\\u2014', ' '))
+            WHERE series_norm_norm IS NULL AND series_norm IS NOT NULL
+        """)
+        logger.info("Migrated getcomics_urls: added series_norm_norm column")
 
     # Migration: remove spurious UNIQUE constraint on full_url.
     # The old CREATE TABLE had "full_url TEXT NOT NULL UNIQUE" which was


### PR DESCRIPTION
The scrape index API and scheduled builder were querying the getcomics_urls table without first ensuring it exists. On a fresh database or a database missing the table, this would fail with "no such table" error.

Call _ensure_urls_table() before any queries to getcomics_urls.

This is a critical fix I recommend pushing to release immediately. I messed up not including the table existence check. Once I get my next minipc for a dedicated linux dev box I'll be in a better place to blow away the database during future testing stages. It's also because the feature was so large which I try to strongly avoid but felt it was unavoidable in this past feature.

Generated with MiniMax