### PR TITLE
Add DB backup/restore API, UI, and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -7994,6 +7994,118 @@ def api_metadata_scan_trigger():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+############################
+# Database settings page   #
+############################
+
+
+@app.route("/api/database/stats", methods=["GET"])
+def api_database_stats():
+    """Database file sizes, per-table row counts, and last-backup info."""
+    try:
+        from core.database import get_database_stats, list_backups
+
+        stats = get_database_stats()
+        backups = list_backups()
+        last_backup = backups[0] if backups else None
+        return jsonify({
+            "success": True,
+            "stats": stats,
+            "last_backup": last_backup,
+            "backup_count": len(backups),
+        })
+    except Exception as e:
+        app_logger.error(f"api_database_stats failed: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/database/backups", methods=["GET"])
+def api_database_backups():
+    """List of available DB backups (newest first)."""
+    try:
+        from core.database import list_backups
+
+        return jsonify({"success": True, "backups": list_backups()})
+    except Exception as e:
+        app_logger.error(f"api_database_backups failed: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/database/backup", methods=["POST"])
+def api_database_backup():
+    """Force a manual backup, bypassing the unchanged-since-last-backup check."""
+    try:
+        from core.database import backup_database
+
+        result = backup_database(max_backups=3, force=True)
+        if result is False:
+            return jsonify({"success": False, "error": "Backup failed (see logs)"}), 500
+        if result is None:
+            return jsonify({"success": False, "error": "Database does not exist"}), 404
+        return jsonify({"success": True, "filename": result})
+    except Exception as e:
+        app_logger.error(f"api_database_backup failed: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/database/backups/<filename>", methods=["DELETE"])
+def api_database_backup_delete(filename):
+    """Delete a single backup ZIP."""
+    try:
+        from core.database import delete_backup
+
+        delete_backup(filename)
+        return jsonify({"success": True, "filename": filename})
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except FileNotFoundError as e:
+        return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
+    except Exception as e:
+        app_logger.error(f"api_database_backup_delete failed: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/database/backups/<filename>/download", methods=["GET"])
+def api_database_backup_download(filename):
+    """Stream a backup ZIP to the user as a download."""
+    try:
+        from core.database import get_backup_path
+
+        full_path = get_backup_path(filename)
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except FileNotFoundError as e:
+        return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
+    return send_file(
+        full_path,
+        as_attachment=True,
+        download_name=filename,
+        mimetype="application/zip",
+    )
+
+
+@app.route("/api/database/restore", methods=["POST"])
+def api_database_restore():
+    """Restore the DB from a previously created backup ZIP. The current DB is
+    snapshotted to a pre-restore safety backup before being replaced."""
+    try:
+        from core.database import restore_database
+
+        body = request.get_json(silent=True) or {}
+        filename = body.get("filename")
+        if not filename:
+            return jsonify({"success": False, "error": "filename is required"}), 400
+        result = restore_database(filename)
+        return jsonify(result)
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except FileNotFoundError as e:
+        return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
+    except Exception as e:
+        app_logger.error(f"api_database_restore failed: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 @app.route("/api/recommendations", methods=["GET", "POST"])
 def api_recommendations():
     try:

--- a/core/database.py
+++ b/core/database.py
@@ -1174,21 +1174,22 @@ def get_db_connection():
 # =============================================================================
 
 
-def backup_database(max_backups: int = 3) -> bool:
+def backup_database(max_backups: int = 3, force: bool = False):
     """
     Create a ZIP backup of the database if it has changed since last backup.
 
     Args:
         max_backups: Maximum number of backups to retain (default 3)
+        force: When True, skip the unchanged-since-last-backup hash check.
 
     Returns:
-        True if backup created, False if skipped or error
+        Backup filename (str) on success, None if skipped, False on error.
     """
     try:
         db_path = get_db_path()
         if not os.path.exists(db_path):
             app_logger.info("Database does not exist yet, skipping backup")
-            return False
+            return None
 
         cache_dir = os.path.dirname(db_path)
 
@@ -1202,14 +1203,14 @@ def backup_database(max_backups: int = 3) -> bool:
 
         current_hash = get_file_hash(db_path)
 
-        # Check last backup hash
+        # Check last backup hash unless caller forced
         hash_file = os.path.join(cache_dir, ".db_backup_hash")
-        if os.path.exists(hash_file):
+        if not force and os.path.exists(hash_file):
             with open(hash_file, "r") as f:
                 last_hash = f.read().strip()
             if last_hash == current_hash:
                 app_logger.debug("Database unchanged since last backup, skipping")
-                return False
+                return None
 
         # Create timestamped backup filename
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -1237,11 +1238,204 @@ def backup_database(max_backups: int = 3) -> bool:
         # Cleanup old backups (keep only max_backups most recent)
         _cleanup_old_backups(cache_dir, max_backups)
 
-        return True
+        return backup_name
 
     except Exception as e:
         app_logger.error(f"Database backup failed: {e}")
         return False
+
+
+_BACKUP_FILENAME_RE = re.compile(r"^comic_utils_backup_\d{8}_\d{6}\.zip$")
+
+
+def list_backups():
+    """Return a list of dicts describing every backup ZIP in the DB directory.
+
+    Each dict: {filename, size, modified_at} sorted newest-first.
+    """
+    db_path = get_db_path()
+    backup_dir = os.path.dirname(db_path)
+    items = []
+    if not os.path.isdir(backup_dir):
+        return items
+    for name in os.listdir(backup_dir):
+        if not _BACKUP_FILENAME_RE.match(name):
+            continue
+        full = os.path.join(backup_dir, name)
+        try:
+            st = os.stat(full)
+        except OSError:
+            continue
+        items.append({
+            "filename": name,
+            "size": st.st_size,
+            "modified_at": st.st_mtime,
+        })
+    # Sort by filename — names embed YYYYMMDD_HHMMSS, so lexical desc = newest first.
+    # Falls back gracefully if mtimes match at filesystem resolution (Windows).
+    items.sort(key=lambda d: d["filename"], reverse=True)
+    return items
+
+
+def delete_backup(filename: str):
+    """Delete a single backup ZIP. Returns the deleted filename.
+
+    Raises ValueError on a malformed filename, FileNotFoundError if missing.
+    """
+    if not _BACKUP_FILENAME_RE.match(filename):
+        raise ValueError(f"Invalid backup filename: {filename}")
+    db_path = get_db_path()
+    backup_dir = os.path.dirname(db_path)
+    target = os.path.join(backup_dir, filename)
+    if not os.path.exists(target):
+        raise FileNotFoundError(filename)
+    os.remove(target)
+    app_logger.info(f"Backup deleted: {filename}")
+    return filename
+
+
+def get_backup_path(filename: str) -> str:
+    """Resolve a backup filename to its full filesystem path. Raises ValueError
+    on a malformed filename, FileNotFoundError if missing. Used by the download
+    route to safely locate a file inside the backup directory."""
+    if not _BACKUP_FILENAME_RE.match(filename):
+        raise ValueError(f"Invalid backup filename: {filename}")
+    db_path = get_db_path()
+    backup_dir = os.path.dirname(db_path)
+    target = os.path.join(backup_dir, filename)
+    if not os.path.exists(target):
+        raise FileNotFoundError(filename)
+    return target
+
+
+def restore_database(filename: str):
+    """Restore the database from a previous backup ZIP.
+
+    The current DB is first snapshotted to a pre-restore backup so the user
+    can roll forward if they pick the wrong file. Then the backup ZIP is
+    extracted into the DB directory, atomically replacing comic_utils.db
+    and its sidecars.
+
+    Returns dict {success, message, pre_restore_backup}. Raises ValueError
+    on invalid filename, FileNotFoundError if the backup is missing.
+    """
+    if not _BACKUP_FILENAME_RE.match(filename):
+        raise ValueError(f"Invalid backup filename: {filename}")
+
+    db_path = get_db_path()
+    backup_dir = os.path.dirname(db_path)
+    backup_path = os.path.join(backup_dir, filename)
+    if not os.path.exists(backup_path):
+        raise FileNotFoundError(filename)
+
+    # Take a safety snapshot of the current DB before clobbering it.
+    pre_restore = backup_database(max_backups=99, force=True)
+    if pre_restore is False:
+        # backup_database returns False on hard error; bail rather than restore blind.
+        raise RuntimeError("Could not create pre-restore safety backup; aborting restore.")
+
+    app_logger.info(f"Restoring database from {filename}")
+
+    # Extract the ZIP into a sibling temp dir, then move files into place.
+    tmp_dir = os.path.join(backup_dir, ".restore_tmp")
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    os.makedirs(tmp_dir)
+    try:
+        with zipfile.ZipFile(backup_path, "r") as zf:
+            for member in ("comic_utils.db", "comic_utils.db-wal", "comic_utils.db-shm"):
+                if member in zf.namelist():
+                    zf.extract(member, tmp_dir)
+        # Sanity check: the extracted main DB must exist.
+        new_db = os.path.join(tmp_dir, "comic_utils.db")
+        if not os.path.exists(new_db):
+            raise RuntimeError(f"Backup {filename} did not contain comic_utils.db")
+
+        # Remove existing sidecar files first so partial state doesn't survive.
+        for suffix in ("-wal", "-shm"):
+            side = db_path + suffix
+            if os.path.exists(side):
+                try:
+                    os.remove(side)
+                except OSError as e:
+                    app_logger.warning(f"Could not remove existing {side}: {e}")
+
+        # os.replace is atomic on the same filesystem.
+        os.replace(new_db, db_path)
+        for suffix in ("-wal", "-shm"):
+            extracted = os.path.join(tmp_dir, "comic_utils.db" + suffix)
+            if os.path.exists(extracted):
+                os.replace(extracted, db_path + suffix)
+
+        # Invalidate the backup hash so the next periodic backup regenerates.
+        hash_file = os.path.join(backup_dir, ".db_backup_hash")
+        try:
+            if os.path.exists(hash_file):
+                os.remove(hash_file)
+        except OSError:
+            pass
+
+        app_logger.info(f"Database restored from {filename}")
+        return {
+            "success": True,
+            "message": f"Database restored from {filename}",
+            "pre_restore_backup": pre_restore,
+        }
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def get_database_stats():
+    """Snapshot of database file sizes and per-table row counts.
+
+    Returns dict suitable for jsonify; never raises.
+    """
+    stats = {
+        "db_path": None,
+        "db_size": 0,
+        "wal_size": 0,
+        "shm_size": 0,
+        "tables": [],
+        "total_rows": 0,
+        "error": None,
+    }
+    try:
+        db_path = get_db_path()
+        stats["db_path"] = db_path
+        if os.path.exists(db_path):
+            stats["db_size"] = os.path.getsize(db_path)
+        for suffix, key in (("-wal", "wal_size"), ("-shm", "shm_size")):
+            side = db_path + suffix
+            if os.path.exists(side):
+                stats[key] = os.path.getsize(side)
+
+        if not os.path.exists(db_path):
+            return stats
+
+        conn = sqlite3.connect(db_path, timeout=5)
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            )
+            tables = [row[0] for row in cur.fetchall()]
+            for table in tables:
+                try:
+                    cur.execute(f'SELECT COUNT(*) FROM "{table}"')
+                    count = cur.fetchone()[0]
+                except sqlite3.Error:
+                    count = None
+                stats["tables"].append({"name": table, "rows": count})
+                if isinstance(count, int):
+                    stats["total_rows"] += count
+        finally:
+            conn.close()
+        return stats
+    except Exception as e:
+        app_logger.error(f"get_database_stats failed: {e}")
+        stats["error"] = str(e)
+        return stats
 
 
 def _cleanup_old_backups(cache_dir: str, max_backups: int):

--- a/static/js/database_panel.js
+++ b/static/js/database_panel.js
@@ -1,0 +1,205 @@
+(function () {
+    function escapeHtml(str) {
+        return String(str ?? '').replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    function formatBytes(n) {
+        if (typeof n !== 'number' || isNaN(n)) return '–';
+        if (n < 1024) return `${n} B`;
+        const units = ['KB', 'MB', 'GB', 'TB'];
+        let i = -1;
+        let size = n;
+        do { size /= 1024; i++; } while (size >= 1024 && i < units.length - 1);
+        return `${size.toFixed(size >= 100 ? 0 : size >= 10 ? 1 : 2)} ${units[i]}`;
+    }
+
+    function formatTimestamp(epochSeconds) {
+        if (!epochSeconds) return '–';
+        try {
+            return new Date(epochSeconds * 1000).toLocaleString();
+        } catch (e) {
+            return '–';
+        }
+    }
+
+    function formatNumber(n) {
+        if (typeof n !== 'number') return '–';
+        return n.toLocaleString();
+    }
+
+    async function postJson(url, body) {
+        const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
+        if (body !== undefined) opts.body = JSON.stringify(body);
+        const res = await fetch(url, opts);
+        let data = {};
+        try { data = await res.json(); } catch (e) { /* ignore */ }
+        return { ok: res.ok, status: res.status, data };
+    }
+
+    function renderStats(stats, lastBackup) {
+        document.getElementById('dbStatsPath').textContent = stats?.db_path || '–';
+        document.getElementById('dbStatsSize').textContent = formatBytes(stats?.db_size);
+        const wal = stats?.wal_size || 0;
+        const shm = stats?.shm_size || 0;
+        document.getElementById('dbStatsWal').textContent =
+            (wal === 0 && shm === 0) ? '–' : `${formatBytes(wal)} / ${formatBytes(shm)}`;
+        const tables = stats?.tables || [];
+        document.getElementById('dbStatsTableCount').textContent = formatNumber(tables.length);
+        document.getElementById('dbStatsTotalRows').textContent = formatNumber(stats?.total_rows || 0);
+
+        const tbody = document.getElementById('dbStatsTablesBody');
+        if (tables.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="2" class="text-muted text-center">No tables</td></tr>';
+        } else {
+            tbody.innerHTML = tables.map(t => `
+                <tr>
+                    <td><code>${escapeHtml(t.name)}</code></td>
+                    <td class="text-end">${t.rows === null ? '<span class="text-muted">err</span>' : formatNumber(t.rows)}</td>
+                </tr>
+            `).join('');
+        }
+
+        document.getElementById('dbLastBackup').textContent = lastBackup
+            ? `${escapeHtml(lastBackup.filename)} — ${formatTimestamp(lastBackup.modified_at)}`
+            : 'no backups yet';
+    }
+
+    function renderBackups(backups) {
+        const tbody = document.getElementById('dbBackupsBody');
+        if (!backups || backups.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" class="text-muted text-center">No backups yet</td></tr>';
+            return;
+        }
+        tbody.innerHTML = backups.map(b => {
+            const fn = escapeHtml(b.filename);
+            return `
+            <tr>
+                <td><code>${fn}</code></td>
+                <td>${escapeHtml(formatTimestamp(b.modified_at))}</td>
+                <td class="text-end">${formatBytes(b.size)}</td>
+                <td class="text-end">
+                    <a class="btn btn-sm btn-outline-secondary me-1"
+                       href="/api/database/backups/${encodeURIComponent(b.filename)}/download"
+                       title="Download">
+                        <i class="bi bi-download"></i>
+                    </a>
+                    <button class="btn btn-sm btn-outline-warning me-1" data-restore="${fn}" title="Restore">
+                        <i class="bi bi-arrow-counterclockwise"></i>
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger" data-delete="${fn}" title="Delete">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </td>
+            </tr>
+            `;
+        }).join('');
+    }
+
+    async function refresh() {
+        try {
+            const [statsRes, backupsRes] = await Promise.all([
+                fetch('/api/database/stats').then(r => r.json()),
+                fetch('/api/database/backups').then(r => r.json()),
+            ]);
+            if (statsRes?.success) {
+                renderStats(statsRes.stats, statsRes.last_backup);
+            }
+            if (backupsRes?.success) {
+                renderBackups(backupsRes.backups);
+            }
+        } catch (e) {
+            console.warn('database panel refresh failed:', e);
+        }
+    }
+
+    async function onBackupNow() {
+        const btn = document.getElementById('dbBackupNowBtn');
+        const original = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Backing up…';
+        try {
+            const { ok, data } = await postJson('/api/database/backup');
+            if (ok && data.success) {
+                window.showToast?.(`Backup created: ${data.filename}`, 'success');
+            } else {
+                window.showToast?.(`Backup failed: ${data.error || 'unknown error'}`, 'error');
+            }
+            await refresh();
+        } finally {
+            btn.disabled = false;
+            btn.innerHTML = original;
+        }
+    }
+
+    async function onRestoreClick(filename) {
+        const ok = window.confirm(
+            `Restore the database from "${filename}"?\n\n` +
+            `This replaces your current database. A safety snapshot of the current DB is ` +
+            `created automatically before restore. Restart the app afterwards to clear ` +
+            `cached state in background workers.`
+        );
+        if (!ok) return;
+        try {
+            const { ok: httpOk, data } = await postJson('/api/database/restore', { filename });
+            if (httpOk && data.success) {
+                window.showToast?.(
+                    `Restored from ${filename}. Safety snapshot: ${data.pre_restore_backup || 'n/a'}. Restart the app.`,
+                    'success', 10000
+                );
+            } else {
+                window.showToast?.(`Restore failed: ${data.error || 'unknown error'}`, 'error');
+            }
+            await refresh();
+        } catch (e) {
+            window.showToast?.(`Restore error: ${e.message}`, 'error');
+        }
+    }
+
+    async function onDeleteClick(filename) {
+        const ok = window.confirm(`Delete backup "${filename}"? This cannot be undone.`);
+        if (!ok) return;
+        try {
+            const res = await fetch(`/api/database/backups/${encodeURIComponent(filename)}`, { method: 'DELETE' });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.success) {
+                window.showToast?.(`Deleted ${filename}`, 'success');
+            } else {
+                window.showToast?.(`Delete failed: ${data.error || 'unknown error'}`, 'error');
+            }
+            await refresh();
+        } catch (e) {
+            window.showToast?.(`Delete error: ${e.message}`, 'error');
+        }
+    }
+
+    function bind() {
+        document.getElementById('dbBackupNowBtn')?.addEventListener('click', onBackupNow);
+        document.getElementById('dbBackupsBody')?.addEventListener('click', e => {
+            const restoreBtn = e.target.closest('button[data-restore]');
+            if (restoreBtn) {
+                onRestoreClick(restoreBtn.dataset.restore);
+                return;
+            }
+            const deleteBtn = e.target.closest('button[data-delete]');
+            if (deleteBtn) {
+                onDeleteClick(deleteBtn.dataset.delete);
+            }
+        });
+    }
+
+    function init() {
+        const tabBtn = document.getElementById('database-tab');
+        if (!tabBtn) return; // not on the config page
+        bind();
+        tabBtn.addEventListener('shown.bs.tab', refresh);
+        if (tabBtn.classList.contains('active')) refresh();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/templates/config.html
+++ b/templates/config.html
@@ -55,6 +55,10 @@
                     Performance</button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="database-tab" data-bs-toggle="tab" data-bs-target="#database"
+                    type="button" role="tab" aria-controls="database" aria-selected="false">Database</button>
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="personalization-tab" data-bs-toggle="tab" data-bs-target="#personalization"
                     type="button" role="tab" aria-controls="personalization"
                     aria-selected="false">Personalization</button>
@@ -1454,6 +1458,72 @@
             </div>
 
             <!-- ========================================== -->
+            <!-- TAB: Database -->
+            <!-- ========================================== -->
+            <div class="tab-pane fade" id="database" role="tabpanel" aria-labelledby="database-tab">
+
+                <!-- Database Stats -->
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <h4 class="mb-2">Current Database</h4>
+                    <p class="text-muted">SQLite file size and row counts per table.</p>
+                    <div class="row g-3 small mb-3">
+                        <div class="col-12 col-md-6"><strong>Path:</strong> <code id="dbStatsPath">–</code></div>
+                        <div class="col-6 col-md-3"><strong>DB size:</strong> <span id="dbStatsSize">–</span></div>
+                        <div class="col-6 col-md-3"><strong>WAL / SHM:</strong> <span id="dbStatsWal">–</span></div>
+                        <div class="col-6 col-md-3"><strong>Tables:</strong> <span id="dbStatsTableCount">–</span></div>
+                        <div class="col-6 col-md-3"><strong>Total rows:</strong> <span id="dbStatsTotalRows">–</span></div>
+                    </div>
+                    <div class="table-responsive" style="max-height: 320px;">
+                        <table class="table table-sm table-striped align-middle mb-0">
+                            <thead class="sticky-top bg-body">
+                                <tr><th>Table</th><th class="text-end">Rows</th></tr>
+                            </thead>
+                            <tbody id="dbStatsTablesBody">
+                                <tr><td colspan="2" class="text-muted text-center">Loading…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- Backups -->
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <div class="d-flex align-items-start justify-content-between mb-2">
+                        <div>
+                            <h4 class="mb-0">Backups</h4>
+                            <p class="text-muted mb-0">Auto-created on container start (when the DB has changed). Up to 3 retained, plus any manual or pre-restore snapshots.</p>
+                        </div>
+                        <button id="dbBackupNowBtn" type="button" class="btn btn-primary btn-sm">
+                            <i class="bi bi-floppy me-1"></i> Back up now
+                        </button>
+                    </div>
+                    <div class="small mb-3">
+                        <strong>Last backup:</strong> <span id="dbLastBackup">–</span>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Filename</th>
+                                    <th>Created</th>
+                                    <th class="text-end">Size</th>
+                                    <th class="text-end">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody id="dbBackupsBody">
+                                <tr><td colspan="4" class="text-muted text-center">Loading…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="alert alert-warning small mt-3 mb-0">
+                        <i class="bi bi-exclamation-triangle me-1"></i>
+                        Restoring replaces the current database. A safety snapshot of the
+                        current DB is taken automatically just before restore. Restart the
+                        app after restoring to ensure all background workers reload state.
+                    </div>
+                </div>
+            </div>
+
+            <!-- ========================================== -->
             <!-- TAB 4: Styling -->
             <!-- ========================================== -->
             <!-- ========================================== -->
@@ -1730,6 +1800,7 @@
 {{ super() }}
 <script src="{{ url_for('static', filename='js/clu-utils.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-streaming.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/database_panel.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script>
     // Toast notification system for config.html
     function showToast(message, type = 'info', duration = 5000) {

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -233,6 +233,81 @@ def app(db_connection, tmp_path):
         ops = app_state.get_active_operations()
         return jsonify({"operations": ops})
 
+    # Database settings page — stubs that mirror app.py routes without
+    # importing app.py (which would start background services).
+    @test_app.route("/api/database/stats", methods=["GET"])
+    def database_stats():
+        from flask import jsonify
+        from core.database import get_database_stats, list_backups
+        try:
+            stats = get_database_stats()
+            backups = list_backups()
+            return jsonify({
+                "success": True,
+                "stats": stats,
+                "last_backup": backups[0] if backups else None,
+                "backup_count": len(backups),
+            })
+        except Exception as e:
+            return jsonify({"success": False, "error": str(e)}), 500
+
+    @test_app.route("/api/database/backups", methods=["GET"])
+    def database_backups():
+        from flask import jsonify
+        from core.database import list_backups
+        return jsonify({"success": True, "backups": list_backups()})
+
+    @test_app.route("/api/database/backup", methods=["POST"])
+    def database_backup():
+        from flask import jsonify
+        from core.database import backup_database
+        result = backup_database(max_backups=3, force=True)
+        if result is False:
+            return jsonify({"success": False, "error": "Backup failed"}), 500
+        if result is None:
+            return jsonify({"success": False, "error": "Database does not exist"}), 404
+        return jsonify({"success": True, "filename": result})
+
+    @test_app.route("/api/database/backups/<filename>", methods=["DELETE"])
+    def database_backup_delete(filename):
+        from flask import jsonify
+        from core.database import delete_backup
+        try:
+            delete_backup(filename)
+            return jsonify({"success": True, "filename": filename})
+        except ValueError as e:
+            return jsonify({"success": False, "error": str(e)}), 400
+        except FileNotFoundError as e:
+            return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
+
+    @test_app.route("/api/database/backups/<filename>/download", methods=["GET"])
+    def database_backup_download(filename):
+        from flask import jsonify, send_file
+        from core.database import get_backup_path
+        try:
+            full_path = get_backup_path(filename)
+        except ValueError as e:
+            return jsonify({"success": False, "error": str(e)}), 400
+        except FileNotFoundError as e:
+            return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
+        return send_file(full_path, as_attachment=True, download_name=filename,
+                         mimetype="application/zip")
+
+    @test_app.route("/api/database/restore", methods=["POST"])
+    def database_restore():
+        from flask import jsonify, request as flask_request
+        from core.database import restore_database
+        body = flask_request.get_json(silent=True) or {}
+        filename = body.get("filename")
+        if not filename:
+            return jsonify({"success": False, "error": "filename is required"}), 400
+        try:
+            return jsonify(restore_database(filename))
+        except ValueError as e:
+            return jsonify({"success": False, "error": str(e)}), 400
+        except FileNotFoundError as e:
+            return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
+
     @test_app.route("/api/on-the-stack")
     def api_on_the_stack():
         from flask import jsonify, request as flask_request

--- a/tests/routes/test_database.py
+++ b/tests/routes/test_database.py
@@ -1,0 +1,180 @@
+"""Route tests for the Database settings page (/api/database/*)."""
+import os
+import zipfile
+
+import pytest
+
+
+def _make_fake_backup(backup_dir, filename, contents=b"fake-db-bytes"):
+    os.makedirs(backup_dir, exist_ok=True)
+    backup_path = os.path.join(backup_dir, filename)
+    with zipfile.ZipFile(backup_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("comic_utils.db", contents)
+    return backup_path
+
+
+class TestDatabaseStats:
+    def test_returns_expected_shape(self, client):
+        resp = client.get("/api/database/stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        stats = data["stats"]
+        for key in ("db_path", "db_size", "wal_size", "shm_size", "tables", "total_rows"):
+            assert key in stats
+        assert isinstance(stats["tables"], list)
+
+    def test_lists_known_tables(self, client):
+        resp = client.get("/api/database/stats")
+        data = resp.get_json()
+        names = [t["name"] for t in data["stats"]["tables"]]
+        # init_db creates these — they should be present after the fixture.
+        assert "file_index" in names
+        assert "thumbnail_jobs" in names
+
+    def test_no_backups_yet(self, client):
+        resp = client.get("/api/database/stats")
+        data = resp.get_json()
+        assert data["last_backup"] is None
+        assert data["backup_count"] == 0
+
+
+class TestDatabaseBackupsList:
+    def test_empty_list_initially(self, client):
+        resp = client.get("/api/database/backups")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["backups"] == []
+
+    def test_lists_only_well_named_backups(self, client, db_path):
+        backup_dir = os.path.dirname(db_path)
+        _make_fake_backup(backup_dir, "comic_utils_backup_20260101_120000.zip")
+        _make_fake_backup(backup_dir, "comic_utils_backup_20260102_120000.zip")
+        # Junk file that should be ignored
+        with open(os.path.join(backup_dir, "random.zip"), "wb") as f:
+            f.write(b"x")
+
+        resp = client.get("/api/database/backups")
+        data = resp.get_json()
+        names = [b["filename"] for b in data["backups"]]
+        assert names == [
+            "comic_utils_backup_20260102_120000.zip",
+            "comic_utils_backup_20260101_120000.zip",
+        ]
+        assert "random.zip" not in names
+
+
+class TestDatabaseBackup:
+    def test_force_creates_backup(self, client, db_path):
+        resp = client.post("/api/database/backup")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["filename"].startswith("comic_utils_backup_")
+        assert data["filename"].endswith(".zip")
+        # File actually exists on disk
+        backup_path = os.path.join(os.path.dirname(db_path), data["filename"])
+        assert os.path.exists(backup_path)
+
+
+class TestDatabaseRestore:
+    def test_missing_filename_returns_400(self, client):
+        resp = client.post("/api/database/restore", json={})
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    def test_invalid_filename_returns_400(self, client):
+        # Path traversal / wrong format
+        for bad in ("../../etc/passwd", "comic_utils_backup_xx.zip", "evil.zip"):
+            resp = client.post("/api/database/restore", json={"filename": bad})
+            assert resp.status_code == 400, f"expected 400 for {bad}"
+            assert resp.get_json()["success"] is False
+
+    def test_unknown_filename_returns_404(self, client):
+        resp = client.post(
+            "/api/database/restore",
+            json={"filename": "comic_utils_backup_19990101_000000.zip"},
+        )
+        assert resp.status_code == 404
+
+    def test_restore_round_trip(self, client, db_path, db_connection):
+        # Create a real backup first.
+        b_resp = client.post("/api/database/backup")
+        backup_filename = b_resp.get_json()["filename"]
+
+        # Close the fixture's open connection so Windows can replace the DB file.
+        db_connection.close()
+
+        # Now restore from it. Should succeed and produce a pre-restore safety backup.
+        r_resp = client.post(
+            "/api/database/restore", json={"filename": backup_filename}
+        )
+        assert r_resp.status_code == 200
+        data = r_resp.get_json()
+        assert data["success"] is True
+        assert data["pre_restore_backup"]
+        assert data["pre_restore_backup"].startswith("comic_utils_backup_")
+
+        # The DB file still exists and has the expected schema (sanity).
+        assert os.path.exists(db_path)
+
+
+class TestDatabaseBackupDelete:
+    def test_invalid_filename_returns_400(self, client):
+        resp = client.delete("/api/database/backups/evil.zip")
+        assert resp.status_code == 400
+
+    def test_path_traversal_rejected(self, client):
+        # Werkzeug normalises ../../etc out before this hits us, but a name like
+        # "comic_utils_backup_../etc/passwd" still doesn't match the regex.
+        resp = client.delete("/api/database/backups/comic_utils_backup_xxxxxxxx_xxxxxx.zip")
+        assert resp.status_code == 400
+
+    def test_unknown_filename_returns_404(self, client):
+        resp = client.delete(
+            "/api/database/backups/comic_utils_backup_19990101_000000.zip"
+        )
+        assert resp.status_code == 404
+
+    def test_delete_round_trip(self, client, db_path):
+        # Create a real backup first.
+        backup_filename = client.post("/api/database/backup").get_json()["filename"]
+        backup_path = os.path.join(os.path.dirname(db_path), backup_filename)
+        assert os.path.exists(backup_path)
+
+        resp = client.delete(f"/api/database/backups/{backup_filename}")
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        assert not os.path.exists(backup_path)
+
+        # Subsequent listing reflects the delete.
+        listed = client.get("/api/database/backups").get_json()["backups"]
+        assert backup_filename not in [b["filename"] for b in listed]
+
+
+class TestDatabaseBackupDownload:
+    def test_invalid_filename_returns_400(self, client):
+        resp = client.get("/api/database/backups/evil.zip/download")
+        assert resp.status_code == 400
+
+    def test_unknown_filename_returns_404(self, client):
+        resp = client.get(
+            "/api/database/backups/comic_utils_backup_19990101_000000.zip/download"
+        )
+        assert resp.status_code == 404
+
+    def test_download_serves_zip_bytes(self, client, db_path):
+        backup_filename = client.post("/api/database/backup").get_json()["filename"]
+        backup_path = os.path.join(os.path.dirname(db_path), backup_filename)
+        with open(backup_path, "rb") as f:
+            expected_first_bytes = f.read(4)
+
+        resp = client.get(f"/api/database/backups/{backup_filename}/download")
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/zip"
+        assert resp.headers.get("Content-Disposition", "").startswith("attachment")
+        assert backup_filename in resp.headers.get("Content-Disposition", "")
+        # ZIP files start with "PK\x03\x04"
+        assert resp.data[:4] == expected_first_bytes
+        assert resp.data[:2] == b"PK"


### PR DESCRIPTION
## 📝 Description
Introduce a Database settings page with API endpoints, core support, frontend, and tests. app.py: add /api/database/* routes for stats, listing, creating (forced) backups, deleting, downloading, and restoring backups. core/database.py: make backup_database support force and return filenames (or None/False), and add list_backups, delete_backup, get_backup_path, restore_database, and get_database_stats helpers with filename validation and pre-restore safety snapshot behavior. templates/config.html & static/js/database_panel.js: add a new Database tab UI and client-side logic for displaying stats, listing backups, and performing backup/restore/delete actions. tests/routes: add test stubs to conftest and comprehensive route tests to verify listing, creation, deletion, download, and restore flows. Validation and error handling added for malformed/unknown filenames; backups are timestamped ZIPs and cleaned up per retention.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1321" height="446" alt="image" src="https://github.com/user-attachments/assets/0675e0b3-bc02-4e05-aedf-6f6662334a39" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass