### PR TITLE
Add Mylar-compatible series.json support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -84,7 +84,11 @@
       "WebFetch(domain:wiki.kavitareader.com)",
       "Bash(py -3.11 --version)",
       "Bash(py -3.12 --version)",
-      "Bash(py -3.13 --version)"
+      "Bash(py -3.13 --version)",
+      "Bash(Get-ChildItem -Recurse -Filter \"*.py\")",
+      "Bash(Select-Object FullName)",
+      "Bash(sed \"s/.*get\\('//\")",
+      "Bash(sed \"s/'$//\")"
     ],
     "deny": [],
     "ask": []

--- a/models/series_json.py
+++ b/models/series_json.py
@@ -1,0 +1,244 @@
+"""
+Mylar3-compatible series.json file support.
+
+Writes a `series.json` file alongside each subscribed/mapped series folder.
+The format mirrors Mylar3's so external tools (readers, sync agents) can
+consume it without API access. See:
+https://github.com/mylar3/mylar3/wiki/The-series.json-file
+
+Public API:
+    write_series_json(folder_path, series, issues=None, api=None,
+                      preserve_existing=True) -> bool
+    read_series_json(folder_path) -> dict | None
+    build_metadata(series, issues=None, api=None) -> dict
+
+`series` may be either a dict (e.g. from `get_series_by_id`) or a Mokkari
+pydantic model (e.g. from `api.series(id)`).
+"""
+
+import json
+import os
+import tempfile
+
+from core.app_logging import app_logger
+
+SERIES_JSON_FILENAME = "series.json"
+
+# Fields a user may have hand-edited; preserved across refreshes when a
+# valid series.json already exists. Matches Mylar3 behavior.
+PRESERVED_FIELDS = (
+    "description_text",
+    "description_formatted",
+    "volume",
+    "booktype",
+    "status",
+)
+
+_ENDED_STATUS_VALUES = {"ended", "cancelled", "canceled", "completed", "finished"}
+
+
+def _get(obj, key, default=None):
+    """Read `key` from a dict or attribute from an object."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _normalize_status(status):
+    """Map Metron/DB status values to Mylar's 'Continuing' or 'Ended'."""
+    if status is None:
+        return "Continuing"
+    if isinstance(status, dict):
+        status = status.get("name", "")
+    text = str(status).strip().lower()
+    if not text:
+        return "Continuing"
+    if text in _ENDED_STATUS_VALUES:
+        return "Ended"
+    return "Continuing"
+
+
+def _format_publication_run(year_began, year_end, status):
+    """Format the publication_run string.
+
+    Mylar uses 'Month YYYY - Month YYYY'; we only track years, so we emit
+    'YYYY - YYYY' for ended series and 'YYYY - Present' for continuing ones.
+    """
+    if not year_began:
+        return ""
+    if _normalize_status(status) == "Ended":
+        if year_end:
+            return f"{year_began} - {year_end}"
+        return str(year_began)
+    return f"{year_began} - Present"
+
+
+def _resolve_publisher(series):
+    """Return the publisher name, handling dict/object/joined-column shapes."""
+    publisher = _get(series, "publisher")
+    if isinstance(publisher, dict):
+        name = publisher.get("name")
+        if name:
+            return name
+    elif publisher is not None and not isinstance(publisher, str):
+        name = getattr(publisher, "name", None)
+        if name:
+            return name
+    elif isinstance(publisher, str) and publisher:
+        return publisher
+    return _get(series, "publisher_name")
+
+
+def _resolve_imprint(series):
+    imprint = _get(series, "imprint")
+    if imprint is None:
+        return None
+    if isinstance(imprint, dict):
+        return imprint.get("name")
+    if not isinstance(imprint, str):
+        return getattr(imprint, "name", None)
+    return imprint or None
+
+
+def _resolve_year_began(series):
+    return _get(series, "year_began") or _get(series, "volume_year")
+
+
+def _resolve_cover_image(series):
+    return _get(series, "cover_image") or _get(series, "image")
+
+
+def _backfill_cv_id(series, api):
+    """If cv_id is missing but we have a Metron id and API, try to fetch it."""
+    if _get(series, "cv_id"):
+        return _get(series, "cv_id")
+    metron_id = _get(series, "id")
+    if not api or not metron_id:
+        return None
+    try:
+        fresh = api.series(metron_id)
+        return _get(fresh, "cv_id")
+    except Exception as e:
+        app_logger.warning(f"series.json cv_id backfill failed for {metron_id}: {e}")
+        return None
+
+
+def build_metadata(series, issues=None, api=None):
+    """Build the Mylar-compatible metadata dict for a series."""
+    metron_id = _get(series, "id")
+    cv_id = _backfill_cv_id(series, api)
+    year_began = _resolve_year_began(series)
+    year_end = _get(series, "year_end")
+    raw_status = _get(series, "status")
+    status = _normalize_status(raw_status)
+    description = _get(series, "desc") or _get(series, "description")
+
+    if issues is not None:
+        total_issues = len(issues)
+    else:
+        total_issues = _get(series, "issue_count") or 0
+
+    return {
+        "type": "comicSeries",
+        "publisher": _resolve_publisher(series),
+        "imprint": _resolve_imprint(series),
+        "name": _get(series, "name"),
+        "comicid": cv_id,
+        "metron_id": metron_id,
+        "year": year_began,
+        "description_text": description,
+        "description_formatted": None,
+        "volume": _get(series, "volume"),
+        "booktype": "Print",
+        "collects": None,
+        "comic_image": _resolve_cover_image(series),
+        "total_issues": total_issues,
+        "publication_run": _format_publication_run(year_began, year_end, raw_status),
+        "status": status,
+    }
+
+
+def read_series_json(folder_path):
+    """Read and parse an existing series.json. Returns dict or None."""
+    if not folder_path:
+        return None
+    path = os.path.join(folder_path, SERIES_JSON_FILENAME)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        app_logger.warning(f"Failed to parse existing {path}: {e}")
+        return None
+
+
+def _merge_preserved(new_metadata, existing_metadata):
+    """Copy non-empty preserved fields from existing into new."""
+    for field in PRESERVED_FIELDS:
+        if field not in existing_metadata:
+            continue
+        old_value = existing_metadata[field]
+        if old_value is None:
+            continue
+        if isinstance(old_value, str) and not old_value.strip():
+            continue
+        new_metadata[field] = old_value
+    return new_metadata
+
+
+def _atomic_write(path, payload):
+    """Write JSON atomically via temp file + os.replace."""
+    folder = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix=".series.json.", suffix=".tmp", dir=folder)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=4, ensure_ascii=False)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def write_series_json(folder_path, series, issues=None, api=None, preserve_existing=True):
+    """Create or update the series.json file in `folder_path`.
+
+    Args:
+        folder_path: Target folder (must exist).
+        series: Dict or Mokkari object with series data.
+        issues: Optional iterable of issues used to compute total_issues.
+        api: Optional Metron API client; used to backfill missing cv_id.
+        preserve_existing: When True, copy user-editable fields from any
+            existing series.json into the new one (Mylar behavior).
+
+    Returns:
+        True on success, False otherwise.
+    """
+    if not folder_path or not os.path.isdir(folder_path):
+        app_logger.warning(
+            f"Cannot write series.json: folder does not exist: {folder_path}"
+        )
+        return False
+
+    try:
+        metadata = build_metadata(series, issues=issues, api=api)
+
+        if preserve_existing:
+            existing = read_series_json(folder_path)
+            existing_metadata = (existing or {}).get("metadata")
+            if isinstance(existing_metadata, dict):
+                _merge_preserved(metadata, existing_metadata)
+
+        target = os.path.join(folder_path, SERIES_JSON_FILENAME)
+        _atomic_write(target, {"metadata": metadata})
+        app_logger.info(f"Wrote series.json at {target}")
+        return True
+
+    except Exception as e:
+        app_logger.error(f"Failed to write series.json in {folder_path}: {e}")
+        return False

--- a/routes/series.py
+++ b/routes/series.py
@@ -467,6 +467,21 @@ def series_view(slug):
             save_issues_bulk(all_issues, series_id)
             update_series_sync_time(series_id, len(all_issues))
 
+            # Mylar-compatible series.json: create or refresh dynamic fields
+            # while preserving any user-edited fields.
+            if existing_mapping and os.path.isdir(existing_mapping):
+                from models.series_json import write_series_json
+                series_for_json = dict(series_dict_for_save)
+                if cover_image and not series_for_json.get("cover_image"):
+                    series_for_json["cover_image"] = cover_image
+                write_series_json(
+                    existing_mapping,
+                    series_for_json,
+                    issues=all_issues,
+                    api=api,
+                    preserve_existing=True,
+                )
+
         # Helper to get attribute from dict or object
         def get_attr(obj, key, default=None):
             if isinstance(obj, dict):
@@ -570,6 +585,13 @@ def series_view(slug):
 
         series_subscription = get_series_subscription(series_id)
 
+        has_series_json = False
+        if mapped_path:
+            from models.series_json import SERIES_JSON_FILENAME
+            has_series_json = os.path.isfile(
+                os.path.join(mapped_path, SERIES_JSON_FILENAME)
+            )
+
         return render_template(
             "series.html",
             series=series_info,
@@ -584,6 +606,7 @@ def series_view(slug):
             libraries=libraries,
             default_library=default_library,
             series_subscription=series_subscription,
+            has_series_json=has_series_json,
         )
     except Exception as e:
         if metron.is_connection_error(e):
@@ -694,6 +717,8 @@ def map_series(series_id):
         success = save_series_mapping(series_data, mapped_path)
 
         if success:
+            from models.series_json import write_series_json
+            write_series_json(mapped_path, series_data, api=metron.get_flask_api())
             return jsonify({"success": True, "mapped_path": mapped_path})
         else:
             return jsonify({"error": "Failed to save mapping"}), 500
@@ -851,6 +876,9 @@ def subscribe_series(series_id):
                 app_logger.info(f"Created cvinfo at {cvinfo_path} with CV ID {cv_id}")
         else:
             app_logger.error(f"Failed to create cvinfo at {cvinfo_path}")
+
+        from models.series_json import write_series_json
+        write_series_json(path, series, api=metron.get_flask_api())
 
         return jsonify({"success": True, "path": path})
     except Exception as e:

--- a/templates/series.html
+++ b/templates/series.html
@@ -26,7 +26,20 @@
                         </div>
                         <!-- Series Info -->
                         <div class="col-md-7">
-                            <h2 class="display-6 fw-bold mb-3">{{ series.name }}</h2>
+                            <div class="d-flex align-items-baseline flex-wrap gap-2 mb-3">
+                                <h2 class="display-6 fw-bold mb-0">{{ series.name }}</h2>
+                                {% if mapped_path %}
+                                {% if has_series_json %}
+                                <span class="badge bg-success" title="series.json is present in the mapped folder">
+                                    <i class="bi bi-file-earmark-check me-1"></i>series.json
+                                </span>
+                                {% else %}
+                                <span class="badge bg-warning text-dark" title="series.json is missing — click Refresh to generate">
+                                    <i class="bi bi-file-earmark-x me-1"></i>series.json
+                                </span>
+                                {% endif %}
+                                {% endif %}
+                            </div>
                             <p class="lead mb-4">{{ series.desc or 'No description available.' }}</p>
 
                             <div class="row g-3 text-muted">

--- a/tests/unit/test_series_json.py
+++ b/tests/unit/test_series_json.py
@@ -1,0 +1,368 @@
+"""Tests for models.series_json -- Mylar3-compatible series.json support."""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ===== _normalize_status =====
+
+class TestNormalizeStatus:
+
+    def test_none_defaults_to_continuing(self):
+        from models.series_json import _normalize_status
+        assert _normalize_status(None) == "Continuing"
+
+    def test_empty_string_defaults_to_continuing(self):
+        from models.series_json import _normalize_status
+        assert _normalize_status("") == "Continuing"
+
+    def test_ongoing_string_maps_to_continuing(self):
+        from models.series_json import _normalize_status
+        assert _normalize_status("Ongoing") == "Continuing"
+        assert _normalize_status("Continuing") == "Continuing"
+
+    def test_ended_maps_to_ended(self):
+        from models.series_json import _normalize_status
+        assert _normalize_status("Ended") == "Ended"
+        assert _normalize_status("ended") == "Ended"
+
+    def test_cancelled_maps_to_ended(self):
+        from models.series_json import _normalize_status
+        assert _normalize_status("Cancelled") == "Ended"
+        assert _normalize_status("Canceled") == "Ended"
+        assert _normalize_status("Completed") == "Ended"
+
+    def test_status_object_with_name(self):
+        from models.series_json import _normalize_status
+        assert _normalize_status({"name": "Ended"}) == "Ended"
+        assert _normalize_status({"name": "Ongoing"}) == "Continuing"
+
+
+# ===== _format_publication_run =====
+
+class TestFormatPublicationRun:
+
+    def test_continuing_with_year_began(self):
+        from models.series_json import _format_publication_run
+        assert _format_publication_run(2021, None, "Ongoing") == "2021 - Present"
+
+    def test_continuing_ignores_year_end(self):
+        from models.series_json import _format_publication_run
+        # If status says continuing, even an end year doesn't matter
+        assert _format_publication_run(2021, 2022, "Ongoing") == "2021 - Present"
+
+    def test_ended_with_both_years(self):
+        from models.series_json import _format_publication_run
+        assert _format_publication_run(2011, 2016, "Ended") == "2011 - 2016"
+
+    def test_ended_without_year_end(self):
+        from models.series_json import _format_publication_run
+        assert _format_publication_run(2011, None, "Ended") == "2011"
+
+    def test_missing_year_began_returns_empty(self):
+        from models.series_json import _format_publication_run
+        assert _format_publication_run(None, None, "Ongoing") == ""
+
+
+# ===== build_metadata =====
+
+class TestBuildMetadata:
+
+    def _dict_series(self, **overrides):
+        base = {
+            "id": 12345,
+            "name": "Test Series",
+            "cv_id": 43022,
+            "volume": 5,
+            "status": "Ended",
+            "year_began": 2011,
+            "year_end": 2016,
+            "desc": "A series description.",
+            "publisher": {"id": 1, "name": "DC Comics"},
+            "imprint": None,
+            "cover_image": "https://example.com/cover.jpg",
+            "issue_count": 55,
+        }
+        base.update(overrides)
+        return base
+
+    def test_full_dict_series_produces_correct_schema(self):
+        from models.series_json import build_metadata
+        meta = build_metadata(self._dict_series())
+        assert meta == {
+            "type": "comicSeries",
+            "publisher": "DC Comics",
+            "imprint": None,
+            "name": "Test Series",
+            "comicid": 43022,
+            "metron_id": 12345,
+            "year": 2011,
+            "description_text": "A series description.",
+            "description_formatted": None,
+            "volume": 5,
+            "booktype": "Print",
+            "collects": None,
+            "comic_image": "https://example.com/cover.jpg",
+            "total_issues": 55,
+            "publication_run": "2011 - 2016",
+            "status": "Ended",
+        }
+
+    def test_missing_cv_id_leaves_comicid_null(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(cv_id=None)
+        meta = build_metadata(series)
+        assert meta["comicid"] is None
+        assert meta["metron_id"] == 12345
+
+    def test_issues_count_overrides_issue_count_field(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(issue_count=5)
+        issues = [{"number": str(i)} for i in range(1, 11)]
+        meta = build_metadata(series, issues=issues)
+        assert meta["total_issues"] == 10
+
+    def test_continuing_series_uses_present(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(status="Ongoing", year_end=None)
+        meta = build_metadata(series)
+        assert meta["publication_run"] == "2011 - Present"
+        assert meta["status"] == "Continuing"
+
+    def test_publisher_name_falls_back_to_joined_column(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(publisher=None)
+        series["publisher_name"] = "Marvel"
+        meta = build_metadata(series)
+        assert meta["publisher"] == "Marvel"
+
+    def test_volume_year_used_when_year_began_missing(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(year_began=None)
+        series["volume_year"] = 2018
+        meta = build_metadata(series)
+        assert meta["year"] == 2018
+
+    def test_mokkari_style_object(self):
+        from models.series_json import build_metadata
+        publisher = MagicMock()
+        publisher.name = "DC Comics"
+        publisher.id = 1
+        series = MagicMock(spec=[
+            "id", "name", "cv_id", "volume", "status", "year_began",
+            "year_end", "desc", "publisher", "imprint", "cover_image",
+            "issue_count",
+        ])
+        series.id = 99
+        series.name = "Mokkari Series"
+        series.cv_id = 11111
+        series.volume = 1
+        series.status = "Ongoing"
+        series.year_began = 2023
+        series.year_end = None
+        series.desc = "Mokkari desc"
+        series.publisher = publisher
+        series.imprint = None
+        series.cover_image = None
+        series.issue_count = 3
+        meta = build_metadata(series)
+        assert meta["name"] == "Mokkari Series"
+        assert meta["publisher"] == "DC Comics"
+        assert meta["metron_id"] == 99
+        assert meta["comicid"] == 11111
+        assert meta["status"] == "Continuing"
+
+    def test_backfills_cv_id_from_api_when_missing(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(cv_id=None)
+        api = MagicMock()
+        api.series.return_value = MagicMock(cv_id=77777)
+        meta = build_metadata(series, api=api)
+        assert meta["comicid"] == 77777
+        api.series.assert_called_once_with(12345)
+
+    def test_api_failure_during_backfill_is_silent(self):
+        from models.series_json import build_metadata
+        series = self._dict_series(cv_id=None)
+        api = MagicMock()
+        api.series.side_effect = RuntimeError("network down")
+        meta = build_metadata(series, api=api)
+        assert meta["comicid"] is None
+
+
+# ===== write_series_json =====
+
+class TestWriteSeriesJson:
+
+    @pytest.fixture
+    def series(self):
+        return {
+            "id": 1,
+            "name": "Aquaman",
+            "cv_id": 43022,
+            "volume": 5,
+            "status": "Ended",
+            "year_began": 2011,
+            "year_end": 2016,
+            "desc": "Original description.",
+            "publisher": {"id": 1, "name": "DC Comics"},
+            "imprint": None,
+            "cover_image": "https://example.com/cover.jpg",
+            "issue_count": 55,
+        }
+
+    def test_creates_file_when_missing(self, tmp_path, series):
+        from models.series_json import write_series_json
+        assert write_series_json(str(tmp_path), series) is True
+
+        target = tmp_path / "series.json"
+        assert target.exists()
+        with open(target, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["metadata"]["name"] == "Aquaman"
+        assert data["metadata"]["comicid"] == 43022
+        assert data["metadata"]["metron_id"] == 1
+
+    def test_returns_false_for_missing_folder(self, tmp_path, series):
+        from models.series_json import write_series_json
+        missing = tmp_path / "does-not-exist"
+        assert write_series_json(str(missing), series) is False
+
+    def test_preserve_existing_keeps_user_editable_fields(self, tmp_path, series):
+        from models.series_json import write_series_json
+        target = tmp_path / "series.json"
+        existing = {
+            "metadata": {
+                "name": "Aquaman",
+                "description_text": "User-edited description.",
+                "description_formatted": "**User formatted**",
+                "volume": 99,
+                "booktype": "HC",
+                "status": "Ended",
+                "total_issues": 1,
+                "publication_run": "stale",
+            }
+        }
+        with open(target, "w", encoding="utf-8") as f:
+            json.dump(existing, f)
+
+        # New fetched data has different values for everything
+        new_series = dict(series, desc="API description", volume=5, status="Ongoing")
+        assert write_series_json(str(tmp_path), new_series, preserve_existing=True) is True
+
+        with open(target, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        meta = data["metadata"]
+
+        # Preserved fields keep old values
+        assert meta["description_text"] == "User-edited description."
+        assert meta["description_formatted"] == "**User formatted**"
+        assert meta["volume"] == 99
+        assert meta["booktype"] == "HC"
+        assert meta["status"] == "Ended"
+
+        # Dynamic fields refresh from current data
+        assert meta["total_issues"] == 55
+        assert meta["publication_run"] != "stale"
+
+    def test_preserve_existing_false_overwrites_everything(self, tmp_path, series):
+        from models.series_json import write_series_json
+        target = tmp_path / "series.json"
+        existing = {
+            "metadata": {
+                "description_text": "User-edited description.",
+                "volume": 99,
+                "booktype": "HC",
+            }
+        }
+        with open(target, "w", encoding="utf-8") as f:
+            json.dump(existing, f)
+
+        assert write_series_json(
+            str(tmp_path), series, preserve_existing=False
+        ) is True
+
+        with open(target, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        meta = data["metadata"]
+        assert meta["description_text"] == "Original description."
+        assert meta["volume"] == 5
+        assert meta["booktype"] == "Print"
+
+    def test_null_preserved_field_does_not_override(self, tmp_path, series):
+        """A null preserved field in the existing file should not blank out
+        the new computed value."""
+        from models.series_json import write_series_json
+        target = tmp_path / "series.json"
+        existing = {
+            "metadata": {
+                "description_text": None,
+                "volume": None,
+            }
+        }
+        with open(target, "w", encoding="utf-8") as f:
+            json.dump(existing, f)
+
+        write_series_json(str(tmp_path), series, preserve_existing=True)
+
+        with open(target, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        meta = data["metadata"]
+        assert meta["description_text"] == "Original description."
+        assert meta["volume"] == 5
+
+    def test_corrupt_existing_file_falls_back_to_overwrite(self, tmp_path, series):
+        from models.series_json import write_series_json
+        target = tmp_path / "series.json"
+        target.write_text("not valid json {{{", encoding="utf-8")
+
+        assert write_series_json(str(tmp_path), series) is True
+
+        with open(target, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["metadata"]["name"] == "Aquaman"
+
+    def test_atomic_write_no_partial_file_on_failure(self, tmp_path, series):
+        """If json.dump fails, no partial series.json should remain."""
+        from models import series_json as sj
+
+        target = tmp_path / "series.json"
+        target.write_text(json.dumps({"metadata": {"name": "old"}}), encoding="utf-8")
+        original_content = target.read_text(encoding="utf-8")
+
+        with patch("models.series_json.json.dump", side_effect=RuntimeError("disk full")):
+            result = sj.write_series_json(str(tmp_path), series)
+
+        assert result is False
+        # Original file remains intact (os.replace never ran)
+        assert target.read_text(encoding="utf-8") == original_content
+        # No stray .tmp files were left behind
+        leftovers = [p for p in os.listdir(tmp_path) if p.startswith(".series.json.")]
+        assert leftovers == []
+
+
+# ===== read_series_json =====
+
+class TestReadSeriesJson:
+
+    def test_returns_none_when_missing(self, tmp_path):
+        from models.series_json import read_series_json
+        assert read_series_json(str(tmp_path)) is None
+
+    def test_returns_none_for_invalid_path(self):
+        from models.series_json import read_series_json
+        assert read_series_json("") is None
+        assert read_series_json(None) is None
+
+    def test_returns_parsed_dict(self, tmp_path):
+        from models.series_json import read_series_json
+        payload = {"metadata": {"name": "Test"}}
+        (tmp_path / "series.json").write_text(json.dumps(payload), encoding="utf-8")
+        assert read_series_json(str(tmp_path)) == payload
+
+    def test_returns_none_on_malformed_json(self, tmp_path):
+        from models.series_json import read_series_json
+        (tmp_path / "series.json").write_text("{{not json", encoding="utf-8")
+        assert read_series_json(str(tmp_path)) is None


### PR DESCRIPTION
## 📝 Description
Introduce `models/series_json.py` to build, read and write Mylar3-style `series.json` files next to mapped/subscribed series. Features include build_metadata (with publisher/imprint/cover/year resolution), cv_id backfill via API, preserved user-editable fields on refresh, and atomic temp-file writes. Integrate writes into routes/series.py (subscribe, map, and refresh paths) and add a UI badge in templates/series.html to show presence/missing status. 

Adds a 'series.json' pill to series page and creates 'series.json' when subscribing to a series

Closes #292 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="859" height="127" alt="image" src="https://github.com/user-attachments/assets/6d3c1a3e-aba7-463d-800d-c41d92cf1900" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass