### PR TITLE
Add List Sorting and CBZ crop to Reading List Views

### DIFF
--- a/routes/files.py
+++ b/routes/files.py
@@ -745,6 +745,42 @@ def crop_image():
         return jsonify({'success': False, 'error': str(e)}), 500
 
 
+@files_bp.route('/crop-cover', methods=['POST'])
+def crop_cover():
+    """
+    Crop the cover image of a CBZ by splitting the first image in half and
+    keeping the right half. Backed by cbz_ops.crop.handle_cbz_file.
+    """
+    try:
+        data = request.json or {}
+        file_path = data.get('target')
+
+        if not file_path:
+            return jsonify({'success': False, 'error': 'Missing file path'}), 400
+
+        if not os.path.exists(file_path):
+            return jsonify({'success': False, 'error': 'File not found'}), 404
+
+        if not file_path.lower().endswith('.cbz'):
+            return jsonify({'success': False, 'error': 'File is not a CBZ'}), 400
+
+        if is_critical_path(file_path):
+            return jsonify({'success': False, 'error': get_critical_path_error_message(file_path)}), 403
+
+        from cbz_ops.crop import handle_cbz_file
+        app_logger.info(f"Crop cover requested for: {file_path}")
+        handle_cbz_file(file_path)
+
+        return jsonify({
+            'success': True,
+            'message': 'Cover cropped successfully.'
+        })
+
+    except Exception as e:
+        app_logger.error(f"Crop cover error: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @files_bp.route('/get-image-data', methods=['POST'])
 def get_full_image_data():
     """Get full-size image data as base64 for display in modal"""

--- a/static/css/reading_lists.css
+++ b/static/css/reading_lists.css
@@ -431,6 +431,36 @@
 .tag-filter-btn.active[data-tag="Complete"] { background: #28a745; border-color: #28a745; }
 .tag-filter-btn.active[data-tag="Crossover"] { background: #6f42c1; border-color: #6f42c1; }
 
+/* Sort Bar */
+.sort-bar {
+    padding: 0.75rem 1rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sort-btn {
+    padding: 0.35rem 0.75rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: transparent;
+    color: var(--bs-body-color);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.sort-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: var(--bs-primary);
+}
+
+.sort-btn.active {
+    background: var(--bs-primary);
+    border-color: var(--bs-primary);
+    color: white;
+}
+
 /* ==========================================================================
    Bulk Select Mode
    ========================================================================== */

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -61,6 +61,45 @@ function applyTagFilters() {
 // Initialize tag filters on page load
 document.addEventListener('DOMContentLoaded', initTagFilters);
 
+// ==========================================
+// Sort System
+// ==========================================
+
+function initSortButtons() {
+    document.querySelectorAll('.sort-btn').forEach(btn => {
+        btn.addEventListener('click', () => applySort(btn));
+    });
+}
+
+function applySort(btn) {
+    document.querySelectorAll('.sort-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+
+    const grid = document.querySelector('.reading-list-grid');
+    if (!grid) return;
+
+    const cards = Array.from(grid.querySelectorAll('.reading-list-card'));
+    const mode = btn.dataset.sort;
+
+    cards.sort((a, b) => {
+        switch (mode) {
+            case 'name-asc':
+                return (a.dataset.name || '').localeCompare(b.dataset.name || '');
+            case 'name-desc':
+                return (b.dataset.name || '').localeCompare(a.dataset.name || '');
+            case 'date-asc':
+                return (a.dataset.created || '').localeCompare(b.dataset.created || '');
+            case 'date-desc':
+            default:
+                return (b.dataset.created || '').localeCompare(a.dataset.created || '');
+        }
+    });
+
+    cards.forEach(card => grid.appendChild(card));
+}
+
+document.addEventListener('DOMContentLoaded', initSortButtons);
+
 // Toast notification system
 let currentProgressToast = null;
 
@@ -572,6 +611,26 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }, true); // capture phase to beat the inline onclick
 });
+
+function cropCover(filePath) {
+    fetch('/crop-cover', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target: filePath })
+    })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                window.location.reload();
+            } else {
+                showToast('Crop failed: ' + (data.error || data.message || 'unknown error'), 'error');
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            showToast('An error occurred while cropping', 'error');
+        });
+}
 
 function setAsThumbnail(filePath) {
     fetch(`/api/reading-lists/${LIST_ID}/thumbnail`, {

--- a/templates/reading_list_view.html
+++ b/templates/reading_list_view.html
@@ -250,6 +250,10 @@
                                 onclick="setAsThumbnail('{{ file_path|replace('\\', '\\\\')|replace("'", "\\'") }}'); return false;">
                                 <i class="bi bi-image me-2"></i>Set as List Thumbnail
                             </a></li>
+                        <li><a class="dropdown-item" href="#"
+                                onclick="cropCover('{{ file_path|replace('\\', '\\\\')|replace("'", "\\'") }}'); return false;">
+                                <i class="bi bi-crop me-2"></i>Crop Cover
+                            </a></li>
                         {% endif %}
                         <li><a class="dropdown-item" href="#"
                                 onclick="openGetComicsSearch('{{ entry.series|replace("'", "\\'") }}', '{{ entry.issue_number }}'); return false;">

--- a/templates/reading_lists.html
+++ b/templates/reading_lists.html
@@ -81,6 +81,27 @@
     {% endif %}
     {% endwith %}
 
+    <!-- Sort Bar -->
+    {% if lists %}
+    <div class="sort-bar mb-3">
+        <div class="d-flex align-items-center gap-2 flex-wrap">
+            <span class="text-muted me-2"><i class="bi bi-sort-down"></i> Sort:</span>
+            <button class="sort-btn active" data-sort="date-desc">
+                <i class="bi bi-calendar3 me-1"></i>Newest First
+            </button>
+            <button class="sort-btn" data-sort="date-asc">
+                <i class="bi bi-calendar3 me-1"></i>Oldest First
+            </button>
+            <button class="sort-btn" data-sort="name-asc">
+                <i class="bi bi-sort-alpha-down me-1"></i>Name (A-Z)
+            </button>
+            <button class="sort-btn" data-sort="name-desc">
+                <i class="bi bi-sort-alpha-up me-1"></i>Name (Z-A)
+            </button>
+        </div>
+    </div>
+    {% endif %}
+
     <!-- Tag Filter -->
     {% if lists %}
     {% set all_tags = lists|map(attribute='tags')|sum(start=[])|unique|sort %}
@@ -102,6 +123,7 @@
     <div class="reading-list-grid">
         {% for list in lists %}
         <div class="reading-list-card stagger-load" data-tags='{{ list.tags|tojson|safe }}'
+            data-name="{{ list.name|lower }}" data-created="{{ list.created_at or '' }}"
             onclick="window.location.href='{{ url_for('reading_lists.view_list', list_id=list.id) }}'">
 
             <!-- Background / Stack -->

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -480,3 +480,42 @@ class TestUploadToFolderOpsIntegration:
 
         after = {o["id"] for o in client.get("/api/operations").get_json()["operations"]}
         assert after.issubset(before), "validation failure must not register a new op"
+
+
+class TestCropCover:
+
+    def test_missing_target(self, client):
+        resp = client.post("/crop-cover", json={})
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    def test_file_not_found(self, client):
+        resp = client.post("/crop-cover", json={"target": "/nope/missing.cbz"})
+        assert resp.status_code == 404
+        assert resp.get_json()["success"] is False
+
+    def test_non_cbz_rejected(self, client, tmp_path):
+        f = tmp_path / "not_a_cbz.txt"
+        f.write_text("hello")
+        resp = client.post("/crop-cover", json={"target": str(f)})
+        assert resp.status_code == 400
+        assert "not a CBZ" in resp.get_json()["error"]
+
+    @patch("routes.files.is_critical_path", return_value=True)
+    @patch("routes.files.get_critical_path_error_message", return_value="Protected")
+    def test_critical_path_blocked(self, mock_msg, mock_crit, client, tmp_path):
+        f = tmp_path / "comic.cbz"
+        f.write_bytes(b"fake")
+        resp = client.post("/crop-cover", json={"target": str(f)})
+        assert resp.status_code == 403
+
+    @patch("routes.files.is_critical_path", return_value=False)
+    @patch("cbz_ops.crop.handle_cbz_file")
+    def test_crop_success(self, mock_handle, mock_crit, client, tmp_path):
+        f = tmp_path / "comic.cbz"
+        f.write_bytes(b"fake")
+        resp = client.post("/crop-cover", json={"target": str(f)})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        mock_handle.assert_called_once_with(str(f))


### PR DESCRIPTION
## 📝 Description
Add POST` /crop-cover` endpoint to crop the cover image of a CBZ (using `cbz_ops.crop.handle_cbz_file`) with validation for missing target, file existence, .cbz extension and critical-path protection; logs success/errors and returns JSON responses. Add frontend support: cropCover() in reading_list.js, a "Crop Cover" menu item in reading_list_view.html, and tests covering error cases and a successful crop. 

Add a sort bar (buttons + CSS) and client-side sorting logic, plus data-name and data-created attributes on reading list cards to enable sorting.

Closes #306 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="664" height="283" alt="image" src="https://github.com/user-attachments/assets/bd08d149-5ceb-4d08-8623-4acdf1d35b6e" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass