### PR TITLE
Support exclude terms for smart rename

### DIFF
--- a/app.py
+++ b/app.py
@@ -6439,11 +6439,19 @@ def save_file_processing_config():
             bool(data.get("smartRenameRecursive", True)),
             category="file_processing",
         )
+        set_user_preference(
+            "smart_rename_exclude_terms",
+            str(data.get("smartRenameExcludeTerms", "Annual,Special") or ""),
+            category="file_processing",
+        )
         app.config["SMART_RENAME_PREVIEW_ENABLED"] = bool(
             data.get("smartRenamePreviewEnabled", True)
         )
         app.config["SMART_RENAME_RECURSIVE"] = bool(
             data.get("smartRenameRecursive", True)
+        )
+        app.config["SMART_RENAME_EXCLUDE_TERMS"] = str(
+            data.get("smartRenameExcludeTerms", "Annual,Special") or ""
         )
 
         # Validate and persist filename cleanup preferences
@@ -7014,6 +7022,9 @@ def config_page():
         smartRenameRecursive=bool(
             get_user_preference("smart_rename_recursive", default=True)
         ),
+        smartRenameExcludeTerms=get_user_preference(
+            "smart_rename_exclude_terms", default="Annual,Special"
+        ) or "",
         enableAutoRename=settings.get("ENABLE_AUTO_RENAME", "False") == "True",
         enableAutoMove=settings.get("ENABLE_AUTO_MOVE", "False") == "True",
         customMovePattern=settings.get(

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -28,6 +28,18 @@ from models import comicvine as cv_mod
 COMIC_EXTS = (".cbz", ".cbr", ".zip")
 
 
+def _load_exclude_terms() -> List[str]:
+    """Read `smart_rename_exclude_terms` and return a normalized list.
+
+    Returns lowercased, whitespace-stripped, non-empty terms. The pref is
+    a comma-separated string; default is "Annual,Special" so out of the box
+    we don't merge Annuals/Specials into the main series namespace.
+    """
+    from core.database import get_user_preference  # lazy: avoid import cycles
+    raw = get_user_preference("smart_rename_exclude_terms", default="Annual,Special") or ""
+    return [t.strip().lower() for t in raw.split(",") if t.strip()]
+
+
 def _get_metron_mod():
     """Lazy import of models.metron so unit tests don't need mokkari."""
     from models import metron as metron_mod  # noqa: WPS433
@@ -223,10 +235,22 @@ def _plan_file(
     pattern: str,
     cleanup_cfg: Dict,
     used_targets: set,
+    exclude_terms: Optional[List[str]] = None,
 ) -> Dict:
     """Build the rename plan entry for a single file."""
     old_name = os.path.basename(file_path)
     stem, ext = os.path.splitext(old_name)
+
+    if exclude_terms:
+        lowered_stem = stem.lower()
+        for term in exclude_terms:
+            if term and term in lowered_stem:
+                return {
+                    "old_path": file_path,
+                    "old_name": old_name,
+                    "status": "excluded_term",
+                    "matched_term": term,
+                }
 
     extracted = extract_comic_values(stem)
     raw_issue = (extracted.get("issue_number") or "").strip()
@@ -296,6 +320,7 @@ def plan_smart_rename(
     """
     custom_enabled, pattern = load_custom_rename_config()
     cleanup_cfg = load_filename_cleanup_config()
+    exclude_terms = _load_exclude_terms()
 
     result = {
         "root": root_dir,
@@ -353,7 +378,14 @@ def plan_smart_rename(
             if not name.lower().endswith(COMIC_EXTS):
                 continue
             dir_entry["files"].append(
-                _plan_file(file_path, metadata, pattern, cleanup_cfg, used_targets)
+                _plan_file(
+                    file_path,
+                    metadata,
+                    pattern,
+                    cleanup_cfg,
+                    used_targets,
+                    exclude_terms=exclude_terms,
+                )
             )
 
         result["directories"].append(dir_entry)

--- a/core/config.py
+++ b/core/config.py
@@ -256,6 +256,7 @@ def load_flask_config(app, logger=None):
     app.config["CUSTOM_RENAME_PATTERN"] = get_user_preference('custom_rename_pattern', default='') or ''
     app.config["SMART_RENAME_PREVIEW_ENABLED"] = bool(get_user_preference('smart_rename_preview_enabled', default=True))
     app.config["SMART_RENAME_RECURSIVE"] = bool(get_user_preference('smart_rename_recursive', default=True))
+    app.config["SMART_RENAME_EXCLUDE_TERMS"] = get_user_preference('smart_rename_exclude_terms', default='Annual,Special') or ''
     app.config["ENABLE_AUTO_RENAME"] = config.getboolean("SETTINGS", "ENABLE_AUTO_RENAME", fallback=False)
     app.config["ENABLE_AUTO_MOVE"] = config.getboolean("SETTINGS", "ENABLE_AUTO_MOVE", fallback=False)
     app.config["CUSTOM_MOVE_PATTERN"] = settings.get("CUSTOM_MOVE_PATTERN", "{publisher}/{series_name}/v{start_year}")

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -6102,7 +6102,10 @@ function showSmartRenameModal(plan, panel) {
         tbody.appendChild(tr);
       } else {
         skipCount++;
-        issues.push(`<li><code>${escapeHtml(f.old_name)}</code>: ${escapeHtml(f.status)}</li>`);
+        const label = f.status === 'excluded_term'
+          ? `skipped (matched "${escapeHtml(f.matched_term || '')}")`
+          : escapeHtml(f.status);
+        issues.push(`<li><code>${escapeHtml(f.old_name)}</code>: ${label}</li>`);
       }
     }
   }

--- a/templates/config.html
+++ b/templates/config.html
@@ -494,6 +494,21 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row mt-2">
+                        <div class="col-md-12">
+                            <label for="smartRenameExcludeTerms" class="form-label">Skip files containing
+                                (comma-separated):</label>
+                            <input type="text" id="smartRenameExcludeTerms" name="smartRenameExcludeTerms"
+                                class="form-control" value="{{ smartRenameExcludeTerms }}"
+                                placeholder="Annual,Special">
+                            <small class="form-text text-muted">
+                                Case-insensitive substring match against the filename. Useful when
+                                Annuals/Specials share a folder with the main series — they have their
+                                own issue numbering and shouldn't be renamed onto the main slots.
+                                Leave blank to skip nothing.
+                            </small>
+                        </div>
+                    </div>
 
                     <!-- Filename Character Cleanup -->
                     <hr class="my-4">
@@ -1684,6 +1699,7 @@
             renameCleanSpecialsReplacement: document.getElementById('renameCleanSpecialsReplacement')?.value || '',
             smartRenamePreviewEnabled: document.getElementById('smartRenamePreviewEnabled')?.checked ?? true,
             smartRenameRecursive: document.getElementById('smartRenameRecursive')?.checked ?? true,
+            smartRenameExcludeTerms: document.getElementById('smartRenameExcludeTerms')?.value ?? '',
             enableAutoRename: document.getElementById('enableAutoRename')?.checked || false,
             enableAutoMove: document.getElementById('enableAutoMove')?.checked || false,
             customMovePattern: document.getElementById('customMovePattern')?.value || '',

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -38,7 +38,10 @@ def _write_cvinfo(folder, cv_id=12345):
         f.write(f"https://comicvine.gamespot.com/volume/4050-{cv_id}/\n")
 
 
-def _enable_custom_rename(pattern="{series_name} {volume_number} {issue_number} ({year})"):
+def _enable_custom_rename(
+    pattern="{series_name} {volume_number} {issue_number} ({year})",
+    exclude_terms="Annual,Special",
+):
     """Patch the pref reader used by smart_rename to enable a custom pattern.
 
     cbz_ops.rename does ``from core.database import get_user_preference``
@@ -52,6 +55,7 @@ def _enable_custom_rename(pattern="{series_name} {volume_number} {issue_number} 
             "custom_rename_pattern": pattern,
             "rename_clean_spaces_enabled": False,
             "rename_clean_specials_enabled": False,
+            "smart_rename_exclude_terms": exclude_terms,
         }.get(key, default),
     )
 
@@ -160,6 +164,56 @@ class TestPlanSmartRenameSeriesJsonPath:
         names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
         assert names == ["Batman - Year One v1 001 (1987).cbz"]
         assert ":" not in names[0]
+
+    def test_excluded_term_skips_annual(self, tmp_path):
+        """Default exclude list ('Annual,Special') keeps Annuals out of the main namespace."""
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Punisher War Zone"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Punisher War Zone", volume=1, year=1992)
+        (d / "Punisher War Zone 001.cbz").write_bytes(b"x")
+        (d / "Punisher War Zone - Annual 001.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename():
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        files = plan["directories"][0]["files"]
+        statuses = {f["old_name"]: f["status"] for f in files}
+        assert statuses["Punisher War Zone 001.cbz"] == "ok"
+        assert statuses["Punisher War Zone - Annual 001.cbz"] == "excluded_term"
+        excluded = next(f for f in files if f["status"] == "excluded_term")
+        assert excluded["matched_term"] == "annual"
+
+    def test_excluded_term_case_insensitive(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        (d / "Sandman SPECIAL 5.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename(exclude_terms="Special"):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        files = plan["directories"][0]["files"]
+        assert files[0]["status"] == "excluded_term"
+        assert files[0]["matched_term"] == "special"
+
+    def test_empty_exclude_terms_disables_filter(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Punisher War Zone"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Punisher War Zone", volume=1, year=1992)
+        (d / "Punisher War Zone - Annual 001.cbz").write_bytes(b"x")
+
+        with _enable_custom_rename(exclude_terms=""):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        files = plan["directories"][0]["files"]
+        assert files[0]["status"] == "ok"
+        assert files[0]["new_name"] == "Punisher War Zone v1 001 (1992).cbz"
 
     def test_recursive_walks_subdirs(self, tmp_path):
         from cbz_ops.smart_rename import plan_smart_rename


### PR DESCRIPTION
## 📝 Description
Add a user-configurable comma-separated list of exclude terms for smart rename **(default: "Annual,Special")**. Persist and expose the preference in app config and the settings page, add a form field and JS to submit it, and load it in core config. Pass the normalized exclude terms into `plan_smart_rename` and have _plan_file mark matching files as "excluded_term" with a `matched_term` value. 
Update the UI to show skipped files with the matched term and add unit tests covering exclusion, case-insensitivity, and disabling the filter.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="938" height="381" alt="image" src="https://github.com/user-attachments/assets/b5cfa185-bec4-4146-91d5-f2cfa8172137" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass