### PR TITLE
Browser Extension - Add /dls/ selector and bump extension version

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -69,6 +69,7 @@ function processComicBookPlus() {
 // Function to process GetComics links
 function processGetComics() {
     const links = document.querySelectorAll([
+        'a[href*="/dls/"]',
         'a[href*="/dlds/"]',
         'a[href*="pixeldrain.com"]',
         'a[href*="mega.nz"]',

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Send Link to CLU",
-  "version": "3.1",
+  "version": "3.2",
   "description": "Click a link to send it to your CLU downloads. Now with Mega.nz support!",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## 📝 Description
Include 'a[href*="/dls/"]' in the GetComics link query so links using the /dls/ path are detected and processed. Also update manifest version from 3.1 to 3.2 to reflect the extension update.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass