### PR TITLE
Add missing-XML Rescan and Preserve has_comicinfo

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -2770,14 +2770,17 @@ def update_file_metadata(file_id, metadata_dict, scanned_at, has_comicinfo=None)
         return False
 
 
-def update_metadata_scanned_at(file_id, scanned_at):
+def update_metadata_scanned_at(file_id, scanned_at, clear_has_comicinfo=False):
     """
     Mark a file as scanned without updating metadata fields.
-    Used when file has no ComicInfo.xml or on error.
 
     Args:
         file_id: ID of the file_index entry
         scanned_at: Unix timestamp (or None)
+        clear_has_comicinfo: If True, also set has_comicinfo=0. Pass True only
+            when the absence of ComicInfo.xml is definitive (file missing,
+            corrupt ZIP). Leave False for transient errors so a previously
+            correct has_comicinfo=1 isn't flipped to 0 by a one-off failure.
 
     Returns:
         True if successful, False otherwise
@@ -2788,10 +2791,16 @@ def update_metadata_scanned_at(file_id, scanned_at):
             return False
 
         c = conn.cursor()
-        c.execute(
-            "UPDATE file_index SET metadata_scanned_at = ?, has_comicinfo = 0 WHERE id = ?",
-            (scanned_at, file_id),
-        )
+        if clear_has_comicinfo:
+            c.execute(
+                "UPDATE file_index SET metadata_scanned_at = ?, has_comicinfo = 0 WHERE id = ?",
+                (scanned_at, file_id),
+            )
+        else:
+            c.execute(
+                "UPDATE file_index SET metadata_scanned_at = ? WHERE id = ?",
+                (scanned_at, file_id),
+            )
 
         conn.commit()
         conn.close()
@@ -3217,6 +3226,52 @@ def get_files_needing_metadata_scan(limit=1000):
 
     except Exception as e:
         app_logger.error(f"Failed to get files needing metadata scan: {e}")
+        return []
+
+
+def get_files_with_missing_comicinfo_for_rescan(limit=10000):
+    """
+    Return file_index rows where has_comicinfo=0, regardless of metadata_scanned_at.
+
+    Use this for a user-initiated force rescan of suspected-missing-XML files,
+    e.g. when ComicInfo.xml was added externally without bumping mtime — the
+    normal `get_files_needing_metadata_scan` query would skip those files.
+
+    Args:
+        limit: Maximum number of files to return
+
+    Returns:
+        List of dicts with id, path, modified_at
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT id, path, modified_at
+            FROM file_index
+            WHERE type = 'file'
+            AND (LOWER(path) LIKE '%.cbz' OR LOWER(path) LIKE '%.zip')
+            AND (has_comicinfo IS NULL OR has_comicinfo = 0)
+            ORDER BY modified_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+
+        rows = c.fetchall()
+        conn.close()
+
+        return [
+            {"id": r["id"], "path": r["path"], "modified_at": r["modified_at"]}
+            for r in rows
+        ]
+
+    except Exception as e:
+        app_logger.error(f"Failed to get files for missing-XML rescan: {e}")
         return []
 
 

--- a/core/metadata_scanner.py
+++ b/core/metadata_scanner.py
@@ -23,6 +23,7 @@ from core.app_logging import app_logger
 from core.config import config
 from core.database import (
     get_files_needing_metadata_scan,
+    get_files_with_missing_comicinfo_for_rescan,
     get_metadata_scan_stats,
     update_file_metadata,
     update_metadata_scanned_at,
@@ -130,7 +131,7 @@ def process_metadata_scan(task):
         # Skip if file doesn't exist
         if not os.path.exists(file_path):
             app_logger.debug(f"Metadata scan skipped (file missing): {task.file_path}")
-            update_metadata_scanned_at(task.file_id, time.time())
+            update_metadata_scanned_at(task.file_id, time.time(), clear_has_comicinfo=True)
             return
 
         # Extract metadata (~5-50ms)
@@ -138,9 +139,11 @@ def process_metadata_scan(task):
             metadata = read_comicinfo_from_zip(file_path)
         except zipfile.BadZipFile:
             app_logger.debug(f"Metadata scan skipped (invalid ZIP): {task.file_path}")
-            update_metadata_scanned_at(task.file_id, time.time())
+            update_metadata_scanned_at(task.file_id, time.time(), clear_has_comicinfo=True)
             return
         except Exception as e:
+            # Transient read error — preserve existing has_comicinfo so a one-off
+            # failure doesn't flip a correct 1 to 0.
             app_logger.warning(f"Error reading ComicInfo.xml from {task.file_path}: {e}")
             update_metadata_scanned_at(task.file_id, time.time())
             return
@@ -300,6 +303,44 @@ def queue_files_for_scan(file_paths, priority=PRIORITY_NEW_FILE):
         app_logger.debug(f"Queued {queued_count} files for metadata scan")
 
     return queued_count
+
+
+def queue_missing_xml_for_rescan(limit=10000):
+    """
+    Queue every CBZ/ZIP currently flagged has_comicinfo=0 for re-scan.
+
+    Used by the user-initiated "Rescan" button on the Missing XML view to
+    pick up files where ComicInfo.xml was added externally without bumping
+    mtime (the normal scan query would skip those).
+
+    Tasks are queued at PRIORITY_MODIFIED so they run ahead of the
+    background batch but behind real-time file_watcher events.
+
+    Returns:
+        Number of files queued.
+    """
+    try:
+        files = get_files_with_missing_comicinfo_for_rescan(limit=limit)
+
+        for f in files:
+            task = ScanTask(
+                priority=PRIORITY_MODIFIED,
+                file_path=f['path'],
+                file_id=f['id'],
+                modified_at=f['modified_at']
+            )
+            metadata_queue.put(task)
+
+        if files:
+            with scanner_lock:
+                scanner_progress['total_pending'] += len(files)
+            app_logger.info(f"Queued {len(files)} missing-XML files for rescan")
+
+        return len(files)
+
+    except Exception as e:
+        app_logger.error(f"Error queuing missing-XML files for rescan: {e}")
+        return 0
 
 
 def queue_monitor():

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -467,6 +467,19 @@ def cbz_bulk_clear_comicinfo():
     return jsonify({"success": True, "op_id": op_id, "total": total})
 
 
+@metadata_bp.route('/api/metadata/rescan-missing-xml', methods=['POST'])
+def api_rescan_missing_xml():
+    """
+    Force re-scan of every file currently flagged has_comicinfo=0.
+
+    Picks up files where ComicInfo.xml was added externally without bumping
+    mtime — the normal incremental scan query skips those.
+    """
+    from core.metadata_scanner import queue_missing_xml_for_rescan
+    queued = queue_missing_xml_for_rescan()
+    return jsonify({"success": True, "queued": queued})
+
+
 # =============================================================================
 # Save CVInfo
 # =============================================================================

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -603,6 +603,7 @@ function updateMainViewButtons() {
 function updateViewButtons(path) {
     const allBooksBtn = document.getElementById('allBooksBtn');
     const missingXmlBtn = document.getElementById('missingXmlBtn');
+    const rescanMissingXmlBtn = document.getElementById('rescanMissingXmlBtn');
     const folderViewBtn = document.getElementById('folderViewBtn');
     const viewToggleButtons = document.getElementById('viewToggleButtons');
 
@@ -613,18 +614,21 @@ function updateViewButtons(path) {
         viewToggleButtons.style.display = 'block';
         allBooksBtn.style.display = 'none';
         if (missingXmlBtn) missingXmlBtn.style.display = 'none';
+        if (rescanMissingXmlBtn) rescanMissingXmlBtn.style.display = 'none';
         folderViewBtn.style.display = 'inline-block';
     } else if (isMissingXmlMode) {
-        // In Missing XML mode: hide All Books and Missing XML, show Folder View
+        // In Missing XML mode: hide All Books and Missing XML, show Rescan + Folder View
         viewToggleButtons.style.display = 'block';
         allBooksBtn.style.display = 'none';
         if (missingXmlBtn) missingXmlBtn.style.display = 'none';
+        if (rescanMissingXmlBtn) rescanMissingXmlBtn.style.display = 'inline-block';
         folderViewBtn.style.display = 'inline-block';
     } else if (isAllBooksMode) {
         // In All Books mode: hide All Books, show Folder View
         viewToggleButtons.style.display = 'block';
         allBooksBtn.style.display = 'none';
         if (missingXmlBtn) missingXmlBtn.style.display = 'none';
+        if (rescanMissingXmlBtn) rescanMissingXmlBtn.style.display = 'none';
         folderViewBtn.style.display = 'inline-block';
     } else {
         // In Folder mode: show All Books and Missing XML (if not root), hide Folder View
@@ -636,6 +640,7 @@ function updateViewButtons(path) {
             allBooksBtn.style.display = 'inline-block';
             if (missingXmlBtn) missingXmlBtn.style.display = 'inline-block';
         }
+        if (rescanMissingXmlBtn) rescanMissingXmlBtn.style.display = 'none';
         folderViewBtn.style.display = 'none';
     }
 }
@@ -929,6 +934,44 @@ async function loadMissingXml(preservePage = false) {
         isMissingXmlMode = false;
         updateViewButtons(currentPath);
         setLoading(false);
+    }
+}
+
+/**
+ * Force a rescan of every file currently flagged as missing ComicInfo.xml.
+ * Picks up files where the XML was added externally without bumping mtime
+ * (the normal incremental scan would skip those).
+ */
+async function rescanMissingXml() {
+    const btn = document.getElementById('rescanMissingXmlBtn');
+    if (btn) btn.disabled = true;
+
+    try {
+        const response = await fetch('/api/metadata/rescan-missing-xml', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        const data = await response.json();
+
+        if (response.ok && data.success) {
+            const queued = data.queued || 0;
+            if (queued === 0) {
+                CLU.showToast('Rescan', 'No files need rescanning.', 'info');
+            } else {
+                CLU.showToast(
+                    'Rescan started',
+                    `Re-checking ${queued} file(s) in the background. Refresh in a moment to see updated results.`,
+                    'info'
+                );
+            }
+        } else {
+            CLU.showError(data.error || 'Failed to start rescan');
+        }
+    } catch (error) {
+        console.error('Error starting missing-XML rescan:', error);
+        CLU.showError('Failed to start rescan: ' + error.message);
+    } finally {
+        if (btn) btn.disabled = false;
     }
 }
 

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -57,6 +57,10 @@
                         style="display: none;">
                         <i class="bi bi-file-earmark-x"></i> Missing XML
                     </button>
+                    <button class="btn btn-outline-warning" id="rescanMissingXmlBtn" onclick="rescanMissingXml()"
+                        style="display: none;" title="Re-check ComicInfo.xml for files currently flagged as missing">
+                        <i class="bi bi-arrow-repeat"></i> Rescan
+                    </button>
                     <button class="btn btn-primary" id="folderViewBtn" onclick="returnToFolderView()"
                         style="display: none;">
                         <i class="bi bi-folder"></i> Collection View

--- a/tests/integration/test_database_file_index.py
+++ b/tests/integration/test_database_file_index.py
@@ -386,3 +386,124 @@ class TestFileMetadata:
         assert row[1] == "Tom King"
         assert row[2] == "DC"
         assert row[3] == 1
+
+
+class TestUpdateMetadataScannedAt:
+    """Verify the clear_has_comicinfo flag added to fix the Missing XML stale-data bug."""
+
+    def _setup_file_with_xml(self, db_connection):
+        from core.database import add_file_index_entry, set_has_comicinfo
+
+        add_file_index_entry("Foo.cbz", "/data/Foo.cbz", "file", parent="/data")
+        set_has_comicinfo("/data/Foo.cbz", 1)
+
+        cur = db_connection.execute("SELECT id FROM file_index WHERE path='/data/Foo.cbz'")
+        return cur.fetchone()[0]
+
+    def test_default_preserves_has_comicinfo(self, db_connection):
+        """Without clear_has_comicinfo=True, transient errors must NOT zero a correct 1."""
+        from core.database import update_metadata_scanned_at
+
+        file_id = self._setup_file_with_xml(db_connection)
+        ts = time.time()
+
+        ok = update_metadata_scanned_at(file_id, ts)
+        assert ok is True
+
+        cur = db_connection.execute(
+            "SELECT has_comicinfo, metadata_scanned_at FROM file_index WHERE id=?",
+            (file_id,),
+        )
+        row = cur.fetchone()
+        assert row[0] == 1, "has_comicinfo must be preserved on transient errors"
+        assert row[1] == ts
+
+    def test_explicit_flag_clears_has_comicinfo(self, db_connection):
+        """With clear_has_comicinfo=True (file missing / bad zip), has_comicinfo flips to 0."""
+        from core.database import update_metadata_scanned_at
+
+        file_id = self._setup_file_with_xml(db_connection)
+        ts = time.time()
+
+        ok = update_metadata_scanned_at(file_id, ts, clear_has_comicinfo=True)
+        assert ok is True
+
+        cur = db_connection.execute(
+            "SELECT has_comicinfo FROM file_index WHERE id=?", (file_id,),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+class TestGetFilesWithMissingComicinfoForRescan:
+    """Force-rescan helper for the user-initiated Missing XML rescan."""
+
+    def test_returns_only_files_with_missing_xml(self, db_connection):
+        from core.database import (
+            add_file_index_entry,
+            set_has_comicinfo,
+            get_files_with_missing_comicinfo_for_rescan,
+        )
+
+        add_file_index_entry("HasXml.cbz", "/data/HasXml.cbz", "file", parent="/data")
+        add_file_index_entry("NoXml.cbz", "/data/NoXml.cbz", "file", parent="/data")
+        add_file_index_entry("Other.cbz", "/data/Other.cbz", "file", parent="/data")
+        set_has_comicinfo("/data/HasXml.cbz", 1)
+        set_has_comicinfo("/data/NoXml.cbz", 0)
+        # Other.cbz left with default (NULL or 0)
+
+        rows = get_files_with_missing_comicinfo_for_rescan(limit=100)
+        paths = {r["path"] for r in rows}
+        assert "/data/NoXml.cbz" in paths
+        assert "/data/HasXml.cbz" not in paths
+
+    def test_ignores_metadata_scanned_at(self, db_connection):
+        """Unlike get_files_needing_metadata_scan, this helper returns files even when
+        metadata_scanned_at >= modified_at (the whole point of force-rescan)."""
+        from core.database import (
+            add_file_index_entry,
+            set_has_comicinfo,
+            update_metadata_scanned_at,
+            get_files_with_missing_comicinfo_for_rescan,
+        )
+
+        add_file_index_entry("Stale.cbz", "/data/Stale.cbz", "file", parent="/data")
+        set_has_comicinfo("/data/Stale.cbz", 0)
+        cur = db_connection.execute("SELECT id FROM file_index WHERE path='/data/Stale.cbz'")
+        file_id = cur.fetchone()[0]
+        # Mark recently scanned so the normal query would skip it
+        update_metadata_scanned_at(file_id, time.time() + 3600, clear_has_comicinfo=True)
+
+        rows = get_files_with_missing_comicinfo_for_rescan(limit=100)
+        assert any(r["path"] == "/data/Stale.cbz" for r in rows)
+
+    def test_respects_limit(self, db_connection):
+        from core.database import (
+            add_file_index_entry,
+            set_has_comicinfo,
+            get_files_with_missing_comicinfo_for_rescan,
+        )
+
+        for i in range(5):
+            path = f"/data/missing_{i}.cbz"
+            add_file_index_entry(f"missing_{i}.cbz", path, "file", parent="/data")
+            set_has_comicinfo(path, 0)
+
+        rows = get_files_with_missing_comicinfo_for_rescan(limit=2)
+        assert len(rows) == 2
+
+    def test_only_cbz_zip(self, db_connection):
+        from core.database import (
+            add_file_index_entry,
+            set_has_comicinfo,
+            get_files_with_missing_comicinfo_for_rescan,
+        )
+
+        add_file_index_entry("a.cbz", "/data/a.cbz", "file", parent="/data")
+        add_file_index_entry("b.txt", "/data/b.txt", "file", parent="/data")
+        set_has_comicinfo("/data/a.cbz", 0)
+        set_has_comicinfo("/data/b.txt", 0)
+
+        rows = get_files_with_missing_comicinfo_for_rescan(limit=100)
+        paths = {r["path"] for r in rows}
+        assert "/data/a.cbz" in paths
+        assert "/data/b.txt" not in paths

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -533,3 +533,56 @@ class TestBatchMangaProviderPriority:
                     break
 
         assert skip_comic_cvinfo is False
+
+
+class TestRescanMissingXmlEndpoint:
+    """POST /api/metadata/rescan-missing-xml triggers a force-rescan of has_comicinfo=0 files."""
+
+    @patch("core.metadata_scanner.queue_missing_xml_for_rescan", return_value=42)
+    def test_returns_queued_count(self, mock_queue, client):
+        resp = client.post('/api/metadata/rescan-missing-xml', json={})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["queued"] == 42
+        mock_queue.assert_called_once()
+
+    @patch("core.metadata_scanner.queue_missing_xml_for_rescan", return_value=0)
+    def test_zero_when_nothing_to_rescan(self, mock_queue, client):
+        resp = client.post('/api/metadata/rescan-missing-xml', json={})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["queued"] == 0
+
+
+class TestRemoveComicInfoUpdatesFileIndex:
+    """Regression: _remove_comicinfo_from_cbz must zero has_comicinfo in file_index
+    so the file shows up in the Missing XML view immediately after removal."""
+
+    def test_file_index_has_comicinfo_set_to_zero(self, db_connection, tmp_path):
+        from routes.metadata import _remove_comicinfo_from_cbz
+        from core.database import add_file_index_entry
+
+        cbz_path = str(tmp_path / "comic.cbz")
+        _make_cbz(cbz_path, with_comicinfo=True)
+
+        add_file_index_entry(
+            name="comic.cbz", path=cbz_path, entry_type="file",
+            size=1234, parent=str(tmp_path),
+        )
+        # Seed has_comicinfo=1 to mirror a previously-scanned file with metadata.
+        db_connection.execute(
+            "UPDATE file_index SET has_comicinfo=1 WHERE path=?", (cbz_path,)
+        )
+        db_connection.commit()
+
+        result = _remove_comicinfo_from_cbz(cbz_path)
+        assert result["success"] is True
+
+        cur = db_connection.execute(
+            "SELECT has_comicinfo FROM file_index WHERE path=?", (cbz_path,)
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0


### PR DESCRIPTION
## 📝 Description
Avoid flipping `has_comicinfo` on transient errors and provide a user-driven rescan for files flagged missing ComicInfo.xml.
Only clears `has_comicinfo` when `clear_has_comicinfo=True` (used for definitive cases like missing/corrupt archives). Default preserves existing has_comicinfo to avoid one-off failures overwriting correct state.\n- Added get_files_with_missing_comicinfo_for_rescan(limit) to return CBZ/ZIP files where has_comicinfo is NULL/0 regardless of metadata_scanned_at.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass