### PR TITLE
Fix/scrape index bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -1339,7 +1339,7 @@ def configure_sitemap_schedule():
 
 # ── GetComics Scrape Index Builder ────────────────────────────────────────────
 
-def scheduled_scrape_index_build(batch_size: int = 20):
+def scheduled_scrape_index_build(batch_size: int = 300):
     """Incrementally build the scrape index by scraping unindexed sitemap URLs.
 
     Picks a series with unindexed (or partially indexed) sitemap URLs and scrapes
@@ -1350,8 +1350,8 @@ def scheduled_scrape_index_build(batch_size: int = 20):
     scrape index so live searches become faster over time.
 
     Args:
-        batch_size: Number of URLs to scrape per run (default 20).
-                    At ~7s/URL with rate limiting, 20 URLs ~2.5 min.
+        batch_size: Number of URLs to scrape per run (default 300).
+                    At ~7s/URL with rate limiting, 300 URLs ~35 min.
     """
     try:
         from core.database import get_db_connection

--- a/app.py
+++ b/app.py
@@ -1387,6 +1387,15 @@ def scheduled_scrape_index_build(batch_size: int = 300):
             conn.close()
             return
 
+        # Deduplicate by full_url — same URL can appear multiple times in results
+        seen = set()
+        unique_unindexed = []
+        for row in unindexed:
+            if row[2] not in seen:
+                seen.add(row[2])
+                unique_unindexed.append(row)
+        unindexed = unique_unindexed
+
         total_urls = len(unindexed)
         scraped = 0
         errors = 0
@@ -1403,6 +1412,9 @@ def scheduled_scrape_index_build(batch_size: int = 300):
                     series_norm=series_norm,
                     lastmod='',
                 )
+                if result is None:
+                    # 304 Not Modified — page hasn't changed, skip (not an error)
+                    continue
                 if result:
                     scraped += 1
                 else:

--- a/app.py
+++ b/app.py
@@ -1333,7 +1333,18 @@ def scheduled_sitemap_rebuild():
 
 
 def configure_sitemap_schedule():
-    """Configure the sitemap index rebuild schedule based on database settings."""
+    """Configure the sitemap index rebuild schedule based on database settings.
+
+    Auto-creates a default weekly schedule if one doesn't exist yet.
+    """
+    try:
+        from core.database import get_schedule, save_schedule
+        existing = get_schedule("sitemap")
+        if existing is None:
+            save_schedule("sitemap", frequency="weekly", time="02:00", weekday=0)
+            app_logger.info("Auto-created default sitemap schedule (weekly on Sunday at 02:00)")
+    except Exception:
+        pass
     configure_schedule("sitemap")
 
 

--- a/app.py
+++ b/app.py
@@ -1382,16 +1382,16 @@ def scheduled_scrape_index_build(batch_size: int = 20):
             list(partially_indexed) + [batch_size]
         ).fetchall()
 
-        if not rows:
+        if not unindexed:
             app_logger.info("Scrape index build: no unindexed URLs found")
             conn.close()
             return
 
-        total_urls = len(rows)
+        total_urls = len(unindexed)
         scraped = 0
         errors = 0
 
-        for row in rows:
+        for row in unindexed:
             series_norm, url_slug, full_url = row
             # Rate limit: be a good GetComics citizen
             time.sleep(1.5)

--- a/app.py
+++ b/app.py
@@ -1403,7 +1403,7 @@ def scheduled_scrape_index_build(batch_size: int = 300):
         for row in unindexed:
             series_norm, url_slug, full_url = row
             # Rate limit: be a good GetComics citizen
-            time.sleep(1.5)
+            time.sleep(0.5)
 
             try:
                 result = _scrape_url_for_index(

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -3883,7 +3883,10 @@ def try_scrape_index(
     resolved = resolve_series_alias(search_name)
     norm_series = resolved.replace('-', ' ').replace('\u2013', ' ').replace('\u2014', ' ').strip().lower()
 
-    target_issue = int(str(issue_num).lstrip('0') or '0') if issue_num else None
+    try:
+        target_issue = float(str(issue_num).lstrip('0') or '0') if issue_num else None
+    except ValueError:
+        target_issue = None
 
     # ── Tier 1: Direct issue-number match via SQL ──────────────────────────────
     # Uses the stored issue_num / issue_range columns — no title scoring needed.

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -2996,6 +2996,8 @@ def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", la
     import re
     from core.database import get_db_connection
 
+    conn = get_db_connection()
+
     def _slugify(text: str) -> str:
         """Create a URL-safe slug from title text for use as entry identifier."""
         # Get issue number if present (e.g., "#1" -> "1", "1-5" -> "1-5")
@@ -3010,8 +3012,17 @@ def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", la
         return slug[:50]
 
     scraper = cloudscraper.create_scraper()
+    # Load stored Last-Modified for conditional fetch (skip if page unchanged)
+    stored_lastmod = conn.execute(
+        "SELECT url_last_modified FROM getcomics_urls WHERE full_url = ? LIMIT 1",
+        (url,)
+    ).fetchone()
+    headers = {}
+    if stored_lastmod and stored_lastmod[0]:
+        headers["If-Modified-Since"] = stored_lastmod[0]
+
     try:
-        resp = scraper.get(url, timeout=15)
+        resp = scraper.get(url, timeout=15, headers=headers)
         if resp.status_code == 304:
             return None
         if resp.status_code != 200:

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -4176,13 +4176,17 @@ def search_getcomics_for_issue(
     if series_year:
         queries_to_try.append(" ".join([series_name, str(series_year), issue_num]))
     if series_volume and series_year:
+        queries_to_try.append(" ".join([series_name, "vol.", str(series_volume), str(series_year), issue_num]))
         queries_to_try.append(" ".join([series_name, "vol", str(series_volume), str(series_year), issue_num]))
         queries_to_try.append(" ".join([series_name, "volume", str(series_volume), str(series_year), issue_num]))
     if series_volume and not series_year:
+        queries_to_try.append(" ".join([series_name, "vol.", str(series_volume), issue_num]))
         queries_to_try.append(" ".join([series_name, "vol", str(series_volume), issue_num]))
         queries_to_try.append(" ".join([series_name, "volume", str(series_volume), issue_num]))
     if issue_year and issue_year != series_year:
         queries_to_try.append(" ".join([series_name, str(issue_year), issue_num]))
+    if series_volume:
+        queries_to_try.append(" ".join([series_name, "vol.", str(series_volume), issue_num]))
     queries_to_try.append(" ".join([series_name, issue_num]))  # bare query always last
 
     # Execute all queries CONCURRENTLY (3 workers)

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -3194,6 +3194,30 @@ def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", la
                     entry_url = f"{url}#{entry_slug}"
                     _parse_and_store(title_text, download_url, entry_url)
 
+        # Listing page (variant 3): <li> based pages with inline-styled download links.
+        # Structure: each comic entry is a <li> containing title text followed by
+        # download links in <strong><a href="..."><span style="color: #ff0000;">...
+        # Links use inline styles (color: #ff0000 for Main Server) not CSS classes.
+        for li in soup.find_all('li'):
+            # Title is the direct text content before the first <strong> or <br>
+            li_text = li.get_text(separator=' ', strip=True)
+            if not li_text or len(li_text) < 10:
+                continue
+            # Extract title: text before the first " :" pattern or download links
+            title_text = li_text.split(' :')[0].strip() if ' :' in li_text else li_text
+            if not title_text or len(title_text) < 5:
+                continue
+            # Get download URL — first http href in an <a> tag
+            download_url = None
+            for a in li.find_all('a', href=True):
+                href = a.get('href', '')
+                if href.startswith('http') and 'getcomics' not in href:
+                    download_url = href
+                    break
+            entry_slug = _slugify(title_text)
+            entry_url = f"{url}#{entry_slug}"
+            _parse_and_store(title_text, download_url, entry_url)
+
         return results
     except Exception as e:
         logger.debug(f"Error scraping {url}: {e}")

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -139,6 +139,10 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
     today = date.today().isoformat()
 
     mapped_series = get_all_mapped_series()
+
+    # If target_series_id is set, filter to just that series
+    if target_series_id:
+        mapped_series = [s for s in mapped_series if s["id"] == target_series_id]
     for series in mapped_series:
         sid = series["id"]
         series_name = series.get("name", "")


### PR DESCRIPTION
## 📝 Description
Fixes and improves the GetComics scrape index builder with the following changes:

Bug Fixes
Fix rows variable bug — The scrape index builder referenced an undefined rows variable when the query result was stored in unindexed
Handle decimal issue numbers — Changed int() to float() for target_issue to handle issues like 23.1 without crashing
Performance Improvements
Batch size increase — Raised default from 20 to 300 URLs per scrape run (~35 min vs hours)
Rate limit reduction — Decreased sleep between requests from 1.5s to 0.5s for faster processing
URL deduplication — Prevents scraping the same URL multiple times in a single batch
Conditional fetching — Uses If-Modified-Since header to skip pages that haven't changed (304 responses are skipped, not counted as errors)

Parser Improvements
New <li>-based parser variant — Handles GetComics pages using inline-styled download links (<span style="color: #ff0000;">) instead of CSS classes (aio-red/aio-blue), fixing empty results for Captain America Vol. 3 listing pages

Search Improvements
Add "vol." search variant — When searching with volume number, now tries "vol." in addition to "vol" and "volume".

Simulation Fixes
Respect series_id filter — Simulation now filters to the target series at query time instead of processing all series then filtering afterward. Now respects floats for dot notation handling, ie  Issue number 2.1 etc.


There is still a greater meta-issue of searching for series that won't ever have downloads; ie repetitive, useless searches. Rather then add sloppy negative-results-cache-until-time-passes handling I think it's better to focus on building up the index and then looking if a more meta-metadata approach to series, searches, and results scoring could be taken.

## 🛠️ Changes Made
- [x ] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [ x] Verified build locally (`docker build -t dev .`) (Partial I hot-patched my running docker instance with the unindexed/rows bugfix.

## 📸 Screenshots / Logs
## 🧪 Testing Performed
- [x ] Manual test 
- [ ] Linting/Unit tests pass