### PR TITLE
Support Home Page Refresh w/ Path

### DIFF
--- a/routes/collection.py
+++ b/routes/collection.py
@@ -136,7 +136,19 @@ def files_page():
 @collection_bp.route('/collection/<path:subpath>')
 def collection(subpath=''):
     """Render the visual browse page with optional path."""
-    initial_path = f'/data/{subpath}' if subpath else ''
+    # ?path= carries an absolute path verbatim — used for the default-library
+    # root and any non-default library, where embedding the absolute path in
+    # /collection/<subpath> would produce a double slash.
+    query_path = (request.args.get('path') or '').strip()
+    if query_path:
+        initial_path = query_path
+    elif subpath:
+        # Legacy clean URL: subpath is relative to the default library root.
+        default_lib = get_default_library()
+        root = default_lib['path'] if default_lib else '/data'
+        initial_path = f'{root}/{subpath}'
+    else:
+        initial_path = ''
     return render_template('collection.html',
                            initial_path=initial_path,
                            rec_enabled=config.get("SETTINGS", "REC_ENABLED", fallback="True") == "True",

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -170,13 +170,17 @@ async function loadDirectory(path, preservePage = false, forceRefresh = false) {
         });
     }
 
-    // Update URL without reloading - use clean URL format
-    // Convert /data/Publisher/Series to /collection/Publisher/Series
+    // Update URL without reloading. Use the legacy clean format
+    // /collection/<relative> for paths inside the default library (/data).
+    // For the /data root itself or any non-default-library absolute path,
+    // encode the full path as ?path= — concatenating an absolute path onto
+    // /collection/ would produce a double slash, which Werkzeug's
+    // merge_slashes 308-redirects on refresh and mangles the path.
     let cleanUrl = '/collection';
     if (path && path.startsWith('/data/')) {
-        cleanUrl = '/collection' + path.substring(5); // Remove '/data' prefix
+        cleanUrl = '/collection' + path.substring(5);
     } else if (path) {
-        cleanUrl = '/collection/' + path;
+        cleanUrl = '/collection?path=' + encodeURIComponent(path);
     }
     window.history.pushState({ path }, '', cleanUrl);
 

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -6,19 +6,17 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
 
 <script>
-    // Initial path from URL (e.g., /collection/Marvel -> /data/Marvel)
-    // If no URL path specified, check localStorage for saved library selection
+    // Initial path from URL (e.g., /collection/Marvel -> /data/Marvel).
+    // If no URL path specified, fall back to the saved library selection.
     (function () {
-        const urlPath = {{ initial_path | default ('') | tojson | safe
-    }};
-    if (urlPath && urlPath !== '') {
-        window.INITIAL_PATH = urlPath;
-    } else {
-        // Check localStorage for saved library preference
-        const savedLibrary = localStorage.getItem('selectedLibrary');
-        window.INITIAL_PATH = savedLibrary || '';
-    }
-    }) ();
+        const urlPath = {{ initial_path | default('') | tojson | safe }};
+        if (urlPath && urlPath !== '') {
+            window.INITIAL_PATH = urlPath;
+        } else {
+            const savedLibrary = localStorage.getItem('selectedLibrary');
+            window.INITIAL_PATH = savedLibrary || '';
+        }
+    })();
 </script>
 {% endblock %}
 {% block content %}

--- a/tests/routes/test_collection_routes.py
+++ b/tests/routes/test_collection_routes.py
@@ -29,6 +29,54 @@ class TestCollectionPage:
         resp = client.get("/collection/DC%20Comics/Batman")
         assert resp.status_code == 200
 
+    @patch("routes.collection.get_dashboard_sections", return_value=[])
+    @patch("routes.collection.config")
+    @patch("routes.collection.get_default_library", return_value=None)
+    def test_collection_subpath_uses_default_library_root(
+            self, mock_lib, mock_config, mock_sections, client):
+        """Legacy clean URL /collection/Marvel resolves to <default-lib>/Marvel.
+        With no library configured, fallback prefix is /data."""
+        mock_config.get.return_value = "True"
+        resp = client.get("/collection/Marvel")
+        assert resp.status_code == 200
+        # The template embeds initial_path via tojson — it appears literally in the HTML.
+        assert b'"/data/Marvel"' in resp.data
+
+    @patch("routes.collection.get_dashboard_sections", return_value=[])
+    @patch("routes.collection.config")
+    @patch("routes.collection.get_default_library",
+           return_value={"path": "/manga", "name": "Manga"})
+    def test_collection_subpath_uses_configured_default_library(
+            self, mock_lib, mock_config, mock_sections, client):
+        """When the default library is /manga, /collection/Naruto -> /manga/Naruto."""
+        mock_config.get.return_value = "True"
+        resp = client.get("/collection/Naruto")
+        assert resp.status_code == 200
+        assert b'"/manga/Naruto"' in resp.data
+
+    @patch("routes.collection.get_dashboard_sections", return_value=[])
+    @patch("routes.collection.config")
+    def test_collection_query_path_preserved_verbatim(
+            self, mock_config, mock_sections, client):
+        """?path= carries an absolute path that doesn't get re-prefixed.
+        This is the refresh-survivability path for non-default libraries
+        and the default-library root."""
+        mock_config.get.return_value = "True"
+        resp = client.get("/collection?path=/manga/Series%20A")
+        assert resp.status_code == 200
+        assert b'"/manga/Series A"' in resp.data
+
+    @patch("routes.collection.get_dashboard_sections", return_value=[])
+    @patch("routes.collection.config")
+    def test_collection_query_path_wins_over_subpath(
+            self, mock_config, mock_sections, client):
+        """If both ?path= and a subpath are present, ?path= wins."""
+        mock_config.get.return_value = "True"
+        resp = client.get("/collection/Marvel?path=/manga/Naruto")
+        assert resp.status_code == 200
+        assert b'"/manga/Naruto"' in resp.data
+        assert b'"/data/Marvel"' not in resp.data
+
 
 class TestToReadPage:
 


### PR DESCRIPTION
## 📝 Description
Prefer an explicit ?path= query param for `initial_path` (used for absolute/non-default library paths) and treat /collection/<subpath> as a legacy relative path under the configured default library (falling back to /data). Update client-side routing to push non-default or absolute paths as /collection?path=<encoded> to avoid double-slash issues and Werkzeug redirects, while preserving the legacy /collection/<relative> form for default-library entries. Small template cleanup and added tests covering default-library resolution, query-path precedence, and verbatim preservation of ?path=.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass