### PR TITLE
Detect and handle missing GCD tables

### DIFF
--- a/models/gcd.py
+++ b/models/gcd.py
@@ -4,7 +4,7 @@ GCD (Grand Comics Database) integration for comic metadata retrieval.
 import os
 import re
 from datetime import datetime
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Optional, Dict, Any, List, Tuple, Set
 from core.app_logging import app_logger
 
 # Check if mysql.connector is available
@@ -19,6 +19,29 @@ except ImportError:
 # =============================================================================
 
 STOPWORDS = {"the", "a", "an", "of", "and", "vol", "volume", "season", "series"}
+
+# Full set of GCD tables CLU touches across all code paths. Used to detect
+# which auxiliary tables a particular MySQL dump excludes — the public dump
+# from comics.org periodically drops tables (e.g. gcd_creator, gcd_issue_credit)
+# while GCD restructures schemas.
+EXPECTED_GCD_TABLES = frozenset({
+    'gcd_series', 'gcd_issue', 'gcd_story', 'gcd_publisher', 'gcd_creator',
+    'gcd_indicia_publisher', 'gcd_story_credit', 'gcd_issue_credit',
+    'gcd_credit_type', 'gcd_story_type', 'gcd_story_character',
+    'gcd_character', 'stddata_language',
+})
+
+# Without these tables, GCD lookups are fundamentally broken. Surface a hard
+# error to the user via the stats endpoint when any of these are missing.
+GCD_CORE_TABLES = frozenset({
+    'gcd_series', 'gcd_issue', 'gcd_publisher', 'stddata_language', 'gcd_story',
+})
+
+# Cached set of GCD tables actually present in the connected database.
+# Populated lazily on first call to get_available_gcd_tables(). Invalidated
+# via invalidate_gcd_table_cache() when credentials change.
+_AVAILABLE_TABLES_CACHE: Optional[Set[str]] = None
+_AVAILABLE_TABLES_LOGGED: bool = False
 
 # =============================================================================
 # Helper Functions
@@ -200,6 +223,75 @@ def get_connection():
 
 
 # =============================================================================
+# Table Availability
+# =============================================================================
+
+def get_available_gcd_tables(conn=None, *, force_refresh: bool = False) -> Set[str]:
+    """
+    Return the set of expected GCD tables actually present in the connected database.
+
+    Caches at module level — first call queries information_schema, subsequent
+    calls return the cached set. Pass force_refresh=True to re-query (e.g. after
+    credentials change). If `conn` is provided, reuses it; otherwise opens a
+    short-lived connection. Returns an empty set on any failure so callers fall
+    back to the safest behavior (skip optional joins, emit empty results).
+    """
+    global _AVAILABLE_TABLES_CACHE, _AVAILABLE_TABLES_LOGGED
+
+    if _AVAILABLE_TABLES_CACHE is not None and not force_refresh:
+        return _AVAILABLE_TABLES_CACHE
+
+    owned_conn = False
+    try:
+        if conn is None:
+            conn = get_connection()
+            owned_conn = True
+        if conn is None:
+            return set()
+
+        cursor = conn.cursor()
+        expected = sorted(EXPECTED_GCD_TABLES)
+        placeholders = ','.join(['%s'] * len(expected))
+        cursor.execute(
+            f"SELECT TABLE_NAME FROM information_schema.TABLES "
+            f"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ({placeholders})",
+            expected,
+        )
+        present = {row[0] for row in cursor.fetchall()}
+        cursor.close()
+
+        _AVAILABLE_TABLES_CACHE = present
+
+        if not _AVAILABLE_TABLES_LOGGED:
+            missing = EXPECTED_GCD_TABLES - present
+            if missing:
+                app_logger.warning(
+                    "GCD: %d expected table(s) missing from dump — credits/characters/story types will be partial: %s",
+                    len(missing),
+                    sorted(missing),
+                )
+            _AVAILABLE_TABLES_LOGGED = True
+
+        return present
+    except Exception as e:
+        app_logger.error(f"Failed to enumerate GCD tables: {e}")
+        return set()
+    finally:
+        if owned_conn and conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def invalidate_gcd_table_cache() -> None:
+    """Reset the cached set so the next call re-queries information_schema."""
+    global _AVAILABLE_TABLES_CACHE, _AVAILABLE_TABLES_LOGGED
+    _AVAILABLE_TABLES_CACHE = None
+    _AVAILABLE_TABLES_LOGGED = False
+
+
+# =============================================================================
 # Database Stats
 # =============================================================================
 
@@ -209,15 +301,8 @@ def get_database_stats() -> Optional[Dict[str, Any]]:
     if not conn:
         return None
     try:
-        cursor = conn.cursor()
-        cursor.execute("""
-            SELECT TABLE_NAME, TABLE_ROWS
-            FROM information_schema.TABLES
-            WHERE TABLE_SCHEMA = DATABASE()
-            AND TABLE_NAME IN ('gcd_series', 'gcd_issue', 'gcd_story', 'gcd_publisher', 'gcd_creator')
-        """)
-        rows = cursor.fetchall()
-        cursor.close()
+        available = get_available_gcd_tables(conn=conn)
+
         mapping = {
             'gcd_series': 'series',
             'gcd_issue': 'issues',
@@ -225,8 +310,29 @@ def get_database_stats() -> Optional[Dict[str, Any]]:
             'gcd_publisher': 'publishers',
             'gcd_creator': 'creators',
         }
-        stats = {mapping[r[0]]: r[1] for r in rows if r[0] in mapping}
-        stats['table_count'] = len(rows)
+
+        # Build IN clause from tables we actually want stats on AND that exist.
+        stats = {friendly: 0 for friendly in mapping.values()}
+        wanted = [t for t in mapping.keys() if t in available]
+
+        if wanted:
+            cursor = conn.cursor()
+            placeholders = ','.join(['%s'] * len(wanted))
+            cursor.execute(
+                f"SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.TABLES "
+                f"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ({placeholders})",
+                wanted,
+            )
+            rows = cursor.fetchall()
+            cursor.close()
+            for table_name, row_count in rows:
+                if table_name in mapping:
+                    stats[mapping[table_name]] = row_count or 0
+
+        stats['table_count'] = len(available)
+        stats['available_tables'] = sorted(available)
+        stats['missing_tables'] = sorted(EXPECTED_GCD_TABLES - available)
+        stats['core_ok'] = GCD_CORE_TABLES.issubset(available)
         return stats
     except Exception as e:
         app_logger.error(f"Failed to get GCD database stats: {e}")
@@ -486,29 +592,38 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
             app_logger.debug(f"GCD get_issue_metadata: Issue #{issue_number} not found in series {series_id}")
             return None
 
-        # Get credits from normalized gcd_story_credit table
-        credits_query = """
-            SELECT DISTINCT
-                ct.name as credit_type,
-                TRIM(COALESCE(
-                    NULLIF(TRIM(sc.credited_as),''),
-                    NULLIF(TRIM(sc.credit_name),''),
-                    NULLIF(TRIM(c.gcd_official_name),''),
-                    NULLIF(TRIM(c.sort_name),'')
-                )) as creator_name
-            FROM gcd_story s
-            JOIN gcd_story_credit sc ON sc.story_id = s.id
-            JOIN gcd_credit_type ct ON ct.id = sc.credit_type_id
-            LEFT JOIN gcd_creator c ON c.id = sc.creator_id
-            WHERE s.issue_id = %s
-              AND (sc.deleted = 0 OR sc.deleted IS NULL)
-        """
-        cursor.execute(credits_query, (issue['id'],))
-        credits = cursor.fetchall()
-        app_logger.debug(f"GCD credits for issue {issue['id']}: {credits}")
+        # Get credits from normalized gcd_story_credit table — but only if the
+        # tables it needs are actually present in this dump.
+        available = get_available_gcd_tables(conn=conn)
+        normalized_ok = {
+            'gcd_story', 'gcd_story_credit', 'gcd_credit_type', 'gcd_creator'
+        }.issubset(available)
 
-        # Fallback: older issues store credits as text columns on gcd_story
-        if not credits:
+        credits = []
+        if normalized_ok:
+            credits_query = """
+                SELECT DISTINCT
+                    ct.name as credit_type,
+                    TRIM(COALESCE(
+                        NULLIF(TRIM(sc.credited_as),''),
+                        NULLIF(TRIM(sc.credit_name),''),
+                        NULLIF(TRIM(c.gcd_official_name),''),
+                        NULLIF(TRIM(c.sort_name),'')
+                    )) as creator_name
+                FROM gcd_story s
+                JOIN gcd_story_credit sc ON sc.story_id = s.id
+                JOIN gcd_credit_type ct ON ct.id = sc.credit_type_id
+                LEFT JOIN gcd_creator c ON c.id = sc.creator_id
+                WHERE s.issue_id = %s
+                  AND (sc.deleted = 0 OR sc.deleted IS NULL)
+            """
+            cursor.execute(credits_query, (issue['id'],))
+            credits = cursor.fetchall()
+            app_logger.debug(f"GCD credits for issue {issue['id']}: {credits}")
+
+        # Fallback: older issues store credits as text columns on gcd_story.
+        # Also runs when gcd_story_credit is missing from the dump entirely.
+        if not credits and 'gcd_story' in available:
             legacy_query = """
                 SELECT script, pencils, inks, colors, letters, editing
                 FROM gcd_story

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -596,6 +596,14 @@ def save_provider_creds(provider_type):
                 load_flask_config(current_app)
             except Exception:
                 pass
+            # GCD credentials may now point at a different MySQL dump with a
+            # different table set — drop the cached table list.
+            if provider_type == 'gcd':
+                try:
+                    from models.gcd import invalidate_gcd_table_cache
+                    invalidate_gcd_table_cache()
+                except Exception:
+                    pass
             return jsonify({"success": True, "message": f"Credentials saved for {provider_type}"})
         else:
             return jsonify({"error": "Failed to save credentials"}), 500
@@ -612,6 +620,12 @@ def delete_provider_creds(provider_type):
 
         success = delete_provider_credentials(provider_type)
         if success:
+            if provider_type == 'gcd':
+                try:
+                    from models.gcd import invalidate_gcd_table_cache
+                    invalidate_gcd_table_cache()
+                except Exception:
+                    pass
             return jsonify({"success": True, "message": f"Credentials deleted for {provider_type}"})
         else:
             return jsonify({"error": "Failed to delete credentials"}), 500
@@ -1807,6 +1821,12 @@ def search_gcd_metadata():
             # Set query timeout to 30 seconds
             cursor.execute("SET SESSION MAX_EXECUTION_TIME=30000")  # 30000 milliseconds = 30 seconds
 
+            # Detect which GCD tables this dump actually contains so we can
+            # skip credit/character/story-type joins when their tables are absent
+            # (the public comics.org dump periodically excludes them).
+            from models.gcd import get_available_gcd_tables
+            gcd_tables = get_available_gcd_tables(conn=connection)
+
             # Helper: build safe IN (...) placeholder list + params
             def build_in_clause(codes):
                 codes = list(codes or [])
@@ -2133,8 +2153,10 @@ def search_gcd_metadata():
                 app_logger.debug(f"DEBUG: Basic issue info retrieved for issue #{issue_number}")
                 issue_id = issue_basic['id']
 
-                # Query 2: Get all credits in a single query (much faster than multiple subqueries)
-                credits_query = """
+                # Query 2: Get all credits in a single query (much faster than multiple subqueries).
+                # Compose the UNION from whichever halves the dump actually has — some
+                # comics.org dumps exclude gcd_story_credit, gcd_issue_credit, or gcd_creator.
+                STORY_CREDIT_HALF = """
                     SELECT
                         ct.name AS credit_type,
                         TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS creator_name,
@@ -2146,7 +2168,8 @@ def search_gcd_metadata():
                     WHERE s.issue_id = %s
                         AND (sc.deleted = 0 OR sc.deleted IS NULL)
                         AND NULLIF(TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)), '') IS NOT NULL
-                    UNION
+                """
+                ISSUE_CREDIT_HALF = """
                     SELECT
                         ct.name AS credit_type,
                         TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS creator_name,
@@ -2159,47 +2182,81 @@ def search_gcd_metadata():
                         AND NULLIF(TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)), '') IS NOT NULL
                 """
 
-                cursor.execute(credits_query, (issue_id, issue_id))
-                credits = cursor.fetchall()
+                story_credit_ok = {'gcd_story', 'gcd_story_credit', 'gcd_credit_type', 'gcd_creator'}.issubset(gcd_tables)
+                issue_credit_ok = {'gcd_issue_credit', 'gcd_credit_type', 'gcd_creator'}.issubset(gcd_tables)
 
-                # Query 3: Story details (title, summary, genre, characters, page count)
-                story_query = """
-                    SELECT
-                        NULLIF(TRIM(s.title), '') AS title,
-                        NULLIF(TRIM(s.synopsis), '') AS synopsis,
-                        NULLIF(TRIM(s.notes), '') AS notes,
-                        NULLIF(TRIM(s.genre), '') AS genre,
-                        NULLIF(TRIM(s.characters), '') AS characters,
-                        s.page_count,
-                        s.sequence_number,
-                        st.name AS story_type
-                    FROM gcd_story s
-                    LEFT JOIN gcd_story_type st ON st.id = s.type_id
-                    WHERE s.issue_id = %s
-                    ORDER BY
-                        CASE WHEN s.sequence_number = 0 THEN 1 ELSE 0 END,
-                        CASE
-                            WHEN LOWER(st.name) IN ('comic story','story') THEN 0
-                            WHEN LOWER(st.name) IN ('text story','text') THEN 1
-                            ELSE 3
-                        END,
-                        s.sequence_number
-                """
+                if story_credit_ok and issue_credit_ok:
+                    cursor.execute(STORY_CREDIT_HALF + "\nUNION\n" + ISSUE_CREDIT_HALF, (issue_id, issue_id))
+                    credits = cursor.fetchall()
+                elif story_credit_ok:
+                    cursor.execute(STORY_CREDIT_HALF, (issue_id,))
+                    credits = cursor.fetchall()
+                elif issue_credit_ok:
+                    cursor.execute(ISSUE_CREDIT_HALF, (issue_id,))
+                    credits = cursor.fetchall()
+                else:
+                    credits = []
 
-                cursor.execute(story_query, (issue_id,))
-                stories = cursor.fetchall()
+                # Query 3: Story details (title, summary, genre, characters, page count).
+                # Drop the gcd_story_type join when that table is absent.
+                if 'gcd_story' not in gcd_tables:
+                    stories = []
+                else:
+                    if 'gcd_story_type' in gcd_tables:
+                        story_query = """
+                            SELECT
+                                NULLIF(TRIM(s.title), '') AS title,
+                                NULLIF(TRIM(s.synopsis), '') AS synopsis,
+                                NULLIF(TRIM(s.notes), '') AS notes,
+                                NULLIF(TRIM(s.genre), '') AS genre,
+                                NULLIF(TRIM(s.characters), '') AS characters,
+                                s.page_count,
+                                s.sequence_number,
+                                st.name AS story_type
+                            FROM gcd_story s
+                            LEFT JOIN gcd_story_type st ON st.id = s.type_id
+                            WHERE s.issue_id = %s
+                            ORDER BY
+                                CASE WHEN s.sequence_number = 0 THEN 1 ELSE 0 END,
+                                CASE
+                                    WHEN LOWER(st.name) IN ('comic story','story') THEN 0
+                                    WHEN LOWER(st.name) IN ('text story','text') THEN 1
+                                    ELSE 3
+                                END,
+                                s.sequence_number
+                        """
+                    else:
+                        story_query = """
+                            SELECT
+                                NULLIF(TRIM(s.title), '') AS title,
+                                NULLIF(TRIM(s.synopsis), '') AS synopsis,
+                                NULLIF(TRIM(s.notes), '') AS notes,
+                                NULLIF(TRIM(s.genre), '') AS genre,
+                                NULLIF(TRIM(s.characters), '') AS characters,
+                                s.page_count,
+                                s.sequence_number,
+                                NULL AS story_type
+                            FROM gcd_story s
+                            WHERE s.issue_id = %s
+                            ORDER BY CASE WHEN s.sequence_number = 0 THEN 1 ELSE 0 END, s.sequence_number
+                        """
+                    cursor.execute(story_query, (issue_id,))
+                    stories = cursor.fetchall()
 
-                # Query 4: Character names from character table
-                characters_query = """
-                    SELECT DISTINCT c.name
-                    FROM gcd_story s
-                    LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
-                    LEFT JOIN gcd_character c ON c.id = sc.character_id
-                    WHERE s.issue_id = %s AND c.name IS NOT NULL
-                """
-
-                cursor.execute(characters_query, (issue_id,))
-                character_results = cursor.fetchall()
+                # Query 4: Character names from character table — skip entirely
+                # if either join table is missing from the dump.
+                if {'gcd_story', 'gcd_story_character', 'gcd_character'}.issubset(gcd_tables):
+                    characters_query = """
+                        SELECT DISTINCT c.name
+                        FROM gcd_story s
+                        LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
+                        LEFT JOIN gcd_character c ON c.id = sc.character_id
+                        WHERE s.issue_id = %s AND c.name IS NOT NULL
+                    """
+                    cursor.execute(characters_query, (issue_id,))
+                    character_results = cursor.fetchall()
+                else:
+                    character_results = []
 
                 # Process credits in Python (faster than 6 separate subqueries)
                 credits_dict = {
@@ -2505,6 +2562,11 @@ def search_gcd_metadata_with_selection():
             )
             cursor = connection.cursor(dictionary=True)
 
+            # Detect available GCD tables so we can compose the credits / genre /
+            # characters subqueries against whatever tables this dump contains.
+            from models.gcd import get_available_gcd_tables
+            gcd_tables = get_available_gcd_tables(conn=connection)
+
             # Get series information
             series_query = """
                 SELECT s.id, s.name, s.year_began, s.year_ended, s.publisher_id,
@@ -2522,11 +2584,121 @@ def search_gcd_metadata_with_selection():
                     "error": f"Series with ID {series_id} not found"
                 }), 404
 
-            # Search for the specific issue using comprehensive query
-            issue_query = """
-                SELECT
-                  i.id,
-                  COALESCE(
+            # Compose credit-role subqueries (Writer/Penciller/Inker/Colorist/
+            # Letterer/CoverArtist) from whichever halves the dump supports.
+            story_credit_ok = {'gcd_story', 'gcd_story_credit', 'gcd_credit_type', 'gcd_creator'}.issubset(gcd_tables)
+            issue_credit_ok = {'gcd_issue_credit', 'gcd_credit_type', 'gcd_creator'}.issubset(gcd_tables)
+
+            def _role_subq(story_where_extra: str, type_clause: str, issue_type_clause: str = None) -> str:
+                """
+                Build the (SELECT GROUP_CONCAT ... FROM (STORY_HALF UNION ISSUE_HALF) ...)
+                expression for one ComicInfo role. Returns the literal "NULL" when
+                neither credit table is available.
+
+                story_where_extra : extra WHERE fragment for the story half (e.g. sequence filter)
+                type_clause       : credit-type LIKE clause for the story half
+                issue_type_clause : credit-type LIKE clause for the issue half (defaults to type_clause)
+                """
+                if issue_type_clause is None:
+                    issue_type_clause = type_clause
+                halves = []
+                if story_credit_ok:
+                    halves.append(f"""
+                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
+                      FROM gcd_story s
+                      JOIN gcd_story_credit sc ON sc.story_id = s.id
+                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
+                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
+                      WHERE s.issue_id = i.id
+                        AND {story_where_extra}
+                        AND {type_clause}
+                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
+                    """)
+                if issue_credit_ok:
+                    halves.append(f"""
+                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
+                      FROM gcd_issue_credit ic
+                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
+                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
+                      WHERE ic.issue_id = i.id
+                        AND {issue_type_clause}
+                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
+                    """)
+                if not halves:
+                    return "NULL"
+                inner = "\nUNION\n".join(halves)
+                return f"""(
+                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
+                    FROM ({inner}) x
+                    WHERE NULLIF(name,'') IS NOT NULL
+                )"""
+
+            non_zero_seq = "(s.sequence_number IS NULL OR s.sequence_number <> 0)"
+
+            writer_expr      = _role_subq(non_zero_seq, "(ct.name LIKE 'script%' OR ct.name LIKE 'writer%' OR ct.name LIKE 'plot%')")
+            penciller_expr   = _role_subq(non_zero_seq, "(ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'illustrat%')")
+            inker_expr       = _role_subq(non_zero_seq, "(ct.name LIKE 'ink%')")
+            colorist_expr    = _role_subq(non_zero_seq, "(ct.name LIKE 'color%' OR ct.name LIKE 'colour%')")
+            letterer_expr    = _role_subq(non_zero_seq, "(ct.name LIKE 'letter%')")
+            cover_expr       = _role_subq(
+                "(s.sequence_number = 0 OR ct.name LIKE 'cover%')",
+                "(ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'ink%' OR ct.name LIKE 'art%' OR ct.name LIKE 'cover%' OR ct.name LIKE 'illustrat%')",
+                issue_type_clause="(ct.name LIKE 'cover%')",
+            )
+
+            # Genre uses only gcd_story.genre text column.
+            if 'gcd_story' in gcd_tables:
+                genre_expr = """(
+                    SELECT TRIM(BOTH ', ' FROM
+                           REPLACE(
+                             GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.genre), '') SEPARATOR ', '),
+                             ';', ','
+                           ))
+                    FROM gcd_story s
+                    WHERE s.issue_id = i.id
+                )"""
+            else:
+                genre_expr = "NULL"
+
+            # Characters: prefer normalized story_character/character join; fall
+            # back to the text column on gcd_story; emit NULL if neither path works.
+            story_char_ok = {'gcd_story', 'gcd_story_character', 'gcd_character'}.issubset(gcd_tables)
+            story_text_ok = 'gcd_story' in gcd_tables
+            if story_char_ok and story_text_ok:
+                characters_expr = """COALESCE(
+                    (
+                      SELECT NULLIF(GROUP_CONCAT(DISTINCT c.name SEPARATOR ', '), '')
+                      FROM gcd_story s
+                      LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
+                      LEFT JOIN gcd_character c ON c.id = sc.character_id
+                      WHERE s.issue_id = i.id
+                    ),
+                    (
+                      SELECT TRIM(BOTH ', ' FROM
+                             REPLACE(
+                               GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.characters), '') SEPARATOR ', '),
+                               ';', ','
+                             ))
+                      FROM gcd_story s
+                      WHERE s.issue_id = i.id
+                    )
+                )"""
+            elif story_text_ok:
+                characters_expr = """(
+                    SELECT TRIM(BOTH ', ' FROM
+                           REPLACE(
+                             GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.characters), '') SEPARATOR ', '),
+                             ';', ','
+                           ))
+                    FROM gcd_story s
+                    WHERE s.issue_id = i.id
+                )"""
+            else:
+                characters_expr = "NULL"
+
+            # Title fallback and Summary subqueries depend on gcd_story.
+            if 'gcd_story' in gcd_tables:
+                title_fallback_expr = """COALESCE(
                     NULLIF(TRIM(i.title), ''),
                     (
                       SELECT NULLIF(TRIM(s.title), '')
@@ -2535,16 +2707,8 @@ def search_gcd_metadata_with_selection():
                       ORDER BY s.sequence_number
                       LIMIT 1
                     )
-                  )                                                   AS Title,
-                  sr.name                                             AS Series,
-                  i.number                                            AS Number,
-                  (
-                    SELECT COUNT(*)
-                    FROM gcd_issue i2
-                    WHERE i2.series_id = i.series_id AND i2.deleted = 0
-                  )                                                   AS `Count`,
-                  i.volume                                            AS Volume,
-                  (
+                )"""
+                summary_expr = """(
                     SELECT COALESCE(
                       NULLIF(TRIM(s.synopsis), ''),
                       NULLIF(TRIM(s.notes), ''),
@@ -2563,7 +2727,25 @@ def search_gcd_metadata_with_selection():
                       CASE WHEN NULLIF(TRIM(s.notes), '') IS NOT NULL THEN 0 ELSE 1 END,
                       s.sequence_number
                     LIMIT 1
-                  )                                                   AS Summary,
+                )"""
+            else:
+                title_fallback_expr = "NULLIF(TRIM(i.title), '')"
+                summary_expr = "NULL"
+
+            # Search for the specific issue using comprehensive query
+            issue_query = f"""
+                SELECT
+                  i.id,
+                  {title_fallback_expr}                                AS Title,
+                  sr.name                                             AS Series,
+                  i.number                                            AS Number,
+                  (
+                    SELECT COUNT(*)
+                    FROM gcd_issue i2
+                    WHERE i2.series_id = i.series_id AND i2.deleted = 0
+                  )                                                   AS `Count`,
+                  i.volume                                            AS Volume,
+                  {summary_expr}                                       AS Summary,
                   CASE
                     WHEN COALESCE(i.key_date, i.on_sale_date) IS NOT NULL
                          AND LENGTH(COALESCE(i.key_date, i.on_sale_date)) >= 4
@@ -2574,172 +2756,15 @@ def search_gcd_metadata_with_selection():
                          AND LENGTH(COALESCE(i.key_date, i.on_sale_date)) >= 7
                       THEN CAST(SUBSTRING(COALESCE(i.key_date, i.on_sale_date), 6, 2) AS UNSIGNED)
                   END AS `Month`,
-                  (
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM (
-                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_story s
-                      JOIN gcd_story_credit sc ON sc.story_id = s.id
-                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
-                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
-                      WHERE s.issue_id = i.id
-                        AND (s.sequence_number IS NULL OR s.sequence_number <> 0)
-                        AND (ct.name LIKE 'script%' OR ct.name LIKE 'writer%' OR ct.name LIKE 'plot%')
-                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
-                      UNION
-                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_issue_credit ic
-                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
-                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                      WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'script%' OR ct.name LIKE 'writer%' OR ct.name LIKE 'plot%')
-                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
-                    ) x
-                    WHERE NULLIF(name,'') IS NOT NULL
-                  )                                                   AS Writer,
-                  (
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM (
-                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_story s
-                      JOIN gcd_story_credit sc ON sc.story_id = s.id
-                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
-                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
-                      WHERE s.issue_id = i.id
-                        AND (s.sequence_number IS NULL OR s.sequence_number <> 0)
-                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'illustrat%')
-                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
-                      UNION
-                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_issue_credit ic
-                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
-                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                      WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'illustrat%')
-                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
-                    ) x
-                    WHERE NULLIF(name,'') IS NOT NULL
-                  )                                                   AS Penciller,
-                  (
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM (
-                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_story s
-                      JOIN gcd_story_credit sc ON sc.story_id = s.id
-                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
-                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
-                      WHERE s.issue_id = i.id
-                        AND (s.sequence_number IS NULL OR s.sequence_number <> 0)
-                        AND (ct.name LIKE 'ink%')
-                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
-                      UNION
-                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_issue_credit ic
-                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
-                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                      WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'ink%')
-                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
-                    ) x
-                    WHERE NULLIF(name,'') IS NOT NULL
-                  )                                                   AS Inker,
-                  (
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM (
-                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_story s
-                      JOIN gcd_story_credit sc ON sc.story_id = s.id
-                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
-                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
-                      WHERE s.issue_id = i.id
-                        AND (s.sequence_number IS NULL OR s.sequence_number <> 0)
-                        AND (ct.name LIKE 'color%' OR ct.name LIKE 'colour%')
-                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
-                      UNION
-                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_issue_credit ic
-                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
-                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                      WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'color%' OR ct.name LIKE 'colour%')
-                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
-                    ) x
-                    WHERE NULLIF(name,'') IS NOT NULL
-                  )                                                   AS Colorist,
-                  (
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM (
-                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_story s
-                      JOIN gcd_story_credit sc ON sc.story_id = s.id
-                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
-                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
-                      WHERE s.issue_id = i.id
-                        AND (s.sequence_number IS NULL OR s.sequence_number <> 0)
-                        AND (ct.name LIKE 'letter%')
-                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
-                      UNION
-                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_issue_credit ic
-                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
-                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                      WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'letter%')
-                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
-                    ) x
-                    WHERE NULLIF(name,'') IS NOT NULL
-                  )                                                   AS Letterer,
-                  (
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM (
-                      SELECT TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_story s
-                      JOIN gcd_story_credit sc ON sc.story_id = s.id
-                      JOIN gcd_credit_type ct   ON ct.id = sc.credit_type_id
-                      LEFT JOIN gcd_creator c   ON c.id = sc.creator_id
-                      WHERE s.issue_id = i.id
-                        AND (s.sequence_number = 0 OR ct.name LIKE 'cover%')
-                        AND (ct.name LIKE 'pencil%' OR ct.name LIKE 'penc%' OR ct.name LIKE 'ink%' OR ct.name LIKE 'art%' OR ct.name LIKE 'cover%' OR ct.name LIKE 'illustrat%')
-                        AND (sc.deleted = 0 OR sc.deleted IS NULL)
-                      UNION
-                      SELECT TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)) AS name
-                      FROM gcd_issue_credit ic
-                      JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
-                      LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                      WHERE ic.issue_id = i.id
-                        AND (ct.name LIKE 'cover%')
-                        AND (ic.deleted = 0 OR ic.deleted IS NULL)
-                    ) z
-                    WHERE NULLIF(name,'') IS NOT NULL
-                  )                                                   AS CoverArtist,
+                  {writer_expr}                                        AS Writer,
+                  {penciller_expr}                                     AS Penciller,
+                  {inker_expr}                                         AS Inker,
+                  {colorist_expr}                                      AS Colorist,
+                  {letterer_expr}                                      AS Letterer,
+                  {cover_expr}                                         AS CoverArtist,
                   COALESCE(ip.name, p.name)                           AS Publisher,
-                  (
-                    SELECT TRIM(BOTH ', ' FROM
-                           REPLACE(
-                             GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.genre), '') SEPARATOR ', '),
-                             ';', ','
-                           ))
-                    FROM gcd_story s
-                    WHERE s.issue_id = i.id
-                  )                                                   AS Genre,
-                  COALESCE(
-                    (
-                      SELECT NULLIF(GROUP_CONCAT(DISTINCT c.name SEPARATOR ', '), '')
-                      FROM gcd_story s
-                      LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
-                      LEFT JOIN gcd_character c ON c.id = sc.character_id
-                      WHERE s.issue_id = i.id
-                    ),
-                    (
-                      SELECT TRIM(BOTH ', ' FROM
-                             REPLACE(
-                               GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.characters), '') SEPARATOR ', '),
-                               ';', ','
-                             ))
-                      FROM gcd_story s
-                      WHERE s.issue_id = i.id
-                    )
-                  )                                                   AS Characters,
+                  {genre_expr}                                         AS Genre,
+                  {characters_expr}                                    AS Characters,
                   i.rating                                            AS AgeRating,
                   l.code                                              AS LanguageISO,
                   i.page_count                                        AS PageCount

--- a/templates/config.html
+++ b/templates/config.html
@@ -3276,7 +3276,7 @@
             if (data.success && data.stats) {
                 const s = data.stats;
                 const fmt = (n) => Number(n).toLocaleString();
-                footer.innerHTML = `
+                let html = `
                     <div class="d-flex flex-wrap gap-2">
                         <span><i class="bi bi-collection me-1"></i>${fmt(s.series)} series</span>
                         <span><i class="bi bi-journal me-1"></i>${fmt(s.issues)} issues</span>
@@ -3284,6 +3284,22 @@
                         <span><i class="bi bi-building me-1"></i>${fmt(s.publishers)} publishers</span>
                         <span><i class="bi bi-person me-1"></i>${fmt(s.creators)} creators</span>
                     </div>`;
+                if (Array.isArray(s.missing_tables) && s.missing_tables.length) {
+                    const list = s.missing_tables.map(escapeHtml).join(', ');
+                    html += `<div class="mt-2 small text-warning">
+                                <i class="bi bi-exclamation-triangle me-1"></i>
+                                GCD dump missing ${s.missing_tables.length} table(s):
+                                <code>${list}</code>
+                                &mdash; credits/characters may be incomplete.
+                             </div>`;
+                }
+                if (s.core_ok === false) {
+                    html = `<div class="alert alert-danger small mb-2 py-2">
+                              <i class="bi bi-x-octagon me-1"></i>
+                              GCD dump is missing core tables &mdash; series/issue lookups will fail. Re-download from comics.org.
+                            </div>` + html;
+                }
+                footer.innerHTML = html;
             } else {
                 footer.textContent = 'Local MySQL database';
             }

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -8,6 +8,19 @@ from models.providers.base import ProviderCredentials, SearchResult, IssueResult
 
 
 # ---------------------------------------------------------------------------
+# Reset module-level GCD table cache between tests so one test's mocked schema
+# doesn't leak into the next.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_gcd_table_cache():
+    from models.gcd import invalidate_gcd_table_cache
+    invalidate_gcd_table_cache()
+    yield
+    invalidate_gcd_table_cache()
+
+
+# ---------------------------------------------------------------------------
 # Common credential fixtures
 # ---------------------------------------------------------------------------
 

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -3,6 +3,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 from tests.mocked.conftest import make_mock_mysql_connection
 
+from models.gcd import EXPECTED_GCD_TABLES
+
 
 class TestIsMysqlAvailable:
 
@@ -66,8 +68,9 @@ class TestSearchSeries:
 class TestGetIssueMetadata:
 
     @patch("models.gcd.MYSQL_AVAILABLE", True)
+    @patch("models.gcd.get_available_gcd_tables", return_value=set(EXPECTED_GCD_TABLES))
     @patch("models.gcd.get_connection")
-    def test_returns_metadata(self, mock_conn):
+    def test_returns_metadata(self, mock_conn, mock_tables):
         from models.gcd import get_issue_metadata
 
         # get_issue_metadata uses a single cursor for three sequential queries:
@@ -97,8 +100,9 @@ class TestGetIssueMetadata:
         assert result["Writer"] == "Bill Finger"
 
     @patch("models.gcd.MYSQL_AVAILABLE", True)
+    @patch("models.gcd.get_available_gcd_tables", return_value=set(EXPECTED_GCD_TABLES))
     @patch("models.gcd.get_connection")
-    def test_issue_not_found(self, mock_conn):
+    def test_issue_not_found(self, mock_conn, mock_tables):
         from models.gcd import get_issue_metadata
 
         conn, cursor = make_mock_mysql_connection(fetchone_result=None)
@@ -106,10 +110,151 @@ class TestGetIssueMetadata:
 
         assert get_issue_metadata(200, "999") is None
 
+    @patch("models.gcd.MYSQL_AVAILABLE", True)
+    @patch("models.gcd.get_connection")
+    def test_falls_back_to_legacy_when_story_credit_missing(self, mock_conn):
+        """When gcd_story_credit is absent the normalized query is skipped and
+        the legacy text-column fallback runs against gcd_story."""
+        from models.gcd import get_issue_metadata
+
+        partial = set(EXPECTED_GCD_TABLES) - {'gcd_story_credit', 'gcd_creator', 'gcd_issue_credit'}
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.side_effect = [
+            # Series query
+            {"id": 200, "name": "Batman", "year_began": 1940, "publisher_name": "DC Comics"},
+            # Issue query
+            {"id": 1, "number": "1", "volume": "1", "title": "Origin",
+             "summary": "Origin", "year": 1940, "month": 4},
+            # Legacy text-column fallback row
+            {"script": "Bill Finger", "pencils": "Bob Kane", "inks": None,
+             "colors": None, "letters": None, "editing": None},
+        ]
+        conn.cursor.return_value = cursor
+        mock_conn.return_value = conn
+
+        with patch("models.gcd.get_available_gcd_tables", return_value=partial):
+            result = get_issue_metadata(200, "1")
+
+        assert result is not None
+        assert result["Writer"] == "Bill Finger"
+        assert result["Penciller"] == "Bob Kane"
+
+    @patch("models.gcd.MYSQL_AVAILABLE", True)
+    @patch("models.gcd.get_connection")
+    def test_no_credits_when_story_table_missing(self, mock_conn):
+        """When gcd_story is itself absent, no credits at all are returned and
+        no 500 is raised."""
+        from models.gcd import get_issue_metadata
+
+        partial = {'gcd_series', 'gcd_issue', 'gcd_publisher', 'stddata_language'}
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.side_effect = [
+            {"id": 200, "name": "Batman", "year_began": 1940, "publisher_name": "DC Comics"},
+            {"id": 1, "number": "1", "volume": "1", "title": "Origin",
+             "summary": "Origin", "year": 1940, "month": 4},
+        ]
+        conn.cursor.return_value = cursor
+        mock_conn.return_value = conn
+
+        with patch("models.gcd.get_available_gcd_tables", return_value=partial):
+            result = get_issue_metadata(200, "1")
+
+        assert result is not None
+        # Core fields still populated; credit fields are absent (None values dropped from result).
+        assert result["Series"] == "Batman"
+        assert "Writer" not in result
+
     @patch("models.gcd.MYSQL_AVAILABLE", False)
     def test_mysql_unavailable(self):
         from models.gcd import get_issue_metadata
         assert get_issue_metadata(200, "1") is None
+
+
+class TestGetAvailableGcdTables:
+    """The cached helper that detects which expected GCD tables exist."""
+
+    def test_caches_after_first_call(self):
+        """Second call must not re-query information_schema."""
+        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
+        invalidate_gcd_table_cache()
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [('gcd_series',), ('gcd_issue',)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        with patch("models.gcd.get_connection", return_value=conn):
+            first = get_available_gcd_tables()
+            second = get_available_gcd_tables()
+
+        assert first == second == {'gcd_series', 'gcd_issue'}
+        # Helper queries information_schema only once across two calls.
+        assert cursor.execute.call_count == 1
+
+    def test_force_refresh_requeries(self):
+        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
+        invalidate_gcd_table_cache()
+
+        cursor = MagicMock()
+        cursor.fetchall.side_effect = [
+            [('gcd_series',)],
+            [('gcd_series',), ('gcd_issue',)],
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        with patch("models.gcd.get_connection", return_value=conn):
+            first = get_available_gcd_tables()
+            second = get_available_gcd_tables(force_refresh=True)
+
+        assert first == {'gcd_series'}
+        assert second == {'gcd_series', 'gcd_issue'}
+        assert cursor.execute.call_count == 2
+
+    def test_returns_empty_set_on_error(self):
+        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
+        invalidate_gcd_table_cache()
+
+        conn = MagicMock()
+        conn.cursor.side_effect = Exception("boom")
+
+        with patch("models.gcd.get_connection", return_value=conn):
+            result = get_available_gcd_tables()
+
+        assert result == set()
+
+    def test_returns_empty_set_when_no_connection(self):
+        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
+        invalidate_gcd_table_cache()
+
+        with patch("models.gcd.get_connection", return_value=None):
+            result = get_available_gcd_tables()
+
+        assert result == set()
+
+    def test_warns_once_when_tables_missing(self, caplog):
+        """A single warning should be logged the first time we detect missing tables."""
+        import logging
+        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
+        invalidate_gcd_table_cache()
+
+        cursor = MagicMock()
+        # Return a partial schema — gcd_creator and gcd_issue_credit missing.
+        present = sorted(set(EXPECTED_GCD_TABLES) - {'gcd_creator', 'gcd_issue_credit'})
+        cursor.fetchall.return_value = [(t,) for t in present]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        with caplog.at_level(logging.WARNING, logger="app_logger"):
+            with patch("models.gcd.get_connection", return_value=conn):
+                get_available_gcd_tables()
+                get_available_gcd_tables()
+                get_available_gcd_tables()
+
+        warnings = [r for r in caplog.records if "missing from dump" in r.getMessage()]
+        assert len(warnings) == 1
 
 
 class TestValidateIssue:

--- a/tests/mocked/test_gcd_stats.py
+++ b/tests/mocked/test_gcd_stats.py
@@ -2,26 +2,36 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from models.gcd import get_database_stats
+from models.gcd import (
+    get_database_stats,
+    EXPECTED_GCD_TABLES,
+    GCD_CORE_TABLES,
+)
 
 
 class TestGetDatabaseStats:
     """Test get_database_stats with mocked connections."""
 
+    def _make_conn(self, fetchall_rows):
+        cursor = MagicMock()
+        cursor.fetchall.return_value = fetchall_rows
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        return conn
+
     def test_returns_stats_on_success(self):
-        """Returns a dict with mapped table counts."""
-        mock_cursor = MagicMock()
-        mock_cursor.fetchall.return_value = [
+        """Returns a dict with mapped table counts when all tables present."""
+        rows = [
             ('gcd_series', 250000),
             ('gcd_issue', 2500000),
             ('gcd_story', 3000000),
             ('gcd_publisher', 50000),
             ('gcd_creator', 400000),
         ]
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value = mock_cursor
+        mock_conn = self._make_conn(rows)
 
-        with patch('models.gcd.get_connection', return_value=mock_conn):
+        with patch('models.gcd.get_connection', return_value=mock_conn), \
+             patch('models.gcd.get_available_gcd_tables', return_value=set(EXPECTED_GCD_TABLES)):
             stats = get_database_stats()
 
         assert stats is not None
@@ -30,7 +40,9 @@ class TestGetDatabaseStats:
         assert stats['stories'] == 3000000
         assert stats['publishers'] == 50000
         assert stats['creators'] == 400000
-        assert stats['table_count'] == 5
+        assert stats['table_count'] == len(EXPECTED_GCD_TABLES)
+        assert stats['missing_tables'] == []
+        assert stats['core_ok'] is True
         mock_conn.close.assert_called_once()
 
     def test_returns_none_when_no_connection(self):
@@ -45,27 +57,46 @@ class TestGetDatabaseStats:
         mock_conn = MagicMock()
         mock_conn.cursor.side_effect = Exception("query failed")
 
-        with patch('models.gcd.get_connection', return_value=mock_conn):
+        with patch('models.gcd.get_connection', return_value=mock_conn), \
+             patch('models.gcd.get_available_gcd_tables', return_value=set(EXPECTED_GCD_TABLES)):
             stats = get_database_stats()
 
         assert stats is None
         mock_conn.close.assert_called_once()
 
-    def test_handles_partial_tables(self):
-        """Works when only some expected tables exist."""
-        mock_cursor = MagicMock()
-        mock_cursor.fetchall.return_value = [
+    def test_reports_missing_tables_when_dump_partial(self):
+        """Surfaces missing_tables / core_ok when the dump excludes tables."""
+        # Simulate the May 2026 GCD dump: gcd_creator and gcd_issue_credit absent.
+        available = set(EXPECTED_GCD_TABLES) - {'gcd_creator', 'gcd_issue_credit'}
+        rows = [
             ('gcd_series', 100),
             ('gcd_issue', 200),
+            ('gcd_story', 300),
+            ('gcd_publisher', 50),
         ]
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value = mock_cursor
+        mock_conn = self._make_conn(rows)
 
-        with patch('models.gcd.get_connection', return_value=mock_conn):
+        with patch('models.gcd.get_connection', return_value=mock_conn), \
+             patch('models.gcd.get_available_gcd_tables', return_value=available):
             stats = get_database_stats()
 
         assert stats is not None
         assert stats['series'] == 100
-        assert stats['issues'] == 200
-        assert 'stories' not in stats
-        assert stats['table_count'] == 2
+        # gcd_creator missing → creators defaults to 0 (key still present)
+        assert stats['creators'] == 0
+        assert 'gcd_creator' in stats['missing_tables']
+        assert 'gcd_issue_credit' in stats['missing_tables']
+        assert stats['core_ok'] is True  # core tables (series/issue/publisher/story/stddata_language) still here
+
+    def test_core_ok_false_when_core_tables_missing(self):
+        """core_ok is False when a core table (gcd_issue) is absent."""
+        available = set(EXPECTED_GCD_TABLES) - {'gcd_issue'}
+        mock_conn = self._make_conn([])
+
+        with patch('models.gcd.get_connection', return_value=mock_conn), \
+             patch('models.gcd.get_available_gcd_tables', return_value=available):
+            stats = get_database_stats()
+
+        assert stats is not None
+        assert stats['core_ok'] is False
+        assert 'gcd_issue' in stats['missing_tables']

--- a/tests/routes/test_gcd_stats.py
+++ b/tests/routes/test_gcd_stats.py
@@ -58,3 +58,21 @@ class TestGcdStatsEndpoint:
         assert resp.status_code == 500
         data = resp.get_json()
         assert 'error' in data
+
+    def test_endpoint_exposes_missing_tables(self, client):
+        """The route forwards the missing_tables / core_ok fields verbatim."""
+        fake_stats = {
+            'series': 100, 'issues': 200, 'stories': 300,
+            'publishers': 10, 'creators': 0,
+            'table_count': 11,
+            'available_tables': ['gcd_issue', 'gcd_series', 'gcd_story'],
+            'missing_tables': ['gcd_creator', 'gcd_issue_credit'],
+            'core_ok': True,
+        }
+        with patch('models.gcd.get_database_stats', return_value=fake_stats):
+            resp = client.get('/api/providers/gcd/stats')
+
+        assert resp.status_code == 200
+        stats = resp.get_json()['stats']
+        assert stats['missing_tables'] == ['gcd_creator', 'gcd_issue_credit']
+        assert stats['core_ok'] is True


### PR DESCRIPTION
## 📝 Description
Add runtime detection and caching of which GCD tables exist in the connected MySQL dump (`EXPECTED_GCD_TABLES, GCD_CORE_TABLES, get_available_gcd_tables(), invalidate_gcd_table_cache())`. Make `get_database_stats()` and GCD metadata queries resilient to partial dumps by skipping joins, using fallbacks, and returning available/missing table info and core_ok. Invalidate the table cache when GCD credentials change. Surface warnings/alerts in the config UI when tables are missing or core tables are absent. Add tests for cache behavior, fallbacks, stats output and a fixture to reset the cache between tests.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass