### PR TITLE
Add multi-select mode and toggle to collection

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -1300,13 +1300,17 @@ def backup_database(max_backups: int = 3, force: bool = False):
         with zipfile.ZipFile(backup_path, "w", zipfile.ZIP_DEFLATED) as zf:
             zf.write(db_path, "comic_utils.db")
 
-            # Include WAL files if they exist
-            wal_path = db_path + "-wal"
-            shm_path = db_path + "-shm"
-            if os.path.exists(wal_path):
-                zf.write(wal_path, "comic_utils.db-wal")
-            if os.path.exists(shm_path):
-                zf.write(shm_path, "comic_utils.db-shm")
+            # Include WAL/SHM sidecars when present. SQLite can checkpoint and
+            # remove them concurrently, so guard against the TOCTOU race —
+            # the sidecars aren't load-bearing for restore (SQLite rebuilds
+            # them on next open).
+            for suffix, arcname in (("-wal", "comic_utils.db-wal"),
+                                    ("-shm", "comic_utils.db-shm")):
+                side_path = db_path + suffix
+                try:
+                    zf.write(side_path, arcname)
+                except (FileNotFoundError, OSError):
+                    pass
 
         app_logger.info(f"Database backup created: {backup_name}")
 

--- a/static/css/collection.css
+++ b/static/css/collection.css
@@ -780,6 +780,33 @@
     opacity: 1;
 }
 
+/* Multi-Select mode: always show checkbox indicator on file cards */
+body.collection-select-mode .grid-item.file .selection-checkbox {
+    opacity: 0.6;
+}
+
+body.collection-select-mode .grid-item.file.bulk-selected .selection-checkbox {
+    opacity: 1;
+}
+
+body.collection-select-mode .grid-item.file {
+    cursor: pointer;
+}
+
+/* Active state for the Multi-Select toggle button */
+#toggleCollectionSelectModeBtn.active {
+    background-color: #6c757d;
+    border-color: #6c757d;
+    color: #fff;
+    box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.35);
+}
+
+#toggleCollectionSelectModeBtn.active:hover {
+    background-color: #5c636a;
+    border-color: #565e64;
+    color: #fff;
+}
+
 /* Hide favorite/to-read button when selection checkbox is visible */
 .grid-item.file.bulk-selected .favorite-button,
 .grid-item.file.bulk-selected .to-read-button {

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -1668,25 +1668,17 @@ function renderGrid(items) {
                     return;
                 }
 
-                if (e.ctrlKey || e.metaKey) {
-                    // Ctrl/Cmd+Click: toggle selection
+                if (isCollectionSelectModeActive()) {
                     e.preventDefault();
-                    toggleFileSelection(gridItem, item.path);
-                    lastClickedFileItem = gridItem;
-                    lastClickedFilePath = item.path;
-                } else if (e.shiftKey && lastClickedFileItem) {
-                    // Shift+Click: range select
-                    e.preventDefault();
-                    selectFileRange(gridItem, item.path);
-                } else {
-                    // Regular click
-                    if (selectedFiles.size > 0) {
-                        // If selection is active, clear it
-                        clearFileSelection();
+                    if (e.shiftKey && lastClickedFileItem) {
+                        selectFileRange(gridItem, item.path);
                     } else {
-                        // No selection active, open file normally
-                        openFileDefault(item);
+                        toggleFileSelection(gridItem, item.path);
+                        lastClickedFileItem = gridItem;
+                        lastClickedFilePath = item.path;
                     }
+                } else {
+                    openFileDefault(item);
                 }
             };
 
@@ -1707,13 +1699,6 @@ function renderGrid(items) {
     });
 
     grid.appendChild(fragment);
-
-    // Show/hide selection hint based on whether files are present
-    const hint = document.getElementById('selectionHint');
-    if (hint) {
-        const hasFiles = items.some(i => i.type !== 'folder');
-        hint.style.display = hasFiles ? '' : 'none';
-    }
 
     // Initialize lazy loading
     initLazyLoading();
@@ -1796,6 +1781,7 @@ function clearFileSelection() {
 
 /**
  * Update the bulk action bar visibility and count.
+ * Visibility tracks Multi-Select mode (not selection size), matching reading_list.js.
  */
 function updateCollectionBulkActionBar() {
     const bar = document.getElementById('collectionBulkActionBar');
@@ -1804,7 +1790,7 @@ function updateCollectionBulkActionBar() {
 
     if (!bar) return;
 
-    if (selectedFiles.size > 0) {
+    if (isCollectionSelectModeActive()) {
         bar.style.display = '';
         if (countEl) countEl.textContent = `${selectedFiles.size} file${selectedFiles.size === 1 ? '' : 's'} selected`;
         if (grid) grid.classList.add('selection-active');
@@ -1812,12 +1798,36 @@ function updateCollectionBulkActionBar() {
         bar.style.display = 'none';
         if (grid) grid.classList.remove('selection-active');
     }
+}
 
-    // Hide selection hint when files are selected (bulk bar takes over)
+/**
+ * Multi-Select mode toggle (touch-friendly entry point).
+ */
+function isCollectionSelectModeActive() {
+    return document.body.classList.contains('collection-select-mode');
+}
+
+function toggleCollectionSelectMode() {
+    const enabling = !isCollectionSelectModeActive();
+    document.body.classList.toggle('collection-select-mode', enabling);
+
+    const toggleBtn = document.getElementById('toggleCollectionSelectModeBtn');
+    if (toggleBtn) toggleBtn.classList.toggle('active', enabling);
+
     const hint = document.getElementById('selectionHint');
-    if (hint) {
-        hint.style.display = selectedFiles.size > 0 ? 'none' : '';
+    if (hint) hint.style.display = enabling ? '' : 'none';
+
+    if (!enabling) {
+        // Exiting: drop selection state
+        selectedFiles.clear();
+        lastClickedFileItem = null;
+        lastClickedFilePath = null;
+        document.querySelectorAll('.grid-item.file.bulk-selected').forEach(el => {
+            el.classList.remove('bulk-selected');
+        });
     }
+
+    updateCollectionBulkActionBar();
 }
 
 /**

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -65,17 +65,14 @@
                     </button>
                 </div>
 
-                <!-- Per Page & Refresh -->
+                <!-- Multi-Select Toggle & Refresh -->
                 <div class="d-flex align-items-center gap-2">
-                    <div class="input-group input-group-sm">
-                        <label class="input-group-text bg-body border-0" for="itemsPerPage">Per page</label>
-                        <select class="form-select border-0 shadow-none bg-body" id="itemsPerPage" onchange="changeItemsPerPage(this.value)">
-                            <option value="21" selected>20</option>
-                            <option value="49">50</option>
-                            <option value="98">100</option>
-                            <option value="252">250</option>
-                        </select>
-                    </div>
+                    <button class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-1"
+                        id="toggleCollectionSelectModeBtn" onclick="toggleCollectionSelectMode()"
+                        title="Toggle multi-select mode">
+                        <i class="bi bi-check2-square"></i>
+                        <span>Multi-Select</span>
+                    </button>
                     <button class="btn btn-light border btn-sm" onclick="refreshCurrentView(true, true)" title="Refresh">
                         <i class="bi bi-arrow-clockwise text-muted"></i>
                     </button>
@@ -93,6 +90,17 @@
             <div id="gridSearchRow" style="flex: 0 0 auto; width: 100%; max-width: 250px;">
                 <!-- Search input will be dynamically populated by JS -->
             </div>
+            <div class="d-flex align-items-center" style="flex: 0 0 auto;">
+                <div class="input-group input-group-sm">
+                    <label class="input-group-text bg-body border-0" for="itemsPerPage">Per page</label>
+                    <select class="form-select border-0 shadow-none bg-body" id="itemsPerPage" onchange="changeItemsPerPage(this.value)">
+                        <option value="21" selected>20</option>
+                        <option value="49">50</option>
+                        <option value="98">100</option>
+                        <option value="252">250</option>
+                    </select>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -106,10 +114,10 @@
                 <h4 class="m-0" id="library-header-title"><i class="bi {{ section.icon }} me-2"></i>{{ section.title }}
                 </h4>
             </div>
-            <!-- Selection Hint -->
+            <!-- Selection Hint (shown only in Multi-Select mode) -->
             <div id="selectionHint" class="selection-hint" style="display: none;">
                 <i class="bi bi-info-circle me-1"></i>
-                <span>Ctrl+Click to select files &bull; Shift+Click for range</span>
+                <span>Click to select &bull; Shift+Click for range</span>
             </div>
             <div id="file-grid" class="file-grid">
             </div>

--- a/templates/partials/modal_bulk_metadata_review.html
+++ b/templates/partials/modal_bulk_metadata_review.html
@@ -31,7 +31,7 @@
 
 <!-- Bulk Metadata Review Modal -->
 <div class="modal fade" id="bulkMetadataReviewModal" tabindex="-1" aria-labelledby="bulkMetadataReviewLabel"
-  aria-hidden="true">
+  aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header d-block">


### PR DESCRIPTION
## 📝 Description
Introduce a touch-friendly Multi-Select mode for the collection view.

- CSS: show selection checkbox in collection-select-mode, add pointer cursor on cards, and active styles for the toggle button.
- JS: add isCollectionSelectModeActive and toggleCollectionSelectMode; change click handling to use Multi-Select mode (supports click to select, shift-range select, toggle selection) while preserving normal open behavior outside the mode; update bulk action bar visibility to track Multi-Select mode; clear selection when exiting mode; remove selection hint auto-toggle based on selectedFiles.
- Templates: add a Multi-Select toggle button and move the Per-page selector into the toolbar; update selection hint text to reflect click-to-select behavior.
- Modal: make bulk metadata review modal backdrop static and disable keyboard closing to avoid accidental dismissal.

These changes provide an explicit mode for bulk selection (better for touch/entry points) and improve UX consistency with the reading-list selection behavior.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass