### PR TITLE
Add issue month/year naming variables

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import re
+import calendar
 import configparser
 from core.app_logging import app_logger
 from helpers import is_hidden
@@ -365,6 +366,21 @@ def _pad_issue_number(num_str, width=3):
     return num_str.zfill(width)
 
 
+def _format_issue_month(month_raw):
+    """Convert a month value (1-12, int or str) into display variants.
+
+    Returns a tuple (month_name, month_padded), e.g. (6) -> ("June", "06").
+    Returns ("", "") when the value is missing or not a valid 1-12 month.
+    """
+    try:
+        m = int(month_raw)
+    except (TypeError, ValueError):
+        return "", ""
+    if 1 <= m <= 12:
+        return calendar.month_name[m], f"{m:02d}"
+    return "", ""
+
+
 _FILENAME_CLEANUP_DEFAULTS = {
     "spaces_enabled": False,
     "spaces_mode": "replace",
@@ -505,6 +521,9 @@ _TOKEN_REGEX = {
     "issue_number": r"(?P<issue_number>\d{1,4}(?:\.\w+)?)",
     "volume_number": r"(?P<volume_number>\d{1,4})",
     "year": r"(?P<year>\d{4})",
+    "issue_year": r"(?P<issue_year>\d{4})",
+    "issue_month_m": r"(?P<issue_month_m>\d{2})",
+    "issue_month_M": r"(?P<issue_month_M>[A-Za-z]+)",
     "issue_title": r"(?P<issue_title>.+?)",
 }
 
@@ -1038,6 +1057,9 @@ def apply_custom_pattern(values, pattern):
     result = result.replace("{series_name}", series_name)
     result = result.replace("{volume_number}", values.get("volume_number", ""))
     result = result.replace("{year}", values.get("year", ""))
+    result = result.replace("{issue_year}", values.get("issue_year", ""))
+    result = result.replace("{issue_month_M}", values.get("issue_month_M", ""))
+    result = result.replace("{issue_month_m}", values.get("issue_month_m", ""))
     result = result.replace("{issue_number}", issue_number)
 
     # Replace issue_title with sanitization
@@ -1049,6 +1071,11 @@ def apply_custom_pattern(values, pattern):
 
     # Clean up extra spaces and trim
     result = re.sub(r"\s+", " ", result).strip()
+
+    # Remove a separator left dangling against a parenthesis boundary when a
+    # token resolved empty (e.g. "(2020-)" -> "(2020)", "(-06)" -> "(06)")
+    result = re.sub(r"\(\s*-\s*", "(", result)
+    result = re.sub(r"\s*-\s*\)", ")", result)
 
     # Remove empty parentheses and space before them
     result = re.sub(r"\s*\(\s*\)", "", result).strip()
@@ -1081,10 +1108,15 @@ def rename_comic_from_metadata(file_path, metadata):
         series = re.sub(r'[<>"/\\|?*]', "", series)
         series = smart_title_case(series)
 
+        issue_month_M, issue_month_m = _format_issue_month(metadata.get("Month"))
+
         values = {
             "series_name": series,
             "volume_number": "",
             "year": str(metadata.get("Year", "")),
+            "issue_year": str(metadata.get("Year", "")),
+            "issue_month_M": issue_month_M,
+            "issue_month_m": issue_month_m,
             "issue_number": _pad_issue_number(str(metadata.get("Number", ""))),
             "issue_title": metadata.get("Title", "") or "",
         }
@@ -1130,6 +1162,9 @@ def validate_custom_pattern(pattern):
         "{series_name}",
         "{volume_number}",
         "{year}",
+        "{issue_year}",
+        "{issue_month_M}",
+        "{issue_month_m}",
         "{issue_number}",
         "{issue_title}",
     ]
@@ -1320,11 +1355,21 @@ def get_renamed_filename(filename, file_path=None):
             # Extract comic values from the filename
             comic_values = extract_comic_values(filename)
 
-            # Read issue title from ComicInfo.xml if needed
+            # Default issue_year to the year parsed from the filename;
+            # ComicInfo.xml (read below) takes precedence when available.
+            comic_values.setdefault("issue_year", comic_values.get("year", ""))
+
+            # Tokens that require reading ComicInfo.xml for accurate values
+            month_year_tokens = ("{issue_year}", "{issue_month_M}", "{issue_month_m}")
+            needs_comicinfo = "{issue_title}" in custom_pattern or any(
+                tok in custom_pattern for tok in month_year_tokens
+            )
+
+            # Read issue title / publication month+year from ComicInfo.xml if needed
             if (
                 file_path
                 and file_path.lower().endswith(".cbz")
-                and "{issue_title}" in custom_pattern
+                and needs_comicinfo
             ):
                 try:
                     from core.comicinfo import read_comicinfo_from_zip
@@ -1332,6 +1377,11 @@ def get_renamed_filename(filename, file_path=None):
                     comicinfo = read_comicinfo_from_zip(file_path)
                     if comicinfo.get("Title"):
                         comic_values["issue_title"] = comicinfo["Title"]
+                    if comicinfo.get("Year"):
+                        comic_values["issue_year"] = str(comicinfo["Year"])
+                    month_M, month_m = _format_issue_month(comicinfo.get("Month"))
+                    comic_values["issue_month_M"] = month_M
+                    comic_values["issue_month_m"] = month_m
                 except Exception:
                     pass
 

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -5814,18 +5814,34 @@ function promptRenameAfterMetadata(filePath, fileName, metadata, renameConfig) {
     const year = metadata.Year || '';
     const volumeNumber = '';  // ComicVine uses year as Volume, not volume number
 
+    // Issue publication year/month variants (from ComicInfo Year/Month)
+    const issueYear = metadata.Year || '';
+    let issueMonthName = '';   // {issue_month_M} e.g. "June"
+    let issueMonthPadded = '';  // {issue_month_m} e.g. "06"
+    const monthNum = parseInt(metadata.Month, 10);
+    if (!isNaN(monthNum) && monthNum >= 1 && monthNum <= 12) {
+      const monthNames = ['', 'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December'];
+      issueMonthName = monthNames[monthNum];
+      issueMonthPadded = String(monthNum).padStart(2, '0');
+    }
+
     let issueTitle = metadata.Title || '';
     issueTitle = issueTitle.replace(/:/g, ' -');
     issueTitle = issueTitle.replace(/[<>"/\\|?*]/g, '');
     issueTitle = issueTitle.replace(/[\x00-\x1f]/g, '');
     issueTitle = issueTitle.replace(/^[.\s]+|[.\s]+$/g, '');
 
-    console.log('Pattern replacement values:', { series, issueNumber, year, volumeNumber, issueTitle, metadata });
+    console.log('Pattern replacement values:', { series, issueNumber, year, volumeNumber, issueTitle, issueYear, issueMonthName, issueMonthPadded, metadata });
 
     // Replace pattern variables (case-insensitive for flexibility)
     let result = pattern;
     result = result.replace(/{series_name}/gi, series);
     result = result.replace(/{issue_number}/gi, issueNumber);
+    // Month variants are case-sensitive: {issue_month_M} (name) vs {issue_month_m} (padded)
+    result = result.replace(/{issue_month_M}/g, issueMonthName);
+    result = result.replace(/{issue_month_m}/g, issueMonthPadded);
+    result = result.replace(/{issue_year}/gi, issueYear);
     result = result.replace(/{year}/gi, year);
     result = result.replace(/{YYYY}/g, year);  // Support YYYY as well
     result = result.replace(/{volume_number}/gi, volumeNumber);
@@ -5833,6 +5849,11 @@ function promptRenameAfterMetadata(filePath, fileName, metadata, renameConfig) {
 
     // Clean up extra spaces
     result = result.replace(/\s+/g, ' ').trim();
+
+    // Remove a separator left dangling against a parenthesis boundary
+    // (e.g. "(2010-)" -> "(2010)") when a token resolved empty
+    result = result.replace(/\(\s*-\s*/g, '(');
+    result = result.replace(/\s*-\s*\)/g, ')');
 
     // Remove empty parentheses
     result = result.replace(/\s*\(\s*\)/g, '').trim();

--- a/templates/config.html
+++ b/templates/config.html
@@ -394,6 +394,8 @@
                             <small class="form-text text-muted">
                                 Use variables to create your naming pattern. Available variables:
                                 <code>{series_name}</code>, <code>{volume_number}</code>, <code>{year}</code>,
+                                <code>{issue_year}</code>, <code>{issue_month_M}</code> (June),
+                                <code>{issue_month_m}</code> (06),
                                 <code>{issue_number}</code>, <code>{issue_title}</code>
                             </small>
                         </div>
@@ -416,7 +418,9 @@
                                 • <code>issue{issue_number}</code> → <code>issue001.cbz</code><br>
                                 • <code>{volume_number}_{issue_number}</code> → <code>v2_044.cbz</code><br>
                                 • <code>{series_name} {issue_number} - {issue_title} ({year})</code> →
-                                <code>Spider-Man 2099 044 - The Last Dance (1992).cbz</code>
+                                <code>Spider-Man 2099 044 - The Last Dance (1992).cbz</code><br>
+                                • <code>{series_name} ({issue_year}-{issue_month_m})</code> →
+                                <code>Spider-Man 2099 (1992-06).cbz</code>
                             </small>
                         </div>
                     </div>
@@ -2623,6 +2627,9 @@
             series_name: 'Spider-Man 2099',
             volume_number: 'v2',
             year: '1992',
+            issue_year: '1992',
+            issue_month_M: 'June',
+            issue_month_m: '06',
             issue_number: '044',
             issue_title: 'The Last Dance'
         };
@@ -2645,11 +2652,19 @@
         result = result.replace(/\{volume_number\}/g, values.volume_number || '');
         result = result.replace(/\{year\}/g, values.year || '');  // For rename patterns
         result = result.replace(/\{start_year\}/g, values.start_year || '');  // For move patterns
+        result = result.replace(/\{issue_year\}/g, values.issue_year || '');
+        result = result.replace(/\{issue_month_M\}/g, values.issue_month_M || '');
+        result = result.replace(/\{issue_month_m\}/g, values.issue_month_m || '');
         result = result.replace(/\{issue_number\}/g, values.issue_number || '');
         result = result.replace(/\{issue_title\}/g, values.issue_title || '');
 
         // Clean up extra spaces
         result = result.replace(/\s+/g, ' ').trim();
+
+        // Remove a separator left dangling against a parenthesis boundary
+        // (e.g. "(2020-)" -> "(2020)") when a token resolved empty
+        result = result.replace(/\(\s*-\s*/g, '(');
+        result = result.replace(/\s*-\s*\)/g, ')');
 
         // Remove empty parentheses
         result = result.replace(/\s*\(\s*\)/g, '').trim();

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -200,6 +200,9 @@ class TestApplyCustomPattern:
             "series_name": "Spider-Man 2099",
             "volume_number": "v2",
             "year": "1992",
+            "issue_year": "1992",
+            "issue_month_M": "June",
+            "issue_month_m": "06",
             "issue_number": "044",
             "issue_title": "The Last Dance",
         }
@@ -214,6 +217,14 @@ class TestApplyCustomPattern:
         (
             "{series_name} {issue_number} - {issue_title} ({year})",
             "Spider-Man 2099 044 - The Last Dance (1992)",
+        ),
+        (
+            "{series_name} ({issue_year}-{issue_month_m})",
+            "Spider-Man 2099 (1992-06)",
+        ),
+        (
+            "{series_name} {issue_number} {issue_month_M} {issue_year}",
+            "Spider-Man 2099 044 June 1992",
         ),
     ])
     def test_custom_patterns(self, sample_values, pattern, expected):
@@ -583,6 +594,43 @@ class TestRenameComicFromMetadata:
         assert was_renamed is True
         assert os.path.basename(result_path) == "Dinosaur Sanctuary v01 (2021).cbz"
         assert os.path.exists(result_path)
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({issue_year}-{issue_month_m})'))
+    def test_renames_with_issue_month_padded(self, mock_config, tmp_path):
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 6})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "Batman 001 (2020-06).cbz"
+        assert os.path.exists(result_path)
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} {issue_month_M} {issue_year}'))
+    def test_renames_with_issue_month_name(self, mock_config, tmp_path):
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 6})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "Batman 001 June 2020.cbz"
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({issue_year}-{issue_month_m})'))
+    def test_missing_month_drops_cleanly(self, mock_config, tmp_path):
+        # No Month in metadata -> {issue_month_m} resolves empty, no stray separators
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020})
+        assert was_renamed is True
+        name = os.path.basename(result_path)
+        assert name == "Batman 001 (2020).cbz"
+        assert "-)" not in name and "(-" not in name
 
 
 # ===== reverse_parse_pattern =====


### PR DESCRIPTION
## 📝 Description
Introduce issue month/year tokens (`{issue_year}`, `{issue_month_M}`,` {issue_month_m}`) and formatting helpers so rename patterns can include publication month (name or zero-padded). Adds _format_issue_month and token regexes, wires values from metadata and ComicInfo.xml, and updates apply_custom_pattern to replace the new tokens. JS and templates are updated to support the new tokens in the UI/preview and to perform the same cleanup logic. Also add logic to remove dangling separators around parentheses when optional tokens resolve empty, and include unit tests covering month/name/padded behavior and missing-month cleanup.

Closes #333 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass