### PR TITLE
Support cover/store dates in renaming

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -381,6 +381,26 @@ def _format_issue_month(month_raw):
     return "", ""
 
 
+def _format_date_parts(date_str):
+    """Parse a 'YYYY-MM-DD' (or 'YYYY') date string into display variants.
+
+    Returns a tuple (year, month_name, month_padded), e.g.
+    "2010-06-01" -> ("2010", "June", "06"). Returns ("", "", "") when blank or
+    unparseable. Month name/padded are empty when only a year is present.
+    """
+    if not date_str:
+        return "", "", ""
+    m = re.match(r"(\d{4})(?:-(\d{1,2}))?", str(date_str).strip())
+    if not m:
+        return "", "", ""
+    year = m.group(1)
+    if m.group(2):
+        month_name, month_padded = _format_issue_month(m.group(2))
+    else:
+        month_name, month_padded = "", ""
+    return year, month_name, month_padded
+
+
 _FILENAME_CLEANUP_DEFAULTS = {
     "spaces_enabled": False,
     "spaces_mode": "replace",
@@ -522,8 +542,12 @@ _TOKEN_REGEX = {
     "volume_number": r"(?P<volume_number>\d{1,4})",
     "year": r"(?P<year>\d{4})",
     "issue_year": r"(?P<issue_year>\d{4})",
-    "issue_month_m": r"(?P<issue_month_m>\d{2})",
-    "issue_month_M": r"(?P<issue_month_M>[A-Za-z]+)",
+    "cover_year": r"(?P<cover_year>\d{4})",
+    "cover_month_m": r"(?P<cover_month_m>\d{2})",
+    "cover_month_M": r"(?P<cover_month_M>[A-Za-z]+)",
+    "store_year": r"(?P<store_year>\d{4})",
+    "store_month_m": r"(?P<store_month_m>\d{2})",
+    "store_month_M": r"(?P<store_month_M>[A-Za-z]+)",
     "issue_title": r"(?P<issue_title>.+?)",
 }
 
@@ -1058,8 +1082,12 @@ def apply_custom_pattern(values, pattern):
     result = result.replace("{volume_number}", values.get("volume_number", ""))
     result = result.replace("{year}", values.get("year", ""))
     result = result.replace("{issue_year}", values.get("issue_year", ""))
-    result = result.replace("{issue_month_M}", values.get("issue_month_M", ""))
-    result = result.replace("{issue_month_m}", values.get("issue_month_m", ""))
+    result = result.replace("{cover_year}", values.get("cover_year", ""))
+    result = result.replace("{cover_month_M}", values.get("cover_month_M", ""))
+    result = result.replace("{cover_month_m}", values.get("cover_month_m", ""))
+    result = result.replace("{store_year}", values.get("store_year", ""))
+    result = result.replace("{store_month_M}", values.get("store_month_M", ""))
+    result = result.replace("{store_month_m}", values.get("store_month_m", ""))
     result = result.replace("{issue_number}", issue_number)
 
     # Replace issue_title with sanitization
@@ -1108,15 +1136,21 @@ def rename_comic_from_metadata(file_path, metadata):
         series = re.sub(r'[<>"/\\|?*]', "", series)
         series = smart_title_case(series)
 
-        issue_month_M, issue_month_m = _format_issue_month(metadata.get("Month"))
+        # Cover/store dates (live-fetch only; absent in ComicInfo-only re-renames)
+        cover_year, cover_month_M, cover_month_m = _format_date_parts(metadata.get("CoverDate"))
+        store_year, store_month_M, store_month_m = _format_date_parts(metadata.get("StoreDate"))
 
         values = {
             "series_name": series,
             "volume_number": "",
             "year": str(metadata.get("Year", "")),
             "issue_year": str(metadata.get("Year", "")),
-            "issue_month_M": issue_month_M,
-            "issue_month_m": issue_month_m,
+            "cover_year": cover_year,
+            "cover_month_M": cover_month_M,
+            "cover_month_m": cover_month_m,
+            "store_year": store_year,
+            "store_month_M": store_month_M,
+            "store_month_m": store_month_m,
             "issue_number": _pad_issue_number(str(metadata.get("Number", ""))),
             "issue_title": metadata.get("Title", "") or "",
         }
@@ -1163,8 +1197,12 @@ def validate_custom_pattern(pattern):
         "{volume_number}",
         "{year}",
         "{issue_year}",
-        "{issue_month_M}",
-        "{issue_month_m}",
+        "{cover_year}",
+        "{cover_month_M}",
+        "{cover_month_m}",
+        "{store_year}",
+        "{store_month_M}",
+        "{store_month_m}",
         "{issue_number}",
         "{issue_title}",
     ]
@@ -1360,12 +1398,11 @@ def get_renamed_filename(filename, file_path=None):
             comic_values.setdefault("issue_year", comic_values.get("year", ""))
 
             # Tokens that require reading ComicInfo.xml for accurate values
-            month_year_tokens = ("{issue_year}", "{issue_month_M}", "{issue_month_m}")
-            needs_comicinfo = "{issue_title}" in custom_pattern or any(
-                tok in custom_pattern for tok in month_year_tokens
+            needs_comicinfo = (
+                "{issue_title}" in custom_pattern or "{issue_year}" in custom_pattern
             )
 
-            # Read issue title / publication month+year from ComicInfo.xml if needed
+            # Read issue title / publication year from ComicInfo.xml if needed
             if (
                 file_path
                 and file_path.lower().endswith(".cbz")
@@ -1379,9 +1416,6 @@ def get_renamed_filename(filename, file_path=None):
                         comic_values["issue_title"] = comicinfo["Title"]
                     if comicinfo.get("Year"):
                         comic_values["issue_year"] = str(comicinfo["Year"])
-                    month_M, month_m = _format_issue_month(comicinfo.get("Month"))
-                    comic_values["issue_month_M"] = month_M
-                    comic_values["issue_month_m"] = month_m
                 except Exception:
                     pass
 

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -430,6 +430,18 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
             year = _extract_year_from_date(date_str)
             app_logger.info(f"DEBUG _issue_to_dict: unknown type {type(date_value)}, converted to string={date_str}, year={year}")
 
+    # Preserve BOTH raw dates separately (normalized to YYYY-MM-DD strings) so
+    # downstream rename templating can distinguish cover vs store dates. The
+    # Year/Month/Day above intentionally remain cover-preferred-then-store.
+    def _norm_date(d):
+        if not d:
+            return None
+        if isinstance(d, (datetime, date)):
+            return d.strftime("%Y-%m-%d")
+        return str(d)
+    cover_date_raw = _norm_date(getattr(issue, 'cover_date', None))
+    store_date_raw = _norm_date(getattr(issue, 'store_date', None))
+
     # Extract person credits (creators)
     writers = []
     pencillers = []
@@ -500,7 +512,8 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
         "volume_name": volume_name,  # BasicIssue.volume.name -> Series
         "volume_id": volume_id,
         "publisher": publisher,
-        "cover_date": date_str,  # BasicIssue.cover_date or store_date
+        "cover_date": cover_date_raw,  # raw cover_date (YYYY-MM-DD) or None
+        "store_date": store_date_raw,  # raw store_date (YYYY-MM-DD) or None
         "year": year,  # Parsed from cover_date or store_date -> Year
         "month": month,  # Parsed from cover_date or store_date -> Month
         "day": day,  # Parsed from cover_date or store_date -> Day
@@ -552,8 +565,8 @@ def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str,
         notes = f'Metadata from ComicVine CVDB — retrieved {current_date}.'
 
     # Append cover_date or store_date if available
-    if issue_data.get('cover_date'):
-        notes += f' Cover/Store Date: {issue_data.get("cover_date")}.'
+    if issue_data.get('cover_date') or issue_data.get('store_date'):
+        notes += f' Cover/Store Date: {issue_data.get("cover_date") or issue_data.get("store_date")}.'
 
     comicinfo = {
         'Series': series_name,
@@ -566,6 +579,10 @@ def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str,
         'Year': issue_data.get('year'),
         'Month': issue_data.get('month'),
         'Day': issue_data.get('day'),
+        # Raw provider dates (NOT written to ComicInfo.xml — generate_comicinfo_xml
+        # uses an explicit tag allowlist; consumed only by rename templating)
+        'CoverDate': issue_data.get('cover_date'),
+        'StoreDate': issue_data.get('store_date'),
         'Writer': ', '.join(issue_data.get('writers', [])) if issue_data.get('writers') else None,
         'Penciller': ', '.join(issue_data.get('pencillers', [])) if issue_data.get('pencillers') else None,
         'Inker': ', '.join(issue_data.get('inkers', [])) if issue_data.get('inkers') else None,

--- a/models/metron.py
+++ b/models/metron.py
@@ -463,6 +463,7 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
 
     # Parse cover_date for Year/Month/Day
     cover_date = _get_attr(issue_data, "cover_date", "")
+    store_date = _get_attr(issue_data, "store_date", "")
     year = None
     month = None
     day = None
@@ -549,6 +550,10 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
         "Year": year,
         "Month": month,
         "Day": day,
+        # Raw provider dates (NOT written to ComicInfo.xml — generate_comicinfo_xml
+        # uses an explicit tag allowlist; consumed only by rename templating)
+        "CoverDate": str(cover_date) if cover_date else None,
+        "StoreDate": str(store_date) if store_date else None,
         "Writer": writer or None,
         "Penciller": penciller or None,
         "Inker": inker or None,

--- a/models/providers/comicvine_provider.py
+++ b/models/providers/comicvine_provider.py
@@ -266,6 +266,9 @@ class ComicVineProvider(BaseProvider):
                 'Number': issue.issue_number,
                 'Title': issue.title,
                 'Summary': issue.summary,
+                # Raw provider dates for rename templating (not written to XML)
+                'CoverDate': issue.cover_date,
+                'StoreDate': issue.store_date,
                 'Notes': f'Metadata from ComicVine. Issue ID: {issue.id}',
             }
 

--- a/models/providers/metron_provider.py
+++ b/models/providers/metron_provider.py
@@ -262,6 +262,9 @@ class MetronProvider(BaseProvider):
                 "Year": int(issue.cover_date[:4])
                 if issue.cover_date and len(issue.cover_date) >= 4
                 else None,
+                # Raw provider dates for rename templating (not written to XML)
+                "CoverDate": issue.cover_date,
+                "StoreDate": issue.store_date,
                 "Notes": f"Metadata from Metron. Issue ID: {issue.id}",
             }
 

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -5792,6 +5792,27 @@ function padIssueNumber(numStr, width = 3) {
   return numStr.padStart(width, '0');
 }
 
+const MONTH_NAMES = ['', 'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'];
+
+// Parse a "YYYY-MM-DD" (or "YYYY") date string into rename-template parts.
+// Returns { year, monthName, monthPadded } with empty strings when unavailable.
+function parseDateParts(dateStr) {
+  const result = { year: '', monthName: '', monthPadded: '' };
+  if (!dateStr) return result;
+  const m = String(dateStr).trim().match(/^(\d{4})(?:-(\d{1,2}))?/);
+  if (!m) return result;
+  result.year = m[1];
+  if (m[2]) {
+    const monthNum = parseInt(m[2], 10);
+    if (monthNum >= 1 && monthNum <= 12) {
+      result.monthName = MONTH_NAMES[monthNum];
+      result.monthPadded = String(monthNum).padStart(2, '0');
+    }
+  }
+  return result;
+}
+
 function promptRenameAfterMetadata(filePath, fileName, metadata, renameConfig) {
   console.log('promptRenameAfterMetadata called with:', { filePath, fileName, metadata, renameConfig });
 
@@ -5814,17 +5835,12 @@ function promptRenameAfterMetadata(filePath, fileName, metadata, renameConfig) {
     const year = metadata.Year || '';
     const volumeNumber = '';  // ComicVine uses year as Volume, not volume number
 
-    // Issue publication year/month variants (from ComicInfo Year/Month)
+    // Issue publication year (from ComicInfo Year)
     const issueYear = metadata.Year || '';
-    let issueMonthName = '';   // {issue_month_M} e.g. "June"
-    let issueMonthPadded = '';  // {issue_month_m} e.g. "06"
-    const monthNum = parseInt(metadata.Month, 10);
-    if (!isNaN(monthNum) && monthNum >= 1 && monthNum <= 12) {
-      const monthNames = ['', 'January', 'February', 'March', 'April', 'May', 'June',
-        'July', 'August', 'September', 'October', 'November', 'December'];
-      issueMonthName = monthNames[monthNum];
-      issueMonthPadded = String(monthNum).padStart(2, '0');
-    }
+
+    // Cover/store date variants (from raw provider dates, when present)
+    const cover = parseDateParts(metadata.CoverDate);
+    const store = parseDateParts(metadata.StoreDate);
 
     let issueTitle = metadata.Title || '';
     issueTitle = issueTitle.replace(/:/g, ' -');
@@ -5832,16 +5848,20 @@ function promptRenameAfterMetadata(filePath, fileName, metadata, renameConfig) {
     issueTitle = issueTitle.replace(/[\x00-\x1f]/g, '');
     issueTitle = issueTitle.replace(/^[.\s]+|[.\s]+$/g, '');
 
-    console.log('Pattern replacement values:', { series, issueNumber, year, volumeNumber, issueTitle, issueYear, issueMonthName, issueMonthPadded, metadata });
+    console.log('Pattern replacement values:', { series, issueNumber, year, volumeNumber, issueTitle, issueYear, cover, store, metadata });
 
     // Replace pattern variables (case-insensitive for flexibility)
     let result = pattern;
     result = result.replace(/{series_name}/gi, series);
     result = result.replace(/{issue_number}/gi, issueNumber);
-    // Month variants are case-sensitive: {issue_month_M} (name) vs {issue_month_m} (padded)
-    result = result.replace(/{issue_month_M}/g, issueMonthName);
-    result = result.replace(/{issue_month_m}/g, issueMonthPadded);
     result = result.replace(/{issue_year}/gi, issueYear);
+    // Month variants are case-sensitive: {..._M} (name) vs {..._m} (padded)
+    result = result.replace(/{cover_month_M}/g, cover.monthName);
+    result = result.replace(/{cover_month_m}/g, cover.monthPadded);
+    result = result.replace(/{cover_year}/gi, cover.year);
+    result = result.replace(/{store_month_M}/g, store.monthName);
+    result = result.replace(/{store_month_m}/g, store.monthPadded);
+    result = result.replace(/{store_year}/gi, store.year);
     result = result.replace(/{year}/gi, year);
     result = result.replace(/{YYYY}/g, year);  // Support YYYY as well
     result = result.replace(/{volume_number}/gi, volumeNumber);

--- a/templates/config.html
+++ b/templates/config.html
@@ -394,9 +394,11 @@
                             <small class="form-text text-muted">
                                 Use variables to create your naming pattern. Available variables:
                                 <code>{series_name}</code>, <code>{volume_number}</code>, <code>{year}</code>,
-                                <code>{issue_year}</code>, <code>{issue_month_M}</code> (June),
-                                <code>{issue_month_m}</code> (06),
-                                <code>{issue_number}</code>, <code>{issue_title}</code>
+                                <code>{issue_year}</code>,
+                                <code>{issue_number}</code>, <code>{issue_title}</code>.
+                                Cover/store dates (from ComicVine/Metron):
+                                <code>{cover_year}</code>, <code>{cover_month_M}</code> (June), <code>{cover_month_m}</code> (06),
+                                <code>{store_year}</code>, <code>{store_month_M}</code>, <code>{store_month_m}</code>
                             </small>
                         </div>
                         <div class="col-md-4">
@@ -419,8 +421,8 @@
                                 • <code>{volume_number}_{issue_number}</code> → <code>v2_044.cbz</code><br>
                                 • <code>{series_name} {issue_number} - {issue_title} ({year})</code> →
                                 <code>Spider-Man 2099 044 - The Last Dance (1992).cbz</code><br>
-                                • <code>{series_name} ({issue_year}-{issue_month_m})</code> →
-                                <code>Spider-Man 2099 (1992-06).cbz</code>
+                                • <code>{series_name} {issue_number} ({cover_year}-{cover_month_m})</code> →
+                                <code>Spider-Man 2099 044 (1992-06).cbz</code>
                             </small>
                         </div>
                     </div>
@@ -2628,8 +2630,12 @@
             volume_number: 'v2',
             year: '1992',
             issue_year: '1992',
-            issue_month_M: 'June',
-            issue_month_m: '06',
+            cover_year: '1992',
+            cover_month_M: 'June',
+            cover_month_m: '06',
+            store_year: '1992',
+            store_month_M: 'July',
+            store_month_m: '07',
             issue_number: '044',
             issue_title: 'The Last Dance'
         };
@@ -2653,8 +2659,12 @@
         result = result.replace(/\{year\}/g, values.year || '');  // For rename patterns
         result = result.replace(/\{start_year\}/g, values.start_year || '');  // For move patterns
         result = result.replace(/\{issue_year\}/g, values.issue_year || '');
-        result = result.replace(/\{issue_month_M\}/g, values.issue_month_M || '');
-        result = result.replace(/\{issue_month_m\}/g, values.issue_month_m || '');
+        result = result.replace(/\{cover_year\}/g, values.cover_year || '');
+        result = result.replace(/\{cover_month_M\}/g, values.cover_month_M || '');
+        result = result.replace(/\{cover_month_m\}/g, values.cover_month_m || '');
+        result = result.replace(/\{store_year\}/g, values.store_year || '');
+        result = result.replace(/\{store_month_M\}/g, values.store_month_M || '');
+        result = result.replace(/\{store_month_m\}/g, values.store_month_m || '');
         result = result.replace(/\{issue_number\}/g, values.issue_number || '');
         result = result.replace(/\{issue_title\}/g, values.issue_title || '');
 

--- a/tests/mocked/test_comicvine_model.py
+++ b/tests/mocked/test_comicvine_model.py
@@ -168,6 +168,24 @@ class TestMapToComicinfo:
         result = map_to_comicinfo(issue_data, None, start_year=2016)
         assert result["Volume"] == 2016
 
+    def test_preserves_cover_and_store_dates(self):
+        from models.comicvine import map_to_comicinfo
+
+        issue_data = {"id": 1, "issue_number": "1", "year": 2020, "month": 3,
+                      "cover_date": "2020-03-01", "store_date": "2020-05-15"}
+        result = map_to_comicinfo(issue_data)
+        assert result["CoverDate"] == "2020-03-01"
+        assert result["StoreDate"] == "2020-05-15"
+
+    def test_omits_absent_dates(self):
+        from models.comicvine import map_to_comicinfo
+
+        issue_data = {"id": 1, "issue_number": "1", "year": 2020}
+        result = map_to_comicinfo(issue_data)
+        # None values are stripped from the output dict
+        assert "CoverDate" not in result
+        assert "StoreDate" not in result
+
 
 class TestGetMetadataByVolumeId:
     """Verify Publisher is populated reliably via volume_data or issue fallback."""

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -246,6 +246,22 @@ class TestMapToComicinfo:
         assert result["Number"] == "1"
         assert "Notes" in result
 
+    def test_preserves_cover_and_store_dates(self):
+        from models.metron import map_to_comicinfo
+
+        issue_data = {"id": 1, "number": "1", "cover_date": "2020-06-15",
+                      "store_date": "2020-06-03"}
+        result = map_to_comicinfo(issue_data)
+        assert result["CoverDate"] == "2020-06-15"
+        assert result["StoreDate"] == "2020-06-03"
+
+    def test_omits_absent_store_date(self):
+        from models.metron import map_to_comicinfo
+
+        result = map_to_comicinfo({"id": 1, "number": "1", "cover_date": "2020-06-15"})
+        assert result["CoverDate"] == "2020-06-15"
+        assert "StoreDate" not in result
+
 
 class TestExtractCreditsByRole:
 

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -201,8 +201,12 @@ class TestApplyCustomPattern:
             "volume_number": "v2",
             "year": "1992",
             "issue_year": "1992",
-            "issue_month_M": "June",
-            "issue_month_m": "06",
+            "cover_year": "1992",
+            "cover_month_M": "June",
+            "cover_month_m": "06",
+            "store_year": "1992",
+            "store_month_M": "July",
+            "store_month_m": "07",
             "issue_number": "044",
             "issue_title": "The Last Dance",
         }
@@ -219,12 +223,20 @@ class TestApplyCustomPattern:
             "Spider-Man 2099 044 - The Last Dance (1992)",
         ),
         (
-            "{series_name} ({issue_year}-{issue_month_m})",
+            "{series_name} {issue_number} ({issue_year})",
+            "Spider-Man 2099 044 (1992)",
+        ),
+        (
+            "{series_name} ({cover_year}-{cover_month_m})",
             "Spider-Man 2099 (1992-06)",
         ),
         (
-            "{series_name} {issue_number} {issue_month_M} {issue_year}",
+            "{series_name} {issue_number} {cover_month_M} {cover_year}",
             "Spider-Man 2099 044 June 1992",
+        ),
+        (
+            "{series_name} {issue_number} [{store_month_M} {store_year}]",
+            "Spider-Man 2099 044 [July 1992]",
         ),
     ])
     def test_custom_patterns(self, sample_values, pattern, expected):
@@ -596,32 +608,46 @@ class TestRenameComicFromMetadata:
         assert os.path.exists(result_path)
 
     @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} ({issue_year}-{issue_month_m})'))
-    def test_renames_with_issue_month_padded(self, mock_config, tmp_path):
+           return_value=(True, '{series_name} {issue_number} ({issue_year})'))
+    def test_renames_with_issue_year(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
         result_path, was_renamed = rename_comic_from_metadata(
-            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 6})
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020})
         assert was_renamed is True
-        assert os.path.basename(result_path) == "Batman 001 (2020-06).cbz"
+        assert os.path.basename(result_path) == "Batman 001 (2020).cbz"
         assert os.path.exists(result_path)
 
     @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} {issue_month_M} {issue_year}'))
-    def test_renames_with_issue_month_name(self, mock_config, tmp_path):
+           return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
+    def test_renames_with_cover_date(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
         result_path, was_renamed = rename_comic_from_metadata(
-            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 6})
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 5,
+                     'CoverDate': '2010-03-01', 'StoreDate': '2010-05-01'})
         assert was_renamed is True
-        assert os.path.basename(result_path) == "Batman 001 June 2020.cbz"
+        # Cover month (March -> 03), distinct from store month
+        assert os.path.basename(result_path) == "Batman 001 (2010-03).cbz"
 
     @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} ({issue_year}-{issue_month_m})'))
-    def test_missing_month_drops_cleanly(self, mock_config, tmp_path):
-        # No Month in metadata -> {issue_month_m} resolves empty, no stray separators
+           return_value=(True, '{series_name} {issue_number} cover-{cover_month_M} store-{store_month_M}'))
+    def test_cover_and_store_months_differ(self, mock_config, tmp_path):
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1',
+                     'CoverDate': '2010-03-01', 'StoreDate': '2010-05-15'})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "Batman 001 cover-March store-May.cbz"
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
+    def test_missing_cover_date_drops_cleanly(self, mock_config, tmp_path):
+        # No CoverDate -> cover tokens resolve empty, no stray separators
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
@@ -629,8 +655,8 @@ class TestRenameComicFromMetadata:
             str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020})
         assert was_renamed is True
         name = os.path.basename(result_path)
-        assert name == "Batman 001 (2020).cbz"
-        assert "-)" not in name and "(-" not in name
+        assert name == "Batman 001.cbz"
+        assert "-)" not in name and "(-" not in name and "()" not in name
 
 
 # ===== reverse_parse_pattern =====


### PR DESCRIPTION
## 📝 Description
Add explicit support for raw cover and store dates used by rename templates. Preserve CoverDate/StoreDate from providers (ComicVine/Metron) and expose them via model mapping, add parsing helpers in cbz_ops.rename and static JS to produce year/month name/padded variants, and introduce new template tokens:` {cover_year}, {cover_month_M}, {cover_month_m}, {store_year}, {store_month_M}, {store_month_m}`. Update token regex, pattern application, and rename logic to use these tokens (and relax reliance on ComicInfo Month), update UI docs/examples, and adjust client-side renaming UI. Tests for ComicVine/Metron mapping and rename behavior were added/updated to cover preservation and formatting of cover/store dates.

Closes #

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass