### PR TITLE
Source Wall - Add Highlight to Selected Rows

### DIFF
--- a/static/js/source_wall.js
+++ b/static/js/source_wall.js
@@ -440,7 +440,7 @@ function renderTable() {
         });
 
         if (swSelectedFiles.has(file.path)) {
-            tr.classList.add('sw-selected');
+            tr.classList.add('sw-selected', 'table-info');
         }
 
         tbody.appendChild(tr);
@@ -766,10 +766,10 @@ function updateRowSelections() {
         const path = tr.dataset.path;
         const cb = tr.querySelector('input[type="checkbox"]');
         if (swSelectedFiles.has(path)) {
-            tr.classList.add('sw-selected');
+            tr.classList.add('sw-selected', 'table-info');
             if (cb) cb.checked = true;
         } else {
-            tr.classList.remove('sw-selected');
+            tr.classList.remove('sw-selected', 'table-info');
             if (cb) cb.checked = false;
         }
     });


### PR DESCRIPTION
## 📝 Description
Apply the Bootstrap 'table-info' class to rows alongside 'sw-selected' so selected files get a visual highlight. Updated both `renderTable `and `updateRowSelections `to add 'table-info' when selecting and remove it when deselecting, keeping checkbox behavior unchanged.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1038" height="361" alt="image" src="https://github.com/user-attachments/assets/d49c8916-3893-4645-9f46-4338f5cbb220" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass