### PR TITLE
Preserve issue-level ComicVine metadata

### DIFF
--- a/models/providers/comicvine_provider.py
+++ b/models/providers/comicvine_provider.py
@@ -243,22 +243,22 @@ class ComicVineProvider(BaseProvider):
         try:
             api_key = self._get_api_key()
             if api_key and issue.series_id and issue.issue_number:
-                # Get full metadata using the existing function
+                # get_metadata_by_volume_id already returns a fully-mapped
+                # ComicInfo dict (it calls map_to_comicinfo internally), so
+                # forward series context and return it directly. Re-running
+                # map_to_comicinfo on this dict would strip every issue-level
+                # field because the keys are already ComicInfo-cased.
                 from models import comicvine as cv_module
                 metadata = cv_module.get_metadata_by_volume_id(
                     api_key,
                     int(issue.series_id),
                     issue.issue_number,
-                    start_year=series.year if series else None
+                    start_year=series.year if series else None,
+                    publisher_name=series.publisher if series else None,
                 )
                 if metadata:
-                    # Get volume data for mapping
-                    volume_data = {'id': issue.series_id}
-                    if series:
-                        volume_data['name'] = series.title
-                        volume_data['start_year'] = series.year
-                        volume_data['publisher_name'] = series.publisher
-                    return cv_module.map_to_comicinfo(metadata, volume_data, series.year if series else None)
+                    metadata.pop('_image_url', None)
+                    return metadata
 
             # Fallback: build from IssueResult
             comicinfo = {

--- a/tests/mocked/test_comicvine_provider.py
+++ b/tests/mocked/test_comicvine_provider.py
@@ -188,3 +188,62 @@ class TestComicVineProviderToComicinfo:
         assert result["Number"] == "5"
         assert result["Publisher"] == "DC Comics"
         assert result["Year"] == 2020
+
+    def test_api_path_returns_full_metadata(self, comicvine_creds):
+        """API-key path must return issue-level fields (Summary, Number, Title,
+        Writer, Characters, etc.) — regression for the double-mapping bug where
+        get_metadata_by_volume_id's already-mapped ComicInfo dict was being run
+        through map_to_comicinfo a second time and stripped to volume-level data.
+        """
+        from models.providers.comicvine_provider import ComicVineProvider
+
+        full_metadata = {
+            "Series": "Incorruptible",
+            "Number": "1",
+            "Volume": 2009,
+            "Title": "Incorruptible, Part One",
+            "Publisher": "Boom! Studios",
+            "Summary": "Max Damage turns over a new leaf.",
+            "Year": 2009,
+            "Month": 12,
+            "Day": 1,
+            "Writer": "Mark Waid",
+            "Penciller": "Jean Diaz",
+            "Characters": "Max Damage, Plutonian",
+            "LanguageISO": "en",
+            "Notes": "Metadata from ComicVine CVDB. Volume ID: 30514 — retrieved 2026-05-30.",
+            "_image_url": "https://example.com/cover.jpg",
+        }
+
+        p = ComicVineProvider(credentials=comicvine_creds)
+        issue = IssueResult(
+            provider=ProviderType.COMICVINE, id="307483", series_id="30514",
+            issue_number="1", title=None, cover_date="2009-12-01", summary=None,
+        )
+        series = SearchResult(
+            provider=ProviderType.COMICVINE, id="30514", title="Incorruptible",
+            year=2009, publisher="Boom! Studios",
+        )
+
+        with patch("models.comicvine.get_metadata_by_volume_id", return_value=full_metadata) as mock_get:
+            result = p.to_comicinfo(issue, series)
+
+        # Forwarded publisher_name so map_to_comicinfo's volume_data path can populate Publisher.
+        mock_get.assert_called_once_with(
+            comicvine_creds.api_key, 30514, "1",
+            start_year=2009, publisher_name="Boom! Studios",
+        )
+        # Volume-level fields survive (these did even before the fix).
+        assert result["Series"] == "Incorruptible"
+        assert result["Publisher"] == "Boom! Studios"
+        assert result["Volume"] == 2009
+        # Issue-level fields — the regression. Before the fix these were all dropped.
+        assert result["Number"] == "1"
+        assert result["Title"] == "Incorruptible, Part One"
+        assert result["Summary"] == "Max Damage turns over a new leaf."
+        assert result["Year"] == 2009
+        assert result["Writer"] == "Mark Waid"
+        assert result["Penciller"] == "Jean Diaz"
+        assert result["Characters"] == "Max Damage, Plutonian"
+        # Internal field should not leak through.
+        assert "_image_url" not in result


### PR DESCRIPTION
## 📝 Description
Avoid double-mapping ComicVine results by returning the already-mapped ComicInfo dict from get_metadata_by_volume_id instead of re-running map_to_comicinfo. Forward series context (start_year and publisher_name) to the API helper, strip the internal _image_url key, and return the full issue-level metadata. Added a test to cover the regression and ensure issue fields (Title, Summary, Writer, Characters, etc.) are preserved and _image_url is not exposed.

## 🛠️ Changes Made
- [] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass