### PR TITLE
Add API to write ComicInfo.xml from DB

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -10092,6 +10092,55 @@ def update_file_index_ci_field(path, field, value):
         return False
 
 
+def get_file_index_ci_for_paths(paths):
+    """
+    Read all ci_ metadata columns for a list of file paths.
+
+    Used by the Source Wall reconcile flow to write XML from DB state — it
+    pulls the current ci_ values for each selected file so the background
+    worker can rewrite ComicInfo.xml to match.
+
+    Args:
+        paths: List of file paths to look up
+
+    Returns:
+        Dict of {path: {ci_field: value, ...}} containing only paths that
+        exist in file_index. Missing paths are silently omitted.
+    """
+    if not paths:
+        return {}
+
+    result = {}
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return {}
+
+        c = conn.cursor()
+        ci_cols = sorted(ALLOWED_CI_FIELDS)
+        cols_sql = ", ".join(ci_cols)
+
+        # SQLite default SQLITE_MAX_VARIABLE_NUMBER is 999 in older builds;
+        # chunk at 500 to stay well under that on any platform.
+        for i in range(0, len(paths), 500):
+            chunk = paths[i:i + 500]
+            placeholders = ",".join("?" * len(chunk))
+            c.execute(
+                f"SELECT path, {cols_sql} FROM file_index WHERE path IN ({placeholders})",
+                chunk,
+            )
+            for row in c.fetchall():
+                d = dict(row)
+                path = d.pop("path")
+                result[path] = {k: (v or "") for k, v in d.items()}
+
+        conn.close()
+        return result
+    except Exception as e:
+        app_logger.error(f"Failed to read ci fields for paths: {e}")
+        return result
+
+
 def bulk_update_file_index_ci_field(paths, field, value):
     """
     Batch update a single ci_ field for multiple files.

--- a/routes/source_wall.py
+++ b/routes/source_wall.py
@@ -16,6 +16,7 @@ from core.database import (
     get_user_preference,
     set_user_preference,
     get_distinct_ci_values,
+    get_file_index_ci_for_paths,
 )
 
 source_wall_bp = Blueprint('source_wall', __name__)
@@ -127,6 +128,76 @@ def save_pending():
         "op_id": op_id,
         "affected": len(items),
         "edits": edit_count,
+    })
+
+
+@source_wall_bp.route('/api/source-wall/reconcile-from-db', methods=['POST'])
+def reconcile_from_db():
+    """Rewrite ComicInfo.xml on disk from current file_index ci_ values.
+
+    Body: {"paths": ["<path>", ...]}
+
+    For each path, reads the committed ci_ fields from file_index and rebuilds
+    the CBZ's ComicInfo.xml to match. Used to fix drift where the DB has
+    metadata but the on-disk XML is missing/stale (e.g., a previous save's
+    background write failed, or the archive was edited externally).
+
+    Treats the DB as the source of truth — any non-empty ci_ field is written;
+    files with all-empty ci_ values are skipped (nothing to write).
+    """
+    data = request.get_json(silent=True) or {}
+    paths = data.get('paths') or []
+
+    if not isinstance(paths, list) or not paths:
+        return jsonify({"success": False, "error": "No paths provided"}), 400
+
+    for path in paths:
+        if not isinstance(path, str) or not is_valid_library_path(path):
+            return jsonify({"success": False, "error": f"Invalid path: {path}"}), 403
+
+    # Deduplicate to preserve the distinct-path contract for bulk writes.
+    unique_paths = list(dict.fromkeys(paths))
+
+    rows = get_file_index_ci_for_paths(unique_paths)
+
+    items = []
+    for path in unique_paths:
+        ci_fields = rows.get(path)
+        if not ci_fields:
+            continue
+        xml_fields = {
+            CI_FIELD_TO_XML[field]: value
+            for field, value in ci_fields.items()
+            if field in CI_FIELD_TO_XML and value
+        }
+        if xml_fields:
+            items.append((path, xml_fields))
+
+    skipped = len(unique_paths) - len(items)
+
+    if not items:
+        return jsonify({
+            "success": False,
+            "error": "No files have ci_ data to write",
+            "skipped": skipped,
+        }), 400
+
+    import core.app_state as app_state
+    label = f"Writing XML for {len(items)} files"
+    op_id = app_state.register_operation("source_wall", label, total=len(items))
+
+    t = threading.Thread(
+        target=_bulk_sync_pending_to_cbz,
+        args=(items, op_id),
+        daemon=True,
+    )
+    t.start()
+
+    return jsonify({
+        "success": True,
+        "op_id": op_id,
+        "affected": len(items),
+        "skipped": skipped,
     })
 
 

--- a/static/js/source_wall.js
+++ b/static/js/source_wall.js
@@ -1175,6 +1175,57 @@ function updateXmlSW() {
     CLU.openUpdateXmlModal(swCurrentPath, folderName);
 }
 
+function reconcileSelectedFromDb() {
+    if (swSelectedFiles.size === 0) return;
+
+    const paths = [...swSelectedFiles];
+
+    // Pending edits aren't committed to the DB yet — writing now would emit
+    // the stale value and overwrite what the user just typed. Make the user
+    // resolve the conflict first.
+    const conflicting = paths.filter(p => swPendingEdits.has(p));
+    if (conflicting.length > 0) {
+        CLU.showError(
+            `${conflicting.length} selected file${conflicting.length === 1 ? ' has' : 's have'} unsaved edits. ` +
+            `Save or discard them before writing XML from DB.`
+        );
+        return;
+    }
+
+    const msg = `Rebuild ComicInfo.xml for ${paths.length} file${paths.length === 1 ? '' : 's'} ` +
+                `from the database? This overwrites any existing ComicInfo.xml on disk.`;
+    if (!confirm(msg)) return;
+
+    fetch('/api/source-wall/reconcile-from-db', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paths }),
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                const skipMsg = data.skipped > 0
+                    ? ` (${data.skipped} skipped — no ci_ data)`
+                    : '';
+                CLU.showSuccess(
+                    `Writing XML for ${data.affected} file${data.affected === 1 ? '' : 's'}${skipMsg}`
+                );
+                paths.forEach(path => {
+                    document.querySelectorAll(`tr[data-path="${CSS.escape(path)}"]`).forEach(tr => {
+                        tr.classList.add('sw-flash-success');
+                        setTimeout(() => tr.classList.remove('sw-flash-success'), 1000);
+                    });
+                });
+            } else {
+                CLU.showError(data.error || 'Reconcile failed');
+            }
+        })
+        .catch(err => {
+            CLU.showError('Network error');
+            console.error(err);
+        });
+}
+
 // ── Utility ──
 
 

--- a/templates/source_wall.html
+++ b/templates/source_wall.html
@@ -108,6 +108,9 @@
   <button class="btn btn-sm btn-outline-info" onclick="updateXmlSW()" title="Update ComicInfo.xml in current folder">
     <i class="bi bi-code-slash me-1"></i>Update XML
   </button>
+  <button class="btn btn-sm btn-outline-warning" onclick="reconcileSelectedFromDb()" title="Rebuild ComicInfo.xml for selected files from the database">
+    <i class="bi bi-arrow-repeat me-1"></i>Write XML from DB
+  </button>
   <button class="btn btn-sm btn-outline-light" onclick="clearSelection()">
     <i class="bi bi-x-lg"></i>
   </button>

--- a/tests/routes/test_source_wall_routes.py
+++ b/tests/routes/test_source_wall_routes.py
@@ -228,6 +228,110 @@ class TestSourceWallHasComicinfoSync:
         assert row is not None and row['has_comicinfo'] == 1
 
 
+class TestSourceWallReconcileFromDb:
+    """`/api/source-wall/reconcile-from-db` reads current ci_ values from
+    file_index and queues a background CBZ rebuild — used to write XML from
+    the database when on-disk ComicInfo.xml has drifted."""
+
+    @patch("core.app_state.register_operation", return_value="op-789")
+    @patch("routes.source_wall.threading")
+    @patch("routes.source_wall.get_file_index_ci_for_paths")
+    @patch("routes.source_wall.is_valid_library_path", return_value=True)
+    def test_reconcile_happy_path(self, mock_valid, mock_get, mock_thread,
+                                  mock_register, client):
+        mock_thread.Thread.return_value = MagicMock()
+        # Path A has mixed fields, B has one — empty values must be dropped.
+        mock_get.return_value = {
+            "/data/a.cbz": {
+                "ci_series": "Batman", "ci_year": "2023", "ci_title": "",
+                "ci_number": "1", "ci_count": "", "ci_volume": "",
+                "ci_writer": "", "ci_penciller": "", "ci_inker": "",
+                "ci_colorist": "", "ci_letterer": "", "ci_coverartist": "",
+                "ci_publisher": "", "ci_genre": "", "ci_characters": "",
+            },
+            "/data/b.cbz": {
+                "ci_series": "Flash", "ci_title": "", "ci_number": "",
+                "ci_count": "", "ci_volume": "", "ci_year": "",
+                "ci_writer": "", "ci_penciller": "", "ci_inker": "",
+                "ci_colorist": "", "ci_letterer": "", "ci_coverartist": "",
+                "ci_publisher": "", "ci_genre": "", "ci_characters": "",
+            },
+        }
+
+        resp = client.post(
+            "/api/source-wall/reconcile-from-db",
+            data=json.dumps({"paths": ["/data/a.cbz", "/data/b.cbz"]}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["op_id"] == "op-789"
+        assert data["affected"] == 2
+        assert data["skipped"] == 0
+
+        # Worker payload uses XML tag names, not ci_ names, and excludes empties.
+        thread_kwargs = mock_thread.Thread.call_args.kwargs
+        items = thread_kwargs["args"][0]
+        items_by_path = {p: fields for p, fields in items}
+        assert items_by_path["/data/a.cbz"] == {
+            "Series": "Batman", "Year": "2023", "Number": "1",
+        }
+        assert items_by_path["/data/b.cbz"] == {"Series": "Flash"}
+
+    @patch("routes.source_wall.get_file_index_ci_for_paths")
+    @patch("routes.source_wall.is_valid_library_path", return_value=True)
+    def test_reconcile_skips_all_empty(self, mock_valid, mock_get, client):
+        empty = {f: "" for f in [
+            "ci_title", "ci_series", "ci_number", "ci_count", "ci_volume",
+            "ci_year", "ci_writer", "ci_penciller", "ci_inker", "ci_colorist",
+            "ci_letterer", "ci_coverartist", "ci_publisher", "ci_genre",
+            "ci_characters",
+        ]}
+        mock_get.return_value = {"/data/empty.cbz": empty}
+
+        resp = client.post(
+            "/api/source-wall/reconcile-from-db",
+            data=json.dumps({"paths": ["/data/empty.cbz"]}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data["skipped"] == 1
+
+    def test_reconcile_empty_paths_rejected(self, client):
+        resp = client.post(
+            "/api/source-wall/reconcile-from-db",
+            data=json.dumps({"paths": []}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    @patch("routes.source_wall.is_valid_library_path", return_value=False)
+    def test_reconcile_invalid_path_rejected(self, mock_valid, client):
+        resp = client.post(
+            "/api/source-wall/reconcile-from-db",
+            data=json.dumps({"paths": ["/etc/passwd"]}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    @patch("routes.source_wall.get_file_index_ci_for_paths", return_value={})
+    @patch("routes.source_wall.is_valid_library_path", return_value=True)
+    def test_reconcile_missing_from_index_skipped(self, mock_valid, mock_get, client):
+        # Path passes validation but isn't in file_index — silently skipped,
+        # then the request fails 400 because there's nothing to write.
+        resp = client.post(
+            "/api/source-wall/reconcile-from-db",
+            data=json.dumps({"paths": ["/data/ghost.cbz"]}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["skipped"] == 1
+
+
 class TestSourceWallColumns:
 
     @patch("routes.source_wall.get_user_preference", return_value=["name", "ci_volume"])


### PR DESCRIPTION
## 📝 Description
Introduce a /api/source-wall/reconcile-from-db endpoint that reads committed ci_ fields from file_index and queues a background worker to rebuild ComicInfo.xml inside CBZ files (DB is treated as source-of-truth). Add core.database.get_file_index_ci_for_paths to fetch ci_ columns for many paths (chunked to avoid SQLite parameter limits) and return {path: {ci_field: value}}. Add front-end UI (button + reconcileSelectedFromDb) to trigger the flow and prevent running when there are unsaved pending edits. Validate library paths, deduplicate inputs, skip files with no ci_ data, register a background operation, and spawn a thread to perform the writes. Tests added to cover happy path, empty/invalid paths, and missing-index behavior.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass