### PR TITLE
Drag and Drop Re-Ordering While Editing CBZ

### DIFF
--- a/cbz_ops/edit.py
+++ b/cbz_ops/edit.py
@@ -1,4 +1,6 @@
 import os
+import json
+import uuid
 import zipfile
 import shutil
 import io
@@ -10,6 +12,28 @@ from core.config import config, load_config
 from helpers import create_thumbnail_streaming, safe_image_open
 import gc
 
+
+def _safe_join(base_folder, rel_path):
+    """Resolve rel_path under base_folder, rejecting traversal escapes.
+
+    Returns the absolute path or raises ValueError.
+    """
+    base_abs = os.path.abspath(base_folder)
+    candidate = os.path.abspath(os.path.join(base_abs, rel_path))
+    if candidate != base_abs and not candidate.startswith(base_abs + os.sep):
+        raise ValueError(f"Path escapes base folder: {rel_path}")
+    return candidate
+
+
+def _validate_final_name(name):
+    """Reject final filenames that could escape the base folder."""
+    if not name or not isinstance(name, str):
+        raise ValueError("final_name must be a non-empty string")
+    if '/' in name or '\\' in name or '\0' in name:
+        raise ValueError(f"final_name contains path separators or NUL: {name!r}")
+    if name in ('.', '..'):
+        raise ValueError(f"final_name reserved: {name!r}")
+
 load_config()
 skipped_exts = config.get("SETTINGS", "SKIPPED_FILES", fallback="")
 deleted_exts = config.get("SETTINGS", "DELETED_FILES", fallback="")
@@ -20,7 +44,7 @@ deletedFiles = [ext.strip().lower() for ext in deleted_exts.split(",") if ext.st
 # Partial template for the modal body (the grid of Bootstrap Cards)
 modal_body_template = '''
     {% for card in file_cards %}
-      <div class="col">
+      <div class="col" data-rel-path="{{ card.rel_path }}">
         <div class="card h-100 shadow-sm cbz-edit-card">
           <div class="cbz-edit-thumb-wrap">
             {% if card.img_data %}
@@ -199,11 +223,94 @@ def save_cbz():
     folder_name = request.form.get('folder_name')
     zip_file_path = request.form.get('zip_file_path')
     original_file_path = request.form.get('original_file_path')
-    
+    pending_deletes_raw = request.form.get('pending_deletes', '[]')
+    pending_order_raw = request.form.get('pending_order', '[]')
+
     if not folder_name or not zip_file_path or not original_file_path:
         return "Missing required data", 400
 
+    # Parse + validate pending operations BEFORE touching disk.
     try:
+        pending_deletes = json.loads(pending_deletes_raw) if pending_deletes_raw else []
+        pending_order = json.loads(pending_order_raw) if pending_order_raw else []
+        if not isinstance(pending_deletes, list):
+            raise ValueError("pending_deletes must be a list")
+        if not isinstance(pending_order, list):
+            raise ValueError("pending_order must be a list")
+        # Validate every delete resolves under folder_name.
+        for rel in pending_deletes:
+            if not isinstance(rel, str):
+                raise ValueError("pending_deletes entries must be strings")
+            _safe_join(folder_name, rel)
+        # Validate every order entry.
+        for entry in pending_order:
+            if not isinstance(entry, dict):
+                raise ValueError("pending_order entries must be objects")
+            rel = entry.get('rel_path')
+            final = entry.get('final_name')
+            if not isinstance(rel, str):
+                raise ValueError("pending_order rel_path must be a string")
+            _safe_join(folder_name, rel)
+            _validate_final_name(final)
+    except (ValueError, json.JSONDecodeError) as e:
+        app_logger.error(f"Invalid pending operations: {e}")
+        return jsonify({"success": False, "error": f"Invalid pending operations: {e}"}), 400
+
+    try:
+        # ── Apply pending deletes ────────────────────────────────────
+        for rel in pending_deletes:
+            target = _safe_join(folder_name, rel)
+            if os.path.isfile(target):
+                try:
+                    os.remove(target)
+                    app_logger.info(f"Pending-delete applied: {rel}")
+                except Exception as e:
+                    app_logger.warning(f"Failed to delete {rel}: {e}")
+            else:
+                app_logger.info(f"Pending-delete target missing (skipped): {rel}")
+
+        # ── Apply pending renames in two phases ──────────────────────
+        # Phase A: source → unique temp name (avoids collisions)
+        # Phase B: temp name → final_name (flat in folder_name)
+        phase_a = []   # list of (orig_abs, temp_abs, final_name)
+        deleted_set = set(pending_deletes)
+        for entry in pending_order:
+            rel = entry['rel_path']
+            if rel in deleted_set:
+                continue
+            final_name = entry['final_name']
+            src_abs = _safe_join(folder_name, rel)
+            if not os.path.isfile(src_abs):
+                app_logger.warning(f"Pending-order source missing (skipped): {rel}")
+                continue
+            target_abs = os.path.join(os.path.abspath(folder_name), final_name)
+            # No-op when source basename already matches final and it's already at the root.
+            if os.path.abspath(src_abs) == target_abs:
+                continue
+            temp_abs = os.path.join(os.path.abspath(folder_name), f".__reorder_{uuid.uuid4().hex}.tmp")
+            phase_a.append((src_abs, temp_abs, target_abs, rel, final_name))
+
+        # Execute phase A
+        for src_abs, temp_abs, _target_abs, rel, _final in phase_a:
+            try:
+                os.rename(src_abs, temp_abs)
+            except Exception as e:
+                app_logger.error(f"Phase A rename failed for {rel}: {e}")
+                raise
+
+        # Execute phase B
+        for _src_abs, temp_abs, target_abs, rel, final_name in phase_a:
+            try:
+                # If a stale file sits at target_abs (e.g., another entry's source
+                # we already temped), this is fine — that file was renamed in
+                # phase A so it no longer occupies target_abs. If something else
+                # blocks, raise.
+                os.rename(temp_abs, target_abs)
+                app_logger.info(f"Pending-rename applied: {rel} -> {final_name}")
+            except Exception as e:
+                app_logger.error(f"Phase B rename failed for {rel} -> {final_name}: {e}")
+                raise
+
         # Step 6: Rename the original .zip file to .bak.
         bak_file_path = zip_file_path + '.bak'
         os.rename(zip_file_path, bak_file_path)
@@ -484,15 +591,19 @@ def cropFreeForm(image_path, x, y, width, height):
         raise
 
 
-def get_image_data_url(image_path):
-    """Open an image, resize it to a height of 100 (keeping aspect ratio),
-    encode it as a PNG in memory, and return a data URL."""
+def get_image_data_url(image_path, target_height=600):
+    """Open an image, resize it to the given height (keeping aspect ratio),
+    encode it as a PNG in memory, and return a data URL.
+
+    Default target_height matches the edit-modal main thumbnail (600px) so
+    crop-result cards render at the same size as the rest of the grid.
+    """
     try:
         with Image.open(image_path) as img:
-            if img.height > 0:
-                ratio = 100 / float(img.height)
-                new_width = int(img.width * ratio)
-                img = img.resize((new_width, 100), Image.LANCZOS)
+            if img.height > 0 and img.height > target_height:
+                ratio = target_height / float(img.height)
+                new_width = max(1, int(img.width * ratio))
+                img = img.resize((new_width, target_height), Image.LANCZOS)
             buffered = io.BytesIO()
             img.save(buffered, format="PNG")
             encoded = base64.b64encode(buffered.getvalue()).decode('utf-8')

--- a/static/js/clu-cbz-edit.js
+++ b/static/js/clu-cbz-edit.js
@@ -1,12 +1,16 @@
 /**
  * CLU CBZ Edit Operations  –  clu-cbz-edit.js
  *
- * Edit modal: reorder pages, upload images, rename filenames, delete images.
- * Provides: CLU.generateCardHTML, CLU.sortInlineEditCards, CLU.deleteCardImage,
- *           CLU.enableFilenameEdit, CLU.saveEditedCBZ, CLU.setupEditModalDropZone,
- *           CLU.handleEditModalUpload
+ * Pending-changes edit modal: drag to reorder, click to rename, delete to flag.
+ * Nothing hits the server until SAVE is clicked.
  *
- * Depends on: clu-utils.js (CLU.showToast, CLU.showError, CLU.showSuccess)
+ * Provides: CLU.generateCardHTML, CLU.sortInlineEditCards, CLU.deleteCardImage,
+ *           CLU.enableFilenameEdit, CLU.performRename, CLU.saveEditedCBZ,
+ *           CLU.setupEditModalDropZone, CLU.handleEditModalUpload,
+ *           CLU.initEditModalReorder
+ *
+ * Depends on: clu-utils.js (CLU.showToast, CLU.showError, CLU.showSuccess),
+ *             Sortable.js (loaded by templates/partials/modal_cbz_edit.html)
  *
  * External contract:
  *   window._cluCbzEdit = { onSaveComplete(filePath) }
@@ -14,7 +18,8 @@
  * DOM contracts:
  *   #editCBZModal  (from modal_cbz_edit.html)
  *   #editInlineContainer, #editInlineFolderName, #editInlineZipFilePath,
- *   #editInlineOriginalFilePath, #editInlineSaveForm
+ *   #editInlineOriginalFilePath, #editInlineSaveForm,
+ *   #editInlinePendingDeletes, #editInlinePendingOrder
  */
 (function () {
   'use strict';
@@ -23,39 +28,74 @@
 
   function _getContract() { return window._cluCbzEdit || {}; }
 
-  // ── Path resolution (shared with clu-cbz-crop.js) ──────────────────────
+  // ── Per-session state ───────────────────────────────────────────────────
 
-  function _resolveFullPath(span) {
-    var fullPath = span.dataset.fullPath || span.getAttribute('data-full-path');
-    if (fullPath) return fullPath;
+  CLU._editState = null;
 
-    var relPath = span.dataset.relPath || span.getAttribute('data-rel-path');
-    if (!relPath) return null;
+  function _newState() {
+    return {
+      baseFolder: '',
+      originalOrder: [],          // rel_paths sorted alphabetically at load
+      pendingDeletes: new Set(),  // rel_paths to delete on save
+      pendingRenames: new Map(),  // rel_path -> user-typed new filename
+      dragged: false,             // any drag-reorder happened
+      dirty: false,
+      sortable: null,
+      closeGuardAttached: false
+    };
+  }
 
-    if (relPath.startsWith('/')) return relPath;
+  function _markDirty() {
+    if (!CLU._editState) return;
+    CLU._editState.dirty = true;
+    var modal = document.getElementById('editCBZModal');
+    if (modal) modal.classList.add('cbz-edit-dirty');
+  }
 
-    var folder = document.getElementById('editInlineFolderName');
-    if (!folder || !folder.value) return null;
-    return folder.value + '/' + relPath;
+  function _clearDirty() {
+    if (!CLU._editState) return;
+    CLU._editState.dirty = false;
+    var modal = document.getElementById('editCBZModal');
+    if (modal) modal.classList.remove('cbz-edit-dirty');
+  }
+
+  // ── Path / extension helpers ────────────────────────────────────────────
+
+  function _splitExt(name) {
+    var i = name.lastIndexOf('.');
+    if (i <= 0) return { stem: name, ext: '' };
+    return { stem: name.substring(0, i), ext: name.substring(i) };
+  }
+
+  function _basename(p) {
+    var s = String(p || '');
+    var i = Math.max(s.lastIndexOf('/'), s.lastIndexOf('\\'));
+    return i < 0 ? s : s.substring(i + 1);
+  }
+
+  function _padNum(n, width) {
+    var s = String(n);
+    while (s.length < width) s = '0' + s;
+    return s;
   }
 
   // ── generateCardHTML ────────────────────────────────────────────────────
 
-  CLU.generateCardHTML = function (imagePath, imageData) {
-    var filenameOnly = imagePath.split('/').pop();
+  CLU.generateCardHTML = function (relPath, imageData) {
+    var filenameOnly = _basename(relPath);
     var safeName = CLU.escapeHtml(filenameOnly);
-    var safePath = CLU.escapeHtml(imagePath);
-    return '<div class="col">' +
+    var safeRel = CLU.escapeHtml(relPath);
+    return '<div class="col" data-rel-path="' + safeRel + '">' +
       '<div class="card h-100 shadow-sm cbz-edit-card">' +
         '<div class="cbz-edit-thumb-wrap">' +
           '<img src="' + imageData + '" class="cbz-edit-thumb" alt="' + safeName + '">' +
         '</div>' +
         '<div class="card-body d-flex flex-column p-2">' +
           '<p class="card-text small text-break mb-2 cbz-edit-filename-wrap">' +
-            '<span class="editable-filename" data-full-path="' + safePath + '" onclick="CLU.enableFilenameEdit(this)">' +
+            '<span class="editable-filename" data-rel-path="' + safeRel + '" onclick="CLU.enableFilenameEdit(this)">' +
               safeName +
             '</span>' +
-            '<input type="text" class="form-control d-none filename-input form-control-sm" value="' + safeName + '" data-full-path="' + safePath + '">' +
+            '<input type="text" class="form-control d-none filename-input form-control-sm" value="' + safeName + '" data-rel-path="' + safeRel + '">' +
           '</p>' +
           '<div class="btn-group btn-group-sm w-100 mt-auto" role="group">' +
             '<button type="button" class="btn btn-outline-primary" onclick="CLU.cropImageFreeForm(this)" title="Free Form Crop"><i class="bi bi-crop"></i></button>' +
@@ -69,7 +109,7 @@
     '</div>';
   };
 
-  // ── sortInlineEditCards ─────────────────────────────────────────────────
+  // ── sortInlineEditCards (initial-load + post-upload alphabetical sort) ──
 
   CLU.sortInlineEditCards = function () {
     var container = document.getElementById('editInlineContainer');
@@ -93,37 +133,62 @@
     cards.forEach(function (c) { container.appendChild(c); });
   };
 
-  // ── deleteCardImage ─────────────────────────────────────────────────────
+  // ── renumberDisplay — refresh visible filenames to NNN.ext in DOM order ─
+
+  CLU.renumberDisplay = function () {
+    var container = document.getElementById('editInlineContainer');
+    if (!container) return;
+    var cards = Array.from(container.children);
+    var width = String(Math.max(cards.length, 1)).length;
+    if (width < 3) width = 3;
+
+    cards.forEach(function (card, idx) {
+      var span = card.querySelector('.editable-filename');
+      var input = card.querySelector('.filename-input');
+      if (!span || !input) return;
+
+      var relPath = card.getAttribute('data-rel-path') || span.getAttribute('data-rel-path');
+      if (!relPath) return;
+
+      // If the user typed a custom rename for this file, don't overwrite it.
+      if (CLU._editState && CLU._editState.pendingRenames.has(relPath)) return;
+
+      var ext = _splitExt(_basename(relPath)).ext;
+      var newName = _padNum(idx + 1, width) + ext;
+      span.textContent = newName;
+      input.value = newName;
+    });
+  };
+
+  // ── deleteCardImage (deferred) ──────────────────────────────────────────
 
   CLU.deleteCardImage = function (buttonElement) {
     var col = buttonElement.closest('.col');
     if (!col) { console.error('Unable to locate column container.'); return; }
-    var span = col.querySelector('.editable-filename');
-    if (!span) { console.error('No file reference found.'); return; }
+    var relPath = col.getAttribute('data-rel-path');
+    if (!relPath) {
+      var span = col.querySelector('.editable-filename');
+      relPath = span ? span.getAttribute('data-rel-path') : null;
+    }
+    if (!relPath) { console.error('No rel_path on card; cannot defer delete.'); return; }
 
-    var fullPath = _resolveFullPath(span);
-    if (!fullPath) return;
+    if (CLU._editState) {
+      CLU._editState.pendingDeletes.add(relPath);
+      CLU._editState.pendingRenames.delete(relPath);
+      _markDirty();
+    }
 
-    console.log('Deleting file:', fullPath);
-
-    fetch('/delete', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ target: fullPath })
-    })
-      .then(function (r) { return r.json(); })
-      .then(function (data) {
-        if (data.success) {
-          col.classList.add('fade-out');
-          setTimeout(function () { col.remove(); }, 300);
-        } else {
-          CLU.showError('Error deleting image: ' + data.error);
-        }
-      })
-      .catch(function (err) {
-        console.error('Error:', err);
-        CLU.showError('An error occurred while deleting the image.');
-      });
+    col.classList.add('fade-out');
+    setTimeout(function () {
+      col.remove();
+      if (CLU._editState && CLU._editState.dragged) {
+        CLU.renumberDisplay();
+      } else {
+        // Even without a drag, removing a card shifts the implicit numbering
+        // shown to the user. Refresh so positions look right.
+        CLU.renumberDisplay();
+      }
+    }, 200);
   };
 
   // ── enableFilenameEdit ──────────────────────────────────────────────────
@@ -145,85 +210,56 @@
 
     input.addEventListener('keydown', function (e) {
       if (e.key === 'Enter') { e.preventDefault(); process(); input.blur(); }
+      if (e.key === 'Escape') { e.preventDefault(); done = true; _cancelEdit(input); input.blur(); }
     });
     input.addEventListener('blur', process, { once: true });
   };
 
-  // ── performRename ───────────────────────────────────────────────────────
+  // ── performRename (deferred — updates state + UI, no fetch) ─────────────
 
   CLU.performRename = function (input) {
     var newFilename = input.value.trim();
-    var oldPath = input.dataset.fullPath || input.getAttribute('data-full-path');
-    var oldFilename, newPath;
+    var relPath = input.getAttribute('data-rel-path');
+    if (!relPath) { _cancelEdit(input); return; }
 
-    if (oldPath) {
-      oldFilename = oldPath.substring(oldPath.lastIndexOf('/') + 1);
-      if (newFilename === oldFilename) { _cancelEdit(input); return; }
-      var dirPath = oldPath.substring(0, oldPath.lastIndexOf('/'));
-      newPath = dirPath + '/' + newFilename;
-    } else {
-      var oldRelPath = input.dataset.relPath || input.getAttribute('data-rel-path');
-      if (!oldRelPath) { console.error('No path found.'); return; }
-
-      if (oldRelPath.startsWith('/')) {
-        oldFilename = oldRelPath.substring(oldRelPath.lastIndexOf('/') + 1);
-        if (newFilename === oldFilename) { _cancelEdit(input); return; }
-        var dp = oldRelPath.substring(0, oldRelPath.lastIndexOf('/'));
-        oldPath = oldRelPath;
-        newPath = dp + '/' + newFilename;
-      } else {
-        var folder = document.getElementById('editInlineFolderName');
-        var folderName = folder ? folder.value : '';
-        oldFilename = oldRelPath.includes('/')
-          ? oldRelPath.substring(oldRelPath.lastIndexOf('/') + 1) : oldRelPath;
-        if (newFilename === oldFilename) { _cancelEdit(input); return; }
-        var relDir = oldRelPath.includes('/')
-          ? oldRelPath.substring(0, oldRelPath.lastIndexOf('/')) : '';
-        var newRel = relDir ? relDir + '/' + newFilename : newFilename;
-        oldPath = folderName + '/' + oldRelPath;
-        newPath = folderName + '/' + newRel;
-      }
+    var oldFilename = _basename(relPath);
+    // If state has a prior rename, the displayed name might differ from oldFilename.
+    if (CLU._editState && CLU._editState.pendingRenames.has(relPath)) {
+      oldFilename = CLU._editState.pendingRenames.get(relPath);
     }
 
-    fetch('/rename', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ old: oldPath, new: newPath })
-    })
-      .then(function (r) { return r.json(); })
-      .then(function (data) {
-        if (data.success) {
-          var span = input.previousElementSibling;
-          span.textContent = newFilename;
-          if (input.dataset.fullPath || input.getAttribute('data-full-path')) {
-            span.setAttribute('data-full-path', newPath);
-            input.setAttribute('data-full-path', newPath);
-          } else {
-            var nr = newPath.substring(newPath.indexOf('/') + 1);
-            span.setAttribute('data-rel-path', nr);
-            input.setAttribute('data-rel-path', nr);
-          }
-          span.classList.remove('d-none');
-          input.classList.add('d-none');
-          CLU.sortInlineEditCards();
-        } else {
-          CLU.showError('Error renaming file: ' + data.error);
-          _cancelEdit(input);
-        }
-      })
-      .catch(function (err) {
-        console.error('Error:', err);
-        CLU.showError('An error occurred while renaming.');
-        _cancelEdit(input);
-      });
+    if (!newFilename || newFilename === oldFilename) {
+      _cancelEdit(input);
+      return;
+    }
+
+    // Basic client-side guard — backend validates definitively.
+    if (newFilename.indexOf('/') !== -1 || newFilename.indexOf('\\') !== -1 || newFilename === '..' || newFilename.indexOf('\0') !== -1) {
+      CLU.showError('Invalid filename: ' + newFilename);
+      _cancelEdit(input);
+      return;
+    }
+
+    var span = input.previousElementSibling;
+    if (span) span.textContent = newFilename;
+    input.value = newFilename;
+    input.classList.add('d-none');
+    if (span) span.classList.remove('d-none');
+
+    if (CLU._editState) {
+      CLU._editState.pendingRenames.set(relPath, newFilename);
+      _markDirty();
+    }
   };
 
   function _cancelEdit(input) {
     input.classList.add('d-none');
     if (input.previousElementSibling) input.previousElementSibling.classList.remove('d-none');
+    // Restore input value to the visible span text in case the user typed and then escaped.
+    if (input.previousElementSibling) input.value = input.previousElementSibling.textContent.trim();
   }
 
-  // ── setupEditModalDropZone ──────────────────────────────────────────────
+  // ── setupEditModalDropZone (upload drop zone, unchanged behavior) ───────
 
   CLU.setupEditModalDropZone = function () {
     var modal = document.getElementById('editCBZModal');
@@ -233,20 +269,35 @@
     body.dataset.dropzoneSetup = 'true';
 
     ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(function (evt) {
-      body.addEventListener(evt, function (e) { e.preventDefault(); e.stopPropagation(); });
+      body.addEventListener(evt, function (e) {
+        // Don't intercept events that originate from a Sortable drag operation.
+        // Sortable uses its own internal drag pipeline; the file drop zone only
+        // wants OS-level file drops (e.dataTransfer.files).
+        if (evt === 'drop' && (!e.dataTransfer || !e.dataTransfer.files || e.dataTransfer.files.length === 0)) {
+          return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+      });
     });
     ['dragenter', 'dragover'].forEach(function (evt) {
-      body.addEventListener(evt, function () { body.classList.add('drag-over'); });
+      body.addEventListener(evt, function (e) {
+        if (e.dataTransfer && e.dataTransfer.types && Array.prototype.indexOf.call(e.dataTransfer.types, 'Files') !== -1) {
+          body.classList.add('drag-over');
+        }
+      });
     });
     ['dragleave', 'drop'].forEach(function (evt) {
       body.addEventListener(evt, function () { body.classList.remove('drag-over'); });
     });
     body.addEventListener('drop', function (e) {
-      if (e.dataTransfer.files.length > 0) CLU.handleEditModalUpload(e.dataTransfer.files);
+      if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        CLU.handleEditModalUpload(e.dataTransfer.files);
+      }
     });
   };
 
-  // ── handleEditModalUpload ───────────────────────────────────────────────
+  // ── handleEditModalUpload — uploads immediately, appends to end ─────────
 
   CLU.handleEditModalUpload = function (files) {
     var folder = document.getElementById('editInlineFolderName');
@@ -278,13 +329,15 @@
             })
               .then(function (r2) { return r2.json(); })
               .then(function (img) {
-                if (img.success) {
-                  var c = document.getElementById('editInlineContainer');
-                  if (c) {
-                    c.insertAdjacentHTML('beforeend', CLU.generateCardHTML(file.path, img.imageData));
-                    CLU.sortInlineEditCards();
-                  }
+                if (!img.success) return;
+                var c = document.getElementById('editInlineContainer');
+                if (!c) return;
+                var relPath = _relativize(file.path, folderName);
+                c.insertAdjacentHTML('beforeend', CLU.generateCardHTML(relPath, img.imageData));
+                if (CLU._editState && CLU._editState.originalOrder.indexOf(relPath) === -1) {
+                  CLU._editState.originalOrder.push(relPath);
                 }
+                CLU.renumberDisplay();
               })
               .catch(function (e) { console.error('Error loading uploaded image:', e); });
           });
@@ -298,11 +351,171 @@
       });
   };
 
-  // ── saveEditedCBZ ───────────────────────────────────────────────────────
+  function _relativize(absPath, baseFolder) {
+    if (!absPath) return '';
+    if (!baseFolder) return absPath;
+    // Normalize trailing slash on base
+    var base = baseFolder.endsWith('/') || baseFolder.endsWith('\\') ? baseFolder : (baseFolder + '/');
+    if (absPath.indexOf(base) === 0) return absPath.substring(base.length);
+    // Try with the alternate separator just in case
+    var altBase = baseFolder.replace(/\\/g, '/');
+    var altPath = absPath.replace(/\\/g, '/');
+    if (altPath.indexOf(altBase + '/') === 0) return altPath.substring(altBase.length + 1);
+    return _basename(absPath); // fallback
+  }
+
+  // ── setEditModalThumbSize ───────────────────────────────────────────────
+
+  var THUMB_SIZE_KEY = 'cbzEditThumbSize';
+  var THUMB_SIZE_GRID = {
+    large: ['row-cols-2', 'row-cols-sm-3', 'row-cols-md-4'],
+    small: ['row-cols-3', 'row-cols-sm-4', 'row-cols-md-6', 'row-cols-lg-8']
+  };
+  var ALL_ROW_COLS = (function () {
+    var set = new Set();
+    Object.keys(THUMB_SIZE_GRID).forEach(function (k) {
+      THUMB_SIZE_GRID[k].forEach(function (c) { set.add(c); });
+    });
+    return Array.from(set);
+  })();
+
+  CLU.setEditModalThumbSize = function (size) {
+    if (size !== 'large' && size !== 'small') size = 'large';
+
+    var modal = document.getElementById('editCBZModal');
+    if (modal) modal.classList.toggle('cbz-edit-size-small', size === 'small');
+
+    var container = document.getElementById('editInlineContainer');
+    if (container) {
+      ALL_ROW_COLS.forEach(function (c) { container.classList.remove(c); });
+      THUMB_SIZE_GRID[size].forEach(function (c) { container.classList.add(c); });
+    }
+
+    document.querySelectorAll('.cbz-edit-size-btn').forEach(function (btn) {
+      btn.classList.toggle('active', btn.getAttribute('data-thumb-size') === size);
+    });
+
+    try { localStorage.setItem(THUMB_SIZE_KEY, size); } catch (e) { /* private mode etc. */ }
+  };
+
+  // ── initEditModalReorder — call after cards render on modal open ────────
+
+  CLU.initEditModalReorder = function () {
+    var container = document.getElementById('editInlineContainer');
+    if (!container) return;
+    if (typeof Sortable === 'undefined') {
+      console.error('Sortable.js not loaded — drag-reorder disabled');
+      return;
+    }
+
+    // Fresh state every modal open.
+    if (CLU._editState && CLU._editState.sortable) {
+      try { CLU._editState.sortable.destroy(); } catch (e) {}
+    }
+    CLU._editState = _newState();
+
+    var folderEl = document.getElementById('editInlineFolderName');
+    CLU._editState.baseFolder = folderEl ? folderEl.value : '';
+
+    // Snapshot initial order in DOM order (post-sortInlineEditCards alphabetical).
+    Array.from(container.children).forEach(function (card) {
+      var rel = card.getAttribute('data-rel-path');
+      if (!rel) {
+        var span = card.querySelector('.editable-filename');
+        rel = span ? span.getAttribute('data-rel-path') : null;
+      }
+      if (rel) {
+        // Promote data-rel-path onto the .col itself so deletes/drags can read it.
+        card.setAttribute('data-rel-path', rel);
+        CLU._editState.originalOrder.push(rel);
+      }
+    });
+
+    // Reset hidden form fields.
+    var pd = document.getElementById('editInlinePendingDeletes');
+    var po = document.getElementById('editInlinePendingOrder');
+    if (pd) pd.value = '[]';
+    if (po) po.value = '[]';
+
+    // Attach Sortable.
+    CLU._editState.sortable = new Sortable(container, {
+      animation: 150,
+      handle: '.cbz-edit-thumb-wrap',
+      ghostClass: 'cbz-edit-ghost',
+      chosenClass: 'cbz-edit-chosen',
+      onEnd: function (evt) {
+        if (evt.oldIndex === evt.newIndex) return;
+        CLU._editState.dragged = true;
+        _markDirty();
+        CLU.renumberDisplay();
+      }
+    });
+
+    _attachCloseGuard();
+    _clearDirty();
+
+    // Restore last-used thumbnail size preference.
+    var stored = null;
+    try { stored = localStorage.getItem(THUMB_SIZE_KEY); } catch (e) { /* ignore */ }
+    CLU.setEditModalThumbSize(stored === 'small' ? 'small' : 'large');
+  };
+
+  // ── Close guard — warn before discarding pending changes ────────────────
+
+  function _attachCloseGuard() {
+    var modalEl = document.getElementById('editCBZModal');
+    if (!modalEl || !CLU._editState || CLU._editState.closeGuardAttached) return;
+    CLU._editState.closeGuardAttached = true;
+
+    modalEl.addEventListener('hide.bs.modal', function (e) {
+      if (!CLU._editState || !CLU._editState.dirty) return;
+      var ok = window.confirm('You have unsaved changes. Discard them?');
+      if (!ok) {
+        e.preventDefault();
+        return;
+      }
+      _clearDirty();
+    });
+  }
+
+  // ── saveEditedCBZ — populate hidden fields and POST ─────────────────────
 
   CLU.saveEditedCBZ = function () {
     var form = document.getElementById('editInlineSaveForm');
     if (!form) { CLU.showError('Form not found'); return; }
+
+    if (!CLU._editState) {
+      // Safety: should be set by initEditModalReorder; if not, build a minimal state.
+      CLU._editState = _newState();
+    }
+
+    var container = document.getElementById('editInlineContainer');
+    var cards = container ? Array.from(container.children) : [];
+    var width = String(Math.max(cards.length, 1)).length;
+    if (width < 3) width = 3;
+
+    var order = [];
+    cards.forEach(function (card, idx) {
+      var rel = card.getAttribute('data-rel-path');
+      if (!rel) return;
+      var finalName;
+      if (CLU._editState.pendingRenames.has(rel)) {
+        finalName = CLU._editState.pendingRenames.get(rel);
+      } else if (CLU._editState.dragged) {
+        var ext = _splitExt(_basename(rel)).ext;
+        finalName = _padNum(idx + 1, width) + ext;
+      } else {
+        finalName = _basename(rel);
+      }
+      order.push({ rel_path: rel, final_name: finalName });
+    });
+
+    var deletes = Array.from(CLU._editState.pendingDeletes);
+
+    var pd = document.getElementById('editInlinePendingDeletes');
+    var po = document.getElementById('editInlinePendingOrder');
+    if (pd) pd.value = JSON.stringify(deletes);
+    if (po) po.value = JSON.stringify(order);
 
     CLU.showToast('Saving', 'Saving CBZ file...', 'info');
     var fd = new FormData(form);
@@ -314,6 +527,7 @@
       .then(function (data) {
         if (data.success) {
           CLU.showSuccess('CBZ file saved successfully!');
+          _clearDirty();
           var modal = bootstrap.Modal.getInstance(document.getElementById('editCBZModal'));
           if (modal) modal.hide();
 

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -3006,7 +3006,7 @@ function initEditMode(filePath) {
 
     // Update modal title with filename
     const filename = filePath.split('/').pop().split('\\').pop();
-    document.getElementById('editCBZModalLabel').textContent = `Editing CBZ File | ${filename}`;
+    document.getElementById('editCBZModalText').textContent = `Editing ${filename}`;
 
     // Setup drag-drop upload zone
     CLU.setupEditModalDropZone();
@@ -3025,6 +3025,7 @@ function initEditMode(filePath) {
             document.getElementById('editInlineZipFilePath').value = data.zip_file_path;
             document.getElementById('editInlineOriginalFilePath').value = data.original_file_path;
             CLU.sortInlineEditCards();
+            CLU.initEditModalReorder();
         })
         .catch(error => {
             container.innerHTML = `<div class="alert alert-danger" role="alert">

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -6202,6 +6202,10 @@ function openEditModal(filePath) {
   editModal.show();
   CLU.setupEditModalDropZone();
 
+  // Update modal title with filename
+  const filename = filePath.split('/').pop().split('\\').pop();
+  document.getElementById('editCBZModalText').textContent = `Editing ${filename}`;
+
   // Load CBZ contents
   fetch(`/edit?file_path=${encodeURIComponent(filePath)}`)
     .then(response => {
@@ -6216,6 +6220,7 @@ function openEditModal(filePath) {
       document.getElementById('editInlineZipFilePath').value = data.zip_file_path;
       document.getElementById('editInlineOriginalFilePath').value = data.original_file_path;
       CLU.sortInlineEditCards();
+      CLU.initEditModalReorder();
     })
     .catch(error => {
       container.innerHTML = `<div class="alert alert-danger" role="alert">

--- a/static/js/metadata_browser.js
+++ b/static/js/metadata_browser.js
@@ -303,7 +303,7 @@
                     </button></div>`;
                 editModal.show();
                 const filename = item.path.split('/').pop().split('\\').pop();
-                document.getElementById('editCBZModalLabel').textContent = `Editing CBZ File | ${filename}`;
+                document.getElementById('editCBZModalText').textContent = `Editing ${filename}`;
                 CLU.setupEditModalDropZone();
                 fetch(`/edit?file_path=${encodeURIComponent(item.path)}`)
                     .then(r => r.ok ? r.json() : Promise.reject(new Error('Failed to load edit content.')))
@@ -313,6 +313,7 @@
                         document.getElementById('editInlineZipFilePath').value = data.zip_file_path;
                         document.getElementById('editInlineOriginalFilePath').value = data.original_file_path;
                         CLU.sortInlineEditCards();
+                        CLU.initEditModalReorder();
                     })
                     .catch(err => {
                         container.innerHTML = `<div class="alert alert-danger"><strong>Error:</strong> ${err.message}</div>`;

--- a/templates/partials/modal_cbz_edit.html
+++ b/templates/partials/modal_cbz_edit.html
@@ -7,12 +7,26 @@
   #editCBZModal .cbz-edit-thumb-wrap {
     /* Constrains thumbnail height regardless of card width.
        Lower max-height = smaller thumbnails. */
-    max-height: 280px;
+    max-height: 336px;
     overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
     background: var(--bs-body-bg);
+    cursor: grab;
+  }
+  #editCBZModal.cbz-edit-size-small .cbz-edit-thumb-wrap {
+    max-height: 168px;
+  }
+  #editCBZModal.cbz-edit-size-small .card-body {
+    padding: 0.25rem !important;
+    font-size: 0.75rem;
+  }
+  #editCBZModal.cbz-edit-size-small .btn-group-sm .btn {
+    padding: 0.15rem 0.3rem;
+  }
+  #editCBZModal .cbz-edit-thumb-wrap:active {
+    cursor: grabbing;
   }
   #editCBZModal .cbz-edit-thumb {
     max-width: 100%;
@@ -20,6 +34,7 @@
     width: auto;
     height: auto;
     object-fit: contain;
+    pointer-events: none; /* let drag events reach the wrap */
   }
   #editCBZModal .cbz-edit-filename-wrap {
     word-break: break-word;
@@ -29,12 +44,44 @@
   #editCBZModal .cbz-edit-filename-wrap .filename-input {
     width: 100%;
   }
+  /* Sortable.js drag feedback */
+  #editCBZModal .cbz-edit-ghost {
+    opacity: 0.4;
+  }
+  #editCBZModal .cbz-edit-chosen {
+    outline: 2px solid var(--bs-primary);
+  }
+  /* Pending-changes badge in modal title */
+  #editCBZModal .cbz-edit-dirty-badge {
+    display: none;
+    margin-left: 0.5rem;
+    font-size: 0.75rem;
+    vertical-align: middle;
+  }
+  #editCBZModal.cbz-edit-dirty .cbz-edit-dirty-badge {
+    display: inline-block;
+  }
 </style>
 <div class="modal fade" id="editCBZModal" tabindex="-1" aria-labelledby="editCBZModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-fullscreen">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="editCBZModalLabel">Editing CBZ File</h5>
+        <h5 class="modal-title flex-grow-1" id="editCBZModalLabel">
+          <span id="editCBZModalText">Editing&hellip;</span>
+          <span class="badge bg-warning text-dark cbz-edit-dirty-badge">unsaved changes</span>
+        </h5>
+        <div class="btn-group btn-group-sm me-2" role="group" aria-label="Thumbnail size">
+          <button type="button" class="btn btn-outline-secondary cbz-edit-size-btn active"
+                  data-thumb-size="large" onclick="CLU.setEditModalThumbSize('large')"
+                  title="Large thumbnails">
+            <i class="bi bi-grid"></i>
+          </button>
+          <button type="button" class="btn btn-outline-secondary cbz-edit-size-btn"
+                  data-thumb-size="small" onclick="CLU.setEditModalThumbSize('small')"
+                  title="Small thumbnails">
+            <i class="bi bi-grid-3x3-gap"></i>
+          </button>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
@@ -50,8 +97,11 @@
           <input type="hidden" name="folder_name" id="editInlineFolderName">
           <input type="hidden" name="zip_file_path" id="editInlineZipFilePath">
           <input type="hidden" name="original_file_path" id="editInlineOriginalFilePath">
+          <input type="hidden" name="pending_deletes" id="editInlinePendingDeletes" value="[]">
+          <input type="hidden" name="pending_order" id="editInlinePendingOrder" value="[]">
         </form>
       </div>
     </div>
   </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>


### PR DESCRIPTION
## 📝 Description
Introduce a deferred edit workflow so client changes (reorders, renames, deletes) are batched and only applied when SAVE is clicked. Adds an 8 thumbnail small view for re-ordering in addition to the newer, larger thumbnail view.
**Server:** add `_safe_join` and `_validate_final_name`, parse/validate `pending_deletes` and `pending_order` JSON, apply deletes and perform atomic two-phase renames (source→temp→final) to avoid collisions, and harden` get_image_data_url` to accept a target height. 
**Client JS:** add CLU._editState, pendingDeletes/pendingRenames, renumbering, deferred delete/rename logic, drag-reorder via Sortable.js, thumbnail size toggle (persisted), close-guard for unsaved edits, and populate hidden pending_* fields before submit. 
**Templates/markup:** update edit modal to include data-rel-path attributes, hidden pending fields, UI tweaks (dirty badge, thumbnail sizing) and load Sortable. Update callers to set modal text and initialize reorder on load.

Closes #317 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1666" height="1051" alt="Screenshot 2026-05-27 123455" src="https://github.com/user-attachments/assets/97cbc704-5ea1-47e2-8ab5-d49454c135bd" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass