### PR TITLE
Add bulk select/delete for reading lists

### DIFF
--- a/routes/reading_lists.py
+++ b/routes/reading_lists.py
@@ -359,6 +359,36 @@ def delete_list(list_id):
     else:
         return jsonify({'success': False, 'message': 'Failed to delete reading list'})
 
+@reading_lists_bp.route('/api/reading-lists/bulk-delete', methods=['POST'])
+def bulk_delete_lists():
+    """Delete multiple reading lists. Body: {"ids": [1,2,3]} or {"all": true}."""
+    data = request.get_json(silent=True) or {}
+    if data.get('all') is True:
+        ids = [row['id'] for row in get_reading_lists()]
+    else:
+        ids = data.get('ids') or []
+    if not ids:
+        return jsonify({'success': False, 'message': 'No lists specified'}), 400
+
+    deleted, failed = [], []
+    for list_id in ids:
+        try:
+            list_id_int = int(list_id)
+        except (TypeError, ValueError):
+            failed.append(list_id)
+            continue
+        if delete_reading_list(list_id_int):
+            deleted.append(list_id_int)
+        else:
+            failed.append(list_id_int)
+
+    return jsonify({
+        'success': len(failed) == 0,
+        'deleted': deleted,
+        'failed': failed,
+        'message': f'Deleted {len(deleted)} of {len(ids)} reading lists'
+    })
+
 @reading_lists_bp.route('/api/reading-lists/import-status/<task_id>')
 def import_status(task_id):
     """Check the status of a background import task."""

--- a/static/css/reading_lists.css
+++ b/static/css/reading_lists.css
@@ -430,4 +430,96 @@
 .tag-filter-btn.active[data-tag="Event"] { background: #ffc107; border-color: #ffc107; color: #000; }
 .tag-filter-btn.active[data-tag="Complete"] { background: #28a745; border-color: #28a745; }
 .tag-filter-btn.active[data-tag="Crossover"] { background: #6f42c1; border-color: #6f42c1; }
+
+/* ==========================================================================
+   Bulk Select Mode
+   ========================================================================== */
+
+.card-select-checkbox {
+    display: none;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 5;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 4px;
+    padding: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.card-select-checkbox .form-check-input {
+    margin: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    cursor: pointer;
+}
+
+body.reading-list-select-mode .card-select-checkbox {
+    display: block;
+}
+
+body.reading-list-select-mode .reading-list-card {
+    cursor: pointer;
+}
+
+.reading-list-card.selected {
+    outline: 3px solid var(--bs-primary);
+    outline-offset: -3px;
+}
+
+#toggleSelectModeBtn.active {
+    background-color: #6c757d;
+    border-color: #6c757d;
+    color: #fff;
+    box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.35);
+}
+
+#toggleSelectModeBtn.active:hover {
+    background-color: #5c636a;
+    border-color: #565e64;
+    color: #fff;
+}
+
+.reading-list-bulk-action-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(180deg, #1a1d21 0%, #0d0f12 100%);
+    border-top: 3px solid var(--bs-primary, #0d6efd);
+    padding: 14px 0;
+    z-index: 1040;
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.55), 0 -2px 0 rgba(13, 110, 253, 0.45);
+    color: #fff;
+    animation: bulkBarSlideIn 0.28s ease-out, bulkBarPulse 1.6s ease-in-out 0.28s 2;
+}
+
+@keyframes bulkBarSlideIn {
+    from { transform: translateY(100%); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes bulkBarPulse {
+    0%, 100% { box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.55), 0 -2px 0 rgba(13, 110, 253, 0.45); }
+    50% { box-shadow: 0 -8px 32px rgba(13, 110, 253, 0.6), 0 -2px 0 rgba(13, 110, 253, 1); }
+}
+
+/* Force readable text on the dark bar, regardless of Bootswatch theme. */
+.reading-list-bulk-action-bar .btn-outline-light {
+    color: #fff !important;
+    border-color: rgba(255, 255, 255, 0.75);
+    background-color: transparent;
+}
+
+.reading-list-bulk-action-bar .btn-outline-light:hover,
+.reading-list-bulk-action-bar .btn-outline-light:focus {
+    color: #1a1d21 !important;
+    background-color: #fff;
+    border-color: #fff;
+}
+
+.reading-list-bulk-action-bar #readingListBulkCount {
+    color: #fff;
+    font-size: 1.05rem;
+}
 .tag-filter-btn.active[data-tag="Reading Order"] { background: #17a2b8; border-color: #17a2b8; }

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -389,6 +389,190 @@ function confirmDelete(id) {
         });
 }
 
+// ==========================================
+// Bulk Select & Delete
+// ==========================================
+
+const selectedListIds = new Set();
+
+function isSelectModeActive() {
+    return document.body.classList.contains('reading-list-select-mode');
+}
+
+function toggleSelectMode() {
+    const enabling = !isSelectModeActive();
+    document.body.classList.toggle('reading-list-select-mode', enabling);
+
+    const toggleBtn = document.getElementById('toggleSelectModeBtn');
+    if (toggleBtn) toggleBtn.classList.toggle('active', enabling);
+
+    // Always clear selection state when toggling, in either direction
+    selectedListIds.clear();
+    document.querySelectorAll('.list-select-cb').forEach(cb => { cb.checked = false; });
+    document.querySelectorAll('.reading-list-card.selected').forEach(c => c.classList.remove('selected'));
+    updateBulkBar();
+}
+
+function onListCheckboxChange(cb) {
+    const id = cb.dataset.listId;
+    const card = cb.closest('.reading-list-card');
+    if (cb.checked) {
+        selectedListIds.add(id);
+        card?.classList.add('selected');
+    } else {
+        selectedListIds.delete(id);
+        card?.classList.remove('selected');
+    }
+    updateBulkBar();
+}
+
+function updateBulkBar() {
+    const bar = document.getElementById('readingListBulkActionBar');
+    const count = document.getElementById('readingListBulkCount');
+    if (!bar || !count) return;
+
+    if (isSelectModeActive()) {
+        bar.style.display = 'block';
+        count.textContent = `${selectedListIds.size} list${selectedListIds.size === 1 ? '' : 's'} selected`;
+    } else {
+        bar.style.display = 'none';
+    }
+}
+
+function selectAllVisibleLists() {
+    document.querySelectorAll('.reading-list-card').forEach(card => {
+        if (card.style.display === 'none') return;
+        const cb = card.querySelector('.list-select-cb');
+        if (cb && !cb.checked) {
+            cb.checked = true;
+            onListCheckboxChange(cb);
+        }
+    });
+}
+
+function clearListSelection() {
+    document.querySelectorAll('.list-select-cb').forEach(cb => {
+        if (cb.checked) {
+            cb.checked = false;
+            onListCheckboxChange(cb);
+        }
+    });
+}
+
+function bulkDeleteSelected() {
+    if (selectedListIds.size === 0) {
+        showToast('No lists selected', 'warning');
+        return;
+    }
+
+    const count = selectedListIds.size;
+    const toastContainer = getToastContainer();
+    const toast = document.createElement('div');
+    toast.className = 'toast align-items-center text-white bg-danger border-0 show';
+    toast.setAttribute('role', 'alert');
+    toast.innerHTML = `
+        <div class="toast-body">
+            <div class="mb-2">Delete ${count} selected reading list${count === 1 ? '' : 's'}?</div>
+            <div class="d-flex gap-2">
+                <button class="btn btn-warning btn-sm confirm-bulk-delete-btn">Delete</button>
+                <button class="btn btn-light btn-sm cancel-bulk-delete-btn">Cancel</button>
+            </div>
+        </div>
+    `;
+    toast.querySelector('.cancel-bulk-delete-btn').addEventListener('click', function () {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+    });
+    toast.querySelector('.confirm-bulk-delete-btn').addEventListener('click', function () {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+        sendBulkDelete({ ids: Array.from(selectedListIds).map(id => parseInt(id, 10)) });
+    });
+    toastContainer.appendChild(toast);
+}
+
+function confirmDeleteAll() {
+    const total = document.querySelectorAll('.reading-list-card').length;
+    if (total === 0) {
+        showToast('No reading lists to delete', 'warning');
+        return;
+    }
+
+    const toastContainer = getToastContainer();
+    const toast = document.createElement('div');
+    toast.className = 'toast align-items-center text-white bg-danger border-0 show';
+    toast.setAttribute('role', 'alert');
+    toast.innerHTML = `
+        <div class="toast-body">
+            <div class="mb-2"><strong>Delete ALL ${total} reading list${total === 1 ? '' : 's'}?</strong></div>
+            <div class="small mb-2">This cannot be undone.</div>
+            <div class="d-flex gap-2">
+                <button class="btn btn-warning btn-sm confirm-delete-all-btn">Delete All</button>
+                <button class="btn btn-light btn-sm cancel-delete-all-btn">Cancel</button>
+            </div>
+        </div>
+    `;
+    toast.querySelector('.cancel-delete-all-btn').addEventListener('click', function () {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+    });
+    toast.querySelector('.confirm-delete-all-btn').addEventListener('click', function () {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+        sendBulkDelete({ all: true });
+    });
+    toastContainer.appendChild(toast);
+}
+
+function sendBulkDelete(payload) {
+    fetch('/api/reading-lists/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    })
+        .then(response => response.json())
+        .then(data => {
+            const deletedCount = (data.deleted || []).length;
+            const failedCount = (data.failed || []).length;
+            if (data.success) {
+                showToast(`Deleted ${deletedCount} reading list${deletedCount === 1 ? '' : 's'}`, 'success');
+            } else if (deletedCount > 0) {
+                showToast(`Deleted ${deletedCount}, failed ${failedCount}`, 'warning');
+            } else {
+                showToast(data.message || 'Bulk delete failed', 'error');
+            }
+            setTimeout(() => window.location.reload(), 600);
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            showToast('An error occurred during bulk delete', 'error');
+        });
+}
+
+// Intercept card clicks while in select mode so the inline onclick="window.location.href=..."
+// is suppressed and the click toggles the checkbox instead.
+document.addEventListener('DOMContentLoaded', function () {
+    const grid = document.querySelector('.reading-list-grid');
+    if (!grid) return;
+    grid.addEventListener('click', function (e) {
+        if (!isSelectModeActive()) return;
+        // Ignore clicks on action buttons within the card; they have their own stopPropagation.
+        if (e.target.closest('.card-actions')) return;
+        // Clicks directly on the checkbox/input wrapper are handled by the input itself.
+        if (e.target.closest('.card-select-checkbox')) return;
+
+        const card = e.target.closest('.reading-list-card');
+        if (!card) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const cb = card.querySelector('.list-select-cb');
+        if (cb) {
+            cb.checked = !cb.checked;
+            onListCheckboxChange(cb);
+        }
+    }, true); // capture phase to beat the inline onclick
+});
+
 function setAsThumbnail(filePath) {
     fetch(`/api/reading-lists/${LIST_ID}/thumbnail`, {
         method: 'POST',

--- a/templates/reading_lists.html
+++ b/templates/reading_lists.html
@@ -8,12 +8,12 @@
 {% block content %}
 <div class="container py-5">
     <!-- Header Section -->
-    <div class="d-flex justify-content-between align-items-center mb-5 fade-in-down">
-        <div>
+    <div class="mb-5 fade-in-down">
+        <div class="mb-3">
             <h2 class="display-4 fw-bold mb-1">Reading Lists</h2>
             <p class="text-muted lead mb-0">Discover and organize your comic journeys</p>
         </div>
-        <div class="d-flex gap-2">
+        <div class="d-flex gap-2 flex-wrap">
             <button class="btn btn-success d-flex align-items-center gap-2" data-bs-toggle="modal"
                 data-bs-target="#createListModal">
                 <i class="bi bi-plus-lg"></i>
@@ -49,6 +49,16 @@
                 data-bs-target="#importCVModal">
                 <i class="bi bi-cloud-arrow-down"></i>
                 <span>ComicVine Import</span>
+            </button>
+            <button class="btn btn-outline-secondary d-flex align-items-center gap-2" id="toggleSelectModeBtn"
+                onclick="toggleSelectMode()" {% if not lists %}disabled{% endif %}>
+                <i class="bi bi-check2-square"></i>
+                <span>Select</span>
+            </button>
+            <button class="btn btn-outline-danger d-flex align-items-center gap-2"
+                onclick="confirmDeleteAll()" {% if not lists %}disabled{% endif %}>
+                <i class="bi bi-trash3"></i>
+                <span>Delete All</span>
             </button>
         </div>
     </div>
@@ -96,6 +106,10 @@
 
             <!-- Background / Stack -->
             <div class="card-stack-container">
+                <div class="card-select-checkbox" onclick="event.stopPropagation();">
+                    <input type="checkbox" class="form-check-input list-select-cb"
+                           data-list-id="{{ list.id }}" onchange="onListCheckboxChange(this)">
+                </div>
                 {% if list.covers and list.covers|length > 0 %}
                 {% for cover in list.covers %}
                 <div class="card-stack-item"
@@ -182,6 +196,29 @@
         </div>
     </div>
     {% endif %}
+</div>
+
+<!-- Bulk Action Bar -->
+<div id="readingListBulkActionBar" class="reading-list-bulk-action-bar" style="display: none;">
+    <div class="container-lg d-flex align-items-center justify-content-between">
+        <div class="d-flex align-items-center gap-3">
+            <span class="text-white fw-bold" id="readingListBulkCount">0 lists selected</span>
+            <button class="btn btn-sm btn-outline-light" onclick="clearListSelection()">
+                <i class="bi bi-x-lg me-1"></i>Clear
+            </button>
+            <button class="btn btn-sm btn-outline-light" onclick="selectAllVisibleLists()">
+                <i class="bi bi-check-all me-1"></i>Select All
+            </button>
+        </div>
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm btn-danger" onclick="bulkDeleteSelected()">
+                <i class="bi bi-trash me-1"></i>Delete Selected
+            </button>
+            <button class="btn btn-sm btn-secondary" onclick="toggleSelectMode()">
+                Exit
+            </button>
+        </div>
+    </div>
 </div>
 
 <!-- Upload Modal -->

--- a/tests/routes/test_reading_lists_routes.py
+++ b/tests/routes/test_reading_lists_routes.py
@@ -114,6 +114,62 @@ class TestDeleteList:
         assert resp.get_json()["success"] is False
 
 
+class TestBulkDeleteLists:
+
+    @patch("routes.reading_lists.delete_reading_list", return_value=True)
+    def test_bulk_delete_by_ids(self, mock_del, client):
+        resp = client.post("/api/reading-lists/bulk-delete",
+                           json={"ids": [1, 2, 3]})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert sorted(data["deleted"]) == [1, 2, 3]
+        assert data["failed"] == []
+        assert mock_del.call_count == 3
+
+    @patch("routes.reading_lists.delete_reading_list", return_value=True)
+    @patch("routes.reading_lists.get_reading_lists",
+           return_value=[{"id": 10}, {"id": 11}])
+    def test_bulk_delete_all(self, mock_get, mock_del, client):
+        resp = client.post("/api/reading-lists/bulk-delete",
+                           json={"all": True})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert sorted(data["deleted"]) == [10, 11]
+        assert mock_del.call_count == 2
+
+    def test_bulk_delete_empty_ids(self, client):
+        resp = client.post("/api/reading-lists/bulk-delete",
+                           json={"ids": []})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+
+    def test_bulk_delete_no_body(self, client):
+        resp = client.post("/api/reading-lists/bulk-delete", json={})
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    @patch("routes.reading_lists.delete_reading_list", return_value=False)
+    def test_bulk_delete_invalid_id_returns_failed(self, mock_del, client):
+        resp = client.post("/api/reading-lists/bulk-delete",
+                           json={"ids": [99999]})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data["failed"] == [99999]
+        assert data["deleted"] == []
+
+    @patch("routes.reading_lists.delete_reading_list", return_value=True)
+    @patch("routes.reading_lists.get_reading_lists", return_value=[])
+    def test_bulk_delete_all_when_none_exist(self, mock_get, mock_del, client):
+        resp = client.post("/api/reading-lists/bulk-delete",
+                           json={"all": True})
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+
 class TestImportStatus:
 
     def test_unknown_task(self, client):


### PR DESCRIPTION
## 📝 Description
Add bulk-delete support and UI for reading lists. Backend: new POST `/api/reading-lists/bulk-delete` that accepts {ids: [...]} or {all: true}, validates ids, calls `delete_reading_list` for each, and returns deleted/failed lists (returns 400 when no lists specified). 

**Frontend:** CSS for select mode and fixed bulk action bar; JS to toggle select mode, manage selections, confirm bulk or delete-all via toast UI, and send bulk delete requests. Templates: add Select/Delete All buttons, per-card checkboxes and a bulk action bar. 

Tests: add unit tests covering bulk-delete behavior (by ids, all, empty payloads, failures, and no lists).

Closes #300 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1328" height="1140" alt="image" src="https://github.com/user-attachments/assets/c41cde9e-b6e6-4629-94ad-03e98863da3a" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass