### PR TITLE
Add Parallel Bulk ComicInfo Updater

### DIFF
--- a/core/comicinfo.py
+++ b/core/comicinfo.py
@@ -4,6 +4,7 @@ import re
 import zipfile
 import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as SafeET
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from core.app_logging import app_logger
 from core.config import config, load_config
 
@@ -359,6 +360,45 @@ def update_comicinfo_in_zip(zip_path: str, updates: dict):
 
     # Replace the original ZIP/CBZ with the updated one
     os.replace(temp_zip_path, zip_path)
+
+
+def bulk_update_comicinfo_in_zips(items, progress_callback=None, max_workers=4):
+    """Run update_comicinfo_in_zip in parallel across many CBZ files.
+
+    :param items: Iterable of (zip_path, updates_dict) tuples. Paths must be
+                  distinct — parallel calls on the same file would race on the
+                  shared .tmpzip sidecar.
+    :param progress_callback: Optional callable(completed_count, total, path, error)
+                              invoked once per file as it finishes. `error` is
+                              None on success, an Exception otherwise.
+    :param max_workers: Hard cap on concurrent workers. Actual worker count is
+                        min(max_workers, len(items)).
+    """
+    items = list(items)
+    total = len(items)
+    if total == 0:
+        return
+
+    worker_count = min(max_workers, max(1, total))
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = {
+            executor.submit(update_comicinfo_in_zip, path, updates): path
+            for path, updates in items
+        }
+        for i, future in enumerate(as_completed(futures), start=1):
+            path = futures[future]
+            try:
+                future.result()
+                err = None
+            except Exception as e:
+                err = e
+                app_logger.error(f"Failed to update ComicInfo in {path}: {e}")
+            if progress_callback is not None:
+                try:
+                    progress_callback(i, total, path, err)
+                except Exception as cb_err:
+                    app_logger.error(f"progress_callback failed for {path}: {cb_err}")
 
 
 if __name__ == "__main__":

--- a/routes/source_wall.py
+++ b/routes/source_wall.py
@@ -189,19 +189,18 @@ def _sync_field_to_cbz(path, updates):
 
 
 def _bulk_sync_to_cbz(paths, xml_tag, value, op_id):
-    """Background worker: sync field change to multiple CBZ files."""
+    """Background worker: sync field change to multiple CBZ files in parallel."""
     import core.app_state as app_state
     import core.comicinfo as comicinfo
 
-    for i, path in enumerate(paths):
-        try:
-            comicinfo.update_comicinfo_in_zip(path, {xml_tag: value})
-        except Exception as e:
-            app_logger.error(f"Failed to sync {xml_tag} to {path}: {e}")
+    items = [(path, {xml_tag: value}) for path in paths]
+
+    def on_progress(completed, total, path, error):
         app_state.update_operation(
             op_id,
-            current=i + 1,
-            detail=f"Updated {i + 1}/{len(paths)}",
+            current=completed,
+            detail=f"Updated {completed}/{total}",
         )
 
+    comicinfo.bulk_update_comicinfo_in_zips(items, progress_callback=on_progress)
     app_state.complete_operation(op_id)


### PR DESCRIPTION
## 📝 Description
Introduce `bulk_update_comicinfo_in_zips` in `core/comicinfo.py` to run `update_comicinfo_in_zip` concurrently using `ThreadPoolExecutor`, with an optional `progress_callback` and configurable `max_workers`. The implementation handles empty input, caps worker count, logs per-file errors, and protects progress callback failures. Update routes/source_wall.py to use the new bulk function: build (path, updates) items, provide a progress callback that updates `app_state` operation status, and replace the sequential loop with the parallel bulk call to speed up batch CBZ updates.

TLDR: When executing bulk updates on the `source_wall` view, this should decrease the amount of time it takes to update files by ~4X

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass