### PR TITLE
Migrate WATCH/TARGET to user_preferences

### DIFF
--- a/app.py
+++ b/app.py
@@ -623,7 +623,33 @@ def process_incoming_wanted_issues():
     from cbz_ops.rename import load_custom_rename_config
     from datetime import date
 
-    target_folder = app.config.get("TARGET", "/downloads/processed")
+    target_folder = (app.config.get("TARGET") or "").strip()
+    if not target_folder:
+        app_logger.error("Wanted scan aborted: TARGET is not configured.")
+        return
+
+    # Safety guard: refuse to scan the collection itself, anything inside it,
+    # or the WATCH folder. Without this a misconfigured TARGET could cause the
+    # scanner to walk /data and move files between series folders.
+    try:
+        real_target = os.path.realpath(target_folder)
+        real_data = os.path.realpath("/data")
+        if real_target == real_data or real_target.startswith(real_data + os.sep):
+            app_logger.error(
+                f"Wanted scan aborted: TARGET ({real_target}) is the data "
+                f"directory or inside it. Refusing to move files out of the collection."
+            )
+            return
+        watch_folder = (app.config.get("WATCH") or "").strip()
+        if watch_folder and os.path.realpath(watch_folder) == real_target:
+            app_logger.error(
+                f"Wanted scan aborted: TARGET equals WATCH ({real_target})."
+            )
+            return
+    except Exception as e:
+        app_logger.error(f"Wanted scan aborted: failed to validate TARGET path: {e}")
+        return
+
     if not os.path.exists(target_folder):
         app_logger.debug(f"TARGET folder does not exist: {target_folder}")
         return
@@ -2306,7 +2332,15 @@ from helpers import is_hidden
 
 # Legacy constant for backwards compatibility - use get_library_roots() instead
 DATA_DIR = "/data"  # Directory to browse (deprecated, kept for compatibility)
-TARGET_DIR = config.get("SETTINGS", "TARGET", fallback="/processed")
+
+
+def get_target_dir_live():
+    """Live accessor for the TARGET directory (reads from app.config).
+
+    Use this instead of the old module-level ``TARGET_DIR`` constant. Backed by
+    ``user_preferences`` via ``load_flask_config()``.
+    """
+    return app.config.get("TARGET") or "/downloads/processed"
 
 
 # Moved to helpers/library.py - re-exported for backward compatibility
@@ -2761,10 +2795,11 @@ def rebuild_entire_cache():
 
 def warmup_cache():
     """Proactively cache frequently accessed directories."""
-    warmup_paths = [DATA_DIR, TARGET_DIR]
+    _target = get_target_dir_live()
+    warmup_paths = [DATA_DIR, _target]
 
     # Add common subdirectories
-    for base_path in [DATA_DIR, TARGET_DIR]:
+    for base_path in [DATA_DIR, _target]:
         try:
             if os.path.exists(base_path):
                 subdirs = [
@@ -5788,7 +5823,7 @@ def download_file():
     normalized_path = os.path.normpath(file_path)
     if not (
         is_valid_library_path(normalized_path)
-        or normalized_path.startswith(os.path.normpath(TARGET_DIR))
+        or normalized_path.startswith(os.path.normpath(get_target_dir_live()))
     ):
         return jsonify({"error": "Access denied"}), 403
 
@@ -5816,7 +5851,7 @@ def read_text_file():
     normalized_path = os.path.normpath(file_path)
     if not (
         is_valid_library_path(normalized_path)
-        or normalized_path.startswith(os.path.normpath(TARGET_DIR))
+        or normalized_path.startswith(os.path.normpath(get_target_dir_live()))
     ):
         return "Access denied", 403
 
@@ -5966,8 +6001,8 @@ scrape_tasks = {}
 @app.route("/scrape")
 def scrape_page():
     """Render the scrape page"""
-    # Use TARGET_DIR directly to avoid file monitor processing
-    target_dir = config.get("SETTINGS", "TARGET", fallback="/processed")
+    # Use TARGET directly to avoid file monitor processing
+    target_dir = get_target_dir_live()
     # Get active tasks for status display
     active_tasks = []
     for task_id, task_info in scrape_tasks.items():
@@ -5985,9 +6020,7 @@ def scrape_readcomiconline():
         data = request.json
         urls = data.get("urls", [])
         # Use TARGET_DIR directly to avoid file monitor processing and overwrites
-        output_dir = data.get(
-            "output_dir", config.get("SETTINGS", "TARGET", fallback="/processed")
-        )
+        output_dir = data.get("output_dir", get_target_dir_live())
 
         if not urls:
             return jsonify({"success": False, "error": "No URLs provided"}), 400
@@ -6050,9 +6083,7 @@ def scrape_ehentai():
         data = request.json
         urls = data.get("urls", [])
         # Use TARGET_DIR directly to avoid file monitor processing and overwrites
-        output_dir = data.get(
-            "output_dir", config.get("SETTINGS", "TARGET", fallback="/processed")
-        )
+        output_dir = data.get("output_dir", get_target_dir_live())
 
         if not urls:
             return jsonify({"success": False, "error": "No URLs provided"}), 400
@@ -6111,9 +6142,7 @@ def scrape_erofus():
         data = request.json
         urls = data.get("urls", [])
         # Use TARGET_DIR directly to avoid file monitor processing and overwrites
-        output_dir = data.get(
-            "output_dir", config.get("SETTINGS", "TARGET", fallback="/processed")
-        )
+        output_dir = data.get("output_dir", get_target_dir_live())
 
         if not urls:
             return jsonify({"success": False, "error": "No URLs provided"}), 400
@@ -6311,9 +6340,34 @@ def save_file_processing_config():
         if "SETTINGS" not in config:
             config["SETTINGS"] = {}
 
-        # Update config values
-        config["SETTINGS"]["WATCH"] = data.get("watch", "/temp")
-        config["SETTINGS"]["TARGET"] = data.get("target", "/processed")
+        # WATCH / TARGET live in user_preferences (not config.ini).
+        from core.database import set_user_preference as _set_pref_path
+        new_watch = sanitize_config_value(data.get("watch", ""))
+        new_target = sanitize_config_value(data.get("target", ""))
+
+        # Reject any value that is /data or inside it — the wanted-scan would
+        # otherwise walk the collection and move library files between folders.
+        real_data = os.path.realpath("/data")
+        for label, value in (("WATCH", new_watch), ("TARGET", new_target)):
+            if not value:
+                continue
+            try:
+                real_value = os.path.realpath(value)
+            except Exception:
+                continue
+            if real_value == real_data or real_value.startswith(real_data + os.sep):
+                return jsonify({
+                    "success": False,
+                    "error": f"{label} cannot be /data or a subdirectory of it.",
+                }), 400
+
+        _set_pref_path("watch", new_watch, category="file_processing")
+        _set_pref_path("target", new_target, category="file_processing")
+        app.config["WATCH"] = new_watch or "/downloads/temp"
+        app.config["TARGET"] = new_target or "/downloads/processed"
+        from core.config import _mirror_watch_target_into_memory_config
+        _mirror_watch_target_into_memory_config()
+
         config["SETTINGS"]["AUTOCONVERT"] = str(data.get("autoConvert", False))
         config["SETTINGS"]["READ_SUBDIRECTORIES"] = str(
             data.get("readSubdirectories", False)
@@ -6678,18 +6732,18 @@ def config_page():
             config["SETTINGS"] = {}
 
         # Safely update config values
-        new_watch = request.form.get("watch", "/temp")
-        new_target = request.form.get("target", "/processed")
+        new_watch = sanitize_config_value(request.form.get("watch", ""))
+        new_target = sanitize_config_value(request.form.get("target", ""))
 
         # Validate that watch and target are not the same
-        if new_watch == new_target:
+        if new_watch and new_target and new_watch == new_target:
             return jsonify(
                 {"error": "Watch and target folders cannot be the same"}
             ), 400
 
         # Validate that watch and target are not subdirectories of each other
-        if new_watch.startswith(new_target + "/") or new_target.startswith(
-            new_watch + "/"
+        if new_watch and new_target and (
+            new_watch.startswith(new_target + "/") or new_target.startswith(new_watch + "/")
         ):
             return jsonify(
                 {
@@ -6697,8 +6751,29 @@ def config_page():
                 }
             ), 400
 
-        config["SETTINGS"]["WATCH"] = new_watch
-        config["SETTINGS"]["TARGET"] = new_target
+        # Reject any value that is /data or inside it.
+        real_data = os.path.realpath("/data")
+        for label, value in (("WATCH", new_watch), ("TARGET", new_target)):
+            if not value:
+                continue
+            try:
+                real_value = os.path.realpath(value)
+            except Exception:
+                continue
+            if real_value == real_data or real_value.startswith(real_data + os.sep):
+                return jsonify(
+                    {"error": f"{label} cannot be /data or a subdirectory of it."}
+                ), 400
+
+        # WATCH / TARGET live in user_preferences (not config.ini).
+        from core.database import set_user_preference as _set_pref_path
+        _set_pref_path("watch", new_watch, category="file_processing")
+        _set_pref_path("target", new_target, category="file_processing")
+        app.config["WATCH"] = new_watch or "/downloads/temp"
+        app.config["TARGET"] = new_target or "/downloads/processed"
+        from core.config import _mirror_watch_target_into_memory_config
+        _mirror_watch_target_into_memory_config()
+
         config["SETTINGS"]["IGNORED_TERMS"] = request.form.get("ignored_terms", "")
         config["SETTINGS"]["IGNORED_FILES"] = request.form.get("ignored_files", "")
         config["SETTINGS"]["IGNORED_EXTENSIONS"] = request.form.get(
@@ -6857,10 +6932,12 @@ def config_page():
         _metron_creds = None
         _cv_creds = None
 
+    from core.config import get_watch_dir, get_target_dir
+
     return render_template(
         "config.html",
-        watch=settings.get("WATCH", "/temp"),
-        target=settings.get("TARGET", "/processed"),
+        watch=get_watch_dir() or "/downloads/temp",
+        target=get_target_dir() or "/downloads/processed",
         ignored_terms=settings.get("IGNORED_TERMS", ""),
         ignored_files=settings.get("IGNORED_FILES", ""),
         ignored_extensions=settings.get("IGNORED_EXTENSIONS", ""),

--- a/core/config.py
+++ b/core/config.py
@@ -28,10 +28,10 @@ def load_config():
     # Log the config file location
     app_logger.debug(f"📁 Config file location: {CONFIG_FILE}")
 
-    # Define default settings with all required keys
+    # Define default settings with all required keys.
+    # NOTE: WATCH and TARGET intentionally live in user_preferences (DB), not config.ini.
+    # See migrate_watch_target_to_user_preferences() and get_watch_dir()/get_target_dir().
     default_settings = {
-        "WATCH": "/downloads/temp",
-        "TARGET": "/downloads/processed",
         "IGNORED_TERMS": "Annual",
         "IGNORED_FILES": "cover.jpg,cvinfo,.DS_Store",
         "IGNORED_EXTENSIONS": ".crdownload,.torrent,.tmp,.mega,.rar,.bak,.zip",
@@ -97,6 +97,100 @@ def load_config():
         else:
             app_logger.debug("✅ Config file loaded successfully (no migration needed)")
 
+    # One-time migration: move WATCH/TARGET from config.ini into user_preferences.
+    # Runs after the load branches so both new and existing installs are handled.
+    migrate_watch_target_to_user_preferences()
+
+    # Always mirror the user_preferences values into the in-memory config object
+    # (NOT to disk) so any legacy reader using ``config.get("SETTINGS", "TARGET")``
+    # picks up the current value. user_preferences remains the source of truth.
+    _mirror_watch_target_into_memory_config()
+
+
+def _mirror_watch_target_into_memory_config():
+    """Copy WATCH/TARGET from user_preferences into the in-memory ``config`` object.
+
+    The values are NOT written to ``config.ini`` (write_config is not called).
+    """
+    try:
+        from core.database import get_user_preference
+    except Exception:
+        return
+    try:
+        if "SETTINGS" not in config:
+            config["SETTINGS"] = {}
+        watch_val = (get_user_preference("watch", default="") or "").strip()
+        target_val = (get_user_preference("target", default="") or "").strip()
+        if watch_val:
+            config["SETTINGS"]["WATCH"] = watch_val
+        if target_val:
+            config["SETTINGS"]["TARGET"] = target_val
+    except Exception as e:
+        app_logger.debug(f"In-memory WATCH/TARGET mirror skipped: {e}")
+
+
+def migrate_watch_target_to_user_preferences():
+    """Move legacy WATCH/TARGET from config.ini into the user_preferences table.
+
+    Runs at most once per install (guarded by the `watch_target_migrated_to_prefs`
+    flag in user_preferences). After migration the keys are stripped from
+    config.ini so user_preferences is the single source of truth.
+    """
+    try:
+        from core.database import get_user_preference, set_user_preference
+    except Exception as e:
+        app_logger.debug(f"Skipping WATCH/TARGET migration (DB not ready): {e}")
+        return
+
+    try:
+        if get_user_preference("watch_target_migrated_to_prefs", default=False):
+            return
+
+        legacy_watch = config["SETTINGS"].get("WATCH") if "SETTINGS" in config else None
+        legacy_target = config["SETTINGS"].get("TARGET") if "SETTINGS" in config else None
+
+        if legacy_watch and not get_user_preference("watch"):
+            set_user_preference("watch", legacy_watch.strip(), category="file_processing")
+            app_logger.info(f"Migrated WATCH ({legacy_watch}) from config.ini to user_preferences")
+
+        if legacy_target and not get_user_preference("target"):
+            set_user_preference("target", legacy_target.strip(), category="file_processing")
+            app_logger.info(f"Migrated TARGET ({legacy_target}) from config.ini to user_preferences")
+
+        # Strip keys from config.ini so future reads can't desync.
+        rewrite = False
+        if "SETTINGS" in config:
+            if "WATCH" in config["SETTINGS"]:
+                config.remove_option("SETTINGS", "WATCH")
+                rewrite = True
+            if "TARGET" in config["SETTINGS"]:
+                config.remove_option("SETTINGS", "TARGET")
+                rewrite = True
+        if rewrite:
+            write_config()
+
+        set_user_preference("watch_target_migrated_to_prefs", True, category="file_processing")
+    except Exception as e:
+        app_logger.error(f"WATCH/TARGET migration failed: {e}")
+
+
+def get_watch_dir() -> str:
+    """Return the configured WATCH path from user_preferences ('' if unset)."""
+    try:
+        from core.database import get_user_preference
+        return (get_user_preference("watch", default="") or "").strip()
+    except Exception:
+        return ""
+
+
+def get_target_dir() -> str:
+    """Return the configured TARGET path from user_preferences ('' if unset)."""
+    try:
+        from core.database import get_user_preference
+        return (get_user_preference("target", default="") or "").strip()
+    except Exception:
+        return ""
+
 
 def load_flask_config(app, logger=None):
     """
@@ -116,9 +210,9 @@ def load_flask_config(app, logger=None):
     # **Ensure SETTINGS is a dictionary before accessing**
     settings = config["SETTINGS"] if "SETTINGS" in config else {}
 
-    # Populate Flask app.config safely
-    app.config["WATCH"] = settings.get("WATCH", "/downloads/temp")
-    app.config["TARGET"] = settings.get("TARGET", "/downloads/processed")
+    # WATCH and TARGET live in user_preferences (single source of truth).
+    app.config["WATCH"] = get_watch_dir() or "/downloads/temp"
+    app.config["TARGET"] = get_target_dir() or "/downloads/processed"
     app.config["IGNORED_TERMS"] = settings.get("IGNORED_TERMS", "")
     app.config["IGNORED_FILES"] = settings.get("IGNORED_FILES", "")
     app.config["IGNORED_EXTENSIONS"] = settings.get("IGNORED_EXTENSIONS", "")

--- a/core/database.py
+++ b/core/database.py
@@ -1782,8 +1782,9 @@ def get_recent_files(limit=100):
             )
         else:
             # Fallback: exclude both TARGET and WATCH download folders
-            target = config.get("SETTINGS", "TARGET", fallback="/data/downloads/processed")
-            watch = config.get("SETTINGS", "WATCH", fallback="/downloads/temp")
+            from core.config import get_target_dir, get_watch_dir
+            target = get_target_dir() or "/data/downloads/processed"
+            watch = get_watch_dir() or "/downloads/temp"
             c.execute(
                 """
                 SELECT path as file_path, name as file_name, size as file_size,
@@ -1871,10 +1872,9 @@ def get_recent_files_paginated(offset=0, limit=50):
                 params + [limit, offset],
             )
         else:
-            target = config.get(
-                "SETTINGS", "TARGET", fallback="/data/downloads/processed"
-            )
-            watch = config.get("SETTINGS", "WATCH", fallback="/downloads/temp")
+            from core.config import get_target_dir, get_watch_dir
+            target = get_target_dir() or "/data/downloads/processed"
+            watch = get_watch_dir() or "/downloads/temp"
             where = (
                 "type = 'file' "
                 "AND (name LIKE '%.cbz' OR name LIKE '%.cbr') "

--- a/helpers/library.py
+++ b/helpers/library.py
@@ -39,10 +39,9 @@ def is_allowed_path(path):
 
     allowed_roots = list(get_library_roots())
 
-    # Add config directories (WATCH and TARGET)
-    from core.config import config
-    for key in ('TARGET', 'WATCH'):
-        val = config.get("SETTINGS", key, fallback="")
+    # Add WATCH and TARGET (user_preferences-backed)
+    from core.config import get_watch_dir, get_target_dir
+    for val in (get_target_dir(), get_watch_dir()):
         if val:
             allowed_roots.append(val)
 
@@ -103,14 +102,14 @@ def is_critical_path(path):
     Check if a path is a critical system path (WATCH, TARGET, or TRASH folders).
     Returns True if the path is critical, False otherwise.
     """
-    from core.config import config
+    from core.config import config, get_watch_dir, get_target_dir
 
     if not path:
         return False
 
-    # Get current watch and target folders from config
-    watch_folder = config.get("SETTINGS", "WATCH", fallback="/temp")
-    target_folder = config.get("SETTINGS", "TARGET", fallback="/processed")
+    # Get current watch and target folders (user_preferences-backed)
+    watch_folder = get_watch_dir() or "/downloads/temp"
+    target_folder = get_target_dir() or "/downloads/processed"
 
     # Check if path is exactly a critical folder
     if path == watch_folder or path == target_folder:
@@ -138,10 +137,10 @@ def get_critical_path_error_message(path, operation="modify"):
     """
     Generate an error message for critical path operations.
     """
-    from core.config import config
+    from core.config import get_watch_dir, get_target_dir
 
-    watch_folder = config.get("SETTINGS", "WATCH", fallback="/temp")
-    target_folder = config.get("SETTINGS", "TARGET", fallback="/processed")
+    watch_folder = get_watch_dir() or "/downloads/temp"
+    target_folder = get_target_dir() or "/downloads/processed"
 
     if path == watch_folder:
         return f"Cannot {operation} watch folder: {path}. Please use the configuration page to change the watch folder."

--- a/monitor.py
+++ b/monitor.py
@@ -9,7 +9,7 @@ from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 from cbz_ops.rename import rename_file, clean_directory_name
 from cbz_ops.single_file import convert_to_cbz
-from core.config import config, load_config
+from core.config import config, load_config, get_watch_dir, get_target_dir
 from helpers import is_hidden
 from core.app_logging import MONITOR_LOG
 from core.database import init_db
@@ -19,9 +19,12 @@ load_config()
 # Initialize database
 init_db()
 
+# Re-run load_config so the WATCH/TARGET migration (which needs the DB) can finish.
+load_config()
+
 # These initial reads remain for startup.
-directory = config.get("SETTINGS", "WATCH", fallback="/temp")
-target_directory = config.get("SETTINGS", "TARGET", fallback="/processed")
+directory = get_watch_dir() or "/downloads/temp"
+target_directory = get_target_dir() or "/downloads/processed"
 ignored_exts_config = config.get("SETTINGS", "IGNORED_EXTENSIONS", fallback=".crdownload")
 ignored_extensions = [ext.strip() for ext in ignored_exts_config.split(",") if ext.strip()]
 autoconvert = config.getboolean("SETTINGS", "AUTOCONVERT", fallback=False)
@@ -77,8 +80,8 @@ class DownloadCompleteHandler(FileSystemEventHandler):
         # Re-reads config values so that if config.ini changes,
         # this handler will use the latest settings.
         ###
-        self.directory = config.get("SETTINGS", "WATCH", fallback="/temp")
-        self.target_directory = config.get("SETTINGS", "TARGET", fallback="/processed")
+        self.directory = get_watch_dir() or "/downloads/temp"
+        self.target_directory = get_target_dir() or "/downloads/processed"
 
         ignored_exts_config = config.get("SETTINGS", "IGNORED_EXTENSIONS", fallback=".crdownload")
         self.ignored_extensions = set(ext.strip().lower() for ext in ignored_exts_config.split(",") if ext.strip())

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -127,8 +127,8 @@ def get_dashboard_sections():
 
 @collection_bp.route('/files')
 def files_page():
-    watch = config.get("SETTINGS", "WATCH", fallback="/temp")
-    target_dir = config.get("SETTINGS", "TARGET", fallback="/processed")
+    watch = current_app.config.get('WATCH') or "/downloads/temp"
+    target_dir = current_app.config.get('TARGET') or "/downloads/processed"
     return render_template('files.html', watch=watch, target_dir=target_dir)
 
 
@@ -998,11 +998,12 @@ def list_new_files():
 @collection_bp.route('/list-downloads', methods=['GET'])
 def list_downloads():
     """List directories and files in the downloads/target path."""
-    from app import (TARGET_DIR, directory_cache, cache_lock, cache_timestamps,
+    from app import (get_target_dir_live, directory_cache, cache_lock, cache_timestamps,
                      cache_stats, MAX_CACHE_SIZE, cleanup_cache, is_cache_valid,
                      get_directory_listing)
 
-    current_path = request.args.get('path', TARGET_DIR)
+    target_dir = get_target_dir_live()
+    current_path = request.args.get('path', target_dir)
 
     if not os.path.exists(current_path):
         return jsonify({"error": "Directory not found"}), 404
@@ -1012,7 +1013,7 @@ def list_downloads():
 
         if is_cache_valid(current_path):
             cached_data = directory_cache[current_path]
-            parent_dir = os.path.dirname(current_path) if current_path != TARGET_DIR else None
+            parent_dir = os.path.dirname(current_path) if current_path != target_dir else None
 
             return jsonify({
                 "current_path": current_path,
@@ -1032,7 +1033,7 @@ def list_downloads():
             if len(directory_cache) > MAX_CACHE_SIZE:
                 cleanup_cache()
 
-        parent_dir = os.path.dirname(current_path) if current_path != TARGET_DIR else None
+        parent_dir = os.path.dirname(current_path) if current_path != target_dir else None
 
         return jsonify({
             "current_path": current_path,

--- a/routes/files.py
+++ b/routes/files.py
@@ -342,8 +342,9 @@ def combine_cbz():
         return jsonify({"error": "Directory not specified"}), 400
 
     # Security: Validate all paths
-    watch_dir = config.get("SETTINGS", "WATCH", fallback="/temp")
-    target_dir = config.get("SETTINGS", "TARGET", fallback="/processed")
+    from core.config import get_watch_dir, get_target_dir
+    watch_dir = get_watch_dir() or "/downloads/temp"
+    target_dir = get_target_dir() or "/downloads/processed"
 
     for f in files:
         normalized = os.path.normpath(f)

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -487,7 +487,8 @@ def api_rescan_missing_xml():
 @metadata_bp.route('/api/save-cvinfo', methods=['POST'])
 def save_cvinfo():
     """Save a cvinfo file in the specified directory."""
-    from app import TARGET_DIR
+    from app import get_target_dir_live
+    TARGET_DIR = get_target_dir_live()
 
     data = request.get_json()
     directory = data.get('directory')
@@ -819,7 +820,8 @@ def _sync_file_index_after_xml_update(directory, xml_field, value, result):
 def update_xml():
     """Update a field in ComicInfo.xml for all CBZ files in a directory."""
     from models.update_xml import update_field_in_cbz_files
-    from app import TARGET_DIR
+    from app import get_target_dir_live
+    TARGET_DIR = get_target_dir_live()
 
     try:
         data = request.get_json()
@@ -914,7 +916,8 @@ def batch_metadata():
        - Try Metron first, then ComicVine, then GCD
     """
     from core.comicinfo import read_comicinfo_from_zip
-    from app import TARGET_DIR
+    from app import get_target_dir_live
+    TARGET_DIR = get_target_dir_live()
 
     try:
         from core.database import get_library_providers

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -85,7 +85,7 @@ def _make_mock_app_module(data_dir, target_dir):
     mock = MagicMock()
     # Attributes accessed by routes/collection.py, routes/files.py, etc.
     mock.DATA_DIR = data_dir
-    mock.TARGET_DIR = target_dir
+    mock.get_target_dir_live = MagicMock(return_value=target_dir)
     mock.directory_cache = {}
     mock.cache_lock = threading.Lock()
     mock.cache_timestamps = {}

--- a/tests/unit/test_watch_target_migration.py
+++ b/tests/unit/test_watch_target_migration.py
@@ -1,0 +1,113 @@
+"""Tests for the WATCH/TARGET migration from config.ini to user_preferences."""
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def fresh_config(tmp_path):
+    """Reload core.config with CONFIG_DIR pointed at a fresh tmp_path."""
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    with patch.dict(os.environ, {"CONFIG_DIR": str(cfg_dir)}):
+        import core.config as cc
+        importlib.reload(cc)
+        yield cc, cfg_dir
+        # Reload again to restore for other tests
+        importlib.reload(cc)
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    """Initialize an empty test DB and patch get_db_path."""
+    db_path = str(tmp_path / "test.db")
+    with patch("core.database.get_db_path", return_value=db_path):
+        from core.database import init_db
+        init_db()
+        yield db_path
+
+
+def test_migration_moves_legacy_values_into_user_preferences(fresh_config, fresh_db, tmp_path):
+    """An existing config.ini with WATCH/TARGET should be migrated."""
+    cc, cfg_dir = fresh_config
+
+    # Pre-seed config.ini with legacy values
+    cfg_file = cfg_dir / "config.ini"
+    cfg_file.write_text(
+        "[SETTINGS]\n"
+        "WATCH = /legacy/watch\n"
+        "TARGET = /legacy/target\n"
+        "IGNORED_TERMS = Annual\n"
+    )
+
+    with patch.object(cc, "CONFIG_FILE", str(cfg_file)):
+        cc.load_config()
+
+        from core.database import get_user_preference
+        assert get_user_preference("watch") == "/legacy/watch"
+        assert get_user_preference("target") == "/legacy/target"
+        assert get_user_preference("watch_target_migrated_to_prefs") is True
+
+        # config.ini should no longer contain WATCH/TARGET keys
+        on_disk = cfg_file.read_text()
+        assert "WATCH" not in on_disk.split("\n")[0:10] or "WATCH = " not in on_disk
+        assert "TARGET = " not in on_disk
+
+
+def test_get_watch_dir_and_get_target_dir_return_user_preference(fresh_config, fresh_db):
+    """Helpers should read from user_preferences."""
+    cc, _ = fresh_config
+    from core.database import set_user_preference
+    set_user_preference("watch", "/x/watch", category="file_processing")
+    set_user_preference("target", "/x/target", category="file_processing")
+
+    assert cc.get_watch_dir() == "/x/watch"
+    assert cc.get_target_dir() == "/x/target"
+
+
+def test_helpers_return_empty_when_unset(fresh_config, fresh_db):
+    """Helpers return '' when no preference is stored."""
+    cc, _ = fresh_config
+    assert cc.get_watch_dir() == ""
+    assert cc.get_target_dir() == ""
+
+
+def test_in_memory_config_mirrors_user_preferences(fresh_config, fresh_db, tmp_path):
+    """Legacy reads via config.get('SETTINGS', 'TARGET') should still work."""
+    cc, cfg_dir = fresh_config
+    cfg_file = cfg_dir / "config.ini"
+    cfg_file.write_text("[SETTINGS]\nIGNORED_TERMS = Annual\n")
+
+    from core.database import set_user_preference
+    set_user_preference("watch", "/m/watch", category="file_processing")
+    set_user_preference("target", "/m/target", category="file_processing")
+
+    with patch.object(cc, "CONFIG_FILE", str(cfg_file)):
+        cc.load_config()
+
+        # Legacy access pattern (api.py and a few other files still use this)
+        assert cc.config.get("SETTINGS", "WATCH") == "/m/watch"
+        assert cc.config.get("SETTINGS", "TARGET") == "/m/target"
+
+
+def test_migration_runs_only_once(fresh_config, fresh_db, tmp_path):
+    """The migration is idempotent and the flag prevents re-runs."""
+    cc, cfg_dir = fresh_config
+    cfg_file = cfg_dir / "config.ini"
+    cfg_file.write_text("[SETTINGS]\nTARGET = /first/target\nWATCH = /first/watch\n")
+
+    with patch.object(cc, "CONFIG_FILE", str(cfg_file)):
+        cc.load_config()
+
+        from core.database import set_user_preference, get_user_preference
+        # User changes their target via the config page (writes to user_preferences)
+        set_user_preference("target", "/user/changed", category="file_processing")
+
+        # Even if config.ini somehow gets a stale TARGET written to it, a second
+        # load_config() must NOT clobber the user's preference.
+        cfg_file.write_text("[SETTINGS]\nTARGET = /stale/leftover\n")
+        cc.load_config()
+
+        assert get_user_preference("target") == "/user/changed"


### PR DESCRIPTION
## 📝 Description
Move WATCH and TARGET settings out of `config.ini` and into the database-backed `user_preferences`. Add `get_watch_dir/get_target_dir` helpers and mirror their values into the in-memory config for backward compatibility. Replace static TARGET_DIR usage with live accessors (`get_target_dir_live`) across app, routes, monitor, helpers and database code. Add validation/safety checks (prevent TARGET/WATCH being /data or inside it, prevent equal/overlapping watch/target) and update config save paths to persist to `user_preferences`. Include unit tests for migration and update monitor to reload config after DB init.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass