### PR TITLE
Add Filename Spaces & Special Character Replacement

### DIFF
--- a/app.py
+++ b/app.py
@@ -6375,6 +6375,68 @@ def save_file_processing_config():
             data.get("customRenamePattern", ""),
             category="file_processing",
         )
+
+        # Validate and persist filename cleanup preferences
+        windows_illegal = set('<>:"/\\|?*')
+        for field, label in (
+            ("renameCleanSpacesReplacement", "space replacement"),
+            ("renameCleanSpecialsReplacement", "special-character replacement"),
+        ):
+            value = str(data.get(field, "") or "")
+            bad = sorted(set(value) & windows_illegal)
+            if bad:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": (
+                                f"The {label} cannot contain Windows-reserved "
+                                f"characters: {''.join(bad)}"
+                            ),
+                        }
+                    ),
+                    400,
+                )
+
+        spaces_mode = data.get("renameCleanSpacesMode", "replace")
+        if spaces_mode not in ("remove", "replace"):
+            spaces_mode = "replace"
+        specials_mode = data.get("renameCleanSpecialsMode", "remove")
+        if specials_mode not in ("remove", "replace"):
+            specials_mode = "remove"
+
+        set_user_preference(
+            "rename_clean_spaces_enabled",
+            bool(data.get("renameCleanSpacesEnabled", False)),
+            category="file_processing",
+        )
+        set_user_preference(
+            "rename_clean_spaces_mode", spaces_mode, category="file_processing"
+        )
+        set_user_preference(
+            "rename_clean_spaces_replacement",
+            str(data.get("renameCleanSpacesReplacement", "_") or ""),
+            category="file_processing",
+        )
+        set_user_preference(
+            "rename_clean_specials_enabled",
+            bool(data.get("renameCleanSpecialsEnabled", False)),
+            category="file_processing",
+        )
+        set_user_preference(
+            "rename_clean_specials_charset",
+            str(data.get("renameCleanSpecialsCharset", "") or ""),
+            category="file_processing",
+        )
+        set_user_preference(
+            "rename_clean_specials_mode", specials_mode, category="file_processing"
+        )
+        set_user_preference(
+            "rename_clean_specials_replacement",
+            str(data.get("renameCleanSpecialsReplacement", "") or ""),
+            category="file_processing",
+        )
+
         config["SETTINGS"]["ENABLE_AUTO_MOVE"] = str(data.get("enableAutoMove", False))
         config["SETTINGS"]["CUSTOM_MOVE_PATTERN"] = data.get(
             "customMovePattern", "{publisher}/{series_name}/v{year}"
@@ -6832,6 +6894,27 @@ def config_page():
         metronPassword=_metron_creds.get("password", "") if _metron_creds else "",
         enableCustomRename=settings.get("ENABLE_CUSTOM_RENAME", "False") == "True",
         customRenamePattern=settings.get("CUSTOM_RENAME_PATTERN", ""),
+        renameCleanSpacesEnabled=get_user_preference(
+            "rename_clean_spaces_enabled", default=False
+        ),
+        renameCleanSpacesMode=get_user_preference(
+            "rename_clean_spaces_mode", default="replace"
+        ),
+        renameCleanSpacesReplacement=get_user_preference(
+            "rename_clean_spaces_replacement", default="_"
+        ),
+        renameCleanSpecialsEnabled=get_user_preference(
+            "rename_clean_specials_enabled", default=False
+        ),
+        renameCleanSpecialsCharset=get_user_preference(
+            "rename_clean_specials_charset", default=""
+        ),
+        renameCleanSpecialsMode=get_user_preference(
+            "rename_clean_specials_mode", default="remove"
+        ),
+        renameCleanSpecialsReplacement=get_user_preference(
+            "rename_clean_specials_replacement", default=""
+        ),
         enableAutoRename=settings.get("ENABLE_AUTO_RENAME", "False") == "True",
         enableAutoMove=settings.get("ENABLE_AUTO_MOVE", "False") == "True",
         customMovePattern=settings.get(

--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -365,9 +365,102 @@ def _pad_issue_number(num_str, width=3):
     return num_str.zfill(width)
 
 
+_FILENAME_CLEANUP_DEFAULTS = {
+    "spaces_enabled": False,
+    "spaces_mode": "replace",
+    "spaces_replacement": "_",
+    "specials_enabled": False,
+    "specials_charset": "",
+    "specials_mode": "remove",
+    "specials_replacement": "",
+}
+
+
+def load_filename_cleanup_config():
+    """
+    Load filename cleanup configuration (spaces + special characters) from
+    user_preferences DB. Returns a dict matching _FILENAME_CLEANUP_DEFAULTS.
+    On any error, returns an all-disabled config (fail-safe: do nothing).
+    """
+    try:
+        from core.database import get_user_preference
+
+        return {
+            "spaces_enabled": bool(
+                get_user_preference("rename_clean_spaces_enabled", default=False)
+            ),
+            "spaces_mode": get_user_preference(
+                "rename_clean_spaces_mode", default="replace"
+            ) or "replace",
+            "spaces_replacement": get_user_preference(
+                "rename_clean_spaces_replacement", default="_"
+            ) or "",
+            "specials_enabled": bool(
+                get_user_preference("rename_clean_specials_enabled", default=False)
+            ),
+            "specials_charset": get_user_preference(
+                "rename_clean_specials_charset", default=""
+            ) or "",
+            "specials_mode": get_user_preference(
+                "rename_clean_specials_mode", default="remove"
+            ) or "remove",
+            "specials_replacement": get_user_preference(
+                "rename_clean_specials_replacement", default=""
+            ) or "",
+        }
+    except Exception as e:
+        app_logger.warning(f"Failed to load filename cleanup config from DB: {e}")
+        return dict(_FILENAME_CLEANUP_DEFAULTS)
+
+
+def apply_filename_cleanup(stem, cfg=None):
+    """
+    Apply user-configured space and special-character cleanup to a filename
+    stem (no extension). Operates on stem only so callers must split off the
+    extension before invoking. Returns the cleaned stem.
+
+    NOTE: The matching JavaScript implementation lives in templates/config.html
+    inside applyCustomPattern(). When changing the algorithm here, update the
+    JS copy in lockstep so the live preview stays accurate.
+    """
+    if not stem:
+        return stem
+    if cfg is None:
+        cfg = load_filename_cleanup_config()
+
+    if not cfg.get("spaces_enabled") and not cfg.get("specials_enabled"):
+        return stem
+
+    original = stem
+    stem = re.sub(r"\s+", " ", stem)
+
+    if cfg.get("specials_enabled"):
+        charset = cfg.get("specials_charset") or ""
+        chars = {c for c in charset if c != " "}
+        if chars:
+            replacement = "" if cfg.get("specials_mode") == "remove" else (
+                cfg.get("specials_replacement") or ""
+            )
+            table = str.maketrans({c: replacement for c in chars})
+            stem = stem.translate(table)
+            stem = re.sub(r"\s+", " ", stem)
+
+    if cfg.get("spaces_enabled"):
+        if cfg.get("spaces_mode") == "remove":
+            stem = stem.replace(" ", "")
+        else:
+            stem = stem.replace(" ", cfg.get("spaces_replacement") or "")
+
+    stem = stem.strip(" .")
+    if not stem:
+        return original
+    return stem
+
+
 def clean_final_filename(filename):
     """
-    Final cleanup of filename to remove empty parentheses and extra spaces.
+    Final cleanup of filename to remove empty parentheses and extra spaces,
+    then apply user-configured space/special-character cleanup to the stem.
     """
     if not filename:
         return filename
@@ -375,7 +468,14 @@ def clean_final_filename(filename):
     filename = re.sub(r"\s*\(\s*\)", "", filename).strip()
     # Clean up any double spaces
     filename = re.sub(r"\s+", " ", filename).strip()
-    return filename
+    # Split off extension so user cleanup operates on stem only
+    last_dot = filename.rfind(".")
+    if last_dot > 0 and last_dot >= len(filename) - 5:
+        stem, ext = filename[:last_dot], filename[last_dot:]
+    else:
+        stem, ext = filename, ""
+    stem = apply_filename_cleanup(stem)
+    return stem + ext
 
 
 def load_custom_rename_config():
@@ -994,6 +1094,7 @@ def rename_comic_from_metadata(file_path, metadata):
             return file_path, False
 
         _, ext = os.path.splitext(file_path)
+        new_name = apply_filename_cleanup(new_name)
         new_name = new_name + ext
         old_name = os.path.basename(file_path)
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -456,6 +456,88 @@
                         </div>
                     </div>
 
+                    <!-- Filename Character Cleanup -->
+                    <hr class="my-4">
+                    <h5>Filename Character Cleanup</h5>
+                    <p class="text-muted">
+                        Apply after pattern substitution to every rename (custom and default logic).
+                        The file extension is always preserved.
+                    </p>
+
+                    <div class="row">
+                        <!-- Spaces -->
+                        <div class="col-md-6">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" role="switch"
+                                    id="renameCleanSpacesEnabled" name="renameCleanSpacesEnabled"
+                                    {% if renameCleanSpacesEnabled %}checked{% endif %}>
+                                <label class="form-check-label" for="renameCleanSpacesEnabled">Clean Spaces in
+                                    Filenames</label>
+                            </div>
+                            <div class="mb-2">
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="radio" name="renameCleanSpacesMode"
+                                        id="renameCleanSpacesModeRemove" value="remove"
+                                        {% if renameCleanSpacesMode == 'remove' %}checked{% endif %}>
+                                    <label class="form-check-label" for="renameCleanSpacesModeRemove">Remove</label>
+                                </div>
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="radio" name="renameCleanSpacesMode"
+                                        id="renameCleanSpacesModeReplace" value="replace"
+                                        {% if renameCleanSpacesMode != 'remove' %}checked{% endif %}>
+                                    <label class="form-check-label" for="renameCleanSpacesModeReplace">Replace</label>
+                                </div>
+                            </div>
+                            <label for="renameCleanSpacesReplacement" class="form-label">Replace with:</label>
+                            <input type="text" id="renameCleanSpacesReplacement"
+                                name="renameCleanSpacesReplacement" maxlength="8" class="form-control"
+                                value="{{ renameCleanSpacesReplacement }}" placeholder="_">
+                            <small class="form-text text-muted">
+                                Example: <code>Batman 001</code> → <code>Batman_001</code>
+                            </small>
+                        </div>
+
+                        <!-- Special Characters -->
+                        <div class="col-md-6">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" role="switch"
+                                    id="renameCleanSpecialsEnabled" name="renameCleanSpecialsEnabled"
+                                    {% if renameCleanSpecialsEnabled %}checked{% endif %}>
+                                <label class="form-check-label" for="renameCleanSpecialsEnabled">Clean Special
+                                    Characters</label>
+                            </div>
+                            <label for="renameCleanSpecialsCharset" class="form-label">Characters to clean
+                                (literal):</label>
+                            <input type="text" id="renameCleanSpecialsCharset" name="renameCleanSpecialsCharset"
+                                class="form-control" value="{{ renameCleanSpecialsCharset }}"
+                                placeholder="&amp;!@#'">
+                            <small class="form-text text-muted">Each character is treated literally, not as
+                                regex.</small>
+                            <div class="mt-2 mb-2">
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="radio" name="renameCleanSpecialsMode"
+                                        id="renameCleanSpecialsModeRemove" value="remove"
+                                        {% if renameCleanSpecialsMode != 'replace' %}checked{% endif %}>
+                                    <label class="form-check-label" for="renameCleanSpecialsModeRemove">Remove</label>
+                                </div>
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="radio" name="renameCleanSpecialsMode"
+                                        id="renameCleanSpecialsModeReplace" value="replace"
+                                        {% if renameCleanSpecialsMode == 'replace' %}checked{% endif %}>
+                                    <label class="form-check-label" for="renameCleanSpecialsModeReplace">Replace</label>
+                                </div>
+                            </div>
+                            <label for="renameCleanSpecialsReplacement" class="form-label">Replace with:</label>
+                            <input type="text" id="renameCleanSpecialsReplacement"
+                                name="renameCleanSpecialsReplacement" maxlength="8" class="form-control"
+                                value="{{ renameCleanSpecialsReplacement }}">
+                            <small class="form-text text-muted">
+                                Replacements cannot contain Windows-reserved characters:
+                                <code>&lt; &gt; : " / \ | ? *</code>
+                            </small>
+                        </div>
+                    </div>
+
                 </div>
 
                 <!-- Save Button for Tab 1 -->
@@ -1554,6 +1636,13 @@
             deletedFiles: document.getElementById('deletedFiles')?.value || '',
             enableCustomRename: document.getElementById('enableCustomRename')?.checked || false,
             customRenamePattern: document.getElementById('customRenamePattern')?.value || '',
+            renameCleanSpacesEnabled: document.getElementById('renameCleanSpacesEnabled')?.checked || false,
+            renameCleanSpacesMode: document.querySelector('input[name="renameCleanSpacesMode"]:checked')?.value || 'replace',
+            renameCleanSpacesReplacement: document.getElementById('renameCleanSpacesReplacement')?.value || '_',
+            renameCleanSpecialsEnabled: document.getElementById('renameCleanSpecialsEnabled')?.checked || false,
+            renameCleanSpecialsCharset: document.getElementById('renameCleanSpecialsCharset')?.value || '',
+            renameCleanSpecialsMode: document.querySelector('input[name="renameCleanSpecialsMode"]:checked')?.value || 'remove',
+            renameCleanSpecialsReplacement: document.getElementById('renameCleanSpecialsReplacement')?.value || '',
             enableAutoRename: document.getElementById('enableAutoRename')?.checked || false,
             enableAutoMove: document.getElementById('enableAutoMove')?.checked || false,
             customMovePattern: document.getElementById('customMovePattern')?.value || '',
@@ -2438,6 +2527,22 @@
             patternInput.addEventListener('input', updateRenamePreview);
             patternInput.addEventListener('change', updateRenamePreview);
 
+            // Cleanup-related inputs also influence the preview
+            const cleanupIds = [
+                'renameCleanSpacesEnabled', 'renameCleanSpacesReplacement',
+                'renameCleanSpecialsEnabled', 'renameCleanSpecialsCharset',
+                'renameCleanSpecialsReplacement'
+            ];
+            cleanupIds.forEach(id => {
+                const el = document.getElementById(id);
+                if (el) {
+                    el.addEventListener('input', updateRenamePreview);
+                    el.addEventListener('change', updateRenamePreview);
+                }
+            });
+            document.querySelectorAll('input[name="renameCleanSpacesMode"], input[name="renameCleanSpecialsMode"]')
+                .forEach(el => el.addEventListener('change', updateRenamePreview));
+
             // Initial preview
             updateRenamePreview();
         }
@@ -2494,6 +2599,33 @@
 
         // Remove orphaned separators (e.g., trailing " - " when issue_title is empty)
         result = result.replace(/\s*-\s*(?=\(|$)/g, ' ').replace(/\s+/g, ' ').trim();
+
+        // Filename character cleanup — mirrors cbz_ops/rename.py:apply_filename_cleanup.
+        // Update both implementations in lockstep when the algorithm changes.
+        const specialsEnabled = document.getElementById('renameCleanSpecialsEnabled')?.checked;
+        const spacesEnabled = document.getElementById('renameCleanSpacesEnabled')?.checked;
+        if (specialsEnabled || spacesEnabled) {
+            if (specialsEnabled) {
+                const charset = document.getElementById('renameCleanSpecialsCharset')?.value || '';
+                const chars = new Set([...charset].filter(c => c !== ' '));
+                if (chars.size > 0) {
+                    const mode = document.querySelector('input[name="renameCleanSpecialsMode"]:checked')?.value || 'remove';
+                    const repl = mode === 'remove' ? '' : (document.getElementById('renameCleanSpecialsReplacement')?.value || '');
+                    result = [...result].map(ch => chars.has(ch) ? repl : ch).join('');
+                    result = result.replace(/\s+/g, ' ');
+                }
+            }
+            if (spacesEnabled) {
+                const mode = document.querySelector('input[name="renameCleanSpacesMode"]:checked')?.value || 'replace';
+                if (mode === 'remove') {
+                    result = result.replace(/ /g, '');
+                } else {
+                    const repl = document.getElementById('renameCleanSpacesReplacement')?.value || '';
+                    result = result.split(' ').join(repl);
+                }
+            }
+            result = result.replace(/^[\s.]+|[\s.]+$/g, '');
+        }
 
         return result;
     }

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -768,3 +768,198 @@ class TestParseComicFilename:
         result = parse_comic_filename("Batman 001 (2020)")
         # Should still attempt parsing even without recognized extension
         assert result["series_name"]
+
+
+# ===== apply_filename_cleanup =====
+
+def _cleanup_cfg(**overrides):
+    base = {
+        "spaces_enabled": False,
+        "spaces_mode": "replace",
+        "spaces_replacement": "_",
+        "specials_enabled": False,
+        "specials_charset": "",
+        "specials_mode": "remove",
+        "specials_replacement": "",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestApplyFilenameCleanup:
+
+    def test_both_disabled_passthrough(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        assert apply_filename_cleanup("Batman 001 (1992)", _cleanup_cfg()) == "Batman 001 (1992)"
+
+    def test_spaces_replace_default_underscore(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(spaces_enabled=True, spaces_mode="replace", spaces_replacement="_")
+        assert apply_filename_cleanup("Batman 001 (1992)", cfg) == "Batman_001_(1992)"
+
+    def test_spaces_remove(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(spaces_enabled=True, spaces_mode="remove")
+        assert apply_filename_cleanup("Batman 001 (1992)", cfg) == "Batman001(1992)"
+
+    def test_specials_remove_charset(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(specials_enabled=True, specials_charset="&", specials_mode="remove")
+        # "Hokum & Hex" -> after specials removal "Hokum  Hex" -> re-collapsed -> "Hokum Hex"
+        assert apply_filename_cleanup("Hokum & Hex", cfg) == "Hokum Hex"
+
+    def test_specials_replace_with_dash(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(
+            specials_enabled=True, specials_charset="&",
+            specials_mode="replace", specials_replacement="-",
+        )
+        assert apply_filename_cleanup("Hokum & Hex", cfg) == "Hokum - Hex"
+
+    def test_specials_then_spaces(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(
+            specials_enabled=True, specials_charset="&", specials_mode="remove",
+            spaces_enabled=True, spaces_mode="replace", spaces_replacement="_",
+        )
+        # "Hokum & Hex 001" -> "Hokum  Hex 001" -> "Hokum Hex 001" -> "Hokum_Hex_001"
+        assert apply_filename_cleanup("Hokum & Hex 001", cfg) == "Hokum_Hex_001"
+
+    def test_replacement_char_in_charset_no_loop(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(
+            specials_enabled=True, specials_charset="_&",
+            specials_mode="replace", specials_replacement="_",
+        )
+        # str.translate is single-pass: '_' stays '_', '&' becomes '_'
+        assert apply_filename_cleanup("a_&b", cfg) == "a__b"
+
+    def test_empty_charset_noop(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(specials_enabled=True, specials_charset="", specials_mode="remove")
+        assert apply_filename_cleanup("Hokum & Hex", cfg) == "Hokum & Hex"
+
+    def test_charset_with_space_does_not_remove_spaces(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        # Space in charset must be ignored — spaces toggle owns space handling.
+        cfg = _cleanup_cfg(
+            specials_enabled=True, specials_charset=" &",
+            specials_mode="remove",
+        )
+        # '&' removed, spaces preserved (and re-collapsed)
+        assert apply_filename_cleanup("Hokum & Hex", cfg) == "Hokum Hex"
+
+    def test_trailing_dot_stripped(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(spaces_enabled=True, spaces_mode="remove")
+        assert apply_filename_cleanup("Title.", cfg) == "Title"
+
+    def test_leading_trailing_whitespace_stripped_when_removing_spaces(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(spaces_enabled=True, spaces_mode="remove")
+        assert apply_filename_cleanup("  Title Word  ", cfg) == "TitleWord"
+
+    def test_empty_stem_returned_unchanged(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(spaces_enabled=True)
+        assert apply_filename_cleanup("", cfg) == ""
+
+    def test_none_cfg_loads_from_db(self, monkeypatch):
+        from cbz_ops import rename
+        monkeypatch.setattr(
+            rename, "load_filename_cleanup_config",
+            lambda: _cleanup_cfg(spaces_enabled=True, spaces_replacement="-"),
+        )
+        assert rename.apply_filename_cleanup("a b c") == "a-b-c"
+
+
+class TestLoadFilenameCleanupConfig:
+
+    def test_returns_defaults_when_db_unavailable(self, monkeypatch):
+        from cbz_ops import rename
+
+        def _raise(*a, **kw):
+            raise RuntimeError("no db")
+
+        # Patch core.database.get_user_preference to raise during import
+        import sys
+        fake_module = type(sys)("fake_core_database")
+        fake_module.get_user_preference = _raise
+        monkeypatch.setitem(sys.modules, "core.database", fake_module)
+        cfg = rename.load_filename_cleanup_config()
+        assert cfg["spaces_enabled"] is False
+        assert cfg["specials_enabled"] is False
+        assert cfg["spaces_mode"] == "replace"
+        assert cfg["spaces_replacement"] == "_"
+        assert cfg["specials_mode"] == "remove"
+        assert cfg["specials_charset"] == ""
+        assert cfg["specials_replacement"] == ""
+
+    def test_reads_values_from_db(self, monkeypatch):
+        from cbz_ops import rename
+        import sys
+
+        stored = {
+            "rename_clean_spaces_enabled": True,
+            "rename_clean_spaces_mode": "remove",
+            "rename_clean_spaces_replacement": "-",
+            "rename_clean_specials_enabled": True,
+            "rename_clean_specials_charset": "&!",
+            "rename_clean_specials_mode": "replace",
+            "rename_clean_specials_replacement": "+",
+        }
+
+        def _get(key, default=None):
+            return stored.get(key, default)
+
+        fake_module = type(sys)("fake_core_database")
+        fake_module.get_user_preference = _get
+        monkeypatch.setitem(sys.modules, "core.database", fake_module)
+        cfg = rename.load_filename_cleanup_config()
+        assert cfg == {
+            "spaces_enabled": True,
+            "spaces_mode": "remove",
+            "spaces_replacement": "-",
+            "specials_enabled": True,
+            "specials_charset": "&!",
+            "specials_mode": "replace",
+            "specials_replacement": "+",
+        }
+
+
+class TestCleanFinalFilenameWithCleanup:
+    """Verify clean_final_filename routes its stem through apply_filename_cleanup
+    while preserving the extension."""
+
+    def test_extension_preserved_when_charset_includes_dot(self, monkeypatch):
+        from cbz_ops import rename
+        monkeypatch.setattr(
+            rename, "load_filename_cleanup_config",
+            lambda: _cleanup_cfg(
+                specials_enabled=True, specials_charset=".",
+                specials_mode="remove",
+            ),
+        )
+        # Stem dot stripped, extension dot preserved
+        assert rename.clean_final_filename("Title v1.5 001.cbz") == "Title v15 001.cbz"
+
+    def test_spaces_replaced_in_stem_only(self, monkeypatch):
+        from cbz_ops import rename
+        monkeypatch.setattr(
+            rename, "load_filename_cleanup_config",
+            lambda: _cleanup_cfg(
+                spaces_enabled=True, spaces_mode="replace", spaces_replacement="_",
+            ),
+        )
+        assert rename.clean_final_filename("Batman 001 (1992).cbz") == "Batman_001_(1992).cbz"
+
+    def test_no_extension_input(self, monkeypatch):
+        from cbz_ops import rename
+        monkeypatch.setattr(
+            rename, "load_filename_cleanup_config",
+            lambda: _cleanup_cfg(
+                spaces_enabled=True, spaces_mode="replace", spaces_replacement="_",
+            ),
+        )
+        # Filenames with no recognizable extension still get cleaned
+        assert rename.clean_final_filename("Batman 001") == "Batman_001"


### PR DESCRIPTION
## 📝 Description
Introduce configurable filename cleanup for renames: allow removing/replacing spaces and removing/replacing literal special characters. Backend: validate and persist preferences in app.save_file_processing_config (with Windows-reserved character checks), expose preferences to the config page, and add load_filename_cleanup_config and apply_filename_cleanup helpers with safe defaults. Integrate cleanup into clean_final_filename and rename flow so the stem is cleaned while preserving extensions. Frontend: add a new UI section, wire inputs into save payload and rename preview logic (JS mirrors Python algorithm). Tests: comprehensive unit tests for loading config, apply_filename_cleanup behavior, and integration with clean_final_filename, including DB-failure fallback and edge cases.

Closes #206 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass