### PR TITLE
Update Recent API to Limit 30 Days

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -1533,18 +1533,26 @@ def get_recent_files(limit=100):
         return []
 
 
+RECENT_FILES_WINDOW_DAYS = 30
+
+
 def get_recent_files_paginated(offset=0, limit=50):
     """
     Paginated sibling of get_recent_files — returns (rows, total).
 
-    Same library/downloads filter as the unpaginated helper. SELECTs `id`
-    too so the API can return file_index.id for client drill-through.
+    Restricted to files indexed within the last RECENT_FILES_WINDOW_DAYS
+    days (currently 30). Same library/downloads filter as the unpaginated
+    helper. SELECTs `id` too so the API can return file_index.id for
+    client drill-through.
     """
     try:
+        import time
+
         conn = get_db_connection()
         if not conn:
             return [], 0
 
+        cutoff = time.time() - (RECENT_FILES_WINDOW_DAYS * 86400)
         c = conn.cursor()
         libraries = get_libraries(enabled_only=True)
         lib_paths = [lib["path"] for lib in libraries if lib.get("path")]
@@ -1556,9 +1564,11 @@ def get_recent_files_paginated(offset=0, limit=50):
                 "type = 'file' "
                 "AND (name LIKE '%.cbz' OR name LIKE '%.cbr') "
                 "AND first_indexed_at IS NOT NULL "
+                "AND first_indexed_at >= ? "
                 f"AND ({lib_clauses})"
             )
-            c.execute(f"SELECT COUNT(*) FROM file_index WHERE {where}", lib_params)
+            params = [cutoff] + lib_params
+            c.execute(f"SELECT COUNT(*) FROM file_index WHERE {where}", params)
             total = c.fetchone()[0] or 0
             c.execute(
                 f"""
@@ -1569,7 +1579,7 @@ def get_recent_files_paginated(offset=0, limit=50):
                 ORDER BY first_indexed_at DESC
                 LIMIT ? OFFSET ?
                 """,
-                lib_params + [limit, offset],
+                params + [limit, offset],
             )
         else:
             target = config.get(
@@ -1580,12 +1590,11 @@ def get_recent_files_paginated(offset=0, limit=50):
                 "type = 'file' "
                 "AND (name LIKE '%.cbz' OR name LIKE '%.cbr') "
                 "AND first_indexed_at IS NOT NULL "
+                "AND first_indexed_at >= ? "
                 "AND parent NOT LIKE ? AND parent NOT LIKE ?"
             )
-            c.execute(
-                f"SELECT COUNT(*) FROM file_index WHERE {where}",
-                (f"{target}%", f"{watch}%"),
-            )
+            params = [cutoff, f"{target}%", f"{watch}%"]
+            c.execute(f"SELECT COUNT(*) FROM file_index WHERE {where}", params)
             total = c.fetchone()[0] or 0
             c.execute(
                 f"""
@@ -1596,7 +1605,7 @@ def get_recent_files_paginated(offset=0, limit=50):
                 ORDER BY first_indexed_at DESC
                 LIMIT ? OFFSET ?
                 """,
-                (f"{target}%", f"{watch}%", limit, offset),
+                params + [limit, offset],
             )
 
         rows = [dict(r) for r in c.fetchall()]

--- a/routes/api_v1_docs.py
+++ b/routes/api_v1_docs.py
@@ -150,7 +150,7 @@ ENDPOINTS = [
         "section": "Library — Dashboard",
         "method": "GET",
         "path": "/api/v1/library/recent",
-        "summary": "Most-recently-indexed CBZ/CBR files inside enabled libraries.",
+        "summary": "CBZ/CBR files indexed in the last 30 days, inside enabled libraries.",
         "auth": True,
         "params": [
             {"name": "page", "type": "int", "default": "1", "desc": "1-indexed."},

--- a/tests/routes/test_api_v1.py
+++ b/tests/routes/test_api_v1.py
@@ -803,12 +803,15 @@ class TestDashboardLists:
             assert "has_progress" in it and "last_page" in it
 
     def test_recent_paginates(self, auth_headers, db_connection, client):
-        # Insert 3 file_index rows directly with explicit first_indexed_at so
+        # Insert 3 file_index rows with timestamps inside the 30-day window so
         # the recent endpoint has predictable data regardless of library
         # configuration.
+        import time as _time
+        now = _time.time()
         conn = get_db_connection()
         c = conn.cursor()
-        for i, ts in enumerate((1700000001, 1700000002, 1700000003), start=1):
+        for i, offset in enumerate((30, 20, 10), start=1):
+            ts = now - offset
             c.execute(
                 """
                 INSERT INTO file_index
@@ -840,16 +843,48 @@ class TestDashboardLists:
         # Page 2 has at least one of the remaining rows
         assert len(body2["items"]) >= 1
 
+    def test_recent_excludes_files_older_than_30_days(
+        self, auth_headers, db_connection, client
+    ):
+        import time as _time
+        now = _time.time()
+        conn = get_db_connection()
+        c = conn.cursor()
+        # One row inside the window (5 days old) and one outside (40 days).
+        c.executemany(
+            """
+            INSERT INTO file_index
+            (name, path, type, size, parent, has_thumbnail, modified_at,
+             first_indexed_at)
+            VALUES (?, ?, 'file', 100, '/data', 0, ?, ?)
+            """,
+            [
+                ("Fresh.cbz", "/data/Fresh.cbz", now - 5 * 86400, now - 5 * 86400),
+                ("Stale.cbz", "/data/Stale.cbz", now - 40 * 86400, now - 40 * 86400),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        body = client.get(
+            "/api/v1/library/recent?page_size=50", headers=auth_headers
+        ).get_json()
+        names = [it["name"] for it in body["items"]]
+        assert "Fresh.cbz" in names
+        assert "Stale.cbz" not in names
+
     def test_recent_progress_enrichment(
         self, auth_headers, seeded_file, client
     ):
-        # Stamp the seeded file with first_indexed_at so it shows up in
-        # recent, then save a reading position and confirm enrichment.
+        # Stamp the seeded file with a recent first_indexed_at (within the
+        # 30-day window) so it shows up in recent, then save a reading
+        # position and confirm enrichment.
+        import time as _time
         conn = get_db_connection()
         c = conn.cursor()
         c.execute(
-            "UPDATE file_index SET first_indexed_at = 1700000999 WHERE path = ?",
-            (seeded_file["path"],),
+            "UPDATE file_index SET first_indexed_at = ? WHERE path = ?",
+            (_time.time(), seeded_file["path"]),
         )
         conn.commit()
         conn.close()


### PR DESCRIPTION
## 📝 Description
Update Recent API to Limit 30 Days to keep it from loading/calling too many files

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass