### PR TITLE
Auto-Download Mismatch for Multi-volume Issues

### DIFF
--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -1267,7 +1267,8 @@ def score_getcomics_result(
         +15  Title tightness (zero extra words beyond series/issue/year)
         +30  Issue number match via #N or "Issue N" pattern
         +20  Issue number match via standalone bare number (lower confidence)
-        +20  Year match (softened to +/-1 if volume_year provided)
+        +20  Issue year match (title year == issue pub year — strongest signal)
+        +10  Volume year match (title year == volume start year +/-1) when issue year not found
         +10  Volume match (when both search and result have explicit volumes)
 
     Penalties:
@@ -1275,7 +1276,10 @@ def score_getcomics_result(
         -30  Sub-series detected (dash after series name OR variant keyword)
         -30  Different series (remaining text indicates different series)
         -30  The prefix swap used but remaining does not match (e.g., The Flash Gordon vs Flash Gordon)
-        -20  Wrong year explicitly present in title (softened if volume_year provided)
+        -10  Title has a year, volume_year set but no issue_year, and year doesn't match volume_year
+        -30  Title year matches NEITHER volume_year nor issue_year when both are known
+             (drops wrong-volume-reprint collisions below ACCEPT threshold)
+        -20  Wrong year explicitly present in title (when only issue year is set)
         -30  Collected edition keyword (omnibus, TPB, hardcover, etc.)
         -40  Confirmed issue mismatch (#N present but points to wrong number)
         -40  Volume mismatch (both search and result have explicit volumes but they differ)
@@ -1525,9 +1529,25 @@ def _score_year(
     if search.volume_year is not None:
         result_years = re.findall(r'\b(\d{4})\b', result_title)
         if result_years:
-            ryr = int(result_years[0])
-            if ryr == search.volume_year or abs(ryr - search.volume_year) == 1:
+            year_ints = [int(y) for y in result_years]
+            ryr = year_ints[0]
+            vol_match = (ryr == search.volume_year or abs(ryr - search.volume_year) == 1)
+            issue_match = search.year is not None and search.year in year_ints
+
+            if issue_match:
+                # Title year matches the wanted issue's publication year — strongest
+                # signal. GetComics posts for ongoing long-running series typically
+                # use the issue's pub year rather than the volume start year, so
+                # this correctly distinguishes reprints/reboots sharing an issue number.
+                score += 20
+            elif vol_match:
                 score += 10
+            elif search.year is not None:
+                # Both volume_year and issue_year are known, yet the title's year
+                # matches neither. This is a strong signal of a wrong-volume match
+                # (common on reboots sharing issue numbers) — penalize hard enough
+                # to drop a same-series-and-issue-number collision below ACCEPT.
+                score -= 30
             else:
                 score -= 10
     else:

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -335,6 +335,50 @@ class TestScoreGetcomicsResult:
         # Year match adds 20; yearless title searched with specific year gets -10 penalty
         assert with_year - without_year == 30
 
+    def test_issue_year_wins_over_volume_year_mismatch(self):
+        """Long-running series: title year == issue publication year, not volume start."""
+        from models.getcomics import score_getcomics_result
+        # Harley Quinn Vol 4 started 2021; issue #61 published 2026.
+        # Both GetComics candidates have the same series + issue #, only year differs.
+        correct, _, _ = score_getcomics_result(
+            "Harley Quinn #61 (2026)", "Harley Quinn", "61", 2026, volume_year=2021,
+        )
+        wrong_volume, _, _ = score_getcomics_result(
+            "Harley Quinn #61 (2019)", "Harley Quinn", "61", 2026, volume_year=2021,
+        )
+        assert correct > wrong_volume + 25, (
+            f"issue_year match must clearly beat mismatch: correct={correct}, "
+            f"wrong_volume={wrong_volume}"
+        )
+
+    def test_wrong_volume_reprint_rejected_when_only_candidate(self):
+        """Lone wrong-volume candidate (neither volume_year nor issue_year matches)
+        must score below ACCEPT so the scheduler skips it instead of downloading
+        the reprint from a different volume."""
+        from models.getcomics import score_getcomics_result, accept_result
+        # Harley Quinn Vol 4 (2021-), issue #61 published 2026; GetComics only
+        # has the 2019 URL from Vol 3 with same issue number.
+        score, is_range, series_match = score_getcomics_result(
+            "Harley Quinn #61 (2019)", "Harley Quinn", "61", 2026,
+            series_volume=4, volume_year=2021,
+        )
+        decision = accept_result(score, is_range, series_match)
+        assert decision != "ACCEPT", (
+            f"Wrong-volume reprint must not ACCEPT: score={score}, decision={decision}"
+        )
+
+    def test_volume_year_match_still_preferred_when_issue_year_absent_from_title(self):
+        """Backward compat: correct edition where title year is volume start, not issue year."""
+        from models.getcomics import score_getcomics_result
+        # Flash Vol (2020), issue #5 from 2024 — title uses volume year, not issue year.
+        correct_edition, _, _ = score_getcomics_result(
+            "Flash #5 (2020)", "Flash", "5", 2024, volume_year=2020,
+        )
+        wrong_edition, _, _ = score_getcomics_result(
+            "Flash #5 (2011)", "Flash", "5", 2024, volume_year=2020,
+        )
+        assert correct_edition > wrong_edition
+
     @pytest.mark.parametrize(
         "title",
         [


### PR DESCRIPTION
## 📝 Description
Auto-Download Mismatch for Multi-volume Issues could occur if multiple issues exist with the same number.
Harley Quinn v3 Issue 61 (2019)
would incorrectly match to 
Harley Quinn v4 Issue 61 (2021)

Updated to use store date year (2026) to resolve multiple matches.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass