### PR TITLE
Create ComicInfo.xml when missing in updater

### DIFF
--- a/core/comicinfo.py
+++ b/core/comicinfo.py
@@ -330,13 +330,16 @@ def update_comicinfo_in_zip(zip_path: str, updates: dict):
     all files to disk. Internally, this still rebuilds the ZIP because
     in-place edits aren't supported by the ZIP format.
 
+    If the archive has no ComicInfo.xml, a fresh one is created at the
+    root containing only the provided tags.
+
     :param zip_path: Path to the .zip or .cbz file.
     :param updates:  Dict of XML tag -> new value, e.g. {'Title': 'Updated Title'}.
     """
     _, ext = os.path.splitext(zip_path)
     if ext.lower() not in ['.zip', '.cbz']:
         raise ValueError("Only .zip or .cbz files are supported by this function.")
-    
+
     temp_zip_path = zip_path + ".tmpzip"
 
     with zipfile.ZipFile(zip_path, 'r') as old_zip, \
@@ -357,6 +360,11 @@ def update_comicinfo_in_zip(zip_path: str, updates: dict):
             else:
                 # Copy all other files as-is
                 new_zip.writestr(item, old_zip.read(item.filename))
+
+        if comicinfo_path is None:
+            empty_xml = b'<?xml version="1.0" encoding="utf-8"?><ComicInfo/>'
+            new_xml = update_comicinfo_xml(empty_xml, updates)
+            new_zip.writestr('ComicInfo.xml', new_xml)
 
     # Replace the original ZIP/CBZ with the updated one
     os.replace(temp_zip_path, zip_path)

--- a/routes/source_wall.py
+++ b/routes/source_wall.py
@@ -181,13 +181,7 @@ def _bulk_sync_pending_to_cbz(items, op_id):
     from core.database import set_has_comicinfo
 
     def _resync_has_comicinfo(path):
-        """Re-read the archive and flip file_index.has_comicinfo to match.
-
-        update_comicinfo_in_zip only mutates an existing ComicInfo.xml; if the
-        file had none to begin with, the rewrite is a no-op and has_comicinfo
-        should stay at 0. Checking disk after the fact is the only reliable
-        signal.
-        """
+        """Re-read the archive and flip file_index.has_comicinfo to match on-disk state."""
         try:
             with zipfile.ZipFile(path, 'r') as z:
                 present = 1 if comicinfo.find_comicinfo_in_zip(z) else 0

--- a/tests/routes/test_source_wall_routes.py
+++ b/tests/routes/test_source_wall_routes.py
@@ -141,8 +141,8 @@ class TestSourceWallHasComicinfoSync:
 
         # File A: has ComicInfo on disk; file_index incorrectly reads 0.
         a = self._make_cbz(tmp_path / 'a.cbz', with_comicinfo=True)
-        # File B: no ComicInfo on disk; the rewrite is a no-op, so the flag
-        # must stay at 0.
+        # File B: no ComicInfo on disk; the save creates a fresh one, so the
+        # flag must flip to 1.
         b = self._make_cbz(tmp_path / 'b.cbz', with_comicinfo=False)
 
         for p in (a, b):
@@ -176,9 +176,56 @@ class TestSourceWallHasComicinfoSync:
         assert a_row is not None and a_row['has_comicinfo'] == 1, (
             "File with existing ComicInfo should now read has_comicinfo=1"
         )
-        assert b_row is not None and b_row['has_comicinfo'] == 0, (
-            "File without ComicInfo should stay at 0 (rewrite was a no-op)"
+        assert b_row is not None and b_row['has_comicinfo'] == 1, (
+            "File without ComicInfo should flip to 1 after a fresh XML is created"
         )
+
+    def test_creates_comicinfo_when_missing(self, db_connection, tmp_path):
+        """Source Wall save on a CBZ with no ComicInfo writes a fresh one
+        containing only the staged fields — no defaults injected."""
+        import zipfile
+        from core.database import (
+            add_file_index_entry,
+            set_has_comicinfo,
+            get_db_connection,
+        )
+        from core.comicinfo import find_comicinfo_in_zip, read_comicinfo_from_zip
+        from routes.source_wall import _bulk_sync_pending_to_cbz
+
+        path = self._make_cbz(tmp_path / 'fresh.cbz', with_comicinfo=False)
+        add_file_index_entry(
+            name='fresh.cbz', path=path, entry_type='file', size=1,
+            parent=str(tmp_path),
+        )
+        set_has_comicinfo(path, 0)
+
+        import core.app_state as app_state
+        op_id = app_state.register_operation('source_wall_test', 'test', total=1)
+
+        _bulk_sync_pending_to_cbz(
+            items=[(path, {'Series': 'X', 'Title': 'Y', 'Year': '2024'})],
+            op_id=op_id,
+        )
+
+        with zipfile.ZipFile(path, 'r') as z:
+            ci_path = find_comicinfo_in_zip(z)
+            assert ci_path is not None, "ComicInfo.xml should now exist"
+            assert "/" not in ci_path and "\\" not in ci_path, (
+                "ComicInfo.xml must be at the archive root"
+            )
+
+        parsed = read_comicinfo_from_zip(path)
+        assert parsed == {'Series': 'X', 'Title': 'Y', 'Year': '2024'}, (
+            "Only staged fields should be written — no LanguageISO/Manga/Notes "
+            "defaults from generate_comicinfo_xml"
+        )
+
+        conn = get_db_connection()
+        row = conn.execute(
+            "SELECT has_comicinfo FROM file_index WHERE path = ?", (path,)
+        ).fetchone()
+        conn.close()
+        assert row is not None and row['has_comicinfo'] == 1
 
 
 class TestSourceWallColumns:

--- a/tests/unit/test_comicinfo.py
+++ b/tests/unit/test_comicinfo.py
@@ -210,3 +210,40 @@ class TestReadComicinfoFromZip:
         rar_file.write_bytes(b"fake data")
         with pytest.raises(ValueError, match="Only .zip or .cbz"):
             read_comicinfo_from_zip(str(rar_file))
+
+
+# ===== update_comicinfo_in_zip =====
+
+class TestUpdateComicinfoInZip:
+
+    def test_patches_existing_comicinfo(self, create_cbz):
+        from core.comicinfo import update_comicinfo_in_zip, read_comicinfo_from_zip
+        xml = '<ComicInfo><Series>Old</Series></ComicInfo>'
+        path = create_cbz("patch.cbz", num_images=1, comicinfo_xml=xml)
+        update_comicinfo_in_zip(path, {"Series": "New", "Title": "Added"})
+        result = read_comicinfo_from_zip(path)
+        assert result["Series"] == "New"
+        assert result["Title"] == "Added"
+
+    def test_creates_comicinfo_when_missing(self, create_cbz):
+        import zipfile
+        from core.comicinfo import (
+            update_comicinfo_in_zip,
+            read_comicinfo_from_zip,
+            find_comicinfo_in_zip,
+        )
+        path = create_cbz("fresh.cbz", num_images=1, comicinfo_xml=None)
+        update_comicinfo_in_zip(path, {"Series": "Batman", "Title": "Year One"})
+
+        with zipfile.ZipFile(path, 'r') as z:
+            ci_path = find_comicinfo_in_zip(z)
+            assert ci_path is not None
+            assert "/" not in ci_path and "\\" not in ci_path  # root-level
+
+        result = read_comicinfo_from_zip(path)
+        assert result["Series"] == "Batman"
+        assert result["Title"] == "Year One"
+        # Only fields the caller asked for — no defaults like LanguageISO / Manga / Notes
+        assert "LanguageISO" not in result
+        assert "Manga" not in result
+        assert "Notes" not in result


### PR DESCRIPTION
## 📝 Description
Make update_comicinfo_in_zip create a fresh ComicInfo.xml at the archive root when none exists, rather than silently doing nothing. This writes only the provided tags and preserves other files by rebuilding the archive using a temporary ZIP.

Also tightened the _resync_has_comicinfo docstring and updated tests to reflect the new behavior: route-level tests now expect has_comicinfo to flip to 1 when a missing ComicInfo is created, and unit tests were added to cover both patching existing ComicInfo.xml and creating a new root-level ComicInfo containing only the staged fields.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass