### PR TITLE
Create cvinfo when mapping series

### DIFF
--- a/routes/series.py
+++ b/routes/series.py
@@ -819,6 +819,26 @@ def map_series(series_id):
         success = save_series_mapping(series_data, mapped_path)
 
         if success:
+            # Create cvinfo file with available metadata (mirrors subscribe flow).
+            # series_data comes from the frontend, where publisher is a nested dict.
+            publisher_name = series_data.get("publisher_name")
+            if not publisher_name:
+                pub = series_data.get("publisher")
+                if isinstance(pub, dict):
+                    publisher_name = pub.get("name")
+
+            if os.path.isdir(mapped_path):
+                cvinfo_path = os.path.join(mapped_path, "cvinfo")
+                created = metron.create_cvinfo_file(
+                    cvinfo_path,
+                    cv_id=series_data.get("cv_id"),  # Pass None if cv_id is missing
+                    series_id=series_data.get("id") or series_id,
+                    publisher_name=publisher_name,
+                    start_year=series_data.get("year_began"),
+                )
+                if not created:
+                    app_logger.error(f"Failed to create cvinfo at {cvinfo_path}")
+
             from models.series_json import write_series_json
             write_series_json(mapped_path, series_data, api=metron.get_flask_api())
             return jsonify({"success": True, "mapped_path": mapped_path})

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -73,6 +73,38 @@ class TestMapSeries:
         resp = client.post("/api/series/100/map", json={"mapped_path": "/x"})
         assert resp.status_code == 400
 
+    @patch("routes.series.metron")
+    @patch("core.database.save_publisher")
+    @patch("core.database.save_series_mapping", return_value=True)
+    def test_map_creates_cvinfo_and_series_json(
+        self, mock_save, mock_pub, mock_metron, client, tmp_path
+    ):
+        # Real metron.create_cvinfo_file so the file is actually written
+        import models.metron as metron_mod
+        mock_metron.create_cvinfo_file.side_effect = metron_mod.create_cvinfo_file
+        mock_metron.get_flask_api.return_value = None
+
+        resp = client.post("/api/series/100/map", json={
+            "mapped_path": str(tmp_path),
+            "series": {
+                "id": 100, "name": "Batman", "cv_id": 167796,
+                "year_began": 2016,
+                "publisher": {"id": 10, "name": "DC Comics"},
+            },
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+        cvinfo = tmp_path / "cvinfo"
+        assert cvinfo.is_file()
+        contents = cvinfo.read_text(encoding="utf-8")
+        assert "4050-167796" in contents
+        assert "series_id: 100" in contents
+        assert "publisher_name: DC Comics" in contents
+        assert "start_year: 2016" in contents
+
+        assert (tmp_path / "series.json").is_file()
+
 
 class TestGetSeriesMapping:
 


### PR DESCRIPTION
## 📝 Description
When a series mapping is created, generate a cvinfo file (mirroring the subscribe flow) with available metadata. The patch extracts publisher_name from series_data or from a nested publisher dict, verifies the mapped path is a directory, and calls metron.create_cvinfo_file with cv_id, series_id (falls back to the route param), publisher_name, and start_year; failures are logged. Also retains existing write_series_json call. Tests updated to assert cvinfo and series.json are created and contain expected fields.

Closes #332 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass