### PR TITLE
Refactor CBZ editor cards and increase thumbnail size

### DIFF
--- a/cbz_ops/edit.py
+++ b/cbz_ops/edit.py
@@ -21,41 +21,25 @@ deletedFiles = [ext.strip().lower() for ext in deleted_exts.split(",") if ext.st
 modal_body_template = '''
     {% for card in file_cards %}
       <div class="col">
-        <div class="card h-100 shadow-sm">
-          <div class="row g-0">
-            <div class="col-3">
-              {% if card.img_data %}
-                <img src="{{ card.img_data }}" class="img-fluid rounded-start object-fit-scale border rounded" alt="{{ card.filename }}">
-              {% else %}
-                <img src="https://via.placeholder.com/100" class="img-fluid rounded-start object-fit-scale border rounded" alt="No image">
-              {% endif %}
-            </div>
-            <div class="col-9">
-              <div class="card-body">
-                <p class="card-text small">
-                    <span class="editable-filename" data-rel-path="{{ card.rel_path }}" onclick="CLU.enableFilenameEdit(this)">
-                      {{ card.filename }}
-                    </span>
-                    <input type="text" class="form-control d-none filename-input form-control-sm" value="{{ card.filename }}" data-rel-path="{{ card.rel_path }}">
-                </p>
-                <div class="d-flex justify-content-end">
-                <div class="btn-group" role="group" aria-label="Basic example">
-                  <button type="button" class="btn btn-outline-primary btn-sm" onclick="CLU.cropImageFreeForm(this)" title="Free Form Crop">
-                    <i class="bi bi-crop"></i> Free
-                  </button>
-                  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="CLU.cropImageLeft(this)" title="Crop Image Left">
-                    <i class="bi bi-arrow-bar-left"></i> Left
-                  </button>
-                  <button type="button" class="btn btn-outline-secondary" onclick="CLU.cropImageCenter(this)" title="Crop Image Center">Middle</button>
-                  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="CLU.cropImageRight(this)" title="Crop Image Right">
-                    Right <i class="bi bi-arrow-bar-right"></i>
-                  </button>
-                  <button type="button" class="btn btn-outline-danger btn-sm" onclick="CLU.deleteCardImage(this)">
-                    <i class="bi bi-trash"></i>
-                  </button>
-                </div>
-                </div>
-              </div>
+        <div class="card h-100 shadow-sm cbz-edit-card">
+          <div class="cbz-edit-thumb-wrap">
+            {% if card.img_data %}
+              <img src="{{ card.img_data }}" class="cbz-edit-thumb" alt="{{ card.filename }}">
+            {% else %}
+              <img src="https://via.placeholder.com/400x600" class="cbz-edit-thumb" alt="No image">
+            {% endif %}
+          </div>
+          <div class="card-body d-flex flex-column p-2">
+            <p class="card-text small text-break mb-2 cbz-edit-filename-wrap">
+                <span class="editable-filename" data-rel-path="{{ card.rel_path }}" onclick="CLU.enableFilenameEdit(this)">{{ card.filename }}</span>
+                <input type="text" class="form-control d-none filename-input form-control-sm" value="{{ card.filename }}" data-rel-path="{{ card.rel_path }}">
+            </p>
+            <div class="btn-group btn-group-sm w-100 mt-auto" role="group">
+              <button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageFreeForm(this)" title="Free Form Crop"><i class="bi bi-crop"></i></button>
+              <button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageLeft(this)" title="Crop Left"><i class="bi bi-arrow-bar-left"></i></button>
+              <button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageCenter(this)" title="Crop Center"><i class="bi bi-bounding-box"></i></button>
+              <button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageRight(this)" title="Crop Right"><i class="bi bi-arrow-bar-right"></i></button>
+              <button type="button" class="btn btn-outline-danger" onclick="CLU.deleteCardImage(this)" title="Delete"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -176,7 +160,7 @@ def get_edit_modal(file_path):
                     full_path = os.path.join(root, f)
                     
                     # Use streaming thumbnail generation
-                    thumbnail_data = create_thumbnail_streaming(full_path, max_size=(100, 100), quality=85)
+                    thumbnail_data = create_thumbnail_streaming(full_path, max_size=(400, 600), quality=85)
                     
                     if thumbnail_data:
                         encoded = base64.b64encode(thumbnail_data).decode('utf-8')

--- a/static/js/clu-cbz-edit.js
+++ b/static/js/clu-cbz-edit.js
@@ -43,30 +43,26 @@
 
   CLU.generateCardHTML = function (imagePath, imageData) {
     var filenameOnly = imagePath.split('/').pop();
+    var safeName = CLU.escapeHtml(filenameOnly);
+    var safePath = CLU.escapeHtml(imagePath);
     return '<div class="col">' +
-      '<div class="card h-100 shadow-sm">' +
-        '<div class="row g-0">' +
-          '<div class="col-3">' +
-            '<img src="' + imageData + '" class="img-fluid rounded-start object-fit-scale border rounded" alt="' + CLU.escapeHtml(filenameOnly) + '">' +
-          '</div>' +
-          '<div class="col-9">' +
-            '<div class="card-body">' +
-              '<p class="card-text small">' +
-                '<span class="editable-filename" data-full-path="' + CLU.escapeHtml(imagePath) + '" onclick="CLU.enableFilenameEdit(this)">' +
-                  CLU.escapeHtml(filenameOnly) +
-                '</span>' +
-                '<input type="text" class="form-control d-none filename-input form-control-sm" value="' + CLU.escapeHtml(filenameOnly) + '" data-full-path="' + CLU.escapeHtml(imagePath) + '">' +
-              '</p>' +
-              '<div class="d-flex justify-content-end">' +
-                '<div class="btn-group" role="group">' +
-                  '<button type="button" class="btn btn-outline-primary btn-sm" onclick="CLU.cropImageFreeForm(this)" title="Free Form Crop"><i class="bi bi-crop"></i> Free</button>' +
-                  '<button type="button" class="btn btn-outline-primary btn-sm" onclick="CLU.cropImageLeft(this)" title="Crop Left"><i class="bi bi-arrow-bar-left"></i> Left</button>' +
-                  '<button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageCenter(this)" title="Crop Center">Middle</button>' +
-                  '<button type="button" class="btn btn-outline-primary btn-sm" onclick="CLU.cropImageRight(this)" title="Crop Right">Right <i class="bi bi-arrow-bar-right"></i></button>' +
-                  '<button type="button" class="btn btn-outline-danger btn-sm" onclick="CLU.deleteCardImage(this)"><i class="bi bi-trash"></i></button>' +
-                '</div>' +
-              '</div>' +
-            '</div>' +
+      '<div class="card h-100 shadow-sm cbz-edit-card">' +
+        '<div class="cbz-edit-thumb-wrap">' +
+          '<img src="' + imageData + '" class="cbz-edit-thumb" alt="' + safeName + '">' +
+        '</div>' +
+        '<div class="card-body d-flex flex-column p-2">' +
+          '<p class="card-text small text-break mb-2 cbz-edit-filename-wrap">' +
+            '<span class="editable-filename" data-full-path="' + safePath + '" onclick="CLU.enableFilenameEdit(this)">' +
+              safeName +
+            '</span>' +
+            '<input type="text" class="form-control d-none filename-input form-control-sm" value="' + safeName + '" data-full-path="' + safePath + '">' +
+          '</p>' +
+          '<div class="btn-group btn-group-sm w-100 mt-auto" role="group">' +
+            '<button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageFreeForm(this)" title="Free Form Crop"><i class="bi bi-crop"></i></button>' +
+            '<button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageLeft(this)" title="Crop Left"><i class="bi bi-arrow-bar-left"></i></button>' +
+            '<button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageCenter(this)" title="Crop Center"><i class="bi bi-bounding-box"></i></button>' +
+            '<button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageRight(this)" title="Crop Right"><i class="bi bi-arrow-bar-right"></i></button>' +
+            '<button type="button" class="btn btn-outline-danger" onclick="CLU.deleteCardImage(this)" title="Delete"><i class="bi bi-trash"></i></button>' +
           '</div>' +
         '</div>' +
       '</div>' +

--- a/templates/partials/modal_cbz_edit.html
+++ b/templates/partials/modal_cbz_edit.html
@@ -1,4 +1,35 @@
 <!-- Edit CBZ Modal – shared partial (clu-cbz-edit.js) -->
+<style>
+  /* === CBZ edit modal — thumbnail sizing ============================
+     Tweak `.cbz-edit-thumb` (or .cbz-edit-thumb-wrap) below to adjust
+     thumbnail size independently of card width.
+     ================================================================ */
+  #editCBZModal .cbz-edit-thumb-wrap {
+    /* Constrains thumbnail height regardless of card width.
+       Lower max-height = smaller thumbnails. */
+    max-height: 280px;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bs-body-bg);
+  }
+  #editCBZModal .cbz-edit-thumb {
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+  }
+  #editCBZModal .cbz-edit-filename-wrap {
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    line-height: 1.3;
+  }
+  #editCBZModal .cbz-edit-filename-wrap .filename-input {
+    width: 100%;
+  }
+</style>
 <div class="modal fade" id="editCBZModal" tabindex="-1" aria-labelledby="editCBZModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-fullscreen">
     <div class="modal-content">
@@ -7,7 +38,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <div id="editInlineContainer" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+        <div id="editInlineContainer" class="row row-cols-2 row-cols-sm-3 row-cols-md-4 g-3">
           <!-- Inline editing content (cards) will be dynamically loaded here -->
         </div>
       </div>


### PR DESCRIPTION
## 📝 Description
Revamp CBZ edit card markup, styles and JS to provide larger, consistent thumbnails and a more compact/responsive card layout. 

**Changes:**
- cbz_ops/edit.py: replaced old multi-column card HTML with a simplified card (cbz-edit-card) and thumbnail wrapper; increased thumbnail streaming size from (100x100) to (400x600) for higher-quality previews.
- static/js/clu-cbz-edit.js: updated CLU.generateCardHTML to match the new markup, added HTML escaping (safeName/safePath), unified button styling/icons, and adjusted data attributes/structure for filename editing.
- templates/partials/modal_cbz_edit.html: added inline CSS to control thumbnail sizing (.cbz-edit-thumb / .cbz-edit-thumb-wrap), improved filename wrapping and input sizing, and changed the grid column counts for a denser responsive layout.

Overall this improves visual fidelity of thumbnails, layout consistency, and safety of generated markup.

Closes #316 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1616" height="843" alt="image" src="https://github.com/user-attachments/assets/c34523c7-ebc8-4577-8571-c0dfc2f4c41e" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass