### PR TITLE
Add pull-list export/import and DB helpers

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -7726,6 +7726,146 @@ def save_series_mapping(series_data, mapped_path, cover_image=None):
         return False
 
 
+def upsert_publisher_by_name(name, publisher_id=None):
+    """
+    Look up a publisher by name (case-insensitive); insert if missing.
+
+    Used by pull-list import to re-link series rows to a publisher on a fresh
+    DB, where the publisher_id from the export may not exist locally.
+
+    Args:
+        name: Publisher name to look up or create.
+        publisher_id: Optional Metron publisher id; used when inserting if
+            the name isn't found and the id is also unused.
+
+    Returns:
+        The publisher id (existing or new), or None if name is falsy.
+    """
+    if not name:
+        return None
+    conn = None
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return None
+        c = conn.cursor()
+        c.execute(
+            "SELECT id FROM publishers WHERE name = ? COLLATE NOCASE LIMIT 1",
+            (name,),
+        )
+        row = c.fetchone()
+        if row:
+            return row["id"] if hasattr(row, "keys") else row[0]
+
+        if publisher_id is not None:
+            c.execute("SELECT 1 FROM publishers WHERE id = ?", (publisher_id,))
+            if not c.fetchone():
+                c.execute(
+                    "INSERT INTO publishers (id, name, created_at) "
+                    "VALUES (?, ?, CURRENT_TIMESTAMP)",
+                    (publisher_id, name),
+                )
+                conn.commit()
+                return publisher_id
+
+        c.execute(
+            "INSERT INTO publishers (name, created_at) VALUES (?, CURRENT_TIMESTAMP)",
+            (name,),
+        )
+        conn.commit()
+        return c.lastrowid
+    except Exception as e:
+        app_logger.error(f"upsert_publisher_by_name failed for {name!r}: {e}")
+        return None
+    finally:
+        if conn:
+            conn.close()
+
+
+def import_series_row(entry):
+    """
+    Insert or update a single series row from a pull-list import payload.
+
+    On conflict only mapped_path and series_subscription are updated;
+    synced metadata (name, status, desc, cover_image, etc.) is preserved.
+    Does not call any external API.
+
+    Args:
+        entry: Dict shaped like the export schema (must contain "id").
+
+    Returns:
+        "inserted" if a new row was created, "updated" if an existing row
+        was modified.
+
+    Raises:
+        ValueError: if entry is missing a usable series id.
+        RuntimeError: if the database is unavailable.
+    """
+    if not isinstance(entry, dict):
+        raise ValueError("Series entry must be an object")
+    series_id = entry.get("id")
+    if not isinstance(series_id, int):
+        raise ValueError("Missing or invalid series id")
+
+    conn = get_db_connection()
+    if not conn:
+        raise RuntimeError("Database unavailable")
+    try:
+        c = conn.cursor()
+
+        # Resolve publisher_id: prefer an exact id match if it exists,
+        # otherwise upsert by name.
+        publisher_id = entry.get("publisher_id")
+        if publisher_id is not None:
+            c.execute("SELECT 1 FROM publishers WHERE id = ?", (publisher_id,))
+            if not c.fetchone():
+                publisher_id = None
+        if publisher_id is None:
+            publisher_id = upsert_publisher_by_name(
+                entry.get("publisher_name"), entry.get("publisher_id")
+            )
+
+        c.execute("SELECT 1 FROM series WHERE id = ?", (series_id,))
+        existed = c.fetchone() is not None
+
+        c.execute(
+            """
+            INSERT INTO series (
+                id, name, sort_name, volume, status, publisher_id,
+                imprint, volume_year, year_end, cv_id, gcd_id,
+                resource_url, mapped_path, series_subscription,
+                created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ON CONFLICT(id) DO UPDATE SET
+                mapped_path = excluded.mapped_path,
+                series_subscription = excluded.series_subscription,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (
+                series_id,
+                entry.get("name"),
+                entry.get("sort_name"),
+                entry.get("volume"),
+                entry.get("status"),
+                publisher_id,
+                entry.get("imprint"),
+                entry.get("volume_year"),
+                entry.get("year_end"),
+                entry.get("cv_id"),
+                entry.get("gcd_id"),
+                entry.get("resource_url"),
+                entry.get("mapped_path"),
+                entry.get("series_subscription"),
+            ),
+        )
+        conn.commit()
+        return "updated" if existed else "inserted"
+    finally:
+        conn.close()
+
+
 def update_series_desc(series_id, desc):
     """
     Update the description for a series.

--- a/routes/series.py
+++ b/routes/series.py
@@ -10,6 +10,7 @@ Provides routes for:
 - Libraries CRUD
 """
 
+import json
 import os
 import re
 import threading
@@ -24,6 +25,7 @@ from flask import (
     url_for,
     flash,
     current_app,
+    Response,
 )
 from models import metron
 import core.app_state as app_state
@@ -264,6 +266,106 @@ def pull_list():
         total_series=len(series_list),
         publishers=publishers,
     )
+
+
+_PULL_LIST_EXPORT_FIELDS = (
+    "id",
+    "name",
+    "sort_name",
+    "volume",
+    "volume_year",
+    "year_end",
+    "status",
+    "publisher_id",
+    "publisher_name",
+    "imprint",
+    "cv_id",
+    "gcd_id",
+    "resource_url",
+    "mapped_path",
+    "series_subscription",
+)
+
+
+def _serialize_series_for_export(row):
+    """Pick only user-set / identity fields from a mapped-series row."""
+    return {k: row.get(k) for k in _PULL_LIST_EXPORT_FIELDS}
+
+
+@series_bp.route("/api/pull-list/export")
+def export_pull_list():
+    """Download the current pull list (all mapped series) as a JSON file."""
+    from core.database import get_all_mapped_series
+    from core.version import __version__
+
+    rows = get_all_mapped_series()
+    payload = {
+        "version": 1,
+        "exported_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "app_version": __version__,
+        "series_count": len(rows),
+        "series": [_serialize_series_for_export(r) for r in rows],
+    }
+    body = json.dumps(payload, indent=2, ensure_ascii=False)
+    filename = f"pull-list-{datetime.utcnow().strftime('%Y-%m-%d')}.json"
+    return Response(
+        body,
+        mimetype="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@series_bp.route("/api/pull-list/import", methods=["POST"])
+def import_pull_list():
+    """Restore series rows + mapped_path from an exported JSON file."""
+    f = request.files.get("file")
+    if not f:
+        return jsonify({"success": False, "error": "No file uploaded"}), 400
+
+    raw = f.read(2 * 1024 * 1024)
+    if f.read(1):
+        return jsonify({"success": False, "error": "File too large (>2MB)"}), 400
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        return jsonify({"success": False, "error": f"Invalid JSON: {e}"}), 400
+
+    if not isinstance(payload, dict) or payload.get("version") != 1:
+        return jsonify({"success": False, "error": "Unsupported file format"}), 400
+
+    series_list = payload.get("series")
+    if not isinstance(series_list, list):
+        return jsonify({"success": False, "error": "Missing 'series' array"}), 400
+
+    from core.database import import_series_row
+
+    imported_new = 0
+    updated_existing = 0
+    skipped = 0
+    errors = []
+    for entry in series_list:
+        try:
+            result = import_series_row(entry)
+            if result == "inserted":
+                imported_new += 1
+            elif result == "updated":
+                updated_existing += 1
+            else:
+                skipped += 1
+        except Exception as e:
+            errors.append({
+                "id": entry.get("id") if isinstance(entry, dict) else None,
+                "error": str(e),
+            })
+
+    return jsonify({
+        "success": True,
+        "imported_new": imported_new,
+        "updated_existing": updated_existing,
+        "skipped": skipped,
+        "errors": errors,
+    })
 
 
 @series_bp.route("/series-search")

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -17,6 +17,14 @@
             <a href="{{ url_for('series.releases') }}" class="btn btn-outline-primary">
                 <i class="bi bi-calendar-week me-1"></i>Weekly Releases
             </a>
+            {% if total_series > 0 %}
+            <a href="{{ url_for('series.export_pull_list') }}" class="btn btn-outline-success" title="Download pull list as JSON">
+                <i class="bi bi-download me-1"></i>Export
+            </a>
+            {% endif %}
+            <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#importModal" title="Restore pull list from JSON">
+                <i class="bi bi-upload me-1"></i>Import
+            </button>
         </div>
     </div>
 
@@ -166,8 +174,78 @@
     {% endif %}
 </div>
 
+<!-- Import Pull List Modal -->
+<div class="modal fade" id="importModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title fw-bold">
+                    <i class="bi bi-upload me-2"></i>Import Pull List
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted small mb-3">
+                    Restore tracked series from a previously exported JSON file. Existing series
+                    will keep their synced metadata; only the mapped path and subscription flag are updated.
+                </p>
+                <div class="mb-3">
+                    <input type="file" class="form-control" id="importFile" accept=".json,application/json">
+                </div>
+                <div id="importResult"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="importSubmit">
+                    <i class="bi bi-upload me-1"></i>Import
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
     document.addEventListener('DOMContentLoaded', function () {
+        const importSubmit = document.getElementById('importSubmit');
+        if (importSubmit) {
+            importSubmit.addEventListener('click', async () => {
+                const fileInput = document.getElementById('importFile');
+                const resultDiv = document.getElementById('importResult');
+                if (!fileInput.files[0]) {
+                    resultDiv.innerHTML = '<div class="alert alert-warning mb-0">Choose a file first.</div>';
+                    return;
+                }
+                const fd = new FormData();
+                fd.append('file', fileInput.files[0]);
+                importSubmit.disabled = true;
+                resultDiv.innerHTML = '<div class="text-center py-2"><div class="spinner-border spinner-border-sm"></div></div>';
+                try {
+                    const resp = await fetch('/api/pull-list/import', { method: 'POST', body: fd });
+                    const data = await resp.json();
+                    if (!data.success) {
+                        resultDiv.innerHTML = `<div class="alert alert-danger mb-0">${data.error}</div>`;
+                        importSubmit.disabled = false;
+                        return;
+                    }
+                    const errNote = data.errors.length
+                        ? `<br><small>${data.errors.length} error${data.errors.length === 1 ? '' : 's'} — see browser console.</small>`
+                        : '';
+                    resultDiv.innerHTML = `
+                        <div class="alert alert-success mb-0">
+                            Imported ${data.imported_new} new, updated ${data.updated_existing}, skipped ${data.skipped}.
+                            ${errNote}
+                            <div class="mt-2">
+                                <button type="button" class="btn btn-sm btn-primary" onclick="location.reload()">Reload page</button>
+                            </div>
+                        </div>`;
+                    if (data.errors.length) console.warn('Pull list import errors:', data.errors);
+                } catch (e) {
+                    resultDiv.innerHTML = `<div class="alert alert-danger mb-0">${e.message}</div>`;
+                    importSubmit.disabled = false;
+                }
+            });
+        }
+
         const searchInput = document.getElementById('searchInput');
         const table = document.getElementById('seriesTable');
         const resultCount = document.getElementById('resultCount');

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -1,4 +1,6 @@
 """Tests for routes/series.py -- series management endpoints."""
+import io
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -309,3 +311,191 @@ class TestSeriesSubscription:
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
         mock_set.assert_called_once_with(100, False)
+
+
+def _post_import(client, payload, *, raw=None, filename="pull-list.json"):
+    """Helper: POST a JSON payload (or raw bytes) to the import endpoint."""
+    if raw is None:
+        raw = json.dumps(payload).encode("utf-8")
+    return client.post(
+        "/api/pull-list/import",
+        data={"file": (io.BytesIO(raw), filename)},
+        content_type="multipart/form-data",
+    )
+
+
+class TestPullListExport:
+
+    def test_returns_attachment_json(self, client_with_data):
+        resp = client_with_data.get("/api/pull-list/export")
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/json"
+        disp = resp.headers.get("Content-Disposition", "")
+        assert disp.startswith("attachment;")
+        assert "pull-list-" in disp
+
+        body = json.loads(resp.get_data(as_text=True))
+        assert body["version"] == 1
+        assert body["series_count"] == 2
+        ids = {s["id"] for s in body["series"]}
+        assert ids == {100, 200}
+
+    def test_excludes_unmapped(self, client_with_data):
+        from tests.factories.db_factories import create_series
+        from core.database import get_db_connection
+        create_series(series_id=300, name="Unmapped", volume=2021,
+                      publisher_id=10)
+        conn = get_db_connection()
+        conn.execute("UPDATE series SET mapped_path = NULL WHERE id = ?", (300,))
+        conn.commit()
+        conn.close()
+
+        body = json.loads(
+            client_with_data.get("/api/pull-list/export").get_data(as_text=True)
+        )
+        ids = {s["id"] for s in body["series"]}
+        assert 300 not in ids
+        assert body["series_count"] == 2
+
+    def test_omits_runtime_fields(self, client_with_data):
+        body = json.loads(
+            client_with_data.get("/api/pull-list/export").get_data(as_text=True)
+        )
+        for entry in body["series"]:
+            assert "cover_image" not in entry
+            assert "last_synced_at" not in entry
+            assert "created_at" not in entry
+            assert "updated_at" not in entry
+            assert "issue_count" not in entry
+            assert "desc" not in entry
+
+    def test_includes_publisher_name(self, client_with_data):
+        body = json.loads(
+            client_with_data.get("/api/pull-list/export").get_data(as_text=True)
+        )
+        batman = next(s for s in body["series"] if s["id"] == 100)
+        assert batman["publisher_name"] == "DC Comics"
+        assert batman["mapped_path"] == "/data/DC Comics/Batman"
+
+
+class TestPullListImport:
+
+    def test_rejects_missing_file(self, client_with_data):
+        resp = client_with_data.post("/api/pull-list/import")
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    def test_rejects_malformed_json(self, client_with_data):
+        resp = _post_import(client_with_data, None, raw=b"{not json")
+        assert resp.status_code == 400
+        assert "Invalid JSON" in resp.get_json()["error"]
+
+    def test_rejects_wrong_version(self, client_with_data):
+        resp = _post_import(client_with_data, {"version": 99, "series": []})
+        assert resp.status_code == 400
+        assert "Unsupported" in resp.get_json()["error"]
+
+    def test_rejects_missing_series_array(self, client_with_data):
+        resp = _post_import(client_with_data, {"version": 1})
+        assert resp.status_code == 400
+        assert "series" in resp.get_json()["error"]
+
+    def test_imports_new_series(self, client_with_data):
+        from core.database import get_series_by_id
+        payload = {
+            "version": 1,
+            "series": [{
+                "id": 999,
+                "name": "New Series",
+                "volume": 2024,
+                "volume_year": 2024,
+                "status": "Ongoing",
+                "publisher_id": 10,
+                "publisher_name": "DC Comics",
+                "mapped_path": "/data/DC Comics/New Series",
+            }],
+        }
+        resp = _post_import(client_with_data, payload)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["imported_new"] == 1
+        assert data["updated_existing"] == 0
+        assert data["errors"] == []
+
+        row = get_series_by_id(999)
+        assert row is not None
+        assert row["mapped_path"] == "/data/DC Comics/New Series"
+        assert row["name"] == "New Series"
+        assert row["publisher_id"] == 10
+
+    def test_existing_updates_mapped_path_only(self, client_with_data):
+        from core.database import get_series_by_id
+        payload = {
+            "version": 1,
+            "series": [{
+                "id": 100,
+                "name": "CLOBBERED",
+                "status": "Cancelled",
+                "mapped_path": "/data/DC Comics/Batman (relocated)",
+                "publisher_id": 10,
+                "publisher_name": "DC Comics",
+            }],
+        }
+        resp = _post_import(client_with_data, payload)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported_new"] == 0
+        assert data["updated_existing"] == 1
+
+        row = get_series_by_id(100)
+        assert row["mapped_path"] == "/data/DC Comics/Batman (relocated)"
+        # Synced metadata must be preserved on update
+        assert row["name"] == "Batman"
+        assert row["status"] != "Cancelled"
+
+    def test_upserts_unknown_publisher(self, client_with_data):
+        from core.database import get_series_by_id, get_db_connection
+        payload = {
+            "version": 1,
+            "series": [{
+                "id": 888,
+                "name": "Indie Comic",
+                "volume": 2024,
+                "publisher_name": "Brand New Pub",
+                "mapped_path": "/data/Indie/Indie Comic",
+            }],
+        }
+        resp = _post_import(client_with_data, payload)
+        assert resp.status_code == 200
+        assert resp.get_json()["imported_new"] == 1
+
+        row = get_series_by_id(888)
+        assert row is not None
+        assert row["publisher_id"] is not None
+
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            "SELECT name FROM publishers WHERE id = ?", (row["publisher_id"],)
+        )
+        pub_row = c.fetchone()
+        conn.close()
+        assert pub_row is not None
+        assert pub_row["name"] == "Brand New Pub"
+
+    def test_per_row_error_isolated(self, client_with_data):
+        from core.database import get_series_by_id
+        payload = {
+            "version": 1,
+            "series": [
+                {"name": "no-id"},                       # invalid: missing id
+                {"id": 777, "name": "Good", "mapped_path": "/data/g"},
+            ],
+        }
+        resp = _post_import(client_with_data, payload)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported_new"] == 1
+        assert len(data["errors"]) == 1
+        assert get_series_by_id(777) is not None


### PR DESCRIPTION
## 📝 Description
**Introduce pull-list export and import functionality.**

- **core/database.py:** add `upsert_publisher_by_name` to find-or-create publishers by name (case-insensitive) and import_series_row to insert/update series rows from an exported payload. import_series_row preserves synced metadata and only updates mapped_path, series_subscription, and updated_at; it also resolves publisher_id via exact id or by upserting publisher name.
- **routes/series.py:** add /api/pull-list/export to stream a JSON attachment of mapped series (select runtime-safe fields) and /api/pull-list/import to accept a JSON file (<=2MB), validate format/version, and import each series row via import_series_row with per-row error isolation.
- **templates/pull_list.html:** add Export button, Import modal UI and client-side JS to upload the JSON file, show progress, and report results.
- **tests/routes/test_series_routes.py:** add tests covering export contents and behavior, and import validation, insertion, updates (mapped_path-only), publisher upsert, and per-row error isolation.

This change enables portable pull-list export/import and ensures imports can re-link publishers when restoring into a fresh DB.

Closes #291 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="561" height="646" alt="Screenshot 2026-05-11 233844" src="https://github.com/user-attachments/assets/95f6424a-8686-498c-b7f0-931e39631a67" />
<img width="1192" height="252" alt="Screenshot 2026-05-11 233853" src="https://github.com/user-attachments/assets/ba593123-11d5-431c-980f-aa36e18258f2" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass