### PR TITLE
Move folder thumbnail probe; harden metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -4285,28 +4285,7 @@ def resize_upload(file_path, target_dir):
         return False
 
 
-def find_folder_thumbnail(folder_path):
-    """Find a folder thumbnail image in the given directory.
-
-    Args:
-        folder_path: Path to the directory to search
-
-    Returns:
-        Path to the thumbnail image if found, None otherwise
-    """
-    allowed_extensions = {".png", ".gif", ".jpg", ".jpeg"}
-    allowed_names = {"folder"}  # Only use folder.* thumbnails, ignore cover.*
-
-    try:
-        entries = os.listdir(folder_path)
-        for entry in entries:
-            name_without_ext, ext = os.path.splitext(entry.lower())
-            if name_without_ext in allowed_names and ext in allowed_extensions:
-                return os.path.join(folder_path, entry)
-    except (OSError, IOError):
-        pass
-
-    return None
+from helpers import find_folder_thumbnail  # noqa: E402  (re-export for callers)
 
 
 def find_folder_thumbnails_batch(folder_paths):

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -64,6 +64,34 @@ def is_hidden(filepath):
     return False
 
 #########################
+#   Folder Thumbnails   #
+#########################
+
+def find_folder_thumbnail(folder_path):
+    """Find a folder thumbnail image in the given directory.
+
+    Stat-based: probes only the lowercase canonical names. Avoids
+    os.listdir on huge directories, which is slow on Docker bind mounts
+    where a publisher folder can contain thousands of series subfolders.
+
+    Args:
+        folder_path: Path to the directory to search
+
+    Returns:
+        Path to the thumbnail image if found, None otherwise
+    """
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp"):
+        candidate = os.path.join(folder_path, f"folder{ext}")
+        try:
+            if os.path.exists(candidate):
+                return candidate
+        except (OSError, IOError):
+            continue
+
+    return None
+
+
+#########################
 #   File Extraction     #
 #########################
 

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -539,10 +539,23 @@ def api_browse_metadata():
                 'has_files': file_count > 0
             }
 
+        # Guarantee a key for every requested path so the frontend never has
+        # to guess whether a missing key means "still loading" or "no data".
+        for p in paths:
+            if p not in results:
+                results[p] = {
+                    'folder_count': 0,
+                    'file_count': 0,
+                    'has_files': False,
+                }
+
         return jsonify({"metadata": results})
 
     except Exception as e:
-        app_logger.error(f"Error fetching browse metadata: {e}")
+        app_logger.error(
+            f"Error fetching browse metadata for {paths[:3]}: {e}",
+            exc_info=True,
+        )
         return jsonify({"error": str(e)}), 500
 
 

--- a/static/css/collection.css
+++ b/static/css/collection.css
@@ -196,6 +196,10 @@
     animation: pulse 1.5s ease-in-out infinite;
 }
 
+.item-meta.metadata-error {
+    opacity: 0.6;
+}
+
 @keyframes pulse {
 
     0%,

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -328,6 +328,14 @@ async function loadDirectory(path, preservePage = false, forceRefresh = false) {
 
         // Use prioritized loading: visible page first, then background
         if (pendingMetadataPaths.length > 0 || pendingThumbnailPaths.length > 0) {
+            if (window._browseMetaDebug) {
+                const gridDataPaths = [...document.querySelectorAll('#file-grid [data-path]')]
+                    .slice(0, 5)
+                    .map(el => el.getAttribute('data-path'));
+                console.log('[browse-metadata] requesting',
+                    pendingMetadataPaths.slice(0, 5),
+                    'gridDataPaths', gridDataPaths);
+            }
             loadBatchDataPrioritized(pendingMetadataPaths, pendingThumbnailPaths);
         }
 
@@ -337,6 +345,26 @@ async function loadDirectory(path, preservePage = false, forceRefresh = false) {
     } finally {
         setLoading(false);
     }
+}
+
+/**
+ * Mark a batch of folder paths as having failed metadata load. Replaces the
+ * persistent "Loading…" placeholder with an em-dash so cards never appear
+ * stuck. The reason is exposed via the `title` attribute for debugging.
+ */
+function markBatchFailed(paths, reason) {
+    paths.forEach(p => {
+        const item = allItems.find(i => i.path === p);
+        if (item) item.metadataPending = false;
+        const gridItem = document.querySelector(`[data-path="${CSS.escape(p)}"]`);
+        if (!gridItem) return;
+        const metaEl = gridItem.querySelector('.item-meta');
+        if (!metaEl) return;
+        metaEl.classList.remove('metadata-loading');
+        metaEl.classList.add('metadata-error');
+        metaEl.textContent = '—';
+        metaEl.title = `Metadata unavailable: ${reason}`;
+    });
 }
 
 /**
@@ -361,11 +389,25 @@ async function loadMetadataInBatches(paths, signal) {
                 signal
             });
 
-            if (!response.ok) return;
+            if (!response.ok) {
+                console.warn('[browse-metadata] non-2xx', response.status, batch.slice(0, 3));
+                markBatchFailed(batch, `http-${response.status}`);
+                return;
+            }
             const data = await response.json();
+
+            if (!data || !data.metadata) {
+                console.warn('[browse-metadata] empty response', data, batch.slice(0, 3));
+                markBatchFailed(batch, 'empty-response');
+                return;
+            }
+
+            const matched = new Set();
 
             // Update allItems and DOM with received metadata
             Object.entries(data.metadata).forEach(([path, meta]) => {
+                matched.add(path);
+
                 const item = allItems.find(i => i.path === path);
                 if (item) {
                     item.folderCount = meta.folder_count;
@@ -375,24 +417,39 @@ async function loadMetadataInBatches(paths, signal) {
                 }
 
                 const gridItem = document.querySelector(`[data-path="${CSS.escape(path)}"]`);
-                if (gridItem) {
-                    const metaEl = gridItem.querySelector('.item-meta');
-                    if (metaEl) {
-                        metaEl.classList.remove('metadata-loading');
-                        const parts = [];
-                        if (meta.folder_count > 0) {
-                            parts.push(`${meta.folder_count} folder${meta.folder_count !== 1 ? 's' : ''}`);
-                        }
-                        if (meta.file_count > 0) {
-                            parts.push(`${meta.file_count} file${meta.file_count !== 1 ? 's' : ''}`);
-                        }
-                        metaEl.textContent = parts.length > 0 ? parts.join(' | ') : 'Empty';
-                    }
+                if (!gridItem) {
+                    const sample = [...document.querySelectorAll('[data-path]')]
+                        .slice(0, 3)
+                        .map(el => el.getAttribute('data-path'));
+                    console.warn('[browse-metadata] no DOM match', { path, sampleDataPaths: sample });
+                    return;
                 }
+                const metaEl = gridItem.querySelector('.item-meta');
+                if (!metaEl) return;
+                metaEl.classList.remove('metadata-loading');
+                metaEl.classList.remove('metadata-error');
+                metaEl.removeAttribute('title');
+                const parts = [];
+                if (meta.folder_count > 0) {
+                    parts.push(`${meta.folder_count} folder${meta.folder_count !== 1 ? 's' : ''}`);
+                }
+                if (meta.file_count > 0) {
+                    parts.push(`${meta.file_count} file${meta.file_count !== 1 ? 's' : ''}`);
+                }
+                metaEl.textContent = parts.length > 0 ? parts.join(' | ') : 'Empty';
             });
+
+            // Any requested path not present in the response is a server-side
+            // miss — fall back rather than leave the card stuck on "Loading…".
+            const missing = batch.filter(p => !matched.has(p));
+            if (missing.length > 0) {
+                console.warn('[browse-metadata] missing keys in response', missing.slice(0, 3));
+                markBatchFailed(missing, 'no-key-in-response');
+            }
         } catch (error) {
-            if (error.name === 'AbortError') return;
+            if (error && error.name === 'AbortError') return;
             console.error('Error loading metadata batch:', error);
+            markBatchFailed(batch, `${error && error.name || 'Error'}:${error && error.message || error}`);
         }
     }));
 }

--- a/tests/routes/test_collection_routes.py
+++ b/tests/routes/test_collection_routes.py
@@ -169,6 +169,36 @@ class TestApiBrowseMetadata:
                            json={"paths": [f"/data/{i}" for i in range(101)]})
         assert resp.status_code == 400
 
+    @patch("routes.collection.get_path_counts_batch", return_value={})
+    def test_returns_zero_counts_for_missing_paths(self, mock_counts, client):
+        """Every requested path must come back keyed in the response, even
+        when the DB layer returns nothing — otherwise the frontend has no
+        way to distinguish 'still loading' from 'no data'."""
+        paths = ["/data/Marvel", "/data/DC", "/data/Image"]
+        resp = client.post("/api/browse-metadata", json={"paths": paths})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        for p in paths:
+            assert p in data["metadata"]
+            assert data["metadata"][p] == {
+                "folder_count": 0,
+                "file_count": 0,
+                "has_files": False,
+            }
+
+    @patch("routes.collection.get_path_counts_batch",
+           side_effect=RuntimeError("db blew up"))
+    def test_logs_input_paths_on_error(self, mock_counts, client, caplog):
+        """A 500 response must log the failing input paths so on-call can
+        correlate browser console errors with server logs."""
+        import logging
+        paths = ["/data/Marvel", "/data/DC"]
+        with caplog.at_level(logging.ERROR, logger="app_logger"):
+            resp = client.post("/api/browse-metadata", json={"paths": paths})
+        assert resp.status_code == 500
+        assert any("/data/Marvel" in rec.message for rec in caplog.records), \
+            f"Expected error log to mention input path; got: {[r.message for r in caplog.records]}"
+
 
 class TestApiClearBrowseCache:
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -154,3 +154,78 @@ class TestModifiedSCurveLut:
         # Values should generally increase (monotonic) in the 128-255 range
         for i in range(128, 255):
             assert lut[i + 1] >= lut[i]
+
+
+# ===== find_folder_thumbnail =====
+
+class TestFindFolderThumbnail:
+    """Stat-based folder thumbnail probe — replaces the old os.listdir
+    implementation that stalled folder browsing on Docker bind mounts."""
+
+    def test_finds_png(self, tmp_path):
+        from helpers import find_folder_thumbnail
+        thumb = tmp_path / "folder.png"
+        thumb.write_bytes(b"fake png")
+        result = find_folder_thumbnail(str(tmp_path))
+        assert result == str(thumb)
+
+    def test_finds_jpg(self, tmp_path):
+        from helpers import find_folder_thumbnail
+        thumb = tmp_path / "folder.jpg"
+        thumb.write_bytes(b"fake jpg")
+        assert find_folder_thumbnail(str(tmp_path)) == str(thumb)
+
+    def test_finds_webp(self, tmp_path):
+        from helpers import find_folder_thumbnail
+        thumb = tmp_path / "folder.webp"
+        thumb.write_bytes(b"fake webp")
+        assert find_folder_thumbnail(str(tmp_path)) == str(thumb)
+
+    def test_returns_none_when_missing(self, tmp_path):
+        from helpers import find_folder_thumbnail
+        # Empty dir — no thumbnail
+        assert find_folder_thumbnail(str(tmp_path)) is None
+
+    def test_rejects_non_canonical_name(self, tmp_path):
+        """Per the lowercase-folder.<ext> contract, files like cover.png or
+        Folder.PNG are NOT treated as folder thumbnails."""
+        from helpers import find_folder_thumbnail
+        (tmp_path / "cover.png").write_bytes(b"fake")
+        # On Linux this is a separate file from folder.png; the function
+        # should not return it.
+        result = find_folder_thumbnail(str(tmp_path))
+        assert result is None or result.endswith("folder.png")
+        # Confirm it didn't pick up cover.png
+        assert result is None
+
+    def test_png_takes_priority_over_jpg(self, tmp_path):
+        """When multiple canonical thumbnails coexist, .png wins (the
+        probe order in the function is fixed)."""
+        from helpers import find_folder_thumbnail
+        (tmp_path / "folder.png").write_bytes(b"png")
+        (tmp_path / "folder.jpg").write_bytes(b"jpg")
+        assert find_folder_thumbnail(str(tmp_path)).endswith("folder.png")
+
+    def test_does_not_call_listdir(self, tmp_path):
+        """Performance regression guard: the function MUST NOT fall back
+        to os.listdir, which is the slow path that caused the 524s."""
+        from helpers import find_folder_thumbnail
+        (tmp_path / "folder.png").write_bytes(b"png")
+        with patch("helpers.os.listdir",
+                   side_effect=AssertionError("os.listdir called — perf regression")):
+            assert find_folder_thumbnail(str(tmp_path)).endswith("folder.png")
+
+    def test_continues_past_oserror(self, tmp_path):
+        """A flaky filesystem returning OSError on one extension must not
+        abort the probe — the loop continues to the next candidate."""
+        from helpers import find_folder_thumbnail
+        (tmp_path / "folder.jpg").write_bytes(b"jpg")
+        original_exists = __import__("os.path", fromlist=["exists"]).exists
+
+        def flaky(path):
+            if path.endswith("folder.png"):
+                raise OSError("simulated I/O error")
+            return original_exists(path)
+
+        with patch("helpers.os.path.exists", side_effect=flaky):
+            assert find_folder_thumbnail(str(tmp_path)).endswith("folder.jpg")


### PR DESCRIPTION
Extract find_folder_thumbnail from app.py into helpers with a stat-based probe (checks canonical folder.<ext> names in priority order and avoids os.listdir), add .webp support and resilient OSError handling, and re-export it from app.py. Harden browse-metadata handling: ensure every requested path is present in the JSON response (defaulting to zero counts), improve error logging to include sample input paths and exception info. Frontend: add metadata failure handling (markBatchFailed), debug logging, handle non-2xx/empty responses and missing keys so cards don't stay stuck on "Loading…", and add a CSS rule for metadata-error. Tests updated/added to cover the new helper behavior and route error/response semantics.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass