### PR TITLE
Add Smart Rename feature for File Manager

### DIFF
--- a/app.py
+++ b/app.py
@@ -6429,6 +6429,22 @@ def save_file_processing_config():
             data.get("customRenamePattern", ""),
             category="file_processing",
         )
+        set_user_preference(
+            "smart_rename_preview_enabled",
+            bool(data.get("smartRenamePreviewEnabled", True)),
+            category="file_processing",
+        )
+        set_user_preference(
+            "smart_rename_recursive",
+            bool(data.get("smartRenameRecursive", True)),
+            category="file_processing",
+        )
+        app.config["SMART_RENAME_PREVIEW_ENABLED"] = bool(
+            data.get("smartRenamePreviewEnabled", True)
+        )
+        app.config["SMART_RENAME_RECURSIVE"] = bool(
+            data.get("smartRenameRecursive", True)
+        )
 
         # Validate and persist filename cleanup preferences
         windows_illegal = set('<>:"/\\|?*')
@@ -6991,6 +7007,12 @@ def config_page():
         ),
         renameCleanSpecialsReplacement=get_user_preference(
             "rename_clean_specials_replacement", default=""
+        ),
+        smartRenamePreviewEnabled=bool(
+            get_user_preference("smart_rename_preview_enabled", default=True)
+        ),
+        smartRenameRecursive=bool(
+            get_user_preference("smart_rename_recursive", default=True)
         ),
         enableAutoRename=settings.get("ENABLE_AUTO_RENAME", "False") == "True",
         enableAutoMove=settings.get("ENABLE_AUTO_MOVE", "False") == "True",

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -1,0 +1,414 @@
+"""
+Smart Rename — metadata-driven bulk rename.
+
+Unlike `cbz_ops.rename.rename_files`, which reverse-engineers series/volume/year
+from each filename via regex, Smart Rename pulls those values from `series.json`
+(created from `cvinfo` if missing, using the library's configured providers)
+and extracts only the issue number from each filename. Values are then fed
+through the existing custom-pattern + filename-cleanup pipeline.
+"""
+
+import os
+import re
+from typing import Dict, List, Optional
+
+from core.app_logging import app_logger
+from cbz_ops.rename import (
+    apply_custom_pattern,
+    apply_filename_cleanup,
+    clean_final_filename,
+    extract_comic_values,
+    load_custom_rename_config,
+    load_filename_cleanup_config,
+    _pad_issue_number,
+)
+from models.series_json import read_series_json, write_series_json
+from models import comicvine as cv_mod
+
+COMIC_EXTS = (".cbz", ".cbr", ".zip")
+
+
+def _get_metron_mod():
+    """Lazy import of models.metron so unit tests don't need mokkari."""
+    from models import metron as metron_mod  # noqa: WPS433
+    return metron_mod
+
+
+def _iter_dirs(root_dir: str, recursive: bool):
+    """Yield directories to process, root first."""
+    if not recursive:
+        yield root_dir
+        return
+    for dirpath, _dirnames, _filenames in os.walk(root_dir):
+        yield dirpath
+
+
+def _has_comic_files(directory: str) -> bool:
+    try:
+        for name in os.listdir(directory):
+            if os.path.isfile(os.path.join(directory, name)) and name.lower().endswith(COMIC_EXTS):
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _resolve_series_via_providers(cvinfo_path: str, library_id: Optional[int]):
+    """
+    Walk the library's configured providers in order and return the first
+    provider-built series object suitable for `write_series_json`.
+
+    Returns a tuple (series_obj, metron_api) where metron_api may be None.
+    Returns (None, None) when nothing usable is found.
+    """
+    cv_id = cv_mod.parse_cvinfo_volume_id(cvinfo_path)
+    if not cv_id:
+        app_logger.warning(f"smart_rename: no CV volume id in {cvinfo_path}")
+        return None, None
+
+    provider_types: List[str] = []
+    if library_id:
+        try:
+            from core.database import get_library_providers
+            for p in get_library_providers(library_id) or []:
+                if p.get("enabled", True):
+                    provider_types.append(p["provider_type"])
+        except Exception as e:
+            app_logger.warning(f"smart_rename: failed to load library providers: {e}")
+    if not provider_types:
+        provider_types = ["metron", "comicvine"]
+
+    metron_api = None
+    for ptype in provider_types:
+        if ptype == "metron":
+            try:
+                metron_mod = _get_metron_mod()
+                if not metron_mod.is_metron_configured():
+                    continue
+                api = metron_mod.get_flask_api()
+                if not api:
+                    continue
+                metron_api = api
+                metron_id = metron_mod.get_series_id(cvinfo_path, api)
+                if not metron_id:
+                    continue
+                series = api.series(metron_id)
+                if series:
+                    return series, metron_api
+            except Exception as e:
+                app_logger.warning(f"smart_rename: metron lookup failed for cv_id={cv_id}: {e}")
+                continue
+
+        elif ptype == "comicvine":
+            try:
+                from flask import current_app
+                api_key = current_app.config.get("COMICVINE_API_KEY", "")
+                if not api_key:
+                    continue
+                series_dict = _build_comicvine_series_dict(api_key, cv_id)
+                if series_dict:
+                    return series_dict, metron_api
+            except Exception as e:
+                app_logger.warning(f"smart_rename: comicvine lookup failed for cv_id={cv_id}: {e}")
+                continue
+        # Other providers (gcd, anilist, manga*) don't populate Mylar-style
+        # series.json today; skip them silently.
+    return None, metron_api
+
+
+def _build_comicvine_series_dict(api_key: str, cv_id: int) -> Optional[Dict]:
+    """Fetch a CV volume and shape it for `write_series_json`."""
+    try:
+        from simyan.comicvine import Comicvine  # type: ignore
+    except ImportError:
+        app_logger.warning("smart_rename: simyan not installed; cannot use ComicVine fallback")
+        return None
+    try:
+        cv = Comicvine(api_key=api_key, cache=None)
+        volume = cv.get_volume(cv_id)
+        if not volume:
+            return None
+        publisher = getattr(volume, "publisher", None)
+        publisher_name = getattr(publisher, "name", None) if publisher else None
+        image = getattr(volume, "image", None)
+        image_url = getattr(image, "original_url", None) if image else None
+        return {
+            "id": None,
+            "cv_id": cv_id,
+            "name": getattr(volume, "name", None),
+            "year_began": getattr(volume, "start_year", None),
+            "year_end": None,
+            "publisher": publisher_name,
+            "imprint": None,
+            "issue_count": getattr(volume, "issue_count", 0) or 0,
+            "desc": getattr(volume, "description", None),
+            "volume": 1,
+            "status": None,
+            "image": image_url,
+        }
+    except Exception as e:
+        app_logger.error(f"smart_rename: ComicVine volume fetch failed for {cv_id}: {e}")
+        return None
+
+
+def _ensure_series_json(directory: str, library_id: Optional[int]) -> Dict:
+    """
+    Ensure `series.json` exists in `directory`. Returns:
+      {"status": "ok", "metadata": {...}} on success
+      {"status": "needs_cvinfo"} if no cvinfo
+      {"status": "series_json_failed", "reason": "..."} if creation failed
+    """
+    cvinfo_path = cv_mod.find_cvinfo_in_folder(directory)
+    if not cvinfo_path:
+        return {"status": "needs_cvinfo"}
+
+    existing = read_series_json(directory)
+    if existing and isinstance(existing.get("metadata"), dict) and existing["metadata"].get("name"):
+        return {"status": "ok", "metadata": existing["metadata"]}
+
+    series_obj, metron_api = _resolve_series_via_providers(cvinfo_path, library_id)
+    if not series_obj:
+        return {"status": "series_json_failed", "reason": "no provider returned series data"}
+
+    ok = write_series_json(directory, series_obj, api=metron_api)
+    if not ok:
+        return {"status": "series_json_failed", "reason": "write_series_json returned False"}
+
+    refreshed = read_series_json(directory) or {}
+    md = refreshed.get("metadata") if isinstance(refreshed, dict) else None
+    if not md or not md.get("name"):
+        return {"status": "series_json_failed", "reason": "series.json missing 'name' after write"}
+    return {"status": "ok", "metadata": md}
+
+
+def _format_volume(volume) -> str:
+    """Format the series.json `volume` field as the {volume_number} token."""
+    if volume in (None, "", 0):
+        return ""
+    text = str(volume).strip()
+    if not text:
+        return ""
+    if text.lower().startswith("v"):
+        return text
+    if text.isdigit():
+        return f"v{int(text)}"
+    return text
+
+
+def _format_year(year) -> str:
+    if year in (None, "", 0):
+        return ""
+    return str(year).strip()
+
+
+def _sanitize_series_name(name: str) -> str:
+    """Strip Windows-illegal chars from a series name.
+
+    Matches the convention used in `rename_comic_from_metadata`: colon is
+    replaced with " -" (not removed) so subtitles like "Batman: Year One"
+    become "Batman - Year One"; the rest of the Windows-reserved set is
+    stripped outright.
+    """
+    if not name:
+        return ""
+    name = name.replace(":", " -")
+    name = re.sub(r'[<>"/\\|?*]', "", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    return name
+
+
+def _plan_file(
+    file_path: str,
+    metadata: Dict,
+    pattern: str,
+    cleanup_cfg: Dict,
+    used_targets: set,
+) -> Dict:
+    """Build the rename plan entry for a single file."""
+    old_name = os.path.basename(file_path)
+    stem, ext = os.path.splitext(old_name)
+
+    extracted = extract_comic_values(stem)
+    raw_issue = (extracted.get("issue_number") or "").strip()
+    if not raw_issue:
+        return {"old_path": file_path, "old_name": old_name, "status": "no_issue"}
+
+    issue = _pad_issue_number(raw_issue, width=3)
+
+    values = {
+        "series_name": _sanitize_series_name((metadata.get("name") or "").strip()),
+        "volume_number": _format_volume(metadata.get("volume")),
+        "year": _format_year(metadata.get("year")),
+        "issue_number": issue,
+        "issue_title": "",
+    }
+
+    new_stem = apply_custom_pattern(values, pattern)
+    if not new_stem:
+        return {"old_path": file_path, "old_name": old_name, "status": "pattern_empty"}
+
+    new_stem = apply_filename_cleanup(new_stem, cleanup_cfg)
+    new_name = clean_final_filename(new_stem + ext.lower())
+
+    if new_name == old_name:
+        return {"old_path": file_path, "old_name": old_name, "status": "unchanged"}
+
+    directory = os.path.dirname(file_path)
+    candidate = os.path.join(directory, new_name)
+    if candidate != file_path and (candidate in used_targets or os.path.exists(candidate)):
+        base, ext_final = os.path.splitext(new_name)
+        suffix = 2
+        while True:
+            unique = f"{base} ({suffix}){ext_final}"
+            candidate = os.path.join(directory, unique)
+            if candidate not in used_targets and not os.path.exists(candidate):
+                new_name = unique
+                break
+            suffix += 1
+
+    used_targets.add(candidate)
+    return {
+        "old_path": file_path,
+        "old_name": old_name,
+        "new_path": candidate,
+        "new_name": new_name,
+        "status": "ok",
+    }
+
+
+def plan_smart_rename(
+    root_dir: str,
+    recursive: bool = True,
+    library_id: Optional[int] = None,
+) -> Dict:
+    """
+    Build a rename plan for `root_dir` (optionally recursive).
+
+    Returns:
+        {
+          "root": root_dir,
+          "recursive": bool,
+          "directories": [
+             {"dir": str, "status": "ok"|"needs_cvinfo"|"series_json_failed"|"empty",
+              "metadata": {...} | None, "files": [<file plan entries>]}
+          ]
+        }
+    """
+    custom_enabled, pattern = load_custom_rename_config()
+    cleanup_cfg = load_filename_cleanup_config()
+
+    result = {
+        "root": root_dir,
+        "recursive": recursive,
+        "pattern": pattern,
+        "directories": [],
+    }
+
+    if not custom_enabled or not pattern:
+        result["error"] = (
+            "Custom rename pattern is not enabled. Configure 'Enable Custom Rename' "
+            "and 'Custom Rename Pattern' in Settings before running Smart Rename."
+        )
+        return result
+
+    if not os.path.isdir(root_dir):
+        result["error"] = f"Directory does not exist: {root_dir}"
+        return result
+
+    for directory in _iter_dirs(root_dir, recursive):
+        if not _has_comic_files(directory):
+            continue
+
+        dir_entry: Dict = {"dir": directory, "files": []}
+        sj = _ensure_series_json(directory, library_id)
+        if sj["status"] != "ok":
+            dir_entry["status"] = sj["status"]
+            if "reason" in sj:
+                dir_entry["reason"] = sj["reason"]
+            dir_entry["metadata"] = None
+            result["directories"].append(dir_entry)
+            continue
+
+        metadata = sj["metadata"]
+        dir_entry["status"] = "ok"
+        dir_entry["metadata"] = {
+            "name": metadata.get("name"),
+            "volume": metadata.get("volume"),
+            "year": metadata.get("year"),
+        }
+
+        used_targets: set = set()
+        try:
+            entries = sorted(os.listdir(directory))
+        except OSError as e:
+            dir_entry["status"] = "list_failed"
+            dir_entry["reason"] = str(e)
+            result["directories"].append(dir_entry)
+            continue
+
+        for name in entries:
+            file_path = os.path.join(directory, name)
+            if not os.path.isfile(file_path):
+                continue
+            if not name.lower().endswith(COMIC_EXTS):
+                continue
+            dir_entry["files"].append(
+                _plan_file(file_path, metadata, pattern, cleanup_cfg, used_targets)
+            )
+
+        result["directories"].append(dir_entry)
+
+    return result
+
+
+def apply_smart_rename(plan: Dict) -> Dict:
+    """
+    Apply a plan produced by `plan_smart_rename`.
+
+    Returns a summary dict with counts and per-file errors.
+    """
+    summary = {"renamed": 0, "skipped": 0, "failed": 0, "errors": [], "directories": []}
+
+    try:
+        from app import update_index_on_move
+    except Exception:
+        update_index_on_move = None
+
+    for dir_entry in plan.get("directories", []):
+        if dir_entry.get("status") != "ok":
+            summary["skipped"] += 1
+            summary["directories"].append(
+                {"dir": dir_entry.get("dir"), "status": dir_entry.get("status")}
+            )
+            continue
+
+        for f in dir_entry.get("files", []):
+            if f.get("status") != "ok":
+                summary["skipped"] += 1
+                continue
+            old_path = f["old_path"]
+            new_path = f["new_path"]
+            try:
+                os.rename(old_path, new_path)
+                summary["renamed"] += 1
+                if update_index_on_move:
+                    try:
+                        update_index_on_move(old_path, new_path)
+                    except Exception as e:
+                        app_logger.warning(
+                            f"smart_rename: index update failed for {old_path} -> {new_path}: {e}"
+                        )
+            except Exception as e:
+                summary["failed"] += 1
+                summary["errors"].append(
+                    {"old_path": old_path, "new_path": new_path, "error": str(e)}
+                )
+                app_logger.error(
+                    f"smart_rename: rename failed {old_path} -> {new_path}: {e}"
+                )
+
+        summary["directories"].append(
+            {"dir": dir_entry.get("dir"), "status": "ok"}
+        )
+
+    return summary

--- a/core/config.py
+++ b/core/config.py
@@ -254,6 +254,8 @@ def load_flask_config(app, logger=None):
     from core.database import get_user_preference
     app.config["ENABLE_CUSTOM_RENAME"] = bool(get_user_preference('enable_custom_rename', default=False))
     app.config["CUSTOM_RENAME_PATTERN"] = get_user_preference('custom_rename_pattern', default='') or ''
+    app.config["SMART_RENAME_PREVIEW_ENABLED"] = bool(get_user_preference('smart_rename_preview_enabled', default=True))
+    app.config["SMART_RENAME_RECURSIVE"] = bool(get_user_preference('smart_rename_recursive', default=True))
     app.config["ENABLE_AUTO_RENAME"] = config.getboolean("SETTINGS", "ENABLE_AUTO_RENAME", fallback=False)
     app.config["ENABLE_AUTO_MOVE"] = config.getboolean("SETTINGS", "ENABLE_AUTO_MOVE", fallback=False)
     app.config["CUSTOM_MOVE_PATTERN"] = settings.get("CUSTOM_MOVE_PATTERN", "{publisher}/{series_name}/v{start_year}")

--- a/routes/files.py
+++ b/routes/files.py
@@ -632,6 +632,103 @@ def rename_directory():
         return jsonify({"error": str(e)}), 500
 
 
+def _validate_smart_rename_target(data):
+    """Shared validation for /smart-rename and /smart-rename/preview.
+
+    Returns (directory_path, recursive, library_id, error_response_or_none).
+    """
+    directory_path = (data or {}).get('directory')
+    if not directory_path:
+        return None, None, None, (jsonify({"error": "Missing directory path"}), 400)
+    if not os.path.exists(directory_path):
+        return None, None, None, (jsonify({"error": "Directory does not exist"}), 404)
+    if not os.path.isdir(directory_path):
+        return None, None, None, (jsonify({"error": "Path is not a directory"}), 400)
+    if is_critical_path(directory_path):
+        return None, None, None, (
+            jsonify({"error": get_critical_path_error_message(directory_path, "rename files in")}),
+            403,
+        )
+
+    recursive = (data or {}).get('recursive')
+    if recursive is None:
+        try:
+            from core.database import get_user_preference
+            recursive = bool(get_user_preference('smart_rename_recursive', default=True))
+        except Exception:
+            recursive = True
+    else:
+        recursive = bool(recursive)
+
+    library_id = (data or {}).get('library_id')
+    if isinstance(library_id, str) and library_id.isdigit():
+        library_id = int(library_id)
+    elif not isinstance(library_id, int):
+        library_id = None
+
+    return directory_path, recursive, library_id, None
+
+
+@files_bp.route('/smart-rename/preview', methods=['POST'])
+def smart_rename_preview():
+    """Build a Smart Rename plan for a directory without applying it."""
+    try:
+        data = request.get_json(silent=True) or {}
+        directory_path, recursive, library_id, err = _validate_smart_rename_target(data)
+        if err is not None:
+            return err
+
+        app_logger.info("********************// Smart Rename Preview //********************")
+        app_logger.info(f"Directory: {directory_path} (recursive={recursive}, library_id={library_id})")
+
+        from cbz_ops.smart_rename import plan_smart_rename
+        plan = plan_smart_rename(directory_path, recursive=recursive, library_id=library_id)
+        return jsonify({"success": True, "plan": plan})
+    except Exception as e:
+        app_logger.error(f"Smart rename preview failed: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@files_bp.route('/smart-rename', methods=['POST'])
+def smart_rename_apply():
+    """
+    Apply a Smart Rename. If `plan` is provided in the request body it is
+    applied directly; otherwise a fresh plan is built from `directory` and
+    applied. Pass `plan` for the modal-confirm flow; omit it for the
+    no-preview flow.
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        plan = data.get('plan')
+
+        if plan is None:
+            directory_path, recursive, library_id, err = _validate_smart_rename_target(data)
+            if err is not None:
+                return err
+            from cbz_ops.smart_rename import plan_smart_rename
+            plan = plan_smart_rename(directory_path, recursive=recursive, library_id=library_id)
+        else:
+            # Even when applying a client-supplied plan, guard the root.
+            root_dir = plan.get('root') if isinstance(plan, dict) else None
+            if not root_dir or not os.path.isdir(root_dir):
+                return jsonify({"error": "Invalid plan: missing or non-existent root"}), 400
+            if is_critical_path(root_dir):
+                return jsonify({"error": get_critical_path_error_message(root_dir, "rename files in")}), 403
+
+        if isinstance(plan, dict) and plan.get('error'):
+            return jsonify({"error": plan['error']}), 400
+
+        app_logger.info("********************// Smart Rename Apply //********************")
+        app_logger.info(f"Root: {plan.get('root') if isinstance(plan, dict) else 'unknown'}")
+
+        from cbz_ops.smart_rename import apply_smart_rename
+        summary = apply_smart_rename(plan)
+        return jsonify({"success": True, "summary": summary, "plan": plan})
+    except Exception as e:
+        app_logger.error(f"Smart rename apply failed: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @files_bp.route('/custom-rename', methods=['POST'])
 def custom_rename():
     """

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -670,6 +670,20 @@ function createListItem(itemName, fullPath, type, panel, isDraggable) {
       enhanceItem.appendChild(enhanceLink);
       dropdownMenu.appendChild(enhanceItem);
 
+      // Smart Rename option
+      const smartRenameItem = document.createElement("li");
+      const smartRenameLink = document.createElement("a");
+      smartRenameLink.className = "dropdown-item";
+      smartRenameLink.href = "#";
+      smartRenameLink.innerHTML = '<i class="bi bi-magic me-2"></i>Smart Rename';
+      smartRenameLink.onclick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        runSmartRename(fullPath, panel);
+      };
+      smartRenameItem.appendChild(smartRenameLink);
+      dropdownMenu.appendChild(smartRenameItem);
+
       // Remove All XML option
       const removeXmlItem = document.createElement("li");
       const removeXmlLink = document.createElement("a");
@@ -6008,6 +6022,142 @@ function bulkRemoveXmlFromDirectory(directoryPath, panel) {
 
   const modal = new bootstrap.Modal(document.getElementById('removeXmlDirModal'));
   modal.show();
+}
+
+// ============================================================================
+// SMART RENAME
+// ============================================================================
+
+async function runSmartRename(directoryPath, panel) {
+  const libraryId = getLibraryIdForPanel(panel);
+  const folderName = directoryPath.split('/').pop() || directoryPath;
+  let previewEnabled = true;
+  try {
+    const resp = await fetch('/api/preferences/smart_rename_preview_enabled');
+    if (resp.ok) {
+      const j = await resp.json();
+      if (j && typeof j.value !== 'undefined' && j.value !== null) {
+        previewEnabled = j.value !== false && j.value !== 0 && j.value !== '0';
+      }
+    }
+  } catch (_) { /* default true */ }
+
+  CLU.showToast('Smart Rename', `Building plan for ${folderName}...`, 'info');
+  let planResp;
+  try {
+    planResp = await fetch('/smart-rename/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ directory: directoryPath, library_id: libraryId })
+    });
+  } catch (e) {
+    CLU.showToast('Smart Rename Error', e.message, 'error');
+    return;
+  }
+  const planJson = await planResp.json();
+  if (!planResp.ok || planJson.error) {
+    CLU.showToast('Smart Rename Error', planJson.error || `HTTP ${planResp.status}`, 'error');
+    return;
+  }
+  const plan = planJson.plan;
+  if (plan && plan.error) {
+    CLU.showToast('Smart Rename Error', plan.error, 'error');
+    return;
+  }
+
+  if (!previewEnabled) {
+    await applySmartRenamePlan(plan, panel);
+    return;
+  }
+
+  showSmartRenameModal(plan, panel);
+}
+
+function showSmartRenameModal(plan, panel) {
+  const summaryEl = document.getElementById('smartRenameSummary');
+  const tbody = document.getElementById('smartRenameTbody');
+  const issuesEl = document.getElementById('smartRenameIssues');
+  const applyBtn = document.getElementById('smartRenameApplyBtn');
+
+  tbody.innerHTML = '';
+  issuesEl.innerHTML = '';
+
+  let okCount = 0;
+  let skipCount = 0;
+  const issues = [];
+
+  for (const dir of (plan.directories || [])) {
+    if (dir.status !== 'ok') {
+      const reason = dir.reason ? ` — ${dir.reason}` : '';
+      issues.push(`<li><code>${escapeHtml(dir.dir)}</code>: ${escapeHtml(dir.status)}${escapeHtml(reason)}</li>`);
+      continue;
+    }
+    for (const f of (dir.files || [])) {
+      if (f.status === 'ok') {
+        okCount++;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td class="text-muted small text-truncate" style="max-width:300px" title="${escapeHtml(f.old_path)}">${escapeHtml(f.old_name)}</td>
+          <td class="small text-truncate" style="max-width:300px" title="${escapeHtml(f.new_path)}">${escapeHtml(f.new_name)}</td>`;
+        tbody.appendChild(tr);
+      } else {
+        skipCount++;
+        issues.push(`<li><code>${escapeHtml(f.old_name)}</code>: ${escapeHtml(f.status)}</li>`);
+      }
+    }
+  }
+
+  summaryEl.textContent = `${okCount} file(s) will be renamed. ${skipCount} skipped.`;
+  issuesEl.innerHTML = issues.length ? `<details class="mt-2"><summary class="text-muted small">Issues (${issues.length})</summary><ul class="small mt-2">${issues.join('')}</ul></details>` : '';
+
+  applyBtn.disabled = okCount === 0;
+  applyBtn.onclick = async () => {
+    applyBtn.disabled = true;
+    applyBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Renaming...';
+    const ok = await applySmartRenamePlan(plan, panel);
+    const modal = bootstrap.Modal.getInstance(document.getElementById('smartRenamePreviewModal'));
+    if (modal) modal.hide();
+    applyBtn.innerHTML = '<i class="bi bi-check2 me-1"></i>Apply';
+    applyBtn.disabled = !ok;
+  };
+
+  const modalEl = document.getElementById('smartRenamePreviewModal');
+  const modal = new bootstrap.Modal(modalEl);
+  modal.show();
+}
+
+async function applySmartRenamePlan(plan, panel) {
+  try {
+    const resp = await fetch('/smart-rename', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan })
+    });
+    const j = await resp.json();
+    if (!resp.ok || j.error) {
+      CLU.showToast('Smart Rename Error', j.error || `HTTP ${resp.status}`, 'error');
+      return false;
+    }
+    const s = j.summary || {};
+    const msg = `Renamed ${s.renamed || 0}, skipped ${s.skipped || 0}, failed ${s.failed || 0}`;
+    CLU.showToast('Smart Rename', msg, (s.failed || 0) > 0 ? 'warning' : 'success');
+    const currentPath = panel === 'source' ? currentSourcePath : currentDestinationPath;
+    if (currentPath) loadDirectories(currentPath, panel);
+    return true;
+  } catch (e) {
+    CLU.showToast('Smart Rename Error', e.message, 'error');
+    return false;
+  }
+}
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 /**

--- a/templates/config.html
+++ b/templates/config.html
@@ -456,6 +456,45 @@
                         </div>
                     </div>
 
+                    <!-- Smart Rename -->
+                    <hr class="my-4">
+                    <h5>Smart Rename</h5>
+                    <p class="text-muted">
+                        Renames files using values from <code>series.json</code> and the issue
+                        number parsed from each filename, instead of regex-matching the whole
+                        name. Available from the folder three-dots menu on the Files page.
+                    </p>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" role="switch"
+                                    id="smartRenamePreviewEnabled" name="smartRenamePreviewEnabled"
+                                    {% if smartRenamePreviewEnabled %}checked{% endif %}>
+                                <label class="form-check-label" for="smartRenamePreviewEnabled">
+                                    Preview Before Renaming
+                                </label>
+                                <small class="form-text text-muted d-block">
+                                    Show a modal of planned renames and require Apply before any
+                                    file is touched. Turn off to rename immediately on click.
+                                </small>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" role="switch"
+                                    id="smartRenameRecursive" name="smartRenameRecursive"
+                                    {% if smartRenameRecursive %}checked{% endif %}>
+                                <label class="form-check-label" for="smartRenameRecursive">
+                                    Recurse Into Subfolders
+                                </label>
+                                <small class="form-text text-muted d-block">
+                                    Walk subdirectories and process each one that has its own
+                                    <code>cvinfo</code>/<code>series.json</code>.
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Filename Character Cleanup -->
                     <hr class="my-4">
                     <h5>Filename Character Cleanup</h5>
@@ -1643,6 +1682,8 @@
             renameCleanSpecialsCharset: document.getElementById('renameCleanSpecialsCharset')?.value || '',
             renameCleanSpecialsMode: document.querySelector('input[name="renameCleanSpecialsMode"]:checked')?.value || 'remove',
             renameCleanSpecialsReplacement: document.getElementById('renameCleanSpecialsReplacement')?.value || '',
+            smartRenamePreviewEnabled: document.getElementById('smartRenamePreviewEnabled')?.checked ?? true,
+            smartRenameRecursive: document.getElementById('smartRenameRecursive')?.checked ?? true,
             enableAutoRename: document.getElementById('enableAutoRename')?.checked || false,
             enableAutoMove: document.getElementById('enableAutoMove')?.checked || false,
             customMovePattern: document.getElementById('customMovePattern')?.value || '',

--- a/templates/files.html
+++ b/templates/files.html
@@ -282,6 +282,43 @@
 </div>
 <!-- End of Remove XML from Directory Modal -->
 
+<!-- Smart Rename Preview Modal -->
+<div class="modal fade" id="smartRenamePreviewModal" tabindex="-1" aria-labelledby="smartRenamePreviewModalLabel"
+  aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="smartRenamePreviewModalLabel">
+          <i class="bi bi-magic me-2"></i>Smart Rename Preview
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p id="smartRenameSummary" class="text-muted small mb-2"></p>
+        <div style="max-height: 50vh; overflow-y: auto;">
+          <table class="table table-sm table-hover small">
+            <thead>
+              <tr>
+                <th>Old name</th>
+                <th>New name</th>
+              </tr>
+            </thead>
+            <tbody id="smartRenameTbody"></tbody>
+          </table>
+        </div>
+        <div id="smartRenameIssues"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="smartRenameApplyBtn">
+          <i class="bi bi-check2 me-1"></i>Apply
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- End of Smart Rename Preview Modal -->
+
 <!-- Create Folder Modal -->
 <div class="modal fade" id="createFolderModal" tabindex="-1" aria-labelledby="createFolderModalLabel"
   aria-hidden="true">

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -136,6 +136,86 @@ class TestCustomRename:
         assert resp.status_code == 400
 
 
+class TestSmartRenamePreview:
+
+    def test_missing_directory(self, client):
+        resp = client.post("/smart-rename/preview", json={})
+        assert resp.status_code == 400
+
+    def test_nonexistent_directory(self, client):
+        resp = client.post("/smart-rename/preview",
+                           json={"directory": "/nope/abs/path"})
+        assert resp.status_code == 404
+
+    @patch("routes.files.is_critical_path", return_value=True)
+    @patch("routes.files.get_critical_path_error_message", return_value="Protected")
+    def test_critical_path_rejected(self, mock_msg, mock_crit, client, tmp_path):
+        resp = client.post("/smart-rename/preview",
+                           json={"directory": str(tmp_path)})
+        assert resp.status_code == 403
+
+    @patch("routes.files.is_critical_path", return_value=False)
+    def test_returns_plan(self, mock_crit, client, tmp_path):
+        # Build a directory with cvinfo + series.json + one file
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        (d / "cvinfo").write_text("https://comicvine.gamespot.com/volume/4050-1/\n")
+        (d / "series.json").write_text(
+            '{"metadata": {"name": "Sandman", "volume": 2, "year": 1989}}'
+        )
+        (d / "Sandman 1.cbz").write_bytes(b"x")
+
+        with patch("core.database.get_user_preference",
+                   side_effect=lambda key, default=None: {
+                       "enable_custom_rename": True,
+                       "custom_rename_pattern": "{series_name} {volume_number} {issue_number} ({year})",
+                       "smart_rename_recursive": False,
+                   }.get(key, default)):
+            resp = client.post("/smart-rename/preview",
+                               json={"directory": str(d), "recursive": False})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert len(data["plan"]["directories"]) == 1
+        dir_entry = data["plan"]["directories"][0]
+        assert dir_entry["status"] == "ok"
+        # The file should still exist (preview does not rename)
+        assert (d / "Sandman 1.cbz").exists()
+
+
+class TestSmartRenameApply:
+
+    @patch("routes.files.is_critical_path", return_value=False)
+    def test_apply_renames_files(self, mock_crit, client, tmp_path):
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        (d / "cvinfo").write_text("https://comicvine.gamespot.com/volume/4050-1/\n")
+        (d / "series.json").write_text(
+            '{"metadata": {"name": "Sandman", "volume": 2, "year": 1989}}'
+        )
+        (d / "Sandman 1.cbz").write_bytes(b"x")
+
+        with patch("core.database.get_user_preference",
+                   side_effect=lambda key, default=None: {
+                       "enable_custom_rename": True,
+                       "custom_rename_pattern": "{series_name} {volume_number} {issue_number} ({year})",
+                   }.get(key, default)):
+            resp = client.post("/smart-rename",
+                               json={"directory": str(d), "recursive": False})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["summary"]["renamed"] == 1
+        assert (d / "Sandman v2 001 (1989).cbz").exists()
+
+    def test_apply_with_invalid_plan(self, client):
+        resp = client.post("/smart-rename",
+                           json={"plan": {"root": "/nonexistent/path"}})
+        assert resp.status_code == 400
+
+
 class TestDelete:
 
     @patch("routes.files.is_critical_path", return_value=False)

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -1,0 +1,298 @@
+"""Tests for cbz_ops/smart_rename.py -- metadata-driven bulk rename."""
+import json
+import os
+from types import SimpleNamespace
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture(autouse=True)
+def _mock_rename_deps():
+    """Stub the few module-level deps so importing smart_rename is cheap."""
+    # Force-import so patch() can resolve the target.
+    import cbz_ops.rename  # noqa: F401
+    import cbz_ops.smart_rename  # noqa: F401
+    with patch("cbz_ops.smart_rename.app_logger"), \
+         patch("cbz_ops.rename.app_logger"), \
+         patch("cbz_ops.rename.is_hidden", return_value=False):
+        yield
+
+
+def _write_series_json(folder, name="Sandman", volume=2, year=1989):
+    payload = {
+        "metadata": {
+            "type": "comicSeries",
+            "name": name,
+            "volume": volume,
+            "year": year,
+            "publisher": "Vertigo",
+            "status": "Ended",
+        }
+    }
+    with open(os.path.join(folder, "series.json"), "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+
+
+def _write_cvinfo(folder, cv_id=12345):
+    with open(os.path.join(folder, "cvinfo"), "w", encoding="utf-8") as f:
+        f.write(f"https://comicvine.gamespot.com/volume/4050-{cv_id}/\n")
+
+
+def _enable_custom_rename(pattern="{series_name} {volume_number} {issue_number} ({year})"):
+    """Patch the pref reader used by smart_rename to enable a custom pattern.
+
+    cbz_ops.rename does ``from core.database import get_user_preference``
+    inside functions, so patching ``core.database.get_user_preference`` is
+    the safest interception point.
+    """
+    return patch(
+        "core.database.get_user_preference",
+        side_effect=lambda key, default=None: {
+            "enable_custom_rename": True,
+            "custom_rename_pattern": pattern,
+            "rename_clean_spaces_enabled": False,
+            "rename_clean_specials_enabled": False,
+        }.get(key, default),
+    )
+
+
+class TestPlanSmartRenameSetup:
+
+    def test_missing_directory_returns_error(self):
+        from cbz_ops.smart_rename import plan_smart_rename
+        with _enable_custom_rename():
+            plan = plan_smart_rename("/no/such/dir")
+        assert "error" in plan
+        assert "does not exist" in plan["error"].lower()
+
+    def test_custom_pattern_disabled_returns_error(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        # Pref reader returns False/empty for every key (default)
+        with patch(
+            "core.database.get_user_preference",
+            side_effect=lambda key, default=None: default,
+        ):
+            plan = plan_smart_rename(str(tmp_path))
+        assert "error" in plan
+        assert "Custom rename pattern" in plan["error"]
+
+
+class TestPlanSmartRenameNeedsCvinfo:
+
+    def test_missing_cvinfo_marks_directory(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "series"
+        d.mkdir()
+        (d / "Issue 001.cbz").write_bytes(b"x")  # one comic file
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d))
+        assert len(plan["directories"]) == 1
+        assert plan["directories"][0]["status"] == "needs_cvinfo"
+        assert plan["directories"][0]["files"] == []
+
+
+class TestPlanSmartRenameSeriesJsonPath:
+
+    def test_happy_path_files_get_renamed(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        (d / "Sandman 1.cbz").write_bytes(b"x")
+        (d / "Sandman 12.cbz").write_bytes(b"x")
+        (d / "ignore.txt").write_bytes(b"x")
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        assert len(plan["directories"]) == 1
+        dir_entry = plan["directories"][0]
+        assert dir_entry["status"] == "ok"
+        names = [f["new_name"] for f in dir_entry["files"] if f["status"] == "ok"]
+        assert "Sandman v2 001 (1989).cbz" in names
+        assert "Sandman v2 012 (1989).cbz" in names
+
+    def test_file_with_no_issue_number_is_skipped(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d)
+        (d / "no-numbers-here.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        files = plan["directories"][0]["files"]
+        assert len(files) == 1
+        assert files[0]["status"] == "no_issue"
+
+    def test_collision_gets_suffix(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        # Existing file at the planned target
+        (d / "Sandman v2 001 (1989).cbz").write_bytes(b"existing")
+        (d / "Sandman 1.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        renames = [f for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert len(renames) == 1
+        assert renames[0]["new_name"] == "Sandman v2 001 (1989) (2).cbz"
+
+    def test_colon_in_series_name_is_replaced_with_dash(self, tmp_path):
+        """Match the existing convention: ':' -> ' -' (Windows-illegal char)."""
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Batman Year One"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Batman: Year One", volume=1, year=1987)
+        (d / "Batman 1.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert names == ["Batman - Year One v1 001 (1987).cbz"]
+        assert ":" not in names[0]
+
+    def test_recursive_walks_subdirs(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        # Subdir A
+        a = tmp_path / "Sandman v1"
+        a.mkdir()
+        _write_cvinfo(a, cv_id=1)
+        _write_series_json(a, name="Sandman", volume=1, year=1989)
+        (a / "Sandman 1.cbz").write_bytes(b"x")
+        # Subdir B
+        b = tmp_path / "Sandman v2"
+        b.mkdir()
+        _write_cvinfo(b, cv_id=2)
+        _write_series_json(b, name="Sandman", volume=2, year=2022)
+        (b / "Sandman 1.cbz").write_bytes(b"x")
+        # Empty top-level dir (no comic files) -- should be skipped
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(tmp_path), recursive=True)
+
+        # Two directories with comics, neither one is the root (which has no comics).
+        dirs = {d["dir"]: d for d in plan["directories"]}
+        assert str(a) in dirs and str(b) in dirs
+        a_names = [f["new_name"] for f in dirs[str(a)]["files"] if f["status"] == "ok"]
+        b_names = [f["new_name"] for f in dirs[str(b)]["files"] if f["status"] == "ok"]
+        assert a_names == ["Sandman v1 001 (1989).cbz"]
+        assert b_names == ["Sandman v2 001 (2022).cbz"]
+
+
+class TestPlanSmartRenameAutoCreateSeriesJson:
+
+    def test_metron_provider_creates_series_json(self, tmp_path):
+        """When series.json is missing, provider lookup builds and writes it."""
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d, cv_id=999)
+        (d / "Sandman 5.cbz").write_bytes(b"x")
+
+        # Fake the Metron series object returned by api.series(metron_id).
+        # Use SimpleNamespace so getattr() on unset fields returns AttributeError
+        # (instead of MagicMock leaking non-JSON-serializable values into series.json).
+        series_obj = SimpleNamespace(
+            id=42,
+            cv_id=999,
+            name="Sandman",
+            volume=1,
+            year_began=1989,
+            year_end=1996,
+            publisher=SimpleNamespace(name="Vertigo"),
+            imprint=None,
+            desc="",
+            issue_count=75,
+            status="Ended",
+            cover_image=None,
+            image=None,
+        )
+
+        fake_api = MagicMock()
+        fake_api.series.return_value = series_obj
+
+        fake_metron = MagicMock()
+        fake_metron.is_metron_configured.return_value = True
+        fake_metron.get_flask_api.return_value = fake_api
+        fake_metron.get_series_id.return_value = 42
+
+        with _enable_custom_rename(), \
+             patch("cbz_ops.smart_rename._get_metron_mod", return_value=fake_metron), \
+             patch("core.database.get_library_providers",
+                   return_value=[{"provider_type": "metron", "enabled": True}]):
+            plan = plan_smart_rename(str(d), recursive=False, library_id=1)
+
+        assert (d / "series.json").exists()
+        dir_entry = plan["directories"][0]
+        assert dir_entry["status"] == "ok"
+        renames = [f for f in dir_entry["files"] if f["status"] == "ok"]
+        assert renames[0]["new_name"] == "Sandman v1 005 (1989).cbz"
+
+    def test_all_providers_fail_marks_series_json_failed(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        (d / "Sandman 5.cbz").write_bytes(b"x")
+
+        fake_metron = MagicMock()
+        fake_metron.is_metron_configured.return_value = False
+
+        with _enable_custom_rename(), \
+             patch("cbz_ops.smart_rename._get_metron_mod", return_value=fake_metron), \
+             patch("core.database.get_library_providers",
+                   return_value=[{"provider_type": "metron", "enabled": True}]):
+            plan = plan_smart_rename(str(d), recursive=False, library_id=1)
+
+        assert plan["directories"][0]["status"] == "series_json_failed"
+
+
+class TestApplySmartRename:
+
+    def test_apply_renames_files_on_disk(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename, apply_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        (d / "Sandman 1.cbz").write_bytes(b"x")
+        (d / "Sandman 2.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d), recursive=False)
+            summary = apply_smart_rename(plan)
+
+        assert summary["renamed"] == 2
+        assert summary["failed"] == 0
+        assert (d / "Sandman v2 001 (1989).cbz").exists()
+        assert (d / "Sandman v2 002 (1989).cbz").exists()
+        assert not (d / "Sandman 1.cbz").exists()
+
+    def test_apply_skips_non_ok_entries(self, tmp_path):
+        from cbz_ops.smart_rename import apply_smart_rename
+        # Hand-built plan with a no-issue entry
+        plan = {
+            "directories": [
+                {
+                    "dir": str(tmp_path),
+                    "status": "ok",
+                    "files": [
+                        {"status": "no_issue", "old_path": str(tmp_path / "a.cbz"),
+                         "old_name": "a.cbz"},
+                    ],
+                }
+            ]
+        }
+        summary = apply_smart_rename(plan)
+        assert summary["renamed"] == 0
+        assert summary["skipped"] >= 1


### PR DESCRIPTION
## 📝 Description
Introduce a metadata-driven Smart Rename capability that uses `series.json` (or `cvinfo` lookups) to build and apply bulk rename plans. 

Adds new module `cbz_ops/smart_rename` with `plan_smart_rename` and `apply_smart_rename`, and new routes /smart-rename/preview and /smart-rename to preview/apply plans. 

**Integrates UI:** folder menu entry, preview modal, and JS handlers in static/js/files.js and templates/files.html; settings toggles added to templates/config.html and persisted/loaded via app.py and core/config.py. Includes validation/critical-path protections and unit/route tests covering preview, apply, provider lookups and edge cases.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="804" height="905" alt="Screenshot 2026-05-20 133723" src="https://github.com/user-attachments/assets/3ee230bd-aea9-4761-9d0d-a77036c5f015" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass