### PR TITLE
Add Bulk Revert for Metadata History

### DIFF
--- a/routes/bulk_metadata.py
+++ b/routes/bulk_metadata.py
@@ -875,36 +875,35 @@ def audit_list():
     return jsonify({"success": True, "items": rows, "total": total})
 
 
-@bulk_metadata_bp.route('/api/bulk-metadata/audit/<int:audit_id>/revert', methods=['POST'])
-def audit_revert(audit_id):
-    """Restore the prior ComicInfo.xml for an audited write.
+def _revert_audit_row(audit_id):
+    """Perform the on-disk revert + file_index sync + mark_audit_reverted for
+    one audit row. Returns ``(success: bool, error: str|None, status: int)``.
 
-    If prior_xml is NULL the file had no ComicInfo before — revert removes
-    the ComicInfo.xml we wrote. Otherwise the prior bytes are re-applied.
+    ``status`` mirrors the HTTP code the single-revert endpoint would return —
+    callers either honour it directly (single revert) or roll it up into an
+    aggregate response (bulk revert).
     """
     row = get_bulk_audit(audit_id)
     if not row:
-        return _err("audit entry not found", status=404)
+        return False, "audit entry not found", 404
     if row.get('reverted_at'):
-        return _err("already reverted", status=409)
+        return False, "already reverted", 409
 
     file_path = row['file_path']
     if not os.path.exists(file_path):
-        return _err(f"file no longer exists: {file_path}", status=410)
+        return False, f"file no longer exists: {file_path}", 410
 
     prior = row.get('prior_xml')
-
     try:
         if prior:
             # Re-apply the prior XML (add_comicinfo_to_cbz overwrites by design).
             from routes.metadata import add_comicinfo_to_cbz
             add_comicinfo_to_cbz(file_path, bytes(prior))
         else:
-            # No prior metadata — strip ComicInfo.xml from the archive.
             _strip_comicinfo_from_cbz(file_path)
     except Exception as e:
         app_logger.error(f"Revert failed for audit {audit_id}: {e}")
-        return _err(f"revert failed: {e}", status=500)
+        return False, f"revert failed: {e}", 500
 
     # Keep file_index in sync with the on-disk state.
     try:
@@ -914,7 +913,58 @@ def audit_revert(audit_id):
         app_logger.warning(f"file_index sync failed for revert of {file_path}: {e}")
 
     mark_audit_reverted(audit_id)
+    return True, None, 200
+
+
+@bulk_metadata_bp.route('/api/bulk-metadata/audit/<int:audit_id>/revert', methods=['POST'])
+def audit_revert(audit_id):
+    """Restore the prior ComicInfo.xml for an audited write.
+
+    If prior_xml is NULL the file had no ComicInfo before — revert removes
+    the ComicInfo.xml we wrote. Otherwise the prior bytes are re-applied.
+    """
+    ok, err, status = _revert_audit_row(audit_id)
+    if not ok:
+        return _err(err, status=status)
     return jsonify({"success": True})
+
+
+@bulk_metadata_bp.route('/api/bulk-metadata/audit/revert-multiple', methods=['POST'])
+def audit_revert_multiple():
+    """Bulk revert: accepts a list of audit ids and reverts each one in turn.
+
+    Body: ``{"ids": [int, ...]}``
+    Response: ``{success, reverted: [ids], failed: [{id, error}], message}``
+    Returns 200 with aggregate results even when some rows fail — matches
+    the `/api/reading-lists/bulk-delete` envelope.
+    """
+    data = request.get_json(silent=True) or {}
+    ids = data.get('ids')
+    if not isinstance(ids, list) or not ids:
+        return _err("ids must be a non-empty list")
+
+    app_logger.info(f"[bulk-meta] revert-multiple count={len(ids)} ids={ids}")
+
+    reverted = []
+    failed = []
+    for raw_id in ids:
+        try:
+            aid = int(raw_id)
+        except (TypeError, ValueError):
+            failed.append({"id": raw_id, "error": "invalid id"})
+            continue
+        ok, err, _ = _revert_audit_row(aid)
+        if ok:
+            reverted.append(aid)
+        else:
+            failed.append({"id": aid, "error": err})
+
+    return jsonify({
+        "success": True,
+        "reverted": reverted,
+        "failed": failed,
+        "message": f"Reverted {len(reverted)} of {len(ids)} entries",
+    })
 
 
 def _strip_comicinfo_from_cbz(file_path):

--- a/templates/metadata_history.html
+++ b/templates/metadata_history.html
@@ -45,21 +45,34 @@
     </div>
   </div>
 
+  <div id="auditBulkBar" class="d-flex align-items-center gap-2 mb-2 d-none">
+    <span class="fw-bold"><span id="auditBulkCount">0</span> selected</span>
+    <button id="auditBulkClear" type="button" class="btn btn-sm btn-outline-secondary">
+      <i class="bi bi-x-lg me-1"></i>Clear
+    </button>
+    <button id="auditBulkRevert" type="button" class="btn btn-sm btn-danger">
+      <i class="bi bi-arrow-counterclockwise me-1"></i>Revert selected
+    </button>
+  </div>
+
   <div class="table-responsive">
     <table class="table table-sm table-hover align-middle">
       <thead>
         <tr>
+          <th style="width: 2.5rem;">
+            <input type="checkbox" id="auditSelectAll" class="form-check-input" title="Select all eligible rows on this page">
+          </th>
           <th>When</th>
           <th>File</th>
           <th>Series → Issue</th>
           <th>Provider</th>
           <th>Source</th>
           <th>Status</th>
-          <th></th>
+          <th class="text-end" style="width: 7rem;">Actions</th>
         </tr>
       </thead>
       <tbody id="auditTbody">
-        <tr><td colspan="7" class="text-center text-muted py-4">Loading…</td></tr>
+        <tr><td colspan="8" class="text-center text-muted py-4">Loading…</td></tr>
       </tbody>
     </table>
   </div>
@@ -69,13 +82,44 @@
   </nav>
 </div>
 
+{% include 'partials/modal_cbz_info.html' %}
+{% include 'partials/toast_container.html' %}
+
+<!-- Confirmation modal — used in place of window.confirm() so the page is
+     toast-only with no native browser dialogs. -->
+<div class="modal fade" id="auditConfirmModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="auditConfirmTitle">Confirm</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="auditConfirmBody">Are you sure?</div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="auditConfirmOk">Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/clu-utils.js') }}?v={{ range(1, 10000) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-cbz-info.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script>
 (function () {
   const tbody = document.getElementById('auditTbody');
   const pageEl = document.getElementById('auditPagination');
+  const bulkBar = document.getElementById('auditBulkBar');
+  const bulkCount = document.getElementById('auditBulkCount');
+  const masterCheckbox = document.getElementById('auditSelectAll');
   const limit = 50;
   let offset = 0;
   let total = 0;
+  const selected = new Set();  // audit ids checked across renders on the current page
 
   function fmtTime(ts) {
     if (!ts) return '';
@@ -91,6 +135,75 @@
     return p.split(/[\\/]/).pop();
   }
 
+  function updateBulkBar() {
+    const n = selected.size;
+    bulkCount.textContent = n;
+    bulkBar.classList.toggle('d-none', n === 0);
+  }
+
+  function clearSelection() {
+    selected.clear();
+    tbody.querySelectorAll('.audit-row-check').forEach(cb => { cb.checked = false; });
+    masterCheckbox.checked = false;
+    masterCheckbox.indeterminate = false;
+    updateBulkBar();
+  }
+
+  function notifyError(message) {
+    if (window.CLU && typeof CLU.showError === 'function') {
+      CLU.showError(message);
+    } else {
+      // Fallback only when clu-utils failed to load — should never happen.
+      console.error('[metadata-history]', message);
+    }
+  }
+
+  function notifySuccess(message) {
+    if (window.CLU && typeof CLU.showSuccess === 'function') {
+      CLU.showSuccess(message);
+    } else {
+      console.info('[metadata-history]', message);
+    }
+  }
+
+  // Modal-based confirmation (replaces window.confirm so the page has no
+  // native browser dialogs). Returns a Promise that resolves true/false.
+  function confirmAction(title, body, okLabel, okVariant) {
+    return new Promise(function (resolve) {
+      const modalEl = document.getElementById('auditConfirmModal');
+      const titleEl = document.getElementById('auditConfirmTitle');
+      const bodyEl = document.getElementById('auditConfirmBody');
+      const okBtn = document.getElementById('auditConfirmOk');
+      titleEl.textContent = title;
+      bodyEl.textContent = body;
+      okBtn.textContent = okLabel || 'Confirm';
+      okBtn.className = 'btn btn-' + (okVariant || 'danger');
+
+      let settled = false;
+      const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+      function cleanup() {
+        okBtn.removeEventListener('click', onOk);
+        modalEl.removeEventListener('hidden.bs.modal', onHide);
+      }
+      function onOk() {
+        settled = true;
+        cleanup();
+        modal.hide();
+        resolve(true);
+      }
+      function onHide() {
+        if (!settled) {
+          cleanup();
+          resolve(false);
+        }
+      }
+      okBtn.addEventListener('click', onOk);
+      modalEl.addEventListener('hidden.bs.modal', onHide);
+      modal.show();
+    });
+  }
+
   async function load() {
     const params = new URLSearchParams({
       limit: String(limit),
@@ -103,7 +216,11 @@
     if (provider) params.set('provider', provider);
     if (status) params.set('status', status);
 
-    tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-4">Loading…</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">Loading…</td></tr>';
+    selected.clear();
+    masterCheckbox.checked = false;
+    masterCheckbox.indeterminate = false;
+    updateBulkBar();
     try {
       const r = await fetch('/api/bulk-metadata/audit?' + params.toString());
       const d = await r.json();
@@ -111,22 +228,27 @@
       renderRows(d.items || []);
       renderPagination();
     } catch (e) {
-      tbody.innerHTML = `<tr><td colspan="7" class="text-danger text-center">Error: ${esc(e.message)}</td></tr>`;
+      tbody.innerHTML = `<tr><td colspan="8" class="text-danger text-center">Error: ${esc(e.message)}</td></tr>`;
+      notifyError('Failed to load audit history: ' + (e.message || 'unknown error'));
     }
   }
 
   function renderRows(items) {
     if (!items.length) {
-      tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-4">No matching entries.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">No matching entries.</td></tr>';
       return;
     }
     tbody.innerHTML = '';
     items.forEach(item => {
       const tr = document.createElement('tr');
       const isReverted = !!item.reverted_at;
+      const fileBase = basename(item.file_path);
       tr.innerHTML = `
+        <td>
+          ${isReverted ? '' : `<input type="checkbox" class="form-check-input audit-row-check" data-id="${item.id}">`}
+        </td>
         <td class="small text-muted">${esc(fmtTime(item.written_at))}</td>
-        <td class="small"><code title="${esc(item.file_path)}">${esc(basename(item.file_path))}</code></td>
+        <td class="small"><code title="${esc(item.file_path)}">${esc(fileBase)}</code></td>
         <td class="small">${esc(item.series_name || '')} ${item.issue_number ? '#' + esc(item.issue_number) : ''}</td>
         <td class="small"><span class="badge bg-secondary">${esc(item.provider || '')}</span></td>
         <td class="small text-muted">${esc(item.matched_via || '')}</td>
@@ -136,30 +258,114 @@
             : '<span class="badge bg-success">written</span>'}
         </td>
         <td class="text-end">
-          ${isReverted ? '' : `<button class="btn btn-sm btn-outline-danger action-revert" data-id="${item.id}">
-            <i class="bi bi-arrow-counterclockwise"></i> Revert
-          </button>`}
+          <div class="btn-group btn-group-sm" role="group">
+            <button class="btn btn-outline-info action-info" type="button"
+                    data-file="${esc(item.file_path)}" data-name="${esc(fileBase)}"
+                    title="View CBZ info">
+              <i class="bi bi-info-circle"></i>
+            </button>
+            ${isReverted ? '' : `<button class="btn btn-outline-danger action-revert" type="button"
+                    data-id="${item.id}" title="Revert this write">
+              <i class="bi bi-arrow-counterclockwise"></i>
+            </button>`}
+          </div>
         </td>`;
-      const btn = tr.querySelector('.action-revert');
-      if (btn) {
-        btn.addEventListener('click', () => doRevert(item.id, tr));
+
+      const revertBtn = tr.querySelector('.action-revert');
+      if (revertBtn) {
+        revertBtn.addEventListener('click', () => doRevert(item.id));
+      }
+      const infoBtn = tr.querySelector('.action-info');
+      if (infoBtn) {
+        infoBtn.addEventListener('click', () => {
+          if (window.CLU && typeof CLU.showCBZInfo === 'function') {
+            CLU.showCBZInfo(infoBtn.dataset.file, infoBtn.dataset.name);
+          } else {
+            notifyError('CBZ Info modal is unavailable.');
+          }
+        });
+      }
+      const cb = tr.querySelector('.audit-row-check');
+      if (cb) {
+        cb.addEventListener('change', () => {
+          if (cb.checked) selected.add(item.id);
+          else selected.delete(item.id);
+          updateBulkBar();
+          syncMasterCheckbox();
+        });
       }
       tbody.appendChild(tr);
     });
+    syncMasterCheckbox();
   }
 
-  async function doRevert(id, tr) {
-    if (!confirm('Revert this metadata write?')) return;
+  function syncMasterCheckbox() {
+    const boxes = tbody.querySelectorAll('.audit-row-check');
+    if (!boxes.length) {
+      masterCheckbox.checked = false;
+      masterCheckbox.indeterminate = false;
+      return;
+    }
+    let checkedCount = 0;
+    boxes.forEach(cb => { if (cb.checked) checkedCount += 1; });
+    masterCheckbox.checked = checkedCount === boxes.length;
+    masterCheckbox.indeterminate = checkedCount > 0 && checkedCount < boxes.length;
+  }
+
+  async function doRevert(id) {
+    const ok = await confirmAction('Revert metadata write', 'Revert this metadata write?', 'Revert', 'danger');
+    if (!ok) return;
     try {
       const r = await fetch(`/api/bulk-metadata/audit/${id}/revert`, { method: 'POST' });
       const d = await r.json();
       if (d && d.success) {
+        notifySuccess('Metadata write reverted.');
         load();
       } else {
-        alert((d && d.error) || 'Revert failed');
+        notifyError((d && d.error) || 'Revert failed');
       }
     } catch (e) {
-      alert(e.message || 'Revert failed');
+      notifyError(e.message || 'Revert failed');
+    }
+  }
+
+  async function doBulkRevert() {
+    if (selected.size === 0) return;
+    const n = selected.size;
+    const ok = await confirmAction(
+      'Revert selected',
+      `Revert ${n} metadata write${n === 1 ? '' : 's'}?`,
+      'Revert ' + n,
+      'danger'
+    );
+    if (!ok) return;
+    const ids = Array.from(selected);
+    try {
+      const r = await fetch('/api/bulk-metadata/audit/revert-multiple', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: ids })
+      });
+      const d = await r.json();
+      if (d && d.success) {
+        const okN = (d.reverted || []).length;
+        const failN = (d.failed || []).length;
+        if (failN === 0) {
+          notifySuccess(`Reverted ${okN} metadata write${okN === 1 ? '' : 's'}.`);
+        } else {
+          // Partial failure — surface BOTH counts so the user knows what
+          // happened. Detail goes to the console for debugging.
+          notifyError(`Reverted ${okN}, ${failN} failed. See console for details.`);
+          if (window.console) {
+            console.warn('[metadata-history] revert-multiple failures:', d.failed);
+          }
+        }
+        load();
+      } else {
+        notifyError((d && d.error) || 'Bulk revert failed');
+      }
+    } catch (e) {
+      notifyError(e.message || 'Bulk revert failed');
     }
   }
 
@@ -185,6 +391,19 @@
     }
     add('»', Math.min(pages, current + 1), current === pages, false);
   }
+
+  masterCheckbox.addEventListener('change', () => {
+    const checked = masterCheckbox.checked;
+    tbody.querySelectorAll('.audit-row-check').forEach(cb => {
+      cb.checked = checked;
+      const id = Number(cb.dataset.id);
+      if (checked) selected.add(id);
+      else selected.delete(id);
+    });
+    updateBulkBar();
+  });
+  document.getElementById('auditBulkClear').addEventListener('click', clearSelection);
+  document.getElementById('auditBulkRevert').addEventListener('click', doBulkRevert);
 
   document.getElementById('auditRefresh').addEventListener('click', () => { offset = 0; load(); });
   ['auditSearch', 'auditProvider', 'auditStatus'].forEach(id => {

--- a/tests/routes/test_bulk_metadata.py
+++ b/tests/routes/test_bulk_metadata.py
@@ -281,6 +281,110 @@ class TestRevert:
         assert _read_xml_from_cbz(cbz) is None
 
 
+class TestRevertMultiple:
+    """`/api/bulk-metadata/audit/revert-multiple` — bulk-revert endpoint with
+    an aggregate result envelope (matches /api/reading-lists/bulk-delete)."""
+
+    def _seed_audit_rows(self, tmp_path, count=3):
+        """Create ``count`` CBZs (each with a prior ComicInfo) + matching
+        audit rows. Returns (cbz_paths, audit_ids)."""
+        import uuid as _uuid
+        from core.database import create_bulk_job, log_bulk_audit
+
+        folder = tmp_path / 'Audit'
+        folder.mkdir(exist_ok=True)
+        cbz_paths = []
+        for i in range(1, count + 1):
+            cbz_paths.append(_make_cbz(folder / f'A 00{i}.cbz', with_comicinfo=True))
+
+        job_id = _uuid.uuid4().hex
+        create_bulk_job(job_id=job_id, scope_type='files', scope_payload={'paths': cbz_paths})
+        audit_ids = []
+        for fp in cbz_paths:
+            new_xml = b'<?xml version="1.0"?><ComicInfo><Series>New</Series></ComicInfo>'
+            # Mimic what _write_metadata does: capture prior, apply new.
+            import zipfile
+            prior_bytes = b'<?xml version="1.0"?><ComicInfo><Series>Old</Series></ComicInfo>'
+            # Re-pack with the new xml so the on-disk state matches an audit row.
+            tmp_zip = fp + '.tmp'
+            with zipfile.ZipFile(fp, 'r') as src:
+                with zipfile.ZipFile(tmp_zip, 'w', zipfile.ZIP_DEFLATED) as dst:
+                    for info in src.infolist():
+                        if os.path.basename(info.filename).lower() == 'comicinfo.xml':
+                            continue
+                        dst.writestr(info, src.read(info.filename))
+                    dst.writestr('ComicInfo.xml', new_xml)
+            os.replace(tmp_zip, fp)
+            aid = log_bulk_audit(
+                job_id=job_id,
+                file_path=fp,
+                folder_path=str(folder),
+                provider='metron',
+                series_id='1',
+                issue_id='1',
+                series_name='A',
+                issue_number='1',
+                year=2020,
+                matched_via='manual_review',
+                prior_xml=prior_bytes,
+                new_xml=new_xml,
+            )
+            audit_ids.append(aid)
+        return cbz_paths, audit_ids
+
+    def test_handles_mixed_outcomes(self, bulk_client, tmp_path):
+        from core.database import mark_audit_reverted
+        cbz_paths, audit_ids = self._seed_audit_rows(tmp_path, count=3)
+        good_id = audit_ids[0]
+        already_id = audit_ids[1]
+        mark_audit_reverted(already_id)  # simulate prior revert
+        missing_id = 999_999
+
+        r = bulk_client.post(
+            '/api/bulk-metadata/audit/revert-multiple',
+            json={'ids': [good_id, already_id, missing_id]},
+        )
+        assert r.status_code == 200
+        d = r.get_json()
+        assert d['success'] is True
+        assert d['reverted'] == [good_id]
+        # Failures mention the appropriate errors.
+        failed_by_id = {f['id']: f['error'] for f in d['failed']}
+        assert already_id in failed_by_id
+        assert 'already reverted' in failed_by_id[already_id]
+        assert missing_id in failed_by_id
+        assert 'not found' in failed_by_id[missing_id]
+        # And the good file actually got reverted on disk (prior XML restored).
+        assert b'<Series>Old</Series>' in _read_xml_from_cbz(cbz_paths[0])
+
+    def test_rejects_empty_ids(self, bulk_client):
+        r = bulk_client.post(
+            '/api/bulk-metadata/audit/revert-multiple',
+            json={'ids': []},
+        )
+        assert r.status_code == 400
+
+    def test_rejects_non_list_ids(self, bulk_client):
+        r = bulk_client.post(
+            '/api/bulk-metadata/audit/revert-multiple',
+            json={'ids': 'not-a-list'},
+        )
+        assert r.status_code == 400
+
+    def test_invalid_id_format_recorded_as_failure(self, bulk_client, tmp_path):
+        """Non-numeric ids land in the failed list with 'invalid id' — they
+        shouldn't break the whole batch."""
+        _, audit_ids = self._seed_audit_rows(tmp_path, count=1)
+        r = bulk_client.post(
+            '/api/bulk-metadata/audit/revert-multiple',
+            json={'ids': [audit_ids[0], 'bogus']},
+        )
+        assert r.status_code == 200
+        d = r.get_json()
+        assert audit_ids[0] in d['reverted']
+        assert any(f.get('id') == 'bogus' for f in d['failed'])
+
+
 class TestApplyCvinfo:
     """The /apply-cvinfo endpoint: direct ID entry writes cvinfo + applies
     metadata to every CBZ in the folder and cascade-resolves sibling reviews."""


### PR DESCRIPTION
## 📝 Description
Introduce server- and client-side support to revert multiple bulk-metadata audit rows.

Server: factor revert logic into _revert_audit_row(...) which returns (ok, error, status); audit_revert() now delegates to it. Add POST /api/bulk-metadata/audit/revert-multiple to accept a list of ids, attempt each revert, and return an aggregate envelope with reverted and failed entries (partial failures allowed).

Client/template: enhance metadata_history.html with per-row checkboxes, a master select, a bulk action bar, a confirmation modal, CBZ-info hooks, and new JS to manage selection, confirm actions, and call the bulk revert endpoint. Adjust table columns and loading states.

Tests: add TestRevertMultiple to validate mixed outcomes, invalid inputs, and partial failures, and ensure on-disk state is correct after a successful revert.

## 🛠️ Changes Made
- [] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1336" height="463" alt="image" src="https://github.com/user-attachments/assets/111b1045-9a45-4daa-a0b7-15dae5bb1ea8" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass