### PR TITLE
ComicVine Blank Publisher

### DIFF
--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -730,7 +730,7 @@ def auto_move_file(file_path: str, volume_data: Dict[str, Any], config: Dict[str
         raise
 
 
-def get_metadata_by_volume_id(api_key: str, volume_id: int, issue_number: str, year: Optional[int] = None, start_year: Optional[int] = None) -> Optional[Dict[str, Any]]:
+def get_metadata_by_volume_id(api_key: str, volume_id: int, issue_number: str, year: Optional[int] = None, start_year: Optional[int] = None, publisher_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """
     Get issue metadata using a known volume ID (from cvinfo file).
 
@@ -740,6 +740,9 @@ def get_metadata_by_volume_id(api_key: str, volume_id: int, issue_number: str, y
         issue_number: Issue number to look up
         year: Optional year for filtering
         start_year: Optional series start year to use for Volume field
+        publisher_name: Optional publisher name (from cvinfo cache or volume details)
+            so Publisher in ComicInfo.xml can be populated reliably without
+            depending on Simyan's issue.volume.publisher expansion.
 
     Returns:
         Dictionary with metadata in ComicInfo.xml format, or None if not found
@@ -751,8 +754,19 @@ def get_metadata_by_volume_id(api_key: str, volume_id: int, issue_number: str, y
         if not issue_data:
             return None
 
-        # Map to ComicInfo format (volume_data=None since we don't have full volume info)
-        comicinfo = map_to_comicinfo(issue_data, None, start_year=start_year)
+        # Build a minimal volume_data dict so map_to_comicinfo can use its
+        # preferred path (volume_data['publisher_name']) instead of relying on
+        # issue.volume.publisher which Simyan's get_issue does not reliably populate.
+        volume_data = None
+        if publisher_name or start_year:
+            volume_data = {
+                'id': volume_id,
+                'name': issue_data.get('volume_name'),
+                'publisher_name': publisher_name,
+                'start_year': start_year,
+            }
+
+        comicinfo = map_to_comicinfo(issue_data, volume_data, start_year=start_year)
         comicinfo['_image_url'] = issue_data.get('image_url')
 
         return comicinfo
@@ -1244,8 +1258,15 @@ def auto_fetch_metadata_for_folder(folder_path: str, api_key: str, target_file: 
                 result['details'].append({'file': file_path, 'status': 'error', 'reason': 'no issue number'})
                 continue
 
-            # Fetch metadata from ComicVine (pass start_year for Volume field)
-            metadata = get_metadata_by_volume_id(api_key, volume_id, issue_number, start_year=start_year)
+            # Fetch metadata from ComicVine (pass start_year + publisher_name
+            # so Volume and Publisher fields are populated from cvinfo cache)
+            metadata = get_metadata_by_volume_id(
+                api_key,
+                volume_id,
+                issue_number,
+                start_year=start_year,
+                publisher_name=publisher_name,
+            )
 
             if not metadata:
                 app_logger.warning(f"No metadata found for {file_path}, issue #{issue_number}")

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -993,6 +993,7 @@ def batch_metadata():
         cvinfo_created = False
         metron_id_added = False
         cvinfo_start_year = None
+        cvinfo_publisher_name = None
         cv_id_missing_warning = False  # Track if CV ID is missing from Metron
 
         # Determine if manga providers have higher priority than comic providers
@@ -1050,6 +1051,7 @@ def batch_metadata():
                         cv_volume_id = metron_series.get('cv_id')
                         series_id = metron_series['id']
                         cvinfo_start_year = metron_series.get('year_began')
+                        cvinfo_publisher_name = metron_series.get('publisher_name')
                         cvinfo_created = True
                         metron_id_added = True
                         app_logger.info(f"Created cvinfo via Metron: series_id={series_id}, cv_id={cv_volume_id}")
@@ -1101,6 +1103,7 @@ def batch_metadata():
                                 volume_details.get('publisher_name'),
                                 volume_details.get('start_year'))
                             cvinfo_start_year = volume_details.get('start_year')
+                            cvinfo_publisher_name = volume_details.get('publisher_name')
                 except Exception as e:
                     app_logger.error(f"Error searching ComicVine: {e}")
         else:
@@ -1139,19 +1142,27 @@ def batch_metadata():
                                 series_details.get('publisher_name'),
                                 series_details.get('year_began'))
                             cvinfo_start_year = series_details.get('year_began')
+                            cvinfo_publisher_name = series_details.get('publisher_name')
                         metron_id_added = True
                         app_logger.info(f"Added Metron data to cvinfo: series_id={series_id}, publisher={series_details.get('publisher_name')}, year={series_details.get('year_began')}")
 
-        # Step 4: Read start_year from cvinfo for ComicVine calls (for Volume field)
-        if not cvinfo_start_year and os.path.exists(cvinfo_path):
+        # Step 4: Read start_year + publisher_name from cvinfo for ComicVine calls
+        # (Volume and Publisher fields in ComicInfo.xml)
+        if (not cvinfo_start_year or not cvinfo_publisher_name) and os.path.exists(cvinfo_path):
             cvinfo_fields = comicvine.read_cvinfo_fields(cvinfo_path)
-            cvinfo_start_year = cvinfo_fields.get('start_year')
-            # If not in cvinfo but we have a volume_id, fetch and save
-            if not cvinfo_start_year and cv_volume_id and comicvine_available:
+            if not cvinfo_start_year:
+                cvinfo_start_year = cvinfo_fields.get('start_year')
+            if not cvinfo_publisher_name:
+                cvinfo_publisher_name = cvinfo_fields.get('publisher_name')
+            # If still missing but we have a volume_id, fetch and save
+            if (not cvinfo_start_year or not cvinfo_publisher_name) and cv_volume_id and comicvine_available:
                 volume_details = comicvine.get_volume_details(comicvine_api_key, cv_volume_id)
                 if volume_details.get('start_year') or volume_details.get('publisher_name'):
-                    cvinfo_start_year = volume_details.get('start_year')
-                    comicvine.write_cvinfo_fields(cvinfo_path, volume_details.get('publisher_name'), cvinfo_start_year)
+                    if not cvinfo_start_year:
+                        cvinfo_start_year = volume_details.get('start_year')
+                    if not cvinfo_publisher_name:
+                        cvinfo_publisher_name = volume_details.get('publisher_name')
+                    comicvine.write_cvinfo_fields(cvinfo_path, volume_details.get('publisher_name'), volume_details.get('start_year'))
 
         # Store year for GCD lookups
         gcd_year = extracted_year or cvinfo_start_year
@@ -1275,7 +1286,13 @@ def batch_metadata():
                         if not (comicvine_available and cv_volume_id):
                             return False
                         try:
-                            metadata = comicvine.get_metadata_by_volume_id(comicvine_api_key, cv_volume_id, issue_number, start_year=cvinfo_start_year)
+                            metadata = comicvine.get_metadata_by_volume_id(
+                                comicvine_api_key,
+                                cv_volume_id,
+                                issue_number,
+                                start_year=cvinfo_start_year,
+                                publisher_name=cvinfo_publisher_name,
+                            )
                             if metadata:
                                 source = 'ComicVine'
                                 app_logger.info(f"Found metadata from ComicVine for {filename}")

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -111,7 +111,8 @@ def make_mock_cv_volume(*, id=4050, name="Batman", start_year=2016,
 
 
 def make_mock_cv_issue(*, id=1001, issue_number="1", name="Rebirth",
-                       cover_date="2020-01-15", store_date=None):
+                       cover_date="2020-01-15", store_date=None,
+                       publisher_name="DC Comics"):
     i = MagicMock()
     i.id = id
     i.issue_number = issue_number
@@ -126,6 +127,12 @@ def make_mock_cv_issue(*, id=1001, issue_number="1", name="Rebirth",
     vol = MagicMock()
     vol.id = 4050
     vol.name = "Batman"
+    if publisher_name is None:
+        vol.publisher = None
+    else:
+        pub = MagicMock()
+        pub.name = publisher_name
+        vol.publisher = pub
     i.volume = vol
     return i
 

--- a/tests/mocked/test_comicvine_model.py
+++ b/tests/mocked/test_comicvine_model.py
@@ -169,6 +169,74 @@ class TestMapToComicinfo:
         assert result["Volume"] == 2016
 
 
+class TestGetMetadataByVolumeId:
+    """Verify Publisher is populated reliably via volume_data or issue fallback."""
+
+    @staticmethod
+    def _wire_cv(mock_cv_class, *, issue_publisher="DC Comics"):
+        mock_cv = MagicMock()
+        basic_issue = MagicMock()
+        basic_issue.id = 1001
+        mock_cv.list_issues.return_value = [basic_issue]
+
+        full_issue = make_mock_cv_issue(id=1001, issue_number="5",
+                                        publisher_name=issue_publisher)
+        full_issue.creators = []
+        full_issue.characters = []
+        full_issue.teams = []
+        full_issue.locations = []
+        full_issue.story_arcs = []
+        mock_cv.get_issue.return_value = full_issue
+        mock_cv_class.return_value = mock_cv
+        return mock_cv
+
+    @patch("models.comicvine.SIMYAN_AVAILABLE", True)
+    @patch("models.comicvine.ComicvineResource", create=True)
+    @patch("models.comicvine.Comicvine", create=True)
+    def test_publisher_from_kwarg(self, mock_cv_class, mock_resource):
+        """publisher_name kwarg must flow into ComicInfo.xml Publisher field."""
+        from models.comicvine import get_metadata_by_volume_id
+
+        # Mock issue has no volume.publisher so the ONLY way Publisher gets
+        # populated is via the explicit publisher_name kwarg.
+        self._wire_cv(mock_cv_class, issue_publisher=None)
+
+        result = get_metadata_by_volume_id(
+            "fake-key", 4050, "5",
+            start_year=2016,
+            publisher_name="Image Comics",
+        )
+        assert result is not None
+        assert result["Publisher"] == "Image Comics"
+        assert result["Volume"] == 2016
+
+    @patch("models.comicvine.SIMYAN_AVAILABLE", True)
+    @patch("models.comicvine.ComicvineResource", create=True)
+    @patch("models.comicvine.Comicvine", create=True)
+    def test_publisher_falls_back_to_issue_volume(self, mock_cv_class, mock_resource):
+        """With no kwarg, Publisher must still resolve from issue.volume.publisher."""
+        from models.comicvine import get_metadata_by_volume_id
+
+        self._wire_cv(mock_cv_class, issue_publisher="DC Comics")
+
+        result = get_metadata_by_volume_id("fake-key", 4050, "5")
+        assert result is not None
+        assert result["Publisher"] == "DC Comics"
+
+    @patch("models.comicvine.SIMYAN_AVAILABLE", True)
+    @patch("models.comicvine.ComicvineResource", create=True)
+    @patch("models.comicvine.Comicvine", create=True)
+    def test_publisher_missing_when_both_sources_absent(self, mock_cv_class, mock_resource):
+        """No kwarg + no issue.volume.publisher = Publisher omitted from output."""
+        from models.comicvine import get_metadata_by_volume_id
+
+        self._wire_cv(mock_cv_class, issue_publisher=None)
+
+        result = get_metadata_by_volume_id("fake-key", 4050, "5")
+        assert result is not None
+        assert "Publisher" not in result
+
+
 class TestGetVolumeDetails:
 
     @patch("models.comicvine.SIMYAN_AVAILABLE", True)


### PR DESCRIPTION
## 📝 Description
`get_metadata_by_volume_id()` was calling `map_to_comicinfo(issue_data, None, …)` with `volume_data=None`, so _Publisher_ could only come from `issue.volume.publisher.name` — which Simyan's cv.get_issue() does not reliably populate. Meanwhile publisher_name was already being read from cvinfo (and fetched via `get_volume_details()` as a fallback) but was never passed into the metadata call.

### Fix
- `models/comicvine.py:733` — added `publisher_name` kwarg to `get_metadata_by_volume_id()` and builds a minimal volume_data dict when publisher/start_year are supplied, so `map_to_comicinfo()` uses its preferred `volume_data['publisher_name']` path.
- `models/comicvine.py:1248` — `auto_fetch_metadata_for_folder()` now forwards the publisher_name it already resolves from cvinfo.
- `routes/metadata.py` — added `cvinfo_publisher_name` tracking alongside `cvinfo_start_year` (captured from Metron branches, ComicVine get_volume_details branches, and the final cvinfo read/fetch step), then forwarded to the` get_metadata_by_volume_id` call at the former line 1278.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass