### PR TITLE
Remove JS warnings, add debug flag and guard grid

### DIFF
--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -422,10 +422,12 @@ async function loadMetadataInBatches(paths, signal) {
 
                 const gridItem = document.querySelector(`[data-path="${CSS.escape(path)}"]`);
                 if (!gridItem) {
-                    const sample = [...document.querySelectorAll('[data-path]')]
-                        .slice(0, 3)
-                        .map(el => el.getAttribute('data-path'));
-                    console.warn('[browse-metadata] no DOM match', { path, sampleDataPaths: sample });
+                    if (window._browseMetaDebug) {
+                        const sample = [...document.querySelectorAll('[data-path]')]
+                            .slice(0, 3)
+                            .map(el => el.getAttribute('data-path'));
+                        console.warn('[browse-metadata] no DOM match', { path, sampleDataPaths: sample });
+                    }
                     return;
                 }
                 const metaEl = gridItem.querySelector('.item-meta');
@@ -3132,11 +3134,11 @@ void 0;
 document.addEventListener('DOMContentLoaded', () => {
     // Add event listener for Update XML confirm button
     const updateXmlBtn = document.getElementById('updateXmlConfirmBtn');
-    if (updateXmlBtn) updateXmlBtn.addEventListener('click', submitUpdateXml);
+    if (updateXmlBtn) updateXmlBtn.addEventListener('click', CLU.submitUpdateXml);
 
     // Add event listener for Update XML field dropdown change
     const updateXmlFieldSelect = document.getElementById('updateXmlField');
-    if (updateXmlFieldSelect) updateXmlFieldSelect.addEventListener('change', updateXmlFieldChanged);
+    if (updateXmlFieldSelect) updateXmlFieldSelect.addEventListener('change', CLU.updateXmlFieldChanged);
 });
 
 

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -647,6 +647,7 @@
     async function loadSavedRecommendations() {
         const grid = document.getElementById('recommendationsGrid');
         const placeholder = document.getElementById('recommendationsPlaceholder');
+        if (!grid) return;
 
         try {
             const response = await fetch('/api/recommendations'); // Default GET


### PR DESCRIPTION
## 📝 Description
Wrap stray DOM-match console warnings behind window._browseMetaDebug to avoid noisy logs. Update DOMContentLoaded event bindings to use CLU.submitUpdateXml and CLU.updateXmlFieldChanged. Add a defensive null-check in the recommendations loader template to return early if the recommendations grid is missing. Files changed: static/js/collection.js, templates/collection.html.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass