### PR TITLE
Ensure WATCH/TARGET defaults in memory config

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -111,22 +111,22 @@ def _mirror_watch_target_into_memory_config():
     """Copy WATCH/TARGET from user_preferences into the in-memory ``config`` object.
 
     The values are NOT written to ``config.ini`` (write_config is not called).
+    Always populates sensible absolute-path defaults so legacy readers using
+    ``config.get("SETTINGS", "WATCH", fallback=...)`` never receive a relative
+    path (which would resolve against CWD and fail to create).
     """
+    if "SETTINGS" not in config:
+        config["SETTINGS"] = {}
+    watch_val = ""
+    target_val = ""
     try:
         from core.database import get_user_preference
-    except Exception:
-        return
-    try:
-        if "SETTINGS" not in config:
-            config["SETTINGS"] = {}
         watch_val = (get_user_preference("watch", default="") or "").strip()
         target_val = (get_user_preference("target", default="") or "").strip()
-        if watch_val:
-            config["SETTINGS"]["WATCH"] = watch_val
-        if target_val:
-            config["SETTINGS"]["TARGET"] = target_val
     except Exception as e:
-        app_logger.debug(f"In-memory WATCH/TARGET mirror skipped: {e}")
+        app_logger.debug(f"WATCH/TARGET lookup from user_preferences skipped: {e}")
+    config["SETTINGS"]["WATCH"] = watch_val or "/downloads/temp"
+    config["SETTINGS"]["TARGET"] = target_val or "/downloads/processed"
 
 
 def migrate_watch_target_to_user_preferences():

--- a/core/version.py
+++ b/core/version.py
@@ -2,4 +2,4 @@
 Version information for Comic Library Utilities (CLU)
 """
 
-__version__ = "4.14"
+__version__ = "4.14.1"


### PR DESCRIPTION
## 📝 Description
Always populate SETTINGS.WATCH and SETTINGS.TARGET in the in-memory config with sensible absolute-path defaults so legacy readers never receive relative paths. The function now ensures the SETTINGS section exists, initializes watch/target variables, attempts to read user preferences if available (logging a debug message on failure) and falls back to "/downloads/temp" and "/downloads/processed". Note: values are mirrored only in memory and are not written to config.ini.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass