### PR TITLE
Add Tab navigation between editable cells

### DIFF
--- a/static/js/source_wall.js
+++ b/static/js/source_wall.js
@@ -629,6 +629,15 @@ function startCellEdit(td, path, field) {
             e.preventDefault();
             input.removeEventListener('blur', commit);
             cancel();
+        } else if (e.key === 'Tab') {
+            const cells = Array.from(document.querySelectorAll('#swTableBody td.sw-editable-cell'));
+            const idx = cells.indexOf(td);
+            const next = e.shiftKey ? cells[idx - 1] : cells[idx + 1];
+            if (!next) return;
+            e.preventDefault();
+            input.removeEventListener('blur', commit);
+            commit();
+            startCellEdit(next, next.dataset.path, next.dataset.field);
         }
     });
 }


### PR DESCRIPTION
## 📝 Description
Handle the Tab key in the cell edit keydown handler to commit the current edit and move focus to the next (or previous with Shift+Tab) editable cell. It finds editable cells in #swTableBody, prevents default browser tab behavior, removes the blur listener, commits the current value, and starts editing the adjacent cell; does nothing if there is no adjacent cell.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x ] Manual test in `dev` container
- [x] Linting/Unit tests pass