### PR TITLE
Remove item in missing-XML mode instead of reload

### DIFF
--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -2825,7 +2825,13 @@ function fetchMetadataCollection(filePath, fileName) {
         getLibraryId: function () { return null; },
         onMetadataFound: function () {
             refreshThumbnail(filePath);
-            loadDirectory(currentPath, true);
+            if (isMissingXmlMode) {
+                const index = allItems.findIndex(i => i.path === filePath);
+                if (index !== -1) allItems.splice(index, 1);
+                renderPage();
+            } else {
+                loadDirectory(currentPath, true);
+            }
         },
         onBatchComplete: function () {
             loadDirectory(currentPath, true);


### PR DESCRIPTION
## 📝 Description
When metadata is found and `isMissingXmlMode` is enabled, remove the corresponding item from allItems and call renderPage rather than reloading the entire directory. For normal mode the previous `loadDirectory(currentPath, true)` behavior is preserved. This avoids unnecessary full-directory reloads when handling missing-XML entries.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass