### PR TITLE
Make UMASK default 002 and setgid data dirs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,8 +36,10 @@ services:
             ## For Windows/WSL, you need to set these to match your Windows user ID (see WINDOWS_WSL_SETUP.md)
             # - PUID=99
             # - PGID=100
-            ## Set the file creation mask (UMASK). 022 is a common value.
-            # - UMASK=022
+            ## File creation mask. Default is 002 -> group-writable folders (775) and files (664),
+            ## so a second account (e.g. your NAS file browser) can write into CLU-created folders
+            ## without needing 777. Set PGID to your NAS share group. Use 022 for owner-only writes.
+            # - UMASK=002
             # GCD Database Additions: Uncomment everything below and update values
             # if you're using a local GCD database for Metadata
             #- GCD_MYSQL_HOST=mysql-gcd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Defaults set in Dockerfile (PUID=99, PGID=100) — can be overridden.
 PUID="${PUID:-99}"
 PGID="${PGID:-100}"
-UMASK="${UMASK:-022}"
+UMASK="${UMASK:-002}"
 
 # Ensure the group exists (re-use if it already does)
 if ! getent group "${PGID}" >/dev/null 2>&1; then
@@ -66,6 +66,15 @@ for subdir in temp processed; do
   if [ ! -e "/downloads/${subdir}" ]; then
     mkdir -p "/downloads/${subdir}"
   fi
+done
+
+# Ensure new sub-folders inherit the share's group (NAS-friendly, avoids needing 777).
+# setgid is inherited by child dirs, so this propagates to future folders automatically.
+CFG_TARGET="$(awk -F= '/^TARGET/ {print $2}' /config/config.ini 2>/dev/null | tr -d '\r')"
+for p in /data /downloads "${CFG_TARGET}"; do
+  [ -n "$p" ] || continue
+  [ -d "$p" ] || continue
+  chmod g+s "$p" 2>/dev/null || true   # non-recursive, fast; failures on Windows mounts are harmless
 done
 
 # Log the directory statuses for debugging


### PR DESCRIPTION
## 📝 Description
Change docker-compose comment and entrypoint defaults to use UMASK=002 (group-writable: folders 775, files 664) so NAS/shared accounts can write without needing 777. Update entrypoint.sh to default UMASK to 002 and add logic to set the setgid bit (chmod g+s) on /data, /downloads and the configured TARGET path (read from /config/config.ini) so new subfolders inherit the share group. Non-recursive chmod is used and failures on Windows mounts are ignored; PUID/PGID defaults remain unchanged.

Closes #331 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass