### PR TITLE
Stage and Save Pending Source-Wall Edits

### DIFF
--- a/routes/source_wall.py
+++ b/routes/source_wall.py
@@ -13,7 +13,6 @@ from helpers.library import is_valid_library_path
 from core.database import (
     get_source_wall_files,
     update_file_index_ci_field,
-    bulk_update_file_index_ci_field,
     get_user_preference,
     set_user_preference,
     get_distinct_ci_values,
@@ -74,71 +73,61 @@ def get_files():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
-@source_wall_bp.route('/api/source-wall/update-field', methods=['POST'])
-def update_field():
-    """Update a single ci_ field for one file, then sync to CBZ in background."""
+@source_wall_bp.route('/api/source-wall/save-pending', methods=['POST'])
+def save_pending():
+    """Commit a stash of staged edits.
+
+    Body: {"updates": {"<path>": {"<ci_field>": "<value>", ...}, ...}}
+
+    Each path appears exactly once with all its accumulated field changes,
+    so the parallel CBZ-write contract (distinct paths) holds, and each
+    file receives a single rebuild rather than one per field.
+    """
     data = request.get_json(silent=True) or {}
-    path = data.get('path', '')
-    field = data.get('field', '')
-    value = data.get('value', '')
+    updates = data.get('updates') or {}
 
-    if not path or not is_valid_library_path(path):
-        return jsonify({"success": False, "error": "Invalid path"}), 403
+    if not isinstance(updates, dict) or not updates:
+        return jsonify({"success": False, "error": "No updates provided"}), 400
 
-    if field not in CI_FIELD_TO_XML:
-        return jsonify({"success": False, "error": f"Invalid field: {field}"}), 400
+    for path, fields in updates.items():
+        if not is_valid_library_path(path):
+            return jsonify({"success": False, "error": f"Invalid path: {path}"}), 403
+        if not isinstance(fields, dict) or not fields:
+            return jsonify({"success": False, "error": f"No fields for path: {path}"}), 400
+        for field in fields.keys():
+            if field not in CI_FIELD_TO_XML:
+                return jsonify({"success": False, "error": f"Invalid field: {field}"}), 400
 
-    ok = update_file_index_ci_field(path, field, value)
-    if not ok:
-        return jsonify({"success": False, "error": "Database update failed"}), 500
+    edit_count = 0
+    for path, fields in updates.items():
+        for field, value in fields.items():
+            ok = update_file_index_ci_field(path, field, value)
+            if not ok:
+                return jsonify({"success": False, "error": "Database update failed"}), 500
+            edit_count += 1
 
-    # Sync to CBZ in background
-    xml_tag = CI_FIELD_TO_XML[field]
-    t = threading.Thread(
-        target=_sync_field_to_cbz,
-        args=(path, {xml_tag: value}),
-        daemon=True,
-    )
-    t.start()
-
-    return jsonify({"success": True})
-
-
-@source_wall_bp.route('/api/source-wall/bulk-update', methods=['POST'])
-def bulk_update():
-    """Bulk update a ci_ field across multiple files with background CBZ sync."""
-    data = request.get_json(silent=True) or {}
-    paths = data.get('paths', [])
-    field = data.get('field', '')
-    value = data.get('value', '')
-
-    if not paths:
-        return jsonify({"success": False, "error": "No files specified"}), 400
-
-    if field not in CI_FIELD_TO_XML:
-        return jsonify({"success": False, "error": f"Invalid field: {field}"}), 400
-
-    for p in paths:
-        if not is_valid_library_path(p):
-            return jsonify({"success": False, "error": f"Invalid path: {p}"}), 403
-
-    affected = bulk_update_file_index_ci_field(paths, field, value)
-    if affected < 0:
-        return jsonify({"success": False, "error": "Database update failed"}), 500
+    items = [
+        (path, {CI_FIELD_TO_XML[field]: value for field, value in fields.items()})
+        for path, fields in updates.items()
+    ]
 
     import core.app_state as app_state
-    xml_tag = CI_FIELD_TO_XML[field]
-    label = f"Updating {xml_tag} for {len(paths)} files"
-    op_id = app_state.register_operation("source_wall", label, total=len(paths))
+    label = f"Saving updates to {len(items)} files"
+    op_id = app_state.register_operation("source_wall", label, total=len(items))
 
     t = threading.Thread(
-        target=_bulk_sync_to_cbz,
-        args=(paths, xml_tag, value, op_id),
+        target=_bulk_sync_pending_to_cbz,
+        args=(items, op_id),
         daemon=True,
     )
     t.start()
 
-    return jsonify({"success": True, "op_id": op_id, "affected": affected})
+    return jsonify({
+        "success": True,
+        "op_id": op_id,
+        "affected": len(items),
+        "edits": edit_count,
+    })
 
 
 @source_wall_bp.route('/api/source-wall/columns')
@@ -179,21 +168,15 @@ def suggest_values():
     return jsonify({"success": True, "values": values})
 
 
-def _sync_field_to_cbz(path, updates):
-    """Sync field changes to the actual CBZ file."""
-    try:
-        import core.comicinfo as comicinfo
-        comicinfo.update_comicinfo_in_zip(path, updates)
-    except Exception as e:
-        app_logger.error(f"Failed to sync field to CBZ {path}: {e}")
+def _bulk_sync_pending_to_cbz(items, op_id):
+    """Background worker: rebuild each CBZ once with all its staged field changes.
 
-
-def _bulk_sync_to_cbz(paths, xml_tag, value, op_id):
-    """Background worker: sync field change to multiple CBZ files in parallel."""
+    `items` is a list of (path, {xml_tag: value, ...}) tuples where each path
+    appears exactly once, satisfying the distinct-path contract of
+    bulk_update_comicinfo_in_zips.
+    """
     import core.app_state as app_state
     import core.comicinfo as comicinfo
-
-    items = [(path, {xml_tag: value}) for path in paths]
 
     def on_progress(completed, total, path, error):
         app_state.update_operation(

--- a/static/css/source_wall.css
+++ b/static/css/source_wall.css
@@ -75,6 +75,17 @@
     animation: swFlashError 1s ease forwards;
 }
 
+/* Pending (staged but not yet saved) edits */
+.sw-cell-pending {
+    background-color: rgba(255, 193, 7, 0.18);
+    border-left: 3px solid rgba(255, 193, 7, 0.9);
+    font-style: italic;
+}
+
+.sw-cell-pending:hover {
+    background-color: rgba(255, 193, 7, 0.28);
+}
+
 /* Directory rows */
 .sw-directory-row {
     cursor: pointer;

--- a/static/js/source_wall.js
+++ b/static/js/source_wall.js
@@ -15,6 +15,14 @@ let swLastSelectedIndex = -1;
 let swActiveFilter = null;
 let swReadIssuesSet = new Set();
 
+// Staged edits awaiting "Save Updates". Map<path, Map<field, value>>.
+// Edits accumulate here instead of firing per-cell saves — avoids the race
+// where two background workers collide on the same .tmpzip sidecar.
+let swPendingEdits = new Map();
+// Snapshot of cell values captured the first time a cell is staged, so
+// Discard can revert without re-fetching.
+let swOriginalValues = new Map();
+
 // Load read issues for source wall
 fetch('/api/issues-read-paths')
     .then(r => r.json())
@@ -416,10 +424,13 @@ function renderTable() {
         tr.appendChild(tdRead);
 
         // Data columns
+        const pendingForFile = swPendingEdits.get(file.path);
         swActiveColumns.forEach(col => {
             const td = document.createElement('td');
             const colDef = SW_COLUMNS[col];
-            const value = file[col] || '';
+            let value = file[col] || '';
+            const pendingValue = pendingForFile ? pendingForFile.get(col) : undefined;
+            if (pendingValue !== undefined) value = pendingValue;
 
             if (col === 'name') {
                 td.className = 'sw-name-cell';
@@ -431,6 +442,7 @@ function renderTable() {
                 td.title = value;
                 td.dataset.path = file.path;
                 td.dataset.field = col;
+                if (pendingValue !== undefined) td.classList.add('sw-cell-pending');
                 td.addEventListener('click', () => startCellEdit(td, file.path, col));
             } else {
                 td.textContent = value;
@@ -590,7 +602,7 @@ function startCellEdit(td, path, field) {
         td.title = newValue;
 
         if (newValue !== originalText) {
-            saveFieldUpdate(path, field, newValue, td);
+            stagePendingEdit(path, field, newValue);
         }
     }
 
@@ -696,36 +708,6 @@ function renderSuggestions(suggestList, values, input, field) {
     suggestList.style.display = 'block';
 }
 
-function saveFieldUpdate(path, field, value, td) {
-    fetch('/api/source-wall/update-field', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path, field, value }),
-    })
-        .then(r => r.json())
-        .then(data => {
-            if (data.success) {
-                td.classList.remove('sw-flash-error');
-                td.classList.add('sw-flash-success');
-                setTimeout(() => td.classList.remove('sw-flash-success'), 1000);
-
-                // Update in-memory data
-                const file = swFiles.find(f => f.path === path);
-                if (file) file[field] = value;
-            } else {
-                td.classList.add('sw-flash-error');
-                setTimeout(() => td.classList.remove('sw-flash-error'), 1000);
-                CLU.showError(data.error || 'Update failed');
-            }
-        })
-        .catch(err => {
-            td.classList.add('sw-flash-error');
-            setTimeout(() => td.classList.remove('sw-flash-error'), 1000);
-            CLU.showError('Network error');
-            console.error(err);
-        });
-}
-
 // ── File Selection ──
 
 function handleFileSelect(path, index, event) {
@@ -785,15 +767,172 @@ function clearSelection() {
 function updateBulkBar() {
     const bar = document.getElementById('swBulkBar');
     const count = document.getElementById('swBulkCount');
+    const selectionGroup = document.getElementById('swBulkSelectionGroup');
+
     if (swSelectedFiles.size > 0) {
-        bar.classList.remove('d-none');
         count.textContent = `${swSelectedFiles.size} selected`;
+        if (selectionGroup) selectionGroup.classList.remove('d-none');
+    } else if (selectionGroup) {
+        selectionGroup.classList.add('d-none');
+    }
+
+    if (swSelectedFiles.size > 0 || swPendingEdits.size > 0) {
+        bar.classList.remove('d-none');
     } else {
         bar.classList.add('d-none');
     }
 }
 
-// ── Bulk Update ──
+// ── Pending Edits (staging) ──
+
+function updatePendingSummary() {
+    const group = document.getElementById('swBulkPendingGroup');
+    const counter = document.getElementById('swPendingCount');
+    let totalEdits = 0;
+    swPendingEdits.forEach(fields => { totalEdits += fields.size; });
+
+    if (totalEdits > 0) {
+        if (group) group.classList.remove('d-none');
+        if (counter) {
+            const files = swPendingEdits.size;
+            counter.textContent = `${totalEdits} pending edit${totalEdits === 1 ? '' : 's'} across ${files} file${files === 1 ? '' : 's'}`;
+        }
+    } else if (group) {
+        group.classList.add('d-none');
+    }
+}
+
+function applyPendingCellVisual(path, field) {
+    document.querySelectorAll(`td[data-path="${CSS.escape(path)}"][data-field="${field}"]`).forEach(td => {
+        td.classList.add('sw-cell-pending');
+    });
+}
+
+function clearPendingCellVisual(path, field) {
+    document.querySelectorAll(`td[data-path="${CSS.escape(path)}"][data-field="${field}"]`).forEach(td => {
+        td.classList.remove('sw-cell-pending');
+    });
+}
+
+function stagePendingEdit(path, field, newValue) {
+    const file = swFiles.find(f => f.path === path);
+    const currentSaved = (file ? (file[field] || '') : '');
+    const normalised = (newValue == null) ? '' : String(newValue);
+
+    // First time we touch this cell, remember its saved value for Discard.
+    if (!swOriginalValues.has(path)) swOriginalValues.set(path, new Map());
+    const origMap = swOriginalValues.get(path);
+    if (!origMap.has(field)) origMap.set(field, currentSaved);
+
+    const originalSaved = origMap.get(field);
+
+    if (normalised === originalSaved) {
+        // Edit reverts to original — drop from stash.
+        if (swPendingEdits.has(path)) {
+            swPendingEdits.get(path).delete(field);
+            if (swPendingEdits.get(path).size === 0) {
+                swPendingEdits.delete(path);
+                swOriginalValues.delete(path);
+            } else {
+                origMap.delete(field);
+            }
+        }
+        clearPendingCellVisual(path, field);
+        // Restore the on-screen cell text to the original saved value.
+        document.querySelectorAll(`td[data-path="${CSS.escape(path)}"][data-field="${field}"]`).forEach(td => {
+            td.textContent = originalSaved;
+            td.title = originalSaved;
+        });
+    } else {
+        if (!swPendingEdits.has(path)) swPendingEdits.set(path, new Map());
+        swPendingEdits.get(path).set(field, normalised);
+        document.querySelectorAll(`td[data-path="${CSS.escape(path)}"][data-field="${field}"]`).forEach(td => {
+            td.textContent = normalised;
+            td.title = normalised;
+            td.classList.add('sw-cell-pending');
+        });
+    }
+
+    updatePendingSummary();
+    updateBulkBar();
+}
+
+function discardPendingEdits() {
+    if (swPendingEdits.size === 0) return;
+
+    swPendingEdits.forEach((fields, path) => {
+        const origMap = swOriginalValues.get(path);
+        fields.forEach((_value, field) => {
+            const orig = (origMap && origMap.has(field)) ? origMap.get(field) : '';
+            document.querySelectorAll(`td[data-path="${CSS.escape(path)}"][data-field="${field}"]`).forEach(td => {
+                td.textContent = orig;
+                td.title = orig;
+                td.classList.remove('sw-cell-pending');
+            });
+        });
+    });
+
+    swPendingEdits.clear();
+    swOriginalValues.clear();
+    updatePendingSummary();
+    updateBulkBar();
+    CLU.showSuccess('Pending edits discarded');
+}
+
+function savePendingEdits() {
+    if (swPendingEdits.size === 0) return;
+
+    const updates = {};
+    swPendingEdits.forEach((fields, path) => {
+        const obj = {};
+        fields.forEach((value, field) => { obj[field] = value; });
+        updates[path] = obj;
+    });
+
+    const btn = document.getElementById('swSavePendingBtn');
+    if (btn) btn.disabled = true;
+
+    fetch('/api/source-wall/save-pending', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ updates }),
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                CLU.showSuccess(`Saving ${data.edits} edit${data.edits === 1 ? '' : 's'} across ${data.affected} file${data.affected === 1 ? '' : 's'}`);
+
+                // Apply staged values to in-memory rows and clear pending visuals.
+                swPendingEdits.forEach((fields, path) => {
+                    const file = swFiles.find(f => f.path === path);
+                    fields.forEach((value, field) => {
+                        if (file) file[field] = value;
+                        document.querySelectorAll(`td[data-path="${CSS.escape(path)}"][data-field="${field}"]`).forEach(td => {
+                            td.classList.remove('sw-cell-pending');
+                            td.classList.add('sw-flash-success');
+                            setTimeout(() => td.classList.remove('sw-flash-success'), 1000);
+                        });
+                    });
+                });
+
+                swPendingEdits.clear();
+                swOriginalValues.clear();
+                updatePendingSummary();
+                updateBulkBar();
+            } else {
+                CLU.showError(data.error || 'Save failed');
+            }
+        })
+        .catch(err => {
+            CLU.showError('Network error');
+            console.error(err);
+        })
+        .finally(() => {
+            if (btn) btn.disabled = false;
+        });
+}
+
+// ── Bulk Stage ──
 
 function applyBulkUpdate() {
     const field = document.getElementById('swBulkField').value;
@@ -807,39 +946,11 @@ function applyBulkUpdate() {
     const paths = [...swSelectedFiles];
     if (paths.length === 0) return;
 
-    fetch('/api/source-wall/bulk-update', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ paths, field, value }),
-    })
-        .then(r => r.json())
-        .then(data => {
-            if (data.success) {
-                CLU.showSuccess(`Updated ${paths.length} files`);
+    paths.forEach(p => stagePendingEdit(p, field, value));
 
-                // Update table cells immediately
-                paths.forEach(p => {
-                    const file = swFiles.find(f => f.path === p);
-                    if (file) file[field] = value;
-
-                    document.querySelectorAll(`td[data-path="${CSS.escape(p)}"][data-field="${field}"]`).forEach(td => {
-                        td.textContent = value;
-                        td.title = value;
-                        td.classList.add('sw-flash-success');
-                        setTimeout(() => td.classList.remove('sw-flash-success'), 1000);
-                    });
-                });
-
-                clearSelection();
-                document.getElementById('swBulkValue').value = '';
-            } else {
-                CLU.showError(data.error || 'Bulk update failed');
-            }
-        })
-        .catch(err => {
-            CLU.showError('Network error');
-            console.error(err);
-        });
+    CLU.showSuccess(`Staged ${paths.length} edit${paths.length === 1 ? '' : 's'} — click Save Updates to commit`);
+    clearSelection();
+    document.getElementById('swBulkValue').value = '';
 }
 
 // ── Column Preferences ──
@@ -1073,6 +1184,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 selectLibrary(lib.path, lib.name, lib.id);
             }
         } catch (e) { /* ignore */ }
+    }
+});
+
+window.addEventListener('beforeunload', (e) => {
+    if (swPendingEdits.size > 0) {
+        e.preventDefault();
+        e.returnValue = '';
     }
 });
 

--- a/templates/source_wall.html
+++ b/templates/source_wall.html
@@ -65,30 +65,42 @@
 
 <!-- Bulk Action Bar -->
 <div id="swBulkBar" class="sw-bulk-action-bar d-none">
-  <span id="swBulkCount" class="fw-bold">0 selected</span>
-  <select id="swBulkField" class="form-select form-select-sm" style="max-width: 180px;">
-    <option value="">Select field...</option>
-    <option value="ci_title">Title</option>
-    <option value="ci_series">Series</option>
-    <option value="ci_number">Number</option>
-    <option value="ci_count">Count</option>
-    <option value="ci_volume">Volume</option>
-    <option value="ci_year">Year</option>
-    <option value="ci_writer">Writer</option>
-    <option value="ci_penciller">Penciller</option>
-    <option value="ci_inker">Inker</option>
-    <option value="ci_colorist">Colorist</option>
-    <option value="ci_letterer">Letterer</option>
-    <option value="ci_coverartist">Cover Artist</option>
-    <option value="ci_publisher">Publisher</option>
-    <option value="ci_genre">Genre</option>
-    <option value="ci_characters">Characters</option>
-  </select>
-  <input type="text" id="swBulkValue" class="form-control form-control-sm" style="max-width: 250px;"
-         placeholder="New value...">
-  <button class="btn btn-sm btn-primary" onclick="applyBulkUpdate()">
-    <i class="bi bi-check2-all me-1"></i>Apply
-  </button>
+  <span id="swBulkSelectionGroup" class="d-flex align-items-center gap-2">
+    <span id="swBulkCount" class="fw-bold">0 selected</span>
+    <select id="swBulkField" class="form-select form-select-sm" style="max-width: 180px;">
+      <option value="">Select field...</option>
+      <option value="ci_title">Title</option>
+      <option value="ci_series">Series</option>
+      <option value="ci_number">Number</option>
+      <option value="ci_count">Count</option>
+      <option value="ci_volume">Volume</option>
+      <option value="ci_year">Year</option>
+      <option value="ci_writer">Writer</option>
+      <option value="ci_penciller">Penciller</option>
+      <option value="ci_inker">Inker</option>
+      <option value="ci_colorist">Colorist</option>
+      <option value="ci_letterer">Letterer</option>
+      <option value="ci_coverartist">Cover Artist</option>
+      <option value="ci_publisher">Publisher</option>
+      <option value="ci_genre">Genre</option>
+      <option value="ci_characters">Characters</option>
+    </select>
+    <input type="text" id="swBulkValue" class="form-control form-control-sm" style="max-width: 250px;"
+           placeholder="New value...">
+    <button class="btn btn-sm btn-primary" onclick="applyBulkUpdate()" title="Stage this value for the selected files">
+      <i class="bi bi-check2-all me-1"></i>Stage
+    </button>
+  </span>
+  <span id="swBulkPendingGroup" class="d-flex align-items-center gap-2 d-none">
+    <span class="vr mx-1 opacity-50"></span>
+    <span id="swPendingCount" class="text-warning fw-bold"></span>
+    <button class="btn btn-sm btn-success" onclick="savePendingEdits()" id="swSavePendingBtn">
+      <i class="bi bi-save me-1"></i>Save Updates
+    </button>
+    <button class="btn btn-sm btn-outline-warning" onclick="discardPendingEdits()" id="swDiscardPendingBtn">
+      <i class="bi bi-arrow-counterclockwise me-1"></i>Discard
+    </button>
+  </span>
   <span class="vr mx-1 opacity-50"></span>
   <button class="btn btn-sm btn-outline-danger" onclick="bulkDeleteSW()" title="Delete selected files">
     <i class="bi bi-trash me-1"></i>Delete

--- a/tests/routes/test_source_wall_routes.py
+++ b/tests/routes/test_source_wall_routes.py
@@ -42,80 +42,76 @@ class TestSourceWallFiles:
         assert resp.status_code == 403
 
 
-class TestSourceWallUpdateField:
+class TestSourceWallSavePending:
 
+    @patch("core.app_state.register_operation", return_value="op-456")
     @patch("routes.source_wall.threading")
     @patch("routes.source_wall.update_file_index_ci_field", return_value=True)
     @patch("routes.source_wall.is_valid_library_path", return_value=True)
-    def test_single_field_update_succeeds(self, mock_valid, mock_update, mock_thread, client):
+    def test_save_pending_multi_path_multi_field(self, mock_valid, mock_update,
+                                                  mock_thread, mock_register, client):
         mock_thread.Thread.return_value = MagicMock()
 
-        resp = client.post("/api/source-wall/update-field",
-                           data=json.dumps({"path": "/data/comic.cbz",
-                                            "field": "ci_series",
-                                            "value": "Spider-Man"}),
-                           content_type="application/json")
+        resp = client.post(
+            "/api/source-wall/save-pending",
+            data=json.dumps({
+                "updates": {
+                    "/data/a.cbz": {"ci_publisher": "Boom", "ci_year": "2023"},
+                    "/data/b.cbz": {"ci_publisher": "Boom"},
+                }
+            }),
+            content_type="application/json",
+        )
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["success"] is True
-        mock_update.assert_called_once_with("/data/comic.cbz", "ci_series", "Spider-Man")
+        assert data["op_id"] == "op-456"
+        assert data["affected"] == 2
+        assert data["edits"] == 3
+
+        calls = {(c.args[0], c.args[1], c.args[2]) for c in mock_update.call_args_list}
+        assert ("/data/a.cbz", "ci_publisher", "Boom") in calls
+        assert ("/data/a.cbz", "ci_year", "2023") in calls
+        assert ("/data/b.cbz", "ci_publisher", "Boom") in calls
+
+        # One distinct path per worker item — guarantees no .tmpzip race.
+        thread_kwargs = mock_thread.Thread.call_args.kwargs
+        items = thread_kwargs["args"][0]
+        paths_in_items = [item[0] for item in items]
+        assert len(paths_in_items) == len(set(paths_in_items))
 
     @patch("routes.source_wall.is_valid_library_path", return_value=True)
-    def test_invalid_field_rejected(self, mock_valid, client):
-        resp = client.post("/api/source-wall/update-field",
-                           data=json.dumps({"path": "/data/comic.cbz",
-                                            "field": "invalid_field",
-                                            "value": "test"}),
+    def test_save_pending_empty_updates_rejected(self, mock_valid, client):
+        resp = client.post("/api/source-wall/save-pending",
+                           data=json.dumps({"updates": {}}),
                            content_type="application/json")
         assert resp.status_code == 400
 
     @patch("routes.source_wall.is_valid_library_path", return_value=False)
-    def test_invalid_path_rejected(self, mock_valid, client):
-        resp = client.post("/api/source-wall/update-field",
-                           data=json.dumps({"path": "/etc/bad",
-                                            "field": "ci_series",
-                                            "value": "test"}),
-                           content_type="application/json")
+    def test_save_pending_invalid_path_rejected(self, mock_valid, client):
+        resp = client.post(
+            "/api/source-wall/save-pending",
+            data=json.dumps({"updates": {"/etc/passwd": {"ci_series": "x"}}}),
+            content_type="application/json",
+        )
         assert resp.status_code == 403
 
-
-class TestSourceWallBulkUpdate:
-
-    @patch("core.app_state.register_operation", return_value="op-123")
-    @patch("routes.source_wall.threading")
-    @patch("routes.source_wall.bulk_update_file_index_ci_field", return_value=3)
     @patch("routes.source_wall.is_valid_library_path", return_value=True)
-    def test_bulk_update_registers_operation(self, mock_valid, mock_bulk, mock_thread,
-                                              mock_register, client):
-        mock_thread.Thread.return_value = MagicMock()
-
-        resp = client.post("/api/source-wall/bulk-update",
-                           data=json.dumps({
-                               "paths": ["/data/a.cbz", "/data/b.cbz", "/data/c.cbz"],
-                               "field": "ci_writer",
-                               "value": "Alan Moore",
-                           }),
-                           content_type="application/json")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["success"] is True
-        assert data["op_id"] == "op-123"
-        assert data["affected"] == 3
-
-    @patch("routes.source_wall.is_valid_library_path", return_value=True)
-    def test_bulk_update_empty_paths_rejected(self, mock_valid, client):
-        resp = client.post("/api/source-wall/bulk-update",
-                           data=json.dumps({"paths": [], "field": "ci_writer", "value": "x"}),
-                           content_type="application/json")
+    def test_save_pending_invalid_field_rejected(self, mock_valid, client):
+        resp = client.post(
+            "/api/source-wall/save-pending",
+            data=json.dumps({"updates": {"/data/a.cbz": {"bad_field": "x"}}}),
+            content_type="application/json",
+        )
         assert resp.status_code == 400
 
     @patch("routes.source_wall.is_valid_library_path", return_value=True)
-    def test_bulk_update_invalid_field_rejected(self, mock_valid, client):
-        resp = client.post("/api/source-wall/bulk-update",
-                           data=json.dumps({"paths": ["/data/a.cbz"],
-                                            "field": "bad",
-                                            "value": "x"}),
-                           content_type="application/json")
+    def test_save_pending_empty_fields_for_path_rejected(self, mock_valid, client):
+        resp = client.post(
+            "/api/source-wall/save-pending",
+            data=json.dumps({"updates": {"/data/a.cbz": {}}}),
+            content_type="application/json",
+        )
         assert resp.status_code == 400
 
 


### PR DESCRIPTION
## 📝 Description
Replace per-cell update and old bulk-update endpoints with a single /api/source-wall/save-pending that accepts a map of path -> {ci_field: value, ...}. The server now applies individual DB updates, registers a single background operation and starts a worker that rebuilds each CBZ once with all staged changes (avoids .tmpzip races). 
JavaScript/UI were extended to support staging edits in-memory (swPendingEdits/swOriginalValues), show a pending visual state (.sw-cell-pending), allow bulk staging, and provide Save Updates / Discard actions; beforeunload warns about unsaved edits. Tests updated to assert batched save behavior and validations; removed old single-field/bulk-update paths and related helper usage.

Closes #322

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass