### PR TITLE
Server-side pagination for All Books

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -2573,6 +2573,186 @@ def get_files_missing_comicinfo(path=None):
         return []
 
 
+def get_files_recursive_paged(
+    path_prefix,
+    offset=0,
+    limit=21,
+    letter=None,
+    search=None,
+    max_retries=3,
+):
+    """
+    Return a paged slice of file rows under path_prefix from file_index, plus
+    the total count and the set of distinct first-letter buckets present
+    under that path/search context.
+
+    Used by /api/browse-recursive to serve the "All Books" view with
+    server-side pagination, search, and letter filtering — replacing the old
+    full-tree os.walk that timed out behind Cloudflare on large libraries.
+
+    Args:
+        path_prefix: Directory path. Matches files whose path starts with
+            ``path_prefix + os.sep`` so '/data/Marvel' won't accidentally
+            match '/data/MarvelOther'.
+        offset: Pagination offset (clamped to >= 0).
+        limit: Page size (clamped to 1-500).
+        letter: Optional first-letter filter — 'A'-'Z' or '#' (non-alpha bucket).
+        search: Optional case-insensitive substring against name and ci_series.
+            LIKE wildcards in the input are escaped.
+        max_retries: Retries on SQLite "database is locked" errors.
+
+    Returns:
+        Tuple ``(rows, total, letters)``:
+            * ``rows`` — list of dicts for the current page, each containing
+              name, path, size, modified_at, has_thumbnail, has_comicinfo,
+              ci_series, ci_number, ci_year.
+            * ``total`` — count of rows matching path/letter/search.
+            * ``letters`` — sorted list of first-letter buckets present under
+              path/search (NOT filtered by letter, so the filter bar shows
+              all available buckets). Non-alpha letters collapse to '#'.
+    """
+    offset = max(0, int(offset or 0))
+    limit = max(1, min(500, int(limit or 21)))
+
+    normalized = path_prefix.rstrip("/\\")
+    like_path = normalized + os.sep + "%"
+
+    # Base WHERE shared by all three queries
+    base_clauses = ["type = 'file'", "path LIKE ?"]
+    base_params = [like_path]
+
+    # Search filter — escape LIKE wildcards in user input
+    if search and search.strip():
+        s = search.strip().lower()
+        s = s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        s_pattern = f"%{s}%"
+        base_clauses.append(
+            "(LOWER(name) LIKE ? ESCAPE '\\' "
+            "OR LOWER(IFNULL(ci_series, '')) LIKE ? ESCAPE '\\')"
+        )
+        base_params.extend([s_pattern, s_pattern])
+
+    # Letters query uses base WHERE (no letter filter) so the filter bar
+    # always shows all available buckets.
+    letters_where_sql = " AND ".join(base_clauses)
+    letters_params = list(base_params)
+
+    # Page + count queries add the letter filter (if any)
+    paged_clauses = list(base_clauses)
+    paged_params = list(base_params)
+    if letter:
+        if letter == "#":
+            paged_clauses.append(
+                "SUBSTR(COALESCE(NULLIF(TRIM(ci_series), ''), name), 1, 1) "
+                "GLOB '[^A-Za-z]'"
+            )
+        elif len(letter) == 1 and letter.isalpha():
+            paged_clauses.append(
+                "UPPER(SUBSTR(COALESCE(NULLIF(TRIM(ci_series), ''), name), 1, 1)) = ?"
+            )
+            paged_params.append(letter.upper())
+    paged_where_sql = " AND ".join(paged_clauses)
+
+    order_sql = (
+        "ORDER BY "
+        "COALESCE(NULLIF(LOWER(TRIM(ci_series)), ''), LOWER(name)) ASC, "
+        "COALESCE(CAST(NULLIF(ci_year, '') AS INTEGER), 0) ASC, "
+        "COALESCE(CAST(NULLIF(ci_number, '') AS REAL), 0) ASC, "
+        "LOWER(name) ASC"
+    )
+
+    for attempt in range(max_retries):
+        conn = None
+        try:
+            conn = get_db_connection()
+            if not conn:
+                app_logger.error(
+                    "Could not get database connection for recursive paged listing"
+                )
+                return [], 0, []
+
+            c = conn.cursor()
+
+            # 1) Page slice
+            c.execute(
+                f"""
+                SELECT name, path, size, modified_at, has_thumbnail, has_comicinfo,
+                       ci_series, ci_number, ci_year
+                FROM file_index
+                WHERE {paged_where_sql}
+                {order_sql}
+                LIMIT ? OFFSET ?
+                """,
+                (*paged_params, limit, offset),
+            )
+            rows = [dict(r) for r in c.fetchall()]
+
+            # 2) Total count for the same filtered set
+            c.execute(
+                f"SELECT COUNT(*) FROM file_index WHERE {paged_where_sql}",
+                paged_params,
+            )
+            total = c.fetchone()[0]
+
+            # 3) Distinct first letters across path/search (no letter filter)
+            c.execute(
+                f"""
+                SELECT DISTINCT
+                    UPPER(SUBSTR(COALESCE(NULLIF(TRIM(ci_series), ''), name), 1, 1))
+                    AS letter
+                FROM file_index
+                WHERE {letters_where_sql}
+                """,
+                letters_params,
+            )
+            buckets = set()
+            for row in c.fetchall():
+                ch = row[0]
+                if not ch:
+                    continue
+                if ch.isalpha():
+                    buckets.add(ch.upper())
+                else:
+                    buckets.add("#")
+            # '#' last
+            letters = sorted(buckets, key=lambda x: (x == "#", x))
+
+            conn.close()
+            return rows, total, letters
+
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e).lower() and attempt < max_retries - 1:
+                app_logger.warning(
+                    f"Database locked, retrying recursive paged listing "
+                    f"({attempt + 1}/{max_retries})..."
+                )
+                if conn:
+                    conn.close()
+                time.sleep(0.5 * (attempt + 1))
+                continue
+            app_logger.error(
+                f"Failed to get paged recursive files for {path_prefix}: {e}"
+            )
+            if conn:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            return [], 0, []
+        except Exception as e:
+            app_logger.error(
+                f"Failed to get paged recursive files for {path_prefix}: {e}"
+            )
+            if conn:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            return [], 0, []
+
+    return [], 0, []
+
+
 def set_has_comicinfo(file_path, value=1):
     """Set has_comicinfo flag for a file by path. Used after writing ComicInfo.xml."""
     try:

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -26,7 +26,7 @@ from helpers.library import get_library_roots, get_default_library, is_valid_lib
 from core.database import (
     get_directory_children, get_path_counts_batch, get_recent_files,
     invalidate_browse_cache, add_file_index_entry, delete_file_index_entry,
-    search_file_index, get_user_preference
+    search_file_index, get_user_preference, get_files_recursive_paged
 )
 
 collection_bp = Blueprint('collection', __name__)
@@ -615,87 +615,116 @@ def api_clear_browse_cache():
 
 @collection_bp.route('/api/browse-recursive')
 def api_browse_recursive():
-    """Get all files recursively from a directory and subdirectories."""
+    """
+    Paginated recursive file listing for the "All Books" view.
+
+    Query params:
+        path:   Directory path to list under (defaults to DATA_DIR).
+        offset: Pagination offset (default 0, clamped >= 0).
+        limit:  Page size (default 21, clamped 1-500).
+        letter: Optional first-letter filter ('A'-'Z' or '#').
+        search: Optional case-insensitive substring against name/ci_series.
+
+    Backed by the file_index SQLite table (kept in sync by file_watcher /
+    metadata_scanner) with sort/filter/paginate pushed into SQL — replaces
+    the previous os.walk-per-request implementation that timed out behind
+    Cloudflare on large libraries.
+
+    Response:
+        {
+          current_path, files, total, offset, limit, letters
+        }
+    """
     from app import DATA_DIR
 
-    path = request.args.get('path', '')
+    request_start = time.time()
 
-    if not path:
-        full_path = DATA_DIR
-    else:
-        full_path = path
+    path = request.args.get('path') or DATA_DIR
 
-    if not os.path.exists(full_path) or not os.path.isdir(full_path):
+    # Path-traversal guard: only paths within DATA_DIR are allowed.
+    abs_path = os.path.abspath(path)
+    abs_data = os.path.abspath(DATA_DIR)
+    try:
+        common = os.path.commonpath([abs_path, abs_data])
+    except ValueError:
+        return jsonify({"error": "Invalid path"}), 400
+    if common != abs_data:
+        return jsonify({"error": "Invalid path"}), 400
+    if not os.path.isdir(abs_path):
         return jsonify({"error": "Invalid path"}), 400
 
-    excluded_extensions = {".png", ".jpg", ".jpeg", ".gif", ".html", ".css", ".ds_store", ".json", ".db", ".xml"}
+    try:
+        offset = max(0, int(request.args.get('offset', 0)))
+    except (TypeError, ValueError):
+        offset = 0
+    try:
+        limit = max(1, min(500, int(request.args.get('limit', 21))))
+    except (TypeError, ValueError):
+        limit = 21
+
+    letter = request.args.get('letter') or None
+    if letter:
+        letter = letter.strip()
+        if not (letter == '#' or (len(letter) == 1 and letter.isalpha())):
+            letter = None
+
+    search = request.args.get('search') or None
+
+    rows, total, letters = get_files_recursive_paged(
+        path, offset=offset, limit=limit, letter=letter, search=search
+    )
+
+    excluded_extensions = {".png", ".jpg", ".jpeg", ".gif", ".html", ".css",
+                           ".ds_store", ".json", ".db", ".xml"}
     excluded_files = {"cvinfo"}
     allowed_files = {"missing.txt"}
 
     files = []
+    for row in rows:
+        filename = row['name']
+        fn_lower = filename.lower()
 
-    for root, dirs, filenames in os.walk(full_path):
-        for filename in filenames:
-            if filename.lower() in excluded_files:
-                continue
+        if fn_lower in excluded_files:
+            continue
+        if filename.startswith(('.', '-', '_')):
+            continue
+        _, ext = os.path.splitext(fn_lower)
+        if fn_lower not in allowed_files and ext in excluded_extensions:
+            continue
 
-            _, ext = os.path.splitext(filename.lower())
+        file_path = row['path']
+        rel_path = os.path.relpath(file_path, DATA_DIR)
 
-            if filename.lower() not in allowed_files and ext in excluded_extensions:
-                continue
-            if filename.startswith(('.', '-', '_')):
-                continue
+        file_info = {
+            "name": filename,
+            "path": rel_path,
+            "size": row['size'] or 0,
+            "modified": row['modified_at'],
+            "type": "file",
+            "has_comicinfo": row['has_comicinfo'],
+        }
 
-            file_path = os.path.join(root, filename)
+        if fn_lower.endswith(('.cbz', '.cbr', '.zip')):
+            file_info['has_thumbnail'] = True
+            file_info['thumbnail_url'] = url_for('get_thumbnail', path=file_path)
+        else:
+            file_info['has_thumbnail'] = bool(row['has_thumbnail']) if row['has_thumbnail'] else False
 
-            rel_path = os.path.relpath(file_path, DATA_DIR)
+        files.append(file_info)
 
-            try:
-                stat_info = os.stat(file_path)
-                file_info = {
-                    "name": filename,
-                    "path": rel_path,
-                    "size": stat_info.st_size,
-                    "modified": stat_info.st_mtime,
-                    "type": "file"
-                }
-
-                if filename.lower().endswith(('.cbz', '.cbr', '.zip')):
-                    file_info['has_thumbnail'] = True
-                    file_info['thumbnail_url'] = url_for('get_thumbnail', path=file_path)
-                else:
-                    file_info['has_thumbnail'] = False
-
-                files.append(file_info)
-            except Exception as e:
-                app_logger.warning(f"Error processing file {file_path}: {e}")
-                continue
-
-    # Sort files by series name, year, then issue number
-    def natural_sort_key(item):
-        filename = item['name']
-
-        match = re.match(r'^(.+?)\s+#?(\d+)\s*\((\d{4})\)', filename, re.IGNORECASE)
-        if match:
-            series_name = match.group(1).strip().lower()
-            issue_number = int(match.group(2))
-            year = int(match.group(3))
-            return (series_name, year, issue_number, filename.lower())
-
-        match_no_year = re.match(r'^(.+?)\s+#?(\d+)', filename, re.IGNORECASE)
-        if match_no_year:
-            series_name = match_no_year.group(1).strip().lower()
-            issue_number = int(match_no_year.group(2))
-            return (series_name, 0, issue_number, filename.lower())
-
-        return (filename.lower(), 0, 0, filename.lower())
-
-    files.sort(key=natural_sort_key)
+    elapsed = time.time() - request_start
+    app_logger.info(
+        f"/api/browse-recursive returned {len(files)} of {total} files "
+        f"for {path} (offset={offset}, limit={limit}) in {elapsed:.3f}s"
+    )
 
     return jsonify({
         "current_path": path,
         "files": files,
-        "total": len(files)
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "letters": letters,
     })
 
 

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -53,6 +53,10 @@ let isAllBooksMode = false;
 let allBooksData = null;
 let folderViewPath = '';
 let backgroundLoadingActive = false; // Track if background loading is happening
+let allBooksTotal = 0;          // Total filtered count returned by the server
+let allBooksLetters = [];       // Available letter buckets returned by the server
+let allBooksAbort = null;       // AbortController for the current paged fetch
+let gridSearchDebounce = null;  // Debounce timer for the search input in all-books mode
 
 // Recently Added mode state
 let isRecentlyAddedMode = false;
@@ -82,6 +86,13 @@ function onGridSearch(value) {
     gridSearchRaw = value;  // Keep original for display
     gridSearchTerm = value.trim().toLowerCase();  // Normalize for filtering
     currentPage = 1; // Reset to first page when searching
+
+    if (isAllBooksMode) {
+        // Debounce — search rounds-trip to the server
+        if (gridSearchDebounce) clearTimeout(gridSearchDebounce);
+        gridSearchDebounce = setTimeout(() => fetchAllBooksPage(), 300);
+        return;
+    }
     renderPage();
     loadVisiblePageData();
 }
@@ -573,91 +584,101 @@ function updateViewButtons(path) {
 }
 
 /**
- * Load all books recursively from current directory
+ * Enter All Books mode at the current directory.
+ * Server-side pagination — every page click, search keystroke, letter
+ * filter, and per-page change re-fetches a small slice from the API.
+ *
+ * @param {boolean} preservePage - If true, keep currentPage/currentFilter/search.
  */
 async function loadAllBooks(preservePage = false) {
     if (isLoading) return;
 
-    setLoading(true);
     folderViewPath = currentPath;  // Save current path to return to
     isAllBooksMode = true;
 
-    try {
-        // Start fetching all data
-        const fetchPromise = fetch(`/api/browse-recursive?path=${encodeURIComponent(currentPath)}`);
+    if (!preservePage) {
+        currentPage = 1;
+        currentFilter = 'all';
+        gridSearchTerm = '';
+        gridSearchRaw = '';
+    }
 
-        // Get the response and start reading
-        const response = await fetchPromise;
+    updateMainViewButtons();
+    updateViewButtons(currentPath);
+
+    await fetchAllBooksPage();
+}
+
+/**
+ * Fetch one page of the All Books listing from the server.
+ * Uses currentPath, currentPage, itemsPerPage, currentFilter, gridSearchTerm
+ * as inputs. Cancels any in-flight previous fetch.
+ */
+async function fetchAllBooksPage() {
+    if (!isAllBooksMode) return;
+
+    const offset = Math.max(0, (currentPage - 1) * itemsPerPage);
+    const params = new URLSearchParams({
+        path: currentPath || '',
+        offset: String(offset),
+        limit: String(itemsPerPage),
+    });
+    if (currentFilter && currentFilter !== 'all') {
+        params.set('letter', currentFilter);
+    }
+    if (gridSearchTerm) {
+        params.set('search', gridSearchTerm);
+    }
+
+    // Cancel any in-flight previous fetch (rapid clicks)
+    if (allBooksAbort) {
+        try { allBooksAbort.abort(); } catch (_) { /* ignore */ }
+    }
+    const ctrl = new AbortController();
+    allBooksAbort = ctrl;
+    const timeoutId = setTimeout(() => ctrl.abort(), 30000);
+
+    setLoading(true);
+    try {
+        const response = await fetch(`/api/browse-recursive?${params.toString()}`, { signal: ctrl.signal });
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
 
         const data = await response.json();
         allBooksData = data;
+        allBooksTotal = data.total || 0;
+        allBooksLetters = Array.isArray(data.letters) ? data.letters : [];
 
-        // Map backend snake_case to frontend camelCase for thumbnails
-        // In All Books mode, paths are relative to DATA_DIR, so prepend /data/
+        // Map backend snake_case to frontend camelCase, prepending /data/ for paths
+        // (server returns paths relative to DATA_DIR for the All Books view).
         const hiddenFiles = new Set(['cvinfo']);
-        const allFiles = data.files
+        allItems = (data.files || [])
             .filter(file => !hiddenFiles.has(file.name.toLowerCase()))
             .map(file => ({
                 ...file,
-                // Ensure path starts with /data/ for consistency with folder view
                 path: file.path.startsWith('/') ? file.path : `/data/${file.path}`,
                 hasThumbnail: file.has_thumbnail,
                 thumbnailUrl: file.thumbnail_url,
-                hasComicinfo: file.has_comicinfo
+                hasComicinfo: file.has_comicinfo,
             }));
 
-        const totalFiles = allFiles.length;
-
-        // If there are many files, show initial batch immediately
-        if (totalFiles > 500) {
-            // Get initial batch size (min 20, max 500, based on itemsPerPage)
-            const initialBatchSize = Math.max(20, Math.min(itemsPerPage, 500));
-
-            // Show initial batch immediately
-            allItems = allFiles.slice(0, initialBatchSize);
-            if (!preservePage) {
-                currentPage = 1;
-                currentFilter = 'all';
-                gridSearchTerm = '';
-                gridSearchRaw = '';
-            }
-
-            updateMainViewButtons();
-            updateViewButtons(currentPath);
-            renderPage();
-            setLoading(false);
-
-            // Show loading indicator for remaining items
-            showLoadingMoreIndicator(initialBatchSize, totalFiles);
-
-            // Load remaining files in batches
-            await loadRemainingBooksInBackground(allFiles, initialBatchSize);
-        } else {
-            // For smaller collections, load everything at once
-            allItems = allFiles;
-            if (!preservePage) {
-                currentPage = 1;
-                currentFilter = 'all';
-                gridSearchTerm = '';
-                gridSearchRaw = '';
-            }
-
-            updateMainViewButtons();
-            updateViewButtons(currentPath);
-            renderPage();
-            setLoading(false);
-        }
-
+        renderPage();
     } catch (error) {
+        if (error && error.name === 'AbortError') {
+            // Superseded by a newer fetch (or timeout) — silent
+            return;
+        }
         console.error('Error loading all books:', error);
         CLU.showError('Failed to load all books: ' + error.message);
-        // Reset state on error
         isAllBooksMode = false;
         allBooksData = null;
+        allBooksTotal = 0;
+        allBooksLetters = [];
         updateViewButtons(currentPath);
+    } finally {
+        clearTimeout(timeoutId);
+        if (allBooksAbort === ctrl) allBooksAbort = null;
         setLoading(false);
     }
 }
@@ -1061,6 +1082,14 @@ async function loadContinueReading(preservePage = false) {
  * Render the current page of items.
  */
 function renderPage() {
+    if (isAllBooksMode) {
+        // Server has already filtered, sorted, and sliced — render directly.
+        renderGrid(allItems);
+        renderPagination(allBooksTotal);
+        updateFilterBar();
+        return;
+    }
+
     const filteredItems = getFilteredItems();
 
     const startIndex = (currentPage - 1) * itemsPerPage;
@@ -2150,6 +2179,15 @@ function renderPagination(totalItems) {
  * @param {number} page - The page number to switch to.
  */
 function changePage(page) {
+    if (isAllBooksMode) {
+        const totalPages = Math.max(1, Math.ceil((allBooksTotal || 0) / itemsPerPage));
+        if (page < 1 || page > totalPages) return;
+        currentPage = page;
+        fetchAllBooksPage();
+        document.getElementById('file-grid').scrollIntoView({ behavior: 'smooth' });
+        return;
+    }
+
     const filteredItems = getFilteredItems();
     const totalPages = Math.ceil(filteredItems.length / itemsPerPage);
     if (page < 1 || page > totalPages) return;
@@ -2177,6 +2215,10 @@ function jumpToPage(page) {
 function changeItemsPerPage(value) {
     itemsPerPage = parseInt(value);
     currentPage = 1;
+    if (isAllBooksMode) {
+        fetchAllBooksPage();
+        return;
+    }
     renderPage();
     loadVisiblePageData();
 }
@@ -2191,18 +2233,29 @@ function updateFilterBar() {
     const btnGroup = filterContainer.querySelector('.btn-group');
     if (!btnGroup) return;
 
-    // Only filter based on directories and files
     let availableLetters = new Set();
     let hasNonAlpha = false;
 
-    allItems.forEach(item => {
-        const firstChar = item.name.charAt(0).toUpperCase();
-        if (firstChar >= 'A' && firstChar <= 'Z') {
-            availableLetters.add(firstChar);
-        } else {
-            hasNonAlpha = true;
-        }
-    });
+    if (isAllBooksMode) {
+        // Letters come from the server (covers the full filtered universe,
+        // not just the current page).
+        (allBooksLetters || []).forEach(letter => {
+            if (letter === '#') {
+                hasNonAlpha = true;
+            } else if (letter && letter.length === 1) {
+                availableLetters.add(letter.toUpperCase());
+            }
+        });
+    } else {
+        allItems.forEach(item => {
+            const firstChar = item.name.charAt(0).toUpperCase();
+            if (firstChar >= 'A' && firstChar <= 'Z') {
+                availableLetters.add(firstChar);
+            } else {
+                hasNonAlpha = true;
+            }
+        });
+    }
 
     // Build filter buttons
     let buttonsHtml = '';
@@ -2222,7 +2275,8 @@ function updateFilterBar() {
     btnGroup.innerHTML = buttonsHtml;
 
     // Show the filter bar if we have items
-    if (allItems.length > 0) {
+    const totalItems = isAllBooksMode ? (allBooksTotal || 0) : allItems.length;
+    if (totalItems > 0 || availableLetters.size > 0 || hasNonAlpha) {
         filterContainer.style.display = 'block';
     } else {
         filterContainer.style.display = 'none';
@@ -2234,7 +2288,7 @@ function updateFilterBar() {
         // Check if search input already exists
         let existingInput = document.getElementById('gridSearch');
 
-        if (allItems.length > 25) {
+        if (totalItems > 25) {
             // Only create input if it doesn't exist
             if (!existingInput) {
                 searchRow.innerHTML = `<input type="text" id="gridSearch" class="form-control form-control-sm" placeholder="Type to filter..." oninput="onGridSearch(this.value)">`;
@@ -2284,6 +2338,10 @@ function filterItems(letter) {
 
     // Reset to first page and re-render
     currentPage = 1;
+    if (isAllBooksMode) {
+        fetchAllBooksPage();
+        return;
+    }
     renderPage();
     loadVisiblePageData();
 }

--- a/tests/routes/test_collection_routes.py
+++ b/tests/routes/test_collection_routes.py
@@ -285,3 +285,298 @@ class TestApiOnTheStack:
         resp = client.get("/api/on-the-stack?limit=5")
         assert resp.status_code == 200
         mock_items.assert_called_once_with(limit=5)
+
+
+# =============================================================================
+# /api/browse-recursive (All Books) — server-side pagination
+# =============================================================================
+
+def _seed_file_index(data_dir, files):
+    """
+    Seed file_index with a list of (filename, ci_series, ci_year[, ci_number])
+    tuples under ``data_dir``.  Returns the list of full paths inserted.
+
+    Uses a fresh connection for each ci_* UPDATE so we don't hold a write
+    transaction across multiple add_file_index_entry calls (which would
+    otherwise produce SQLite "database is locked" errors).
+    """
+    from core.database import add_file_index_entry, get_db_connection
+
+    paths = []
+    for entry in files:
+        if len(entry) == 3:
+            name, ci_series, ci_year = entry
+            ci_number = None
+        else:
+            name, ci_series, ci_year, ci_number = entry
+        full_path = os.path.join(data_dir, name)
+        ok = add_file_index_entry(
+            name=name,
+            path=full_path,
+            entry_type="file",
+            size=1234,
+            parent=data_dir,
+            modified_at=1_700_000_000.0,
+        )
+        assert ok, f"failed to seed {full_path}"
+        if ci_series is not None or ci_year is not None or ci_number is not None:
+            conn = get_db_connection()
+            try:
+                conn.execute(
+                    "UPDATE file_index SET ci_series=?, ci_year=?, ci_number=? WHERE path=?",
+                    (ci_series, ci_year, ci_number, full_path),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        paths.append(full_path)
+    return paths
+
+
+class TestBrowseRecursivePagination:
+    """Server-side paginated /api/browse-recursive."""
+
+    def test_default_response_shape(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Avengers 001 (2018).cbz", "Avengers", "2018", "1"),
+        ])
+
+        resp = client.get(f"/api/browse-recursive?path={data_dir}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Required envelope keys
+        for key in ("current_path", "files", "total", "offset", "limit", "letters"):
+            assert key in data, f"missing {key}"
+        assert data["total"] == 1
+        assert data["offset"] == 0
+        assert data["limit"] == 21
+        assert len(data["files"]) == 1
+
+        f = data["files"][0]
+        assert f["name"] == "Avengers 001 (2018).cbz"
+        assert f["size"] == 1234
+        assert f["has_thumbnail"] is True
+        assert "thumbnail_url" in f
+        assert "has_comicinfo" in f
+
+    def test_offset_and_limit(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        rows = [(f"Series{i:02d} 001 (2020).cbz", f"Series {i:02d}", "2020", "1")
+                for i in range(25)]
+        _seed_file_index(data_dir, rows)
+
+        resp1 = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=0&limit=10"
+        )
+        resp2 = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=10&limit=10"
+        )
+        resp3 = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=20&limit=10"
+        )
+
+        for r in (resp1, resp2, resp3):
+            assert r.status_code == 200
+            assert r.get_json()["total"] == 25
+
+        names1 = [f["name"] for f in resp1.get_json()["files"]]
+        names2 = [f["name"] for f in resp2.get_json()["files"]]
+        names3 = [f["name"] for f in resp3.get_json()["files"]]
+
+        assert len(names1) == 10
+        assert len(names2) == 10
+        assert len(names3) == 5  # last partial page
+
+        # No overlap, full coverage when concatenated
+        assert set(names1).isdisjoint(set(names2))
+        assert set(names2).isdisjoint(set(names3))
+        assert len(set(names1 + names2 + names3)) == 25
+
+    def test_sort_is_stable_across_pages(self, client, app, db_connection):
+        """Concat of paged results must equal the full sorted list."""
+        data_dir = app.config["DATA_DIR"]
+        rows = [
+            ("Zatanna 001.cbz", "Zatanna", "2010", "1"),
+            ("Avengers 010.cbz", "Avengers", "2018", "10"),
+            ("Avengers 002.cbz", "Avengers", "2018", "2"),
+            ("Avengers 001.cbz", "Avengers", "2018", "1"),
+            ("Batman 003.cbz", "Batman", "2016", "3"),
+            ("Batman 001.cbz", "Batman", "2016", "1"),
+        ]
+        _seed_file_index(data_dir, rows)
+
+        # Full unpaginated query for the canonical sorted order
+        full = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=0&limit=100"
+        ).get_json()
+        full_names = [f["name"] for f in full["files"]]
+
+        page1 = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=0&limit=2"
+        ).get_json()["files"]
+        page2 = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=2&limit=2"
+        ).get_json()["files"]
+        page3 = client.get(
+            f"/api/browse-recursive?path={data_dir}&offset=4&limit=2"
+        ).get_json()["files"]
+
+        concat = [f["name"] for f in (page1 + page2 + page3)]
+        assert concat == full_names
+        # Sanity: Avengers 001 < 002 < 010 (CAST AS REAL beats lexicographic)
+        avengers_idx = [i for i, n in enumerate(full_names) if n.startswith("Avengers")]
+        assert full_names[avengers_idx[0]] == "Avengers 001.cbz"
+        assert full_names[avengers_idx[1]] == "Avengers 002.cbz"
+        assert full_names[avengers_idx[2]] == "Avengers 010.cbz"
+
+    def test_letter_filter_alpha(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Avengers 001.cbz", "Avengers", "2018", "1"),
+            ("Batman 001.cbz", "Batman", "2016", "1"),
+            ("Batman 002.cbz", "Batman", "2016", "2"),
+            ("Catwoman 001.cbz", "Catwoman", "2018", "1"),
+        ])
+
+        resp = client.get(f"/api/browse-recursive?path={data_dir}&letter=B")
+        data = resp.get_json()
+        assert data["total"] == 2
+        names = [f["name"] for f in data["files"]]
+        assert all("Batman" in n for n in names)
+        # Letters list reflects available buckets BEFORE the letter filter
+        assert "A" in data["letters"]
+        assert "B" in data["letters"]
+        assert "C" in data["letters"]
+
+    def test_letter_filter_hash_for_non_alpha(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Avengers 001.cbz", "Avengers", "2018", "1"),
+            # Non-alpha first char in ci_series → '#'
+            ("52 #001.cbz", "52", "2006", "1"),
+            ("100 Bullets 001.cbz", "100 Bullets", "1999", "1"),
+        ])
+
+        resp = client.get(f"/api/browse-recursive?path={data_dir}&letter=%23")
+        data = resp.get_json()
+        names = [f["name"] for f in data["files"]]
+        assert "52 #001.cbz" in names
+        assert "100 Bullets 001.cbz" in names
+        assert "Avengers 001.cbz" not in names
+        assert "#" in data["letters"]
+
+    def test_search_filter(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Batman 001.cbz", "Batman", "2016", "1"),
+            ("Detective Comics 001.cbz", "Detective Comics", "2016", "1"),
+            ("Superman 001.cbz", "Superman", "2018", "1"),
+        ])
+
+        # Match via name
+        resp = client.get(f"/api/browse-recursive?path={data_dir}&search=batman")
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["files"][0]["name"] == "Batman 001.cbz"
+
+        # Match via ci_series (file name doesn't contain 'detective' but ci_series does)
+        resp2 = client.get(
+            f"/api/browse-recursive?path={data_dir}&search=detective"
+        )
+        assert resp2.get_json()["total"] == 1
+
+    def test_search_escapes_like_wildcards(self, client, app, db_connection):
+        """A user typing '%' should NOT match everything."""
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Batman 001.cbz", "Batman", "2016", "1"),
+            ("Superman 001.cbz", "Superman", "2018", "1"),
+            ("50_off 001.cbz", "50% Off", "2020", "1"),
+        ])
+
+        resp = client.get(f"/api/browse-recursive?path={data_dir}&search=%25")
+        data = resp.get_json()
+        # Only files containing literal '%' in name or ci_series should match.
+        # ci_series='50% Off' contains '%', so that file matches; the others don't.
+        assert data["total"] == 1
+        assert data["files"][0]["name"] == "50_off 001.cbz"
+
+    def test_trailing_separator_collision_guard(self, client, app, db_connection):
+        """path=/data/Marvel must NOT match files under /data/MarvelOther."""
+        data_dir = app.config["DATA_DIR"]
+        marvel_dir = os.path.join(data_dir, "Marvel")
+        marvel_other_dir = os.path.join(data_dir, "MarvelOther")
+        os.makedirs(marvel_dir, exist_ok=True)
+        os.makedirs(marvel_other_dir, exist_ok=True)
+
+        from core.database import add_file_index_entry
+        add_file_index_entry(
+            name="X-Men 001.cbz",
+            path=os.path.join(marvel_dir, "X-Men 001.cbz"),
+            entry_type="file", size=100, parent=marvel_dir,
+            modified_at=1_700_000_000.0,
+        )
+        add_file_index_entry(
+            name="Knockoff 001.cbz",
+            path=os.path.join(marvel_other_dir, "Knockoff 001.cbz"),
+            entry_type="file", size=100, parent=marvel_other_dir,
+            modified_at=1_700_000_000.0,
+        )
+
+        resp = client.get(f"/api/browse-recursive?path={marvel_dir}")
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["files"][0]["name"] == "X-Men 001.cbz"
+
+    def test_path_traversal_rejected(self, client, app, tmp_path):
+        """A path outside DATA_DIR returns 400."""
+        outside = str(tmp_path)  # parent of data_dir, not within
+        resp = client.get(f"/api/browse-recursive?path={outside}")
+        assert resp.status_code == 400
+
+    def test_excludes_dot_dash_underscore_and_extensions(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Batman 001.cbz", "Batman", "2016", "1"),
+            (".hidden.cbz", None, None),
+            ("-leading-dash.cbz", None, None),
+            ("_leading-underscore.cbz", None, None),
+            ("cvinfo", None, None),
+            ("folder.jpg", None, None),
+            ("ComicInfo.xml", None, None),
+        ])
+
+        resp = client.get(f"/api/browse-recursive?path={data_dir}")
+        names = [f["name"] for f in resp.get_json()["files"]]
+        # Only the legit cbz survives the route's exclusion filter
+        assert names == ["Batman 001.cbz"]
+
+    def test_empty_index_returns_empty(self, client, app, db_connection):
+        data_dir = app.config["DATA_DIR"]
+        resp = client.get(f"/api/browse-recursive?path={data_dir}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 0
+        assert data["files"] == []
+        assert data["letters"] == []
+
+    def test_does_not_call_os_walk(self, client, app, db_connection):
+        """Performance regression guard: route must not fall back to os.walk."""
+        data_dir = app.config["DATA_DIR"]
+        _seed_file_index(data_dir, [
+            ("Batman 001.cbz", "Batman", "2016", "1"),
+        ])
+
+        with patch("routes.collection.os.walk",
+                   side_effect=RuntimeError("os.walk must not be called")):
+            resp = client.get(f"/api/browse-recursive?path={data_dir}")
+
+        assert resp.status_code == 200
+        assert resp.get_json()["total"] == 1
+
+    def test_invalid_path_returns_400(self, client, app):
+        data_dir = app.config["DATA_DIR"]
+        bogus = os.path.join(data_dir, "DoesNotExist")
+        resp = client.get(f"/api/browse-recursive?path={bogus}")
+        assert resp.status_code == 400


### PR DESCRIPTION
Add server-side, paged recursive listing for the "All Books" view backed by the file_index table.

- core/database.py: introduce get_files_recursive_paged(...) to return a paged slice, total count, and available first-letter buckets; supports search (with LIKE-escape), letter filters (A-Z and '#'), stable ordering, and retry on SQLITE locked errors.
- routes/collection.py: replace expensive os.walk listing with the new DB-backed /api/browse-recursive endpoint, add path traversal guard, sanitize/validate offset/limit/letter, map DB rows to API envelope, logging, and preserve existing exclusion rules.
- static/js/collection.js: implement All Books client flow to fetch paged results (debounced search, AbortController + timeout for concurrent requests), render server-provided pages, update pagination/filter UI to use server totals/letters, and avoid client-side full-tree loading.
- tests/routes/test_collection_routes.py: add extensive tests for /api/browse-recursive covering response shape, pagination, sorting stability, letter and search filters (including LIKE-escaping), path collision guard, exclusions, empty index, and ensuring no os.walk fallback.

Purpose: replace the previous full-tree os.walk approach (which timed out on large libraries) with efficient SQL-driven paging/filtering to improve performance and reliability.

## 📝 Description
Closes #

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass