### PR TITLE
Support PDF Uploads and Track upload operations

### DIFF
--- a/routes/files.py
+++ b/routes/files.py
@@ -191,6 +191,7 @@ def upload_to_folder():
     """
     from app import log_file_if_in_data, resize_upload
 
+    op_id = None
     try:
         # Get target directory from form data
         target_dir = request.form.get('target_dir')
@@ -214,16 +215,31 @@ def upload_to_folder():
         if not files or all(f.filename == '' for f in files):
             return jsonify({"success": False, "error": "No files selected"}), 400
 
+        # Filter out empty filenames once, up-front, so the op total reflects real work.
+        files_to_process = [f for f in files if f.filename]
+        if not files_to_process:
+            return jsonify({"success": False, "error": "No files selected"}), 400
+
+        target_label = os.path.basename(os.path.normpath(target_dir)) or target_dir
+        op_id = app_state.register_operation(
+            "upload",
+            f"Upload to {target_label}",
+            total=len(files_to_process),
+        )
+
         # Allowed file extensions
-        allowed_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.cbz', '.cbr'}
+        allowed_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.cbz', '.cbr', '.pdf'}
 
         uploaded_files = []
         skipped_files = []
         errors = []
 
-        for file in files:
-            if file.filename == '':
-                continue
+        for i, file in enumerate(files_to_process):
+            app_state.update_operation(
+                op_id,
+                current=i,
+                detail=f"Uploading {os.path.basename(file.filename)}",
+            )
 
             # Sanitize filename: strip path separators but preserve spaces
             filename = os.path.basename(file.filename)
@@ -284,9 +300,12 @@ def upload_to_folder():
                 })
                 app_logger.error(f"Error uploading file {filename}: {e}")
 
+        app_state.complete_operation(op_id, error=bool(errors))
+
         # Return results
         response = {
             "success": True,
+            "op_id": op_id,
             "uploaded": uploaded_files,
             "skipped": skipped_files,
             "errors": errors,
@@ -298,6 +317,8 @@ def upload_to_folder():
         return jsonify(response)
 
     except Exception as e:
+        if op_id is not None:
+            app_state.complete_operation(op_id, error=True)
         app_logger.error(f"Error in upload_to_folder: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -171,7 +171,7 @@
             return b.started_at - a.started_at;
           });
 
-          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload' };
+          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up' };
           let html = '';
           ops.forEach(op => {
             const icon = iconMap[op.op_type] || 'bi-gear';

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -428,3 +428,55 @@ class TestConvertPreview:
         resp = client.get(f"/api/convert/preview?directory={tmp_path}")
         assert resp.status_code == 200
         assert resp.get_json()["count"] == 0
+
+
+class TestUploadToFolderOpsIntegration:
+    """The upload route should register an operation with app_state so the
+    Global Operations Indicator in the navbar can show progress."""
+
+    def test_upload_registers_operation_and_returns_op_id(self, client, tmp_path):
+        from io import BytesIO
+
+        target = tmp_path / "uploads"
+        target.mkdir()
+
+        # PNG signature is the only thing the route inspects (via extension).
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        data = {
+            "target_dir": str(target),
+            "files": [(BytesIO(png_bytes), "a.png"), (BytesIO(png_bytes), "b.png")],
+        }
+
+        resp = client.post(
+            "/upload-to-folder",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["total_uploaded"] == 2
+        assert body.get("op_id"), "upload response must include op_id"
+
+        ops = client.get("/api/operations").get_json()["operations"]
+        match = next((o for o in ops if o["id"] == body["op_id"]), None)
+        assert match is not None, "registered op should appear in /api/operations"
+        assert match["op_type"] == "upload"
+        # On success the framework clamps current to total
+        assert match["current"] == match["total"] == 2
+        assert match["status"] == "completed"
+
+    def test_upload_no_target_dir_does_not_register_op(self, client):
+        # Validation failure should not register an op, regardless of any ops
+        # left over from prior tests in the session.
+        before = {o["id"] for o in client.get("/api/operations").get_json()["operations"]}
+
+        resp = client.post(
+            "/upload-to-folder",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+
+        after = {o["id"] for o in client.get("/api/operations").get_json()["operations"]}
+        assert after.issubset(before), "validation failure must not register a new op"


### PR DESCRIPTION
## 📝 Description
Register and track upload operations in upload_to_folder so the Global Operations Indicator can show progress. Initialize op_id, filter out empty filenames up-front, register an "upload" operation with a total count, update progress per-file, and complete the operation on success or error. Include the op_id in the JSON response and ensure failed validation does not register an operation. Also add PDF to allowed extensions and add an "upload" icon mapping in templates/base.html. Tests were added to verify operation registration, op_id return, and that validation errors do not create ops.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass