### PR TITLE
Add trash manifest and file restore functionality

### DIFF
--- a/helpers/trash.py
+++ b/helpers/trash.py
@@ -6,10 +6,53 @@ Oldest items are automatically evicted when the trash exceeds TRASH_MAX_SIZE_MB.
 When TRASH_ENABLED is False, move_to_trash() falls back to permanent deletion.
 """
 
+import json
 import os
 import shutil
 import time
 from core.app_logging import app_logger
+
+
+MANIFEST_FILENAME = "trash_manifest.json"
+
+
+def _get_manifest_path():
+    """Return the path to the trash manifest file, or None if trash is disabled."""
+    trash_dir = get_trash_dir()
+    if not trash_dir:
+        return None
+    return os.path.join(trash_dir, MANIFEST_FILENAME)
+
+
+def _load_manifest():
+    """Load the trash manifest. Returns {} on missing or corrupt file."""
+    path = _get_manifest_path()
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_manifest(manifest):
+    """Atomically write the manifest dict to disk."""
+    path = _get_manifest_path()
+    if not path:
+        return
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2)
+        os.replace(tmp_path, path)
+    except OSError as e:
+        app_logger.error(f"Failed to save trash manifest: {e}")
+
+
+def get_trash_manifest():
+    """Public accessor for the trash manifest dict."""
+    return _load_manifest()
 
 
 def get_trash_dir():
@@ -64,6 +107,8 @@ def get_trash_size():
 
     total = 0
     for entry in os.scandir(trash_dir):
+        if entry.name == MANIFEST_FILENAME:
+            continue
         if entry.is_file(follow_symlinks=False):
             total += entry.stat().st_size
         elif entry.is_dir(follow_symlinks=False):
@@ -87,6 +132,8 @@ def get_trash_contents():
 
     items = []
     for entry in os.scandir(trash_dir):
+        if entry.name == MANIFEST_FILENAME:
+            continue
         try:
             stat = entry.stat(follow_symlinks=False)
             if entry.is_dir(follow_symlinks=False):
@@ -122,6 +169,9 @@ def _evict_oldest(needed_bytes):
     max_size = get_trash_max_size_bytes()
     current_size = sum(item["size"] for item in contents)
 
+    manifest = _load_manifest()
+    manifest_changed = False
+
     for item in contents:
         if current_size + needed_bytes <= max_size:
             break
@@ -132,8 +182,14 @@ def _evict_oldest(needed_bytes):
                 os.remove(item["path"])
             current_size -= item["size"]
             app_logger.info(f"Trash evicted oldest item: {item['name']} ({item['size']} bytes)")
+            if item["name"] in manifest:
+                del manifest[item["name"]]
+                manifest_changed = True
         except OSError as e:
             app_logger.error(f"Error evicting trash item {item['name']}: {e}")
+
+    if manifest_changed:
+        _save_manifest(manifest)
 
 
 def _get_item_size(source_path):
@@ -236,6 +292,15 @@ def move_to_trash(source_path):
         parent_dir = os.path.dirname(source_path)
         shutil.move(source_path, dest_path)
         app_logger.info(f"Moved to trash: {source_path} -> {dest_path}")
+
+        # Record original path in manifest for restore
+        manifest = _load_manifest()
+        manifest[os.path.basename(dest_path)] = {
+            "original_path": source_path,
+            "deleted_at": time.time(),
+        }
+        _save_manifest(manifest)
+
         _cleanup_empty_parent(parent_dir)
         return {"trashed": True, "path": dest_path}
     except Exception as e:
@@ -261,6 +326,8 @@ def empty_trash():
     size_freed = 0
 
     for entry in os.scandir(trash_dir):
+        if entry.name == MANIFEST_FILENAME:
+            continue
         try:
             stat = entry.stat(follow_symlinks=False)
             if entry.is_dir(follow_symlinks=False):
@@ -279,6 +346,14 @@ def empty_trash():
             count += 1
         except OSError as e:
             app_logger.error(f"Error emptying trash item {entry.name}: {e}")
+
+    # Clear the manifest file
+    manifest_path = _get_manifest_path()
+    if manifest_path and os.path.exists(manifest_path):
+        try:
+            os.remove(manifest_path)
+        except OSError:
+            pass
 
     app_logger.info(f"Emptied trash: {count} items, {size_freed} bytes freed")
     return {"count": count, "size_freed": size_freed}
@@ -311,7 +386,75 @@ def permanently_delete_from_trash(item_name):
         else:
             os.remove(item_path)
         app_logger.info(f"Permanently deleted from trash: {item_name} ({size} bytes)")
+
+        # Remove from manifest
+        manifest = _load_manifest()
+        if item_name in manifest:
+            del manifest[item_name]
+            _save_manifest(manifest)
+
         return {"success": True, "size_freed": size}
     except OSError as e:
         app_logger.error(f"Error deleting trash item {item_name}: {e}")
         return {"success": False, "size_freed": 0, "error": str(e)}
+
+
+def restore_from_trash(item_name):
+    """
+    Restore a trashed item to its original location.
+
+    Returns dict: {success, restored_path, error}.
+    May also include no_manifest or conflict flags.
+    """
+    trash_dir = get_trash_dir()
+    if not trash_dir:
+        return {"success": False, "error": "Trash is disabled"}
+
+    item_path = os.path.join(trash_dir, item_name)
+
+    if not os.path.exists(item_path):
+        return {"success": False, "error": "Item not found in trash"}
+
+    # Prevent path traversal
+    normalized_item = os.path.normpath(item_path)
+    normalized_trash = os.path.normpath(trash_dir)
+    if not normalized_item.startswith(normalized_trash + os.sep):
+        return {"success": False, "error": "Invalid item path"}
+
+    # Look up original path in manifest
+    manifest = _load_manifest()
+    entry = manifest.get(item_name)
+    if not entry:
+        return {
+            "success": False,
+            "error": "No original path recorded for this item. Use drag-and-drop to restore it manually.",
+            "no_manifest": True,
+        }
+
+    original_path = entry["original_path"]
+
+    # Check for conflict at original location
+    if os.path.exists(original_path):
+        return {
+            "success": False,
+            "error": "A file already exists at the original location",
+            "conflict": True,
+            "original_path": original_path,
+        }
+
+    # Recreate parent directory if needed
+    parent_dir = os.path.dirname(original_path)
+    os.makedirs(parent_dir, exist_ok=True)
+
+    try:
+        shutil.move(item_path, original_path)
+        app_logger.info(f"Restored from trash: {item_name} -> {original_path}")
+
+        # Remove from manifest
+        del manifest[item_name]
+        _save_manifest(manifest)
+
+        return {"success": True, "restored_path": original_path}
+    except Exception as e:
+        app_logger.error(f"Failed to restore from trash {item_name}: {e}")
+        return {"success": False, "error": str(e)}

--- a/routes/files.py
+++ b/routes/files.py
@@ -22,7 +22,7 @@ import zipfile
 from flask import Blueprint, request, jsonify, render_template_string, Response
 from core.app_logging import app_logger
 from helpers.library import is_critical_path, get_critical_path_error_message, is_valid_library_path
-from helpers.trash import move_to_trash, is_trash_path, get_trash_dir, get_trash_size, get_trash_max_size_bytes, get_trash_contents, empty_trash as do_empty_trash, permanently_delete_from_trash
+from helpers.trash import move_to_trash, is_trash_path, get_trash_dir, get_trash_size, get_trash_max_size_bytes, get_trash_contents, empty_trash as do_empty_trash, permanently_delete_from_trash, restore_from_trash, get_trash_manifest
 from helpers import is_hidden
 from core.config import config
 from cbz_ops.edit import cropCenter, cropLeft, cropRight, cropFreeForm, get_image_data_url, modal_body_template
@@ -953,6 +953,12 @@ def trash_list():
     # Reverse to newest first for display
     contents.reverse()
 
+    # Enrich with original path from manifest
+    manifest = get_trash_manifest()
+    for item in contents:
+        entry = manifest.get(item["name"])
+        item["original_path"] = entry["original_path"] if entry else None
+
     return jsonify({"enabled": True, "items": contents})
 
 
@@ -978,6 +984,29 @@ def trash_delete_item():
     result = permanently_delete_from_trash(item_name)
     if not result["success"]:
         return jsonify(result), 404 if result["error"] == "Item not found in trash" else 400
+    return jsonify(result)
+
+
+@files_bp.route('/api/trash/restore', methods=['POST'])
+def trash_restore_item():
+    """Restore a trashed item to its original location."""
+    from app import update_index_on_create
+
+    data = request.get_json()
+    item_name = data.get("name")
+    if not item_name:
+        return jsonify({"success": False, "error": "Missing item name"}), 400
+
+    result = restore_from_trash(item_name)
+    if not result["success"]:
+        if result.get("conflict"):
+            return jsonify(result), 409
+        return jsonify(result), 400
+
+    # Update file index for the restored file
+    restored_path = result["restored_path"]
+    threading.Thread(target=update_index_on_create, args=(restored_path,), daemon=True).start()
+
     return jsonify(result)
 
 

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -1869,6 +1869,7 @@ function loadTrash(panel) {
             <div class="small text-muted mt-1">
               <span>${CLU.formatFileSize(item.size)}</span>
               <span class="ms-2"><i class="bi bi-clock me-1"></i>${CLU.escapeHtml(timeAgo)}</span>
+              ${item.original_path ? `<span class="ms-2" title="${CLU.escapeHtml(item.original_path)}"><i class="bi bi-arrow-return-left me-1"></i>${CLU.escapeHtml(truncatePath(item.original_path))}</span>` : ''}
             </div>
           </div>
         `;
@@ -1877,6 +1878,21 @@ function loadTrash(panel) {
         const iconContainer = document.createElement('div');
         iconContainer.className = 'btn-group';
         iconContainer.setAttribute('role', 'group');
+
+        // Restore button
+        const restoreBtn = document.createElement('button');
+        restoreBtn.className = 'btn btn-sm btn-outline-success';
+        restoreBtn.innerHTML = '<i class="bi bi-arrow-counterclockwise"></i>';
+        restoreBtn.title = item.original_path
+          ? `Restore to ${item.original_path}`
+          : 'No original path recorded — use drag and drop';
+        restoreBtn.disabled = !item.original_path;
+        restoreBtn.setAttribute('type', 'button');
+        restoreBtn.onclick = function (e) {
+          e.stopPropagation();
+          restoreTrashItem(item.name, item.original_path, restoreBtn);
+        };
+        iconContainer.appendChild(restoreBtn);
 
         // CBZ info button (files only)
         if (!item.is_dir) {
@@ -2011,6 +2027,34 @@ function permanentlyDeleteTrashItem(name, btnEl) {
       }
     })
     .catch(err => CLU.showError('Error: ' + err.message));
+}
+
+function restoreTrashItem(name, originalPath, btnEl) {
+  fetch('/api/trash/restore', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: name })
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (data.success) {
+        const li = btnEl.closest('li');
+        if (li) li.remove();
+        updateTrashBadge();
+        CLU.showSuccess(`Restored to ${data.restored_path}`);
+      } else if (data.conflict) {
+        CLU.showError(`Cannot restore: a file already exists at ${data.original_path}`);
+      } else {
+        CLU.showError(data.error || 'Failed to restore item');
+      }
+    })
+    .catch(err => CLU.showError('Error: ' + err.message));
+}
+
+function truncatePath(fullPath) {
+  const parts = fullPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (parts.length <= 3) return fullPath;
+  return '.../' + parts.slice(-3).join('/');
 }
 
 // Helper function to format date/time

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -212,16 +212,30 @@ class TestTrashInfo:
 
 class TestTrashList:
 
+    @patch("routes.files.get_trash_manifest", return_value={
+        "a.cbz": {"original_path": "/data/comics/a.cbz", "deleted_at": 1000},
+    })
     @patch("routes.files.get_trash_contents", return_value=[
         {"name": "a.cbz", "path": "/trash/a.cbz", "size": 100, "is_dir": False, "mtime": 1000},
     ])
-    def test_trash_list(self, mock_contents, client):
+    def test_trash_list(self, mock_contents, mock_manifest, client):
         resp = client.get("/api/trash/list")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["enabled"] is True
         assert len(data["items"]) == 1
         assert data["items"][0]["name"] == "a.cbz"
+        assert data["items"][0]["original_path"] == "/data/comics/a.cbz"
+
+    @patch("routes.files.get_trash_manifest", return_value={})
+    @patch("routes.files.get_trash_contents", return_value=[
+        {"name": "old.cbz", "path": "/trash/old.cbz", "size": 50, "is_dir": False, "mtime": 900},
+    ])
+    def test_trash_list_no_manifest_entry(self, mock_contents, mock_manifest, client):
+        """Items without manifest entry have original_path=None."""
+        resp = client.get("/api/trash/list")
+        data = resp.get_json()
+        assert data["items"][0]["original_path"] is None
 
 
 class TestTrashEmpty:
@@ -255,6 +269,42 @@ class TestTrashDeleteItem:
     def test_not_found(self, mock_del, client):
         resp = client.post("/api/trash/delete", json={"name": "nope.cbz"})
         assert resp.status_code == 404
+
+
+class TestTrashRestore:
+
+    @patch("routes.files.restore_from_trash",
+           return_value={"success": True, "restored_path": "/data/DC/Batman/issue1.cbz"})
+    def test_restore_item(self, mock_restore, client):
+        resp = client.post("/api/trash/restore", json={"name": "issue1.cbz"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["restored_path"] == "/data/DC/Batman/issue1.cbz"
+        mock_restore.assert_called_once_with("issue1.cbz")
+
+    def test_missing_name(self, client):
+        resp = client.post("/api/trash/restore", json={})
+        assert resp.status_code == 400
+
+    @patch("routes.files.restore_from_trash",
+           return_value={"success": False, "error": "A file already exists at the original location",
+                         "conflict": True, "original_path": "/data/DC/issue1.cbz"})
+    def test_conflict(self, mock_restore, client):
+        resp = client.post("/api/trash/restore", json={"name": "issue1.cbz"})
+        assert resp.status_code == 409
+        data = resp.get_json()
+        assert data.get("conflict") is True
+
+    @patch("routes.files.restore_from_trash",
+           return_value={"success": False,
+                         "error": "No original path recorded for this item. Use drag-and-drop to restore it manually.",
+                         "no_manifest": True})
+    def test_no_manifest(self, mock_restore, client):
+        resp = client.post("/api/trash/restore", json={"name": "orphan.cbz"})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data.get("no_manifest") is True
 
 
 class TestCreateFolder:

--- a/tests/unit/test_trash.py
+++ b/tests/unit/test_trash.py
@@ -79,7 +79,7 @@ class TestMoveToTrash:
 
         assert result["trashed"] is True
         assert not source.exists()
-        trash_files = os.listdir(str(trash_dir))
+        trash_files = [f for f in os.listdir(str(trash_dir)) if f != "trash_manifest.json"]
         assert len(trash_files) == 2
         assert "comic.cbz" in trash_files
 

--- a/tests/unit/test_trash.py
+++ b/tests/unit/test_trash.py
@@ -1,5 +1,6 @@
 """Tests for helpers/trash.py — Trash Can module."""
 
+import json
 import os
 import time
 import pytest
@@ -288,3 +289,207 @@ class TestCleanupEmptyParent:
             move_to_trash(str(comic))
 
         assert data_dir.exists()
+
+
+class TestManifest:
+
+    def test_move_to_trash_records_manifest(self, app, trash_dir, tmp_path):
+        """Trashing a file creates a manifest entry with original_path."""
+        source = tmp_path / "comic.cbz"
+        source.write_bytes(b"data")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash, MANIFEST_FILENAME
+            move_to_trash(str(source))
+
+            manifest_path = trash_dir / MANIFEST_FILENAME
+            assert manifest_path.exists()
+            manifest = json.loads(manifest_path.read_text())
+            assert "comic.cbz" in manifest
+            assert manifest["comic.cbz"]["original_path"] == str(source)
+            assert "deleted_at" in manifest["comic.cbz"]
+
+    def test_collision_records_suffixed_name(self, app, trash_dir, tmp_path):
+        """Collision-suffixed filenames are keyed correctly in manifest."""
+        existing = trash_dir / "comic.cbz"
+        existing.write_bytes(b"old")
+
+        source = tmp_path / "comic.cbz"
+        source.write_bytes(b"new")
+
+        with app.app_context():
+            from helpers.trash import move_to_trash, _load_manifest
+            move_to_trash(str(source))
+
+            manifest = _load_manifest()
+            # Should have the collision-suffixed entry, not "comic.cbz"
+            assert len(manifest) == 1
+            key = list(manifest.keys())[0]
+            assert key.startswith("comic_")
+            assert key.endswith(".cbz")
+            assert manifest[key]["original_path"] == str(source)
+
+    def test_empty_trash_clears_manifest(self, app, trash_dir):
+        """Emptying trash removes the manifest file."""
+        (trash_dir / "a.cbz").write_bytes(b"data")
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({"a.cbz": {"original_path": "/data/a.cbz", "deleted_at": 1000}}))
+
+        with app.app_context():
+            from helpers.trash import empty_trash, MANIFEST_FILENAME
+            empty_trash()
+
+            assert not manifest_path.exists()
+
+    def test_permanently_delete_removes_entry(self, app, trash_dir):
+        """Permanently deleting one item removes only its manifest entry."""
+        (trash_dir / "a.cbz").write_bytes(b"data")
+        (trash_dir / "b.cbz").write_bytes(b"data")
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({
+            "a.cbz": {"original_path": "/data/a.cbz", "deleted_at": 1000},
+            "b.cbz": {"original_path": "/data/b.cbz", "deleted_at": 1001},
+        }))
+
+        with app.app_context():
+            from helpers.trash import permanently_delete_from_trash, _load_manifest
+            permanently_delete_from_trash("a.cbz")
+
+            manifest = _load_manifest()
+            assert "a.cbz" not in manifest
+            assert "b.cbz" in manifest
+
+    def test_load_manifest_handles_corruption(self, app, trash_dir):
+        """Corrupt manifest returns empty dict without crashing."""
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text("NOT VALID JSON {{{{")
+
+        with app.app_context():
+            from helpers.trash import _load_manifest
+            manifest = _load_manifest()
+            assert manifest == {}
+
+    def test_manifest_excluded_from_contents(self, app, trash_dir):
+        """Manifest file is not listed in get_trash_contents()."""
+        (trash_dir / "comic.cbz").write_bytes(b"data")
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({"comic.cbz": {"original_path": "/data/comic.cbz", "deleted_at": 1000}}))
+
+        with app.app_context():
+            from helpers.trash import get_trash_contents
+            contents = get_trash_contents()
+            names = [item["name"] for item in contents]
+            assert "trash_manifest.json" not in names
+            assert "comic.cbz" in names
+
+
+class TestRestoreFromTrash:
+
+    def test_restore_file(self, app, trash_dir, tmp_path):
+        """File is moved back to original location and manifest entry removed."""
+        original_dir = tmp_path / "data" / "DC" / "Batman"
+        original_dir.mkdir(parents=True)
+        original_path = str(original_dir / "issue1.cbz")
+
+        trashed = trash_dir / "issue1.cbz"
+        trashed.write_bytes(b"comic data")
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({
+            "issue1.cbz": {"original_path": original_path, "deleted_at": 1000}
+        }))
+
+        with app.app_context():
+            from helpers.trash import restore_from_trash, _load_manifest
+            result = restore_from_trash("issue1.cbz")
+
+        assert result["success"] is True
+        assert result["restored_path"] == original_path
+        assert os.path.exists(original_path)
+        assert not trashed.exists()
+
+        with app.app_context():
+            manifest = _load_manifest()
+            assert "issue1.cbz" not in manifest
+
+    def test_restore_recreates_parent_dirs(self, app, trash_dir, tmp_path):
+        """Parent directories are recreated if they were cleaned up."""
+        original_path = str(tmp_path / "data" / "DC" / "Batman" / "issue1.cbz")
+
+        trashed = trash_dir / "issue1.cbz"
+        trashed.write_bytes(b"comic data")
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({
+            "issue1.cbz": {"original_path": original_path, "deleted_at": 1000}
+        }))
+
+        with app.app_context():
+            from helpers.trash import restore_from_trash
+            result = restore_from_trash("issue1.cbz")
+
+        assert result["success"] is True
+        assert os.path.exists(original_path)
+
+    def test_restore_conflict(self, app, trash_dir, tmp_path):
+        """Returns conflict error when original path is occupied."""
+        original_dir = tmp_path / "data" / "DC"
+        original_dir.mkdir(parents=True)
+        original_path = str(original_dir / "issue1.cbz")
+        (original_dir / "issue1.cbz").write_bytes(b"new version")
+
+        trashed = trash_dir / "issue1.cbz"
+        trashed.write_bytes(b"old version")
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({
+            "issue1.cbz": {"original_path": original_path, "deleted_at": 1000}
+        }))
+
+        with app.app_context():
+            from helpers.trash import restore_from_trash
+            result = restore_from_trash("issue1.cbz")
+
+        assert result["success"] is False
+        assert result.get("conflict") is True
+        assert trashed.exists()  # Not moved
+
+    def test_restore_no_manifest_entry(self, app, trash_dir):
+        """Returns no_manifest error for untracked items."""
+        trashed = trash_dir / "orphan.cbz"
+        trashed.write_bytes(b"data")
+
+        with app.app_context():
+            from helpers.trash import restore_from_trash
+            result = restore_from_trash("orphan.cbz")
+
+        assert result["success"] is False
+        assert result.get("no_manifest") is True
+        assert trashed.exists()  # Not touched
+
+    def test_restore_not_found(self, app, trash_dir):
+        """Returns error for missing item."""
+        with app.app_context():
+            from helpers.trash import restore_from_trash
+            result = restore_from_trash("nope.cbz")
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_restore_directory(self, app, trash_dir, tmp_path):
+        """Directories can be restored too."""
+        original_path = str(tmp_path / "data" / "DC" / "Batman")
+
+        trashed_dir = trash_dir / "Batman"
+        trashed_dir.mkdir()
+        (trashed_dir / "issue1.cbz").write_bytes(b"data")
+
+        manifest_path = trash_dir / "trash_manifest.json"
+        manifest_path.write_text(json.dumps({
+            "Batman": {"original_path": original_path, "deleted_at": 1000}
+        }))
+
+        with app.app_context():
+            from helpers.trash import restore_from_trash
+            result = restore_from_trash("Batman")
+
+        assert result["success"] is True
+        assert os.path.isdir(original_path)
+        assert os.path.exists(os.path.join(original_path, "issue1.cbz"))


### PR DESCRIPTION
## 📝 Description
Introduce a trash manifest (trash_manifest.json) to track original paths and deletion timestamps so trashed items can be restored. helpers/trash.py: add manifest load/save, atomic writes, exclude manifest from size/listing, record entries on move_to_trash, update eviction/permanent-delete/empty_trash to keep manifest in sync, and implement restore_from_trash with conflict and path-safety checks. routes/files.py: include manifest data in /api/trash/list and add /api/trash/restore endpoint that triggers index update after successful restore. static/js/files.js: show original path in trash UI, add restore button/handler and path truncation helper. Tests updated/added to verify manifest behavior and restore scenarios.

  helpers/trash.py — Manifest infrastructure:
  - _get_manifest_path(), _load_manifest(), _save_manifest(), get_trash_manifest() for atomic JSON manifest I/O
  - move_to_trash() now records {original_path, deleted_at} in the manifest
  - _evict_oldest(), empty_trash(), permanently_delete_from_trash() clean up manifest entries
  - get_trash_contents(), get_trash_size(), empty_trash() filter out trash_manifest.json
  - New restore_from_trash(item_name) — moves file back, recreates parent dirs, handles conflicts and missing manifest entries

  routes/files.py:
  - trash_list() enriches each item with original_path from manifest
  - New POST /api/trash/restore endpoint — calls restore_from_trash(), updates file index, returns 409 on conflict

  static/js/files.js:
  - Restore button (green, bi-arrow-counterclockwise) on each trash item, disabled if no manifest entry
  - Truncated original path shown as hint text
  - restoreTrashItem() and truncatePath() helper functions

  Tests:
  - 7 new unit tests (TestManifest, TestRestoreFromTrash) covering manifest recording, collision keys, cleanup, corruption handling, restore with
  parent recreation, conflicts, and missing entries
  - 4 new route tests (TestTrashRestore) covering success, missing name, conflict, and no-manifest cases
  - Updated existing TestTrashList to verify original_path enrichment
  - Fixed existing test_collision_handling to filter manifest file from directory listing

Closes #267 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
## 🧪 Testing Performed
- [ ] Manual test in `dev` container
- [x] Linting/Unit tests pass