### PR TITLE
Add ComicVine timeouts and failover

### DIFF
--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -23,6 +23,27 @@ try:
 except ImportError:
     SIMYAN_AVAILABLE = False
 
+
+def _get_cv_request_timeout() -> int:
+    """Per-request timeout (seconds) for the Simyan ComicVine client.
+
+    Bounds each HTTP call so a slow/unresponsive ComicVine can't stall the
+    worker indefinitely. Overridable via the COMICVINE_TIMEOUT env var.
+    """
+    try:
+        return int(os.environ.get("COMICVINE_TIMEOUT", "20"))
+    except (ValueError, TypeError):
+        return 20
+
+
+CV_REQUEST_TIMEOUT = _get_cv_request_timeout()
+
+
+def _make_cv_client(api_key: str):
+    """Construct a Simyan ComicVine client with an explicit request timeout."""
+    return Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
+
+
 def is_simyan_available() -> bool:
     """Check if the Simyan library is available."""
     return SIMYAN_AVAILABLE
@@ -75,7 +96,7 @@ def fetch_cv_arcs(api_key, search=None):
         return []
 
     try:
-        cv = Comicvine(api_key=api_key, cache=None)
+        cv = _make_cv_client(api_key)
         if search:
             arcs = cv.search(resource=ComicvineResource.STORY_ARC, query=search)
         else:
@@ -120,7 +141,7 @@ def fetch_cv_arc_detail(api_key, arc_id):
         return None
 
     try:
-        cv = Comicvine(api_key=api_key, cache=None)
+        cv = _make_cv_client(api_key)
         arc = cv.get_story_arc(arc_id)
         if not arc:
             return None
@@ -163,7 +184,7 @@ def fetch_cv_arc_issues(api_key, arc_id):
         if not detail or not detail.get('issues'):
             return []
 
-        cv = Comicvine(api_key=api_key, cache=None)
+        cv = _make_cv_client(api_key)
         resolved = []
 
         for i, entry in enumerate(detail['issues']):
@@ -232,7 +253,7 @@ def search_volumes(api_key: str, series_name: str, year: Optional[int] = None) -
         app_logger.info(f"Searching ComicVine for volume: '{series_name}' (year: {year})")
 
         # Initialize ComicVine API client
-        cv = Comicvine(api_key=api_key, cache=None)
+        cv = _make_cv_client(api_key)
 
         # Search for volumes using fuzzy search
         volumes = cv.search(resource=ComicvineResource.VOLUME, query=series_name)
@@ -318,7 +339,7 @@ def get_issue_by_number(api_key: str, volume_id: int, issue_number: str, year: O
         app_logger.info(f"Searching for issue #{issue_number} in volume {volume_id} (year: {year})")
 
         # Initialize ComicVine API client
-        cv = Comicvine(api_key=api_key, cache=None)
+        cv = _make_cv_client(api_key)
 
         # Get issues from the volume
         # Build filter string
@@ -997,7 +1018,7 @@ def get_volume_details(api_key: str, volume_id: int) -> Dict[str, Any]:
 
     try:
         app_logger.info(f"Fetching volume details for volume ID: {volume_id}")
-        cv = Comicvine(api_key=api_key, cache=None)
+        cv = _make_cv_client(api_key)
         volume = cv.get_volume(volume_id)
 
         if volume:

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -34,6 +34,18 @@ from models.gcd import STOPWORDS
 metadata_bp = Blueprint('metadata', __name__)
 
 
+# Hard wall-clock budget (seconds) for a single ComicVine attempt in the
+# search-metadata cascade. Slightly above the Simyan per-request httpx timeout
+# (COMICVINE_TIMEOUT, default 20s) so a slow-but-completing response isn't
+# killed, while a true hang (rate-limiter / SQLite-lock blocking that happens
+# before the HTTP call) is bounded so the cascade can fail over to the next
+# provider. Overridable via COMICVINE_TIMEOUT (+5s headroom).
+try:
+    CV_ATTEMPT_TIMEOUT = int(os.environ.get("COMICVINE_TIMEOUT", "20")) + 5
+except (ValueError, TypeError):
+    CV_ATTEMPT_TIMEOUT = 25
+
+
 # =============================================================================
 # Helper Functions (used by multiple routes)
 # =============================================================================
@@ -2948,6 +2960,47 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
 
 
 def _try_comicvine_single(cvinfo_path, series_name, issue_number, year):
+    """Try ComicVine provider for a single file, bounded by a wall-clock guard.
+
+    Runs the actual lookup in a worker thread and gives up after
+    CV_ATTEMPT_TIMEOUT seconds so a hung ComicVine request (rate-limiter or
+    SQLite-lock blocking that the httpx timeout doesn't cover) can't stall the
+    request. On timeout or any error it returns (None, None, None, None), which
+    the search-metadata cascade treats as "no result → try next provider"
+    (e.g. gcd_api).
+    """
+    from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+
+    # current_app is request-bound; capture the real app so the worker thread
+    # (which has no request/app context of its own) can push one.
+    app = current_app._get_current_object()
+
+    def _run():
+        with app.app_context():
+            return _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year)
+
+    # Don't use ThreadPoolExecutor as a context manager: its __exit__ calls
+    # shutdown(wait=True), which would block on a hung worker and defeat the
+    # timeout. shutdown(wait=False) lets the request return immediately; the
+    # orphaned worker unwinds on its own once the Simyan per-request timeout
+    # (CV_REQUEST_TIMEOUT) fires.
+    ex = ThreadPoolExecutor(max_workers=1)
+    try:
+        return ex.submit(_run).result(timeout=CV_ATTEMPT_TIMEOUT)
+    except FutureTimeout:
+        app_logger.warning(
+            f"[search-metadata] ComicVine timed out after {CV_ATTEMPT_TIMEOUT}s "
+            "— failing over to next provider"
+        )
+        return None, None, None, None
+    except Exception as e:
+        app_logger.warning(f"[search-metadata] ComicVine lookup failed: {e}")
+        return None, None, None, None
+    finally:
+        ex.shutdown(wait=False)
+
+
+def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year):
     """Try ComicVine provider for a single file.
     Returns (metadata_dict, image_url, volume_data, None) on success,
     or (None, None, None, selection_data) when user selection is needed,

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -453,6 +453,112 @@ class TestSearchMetadataParsedFilename:
         assert data["parsed_filename"]["year"] == 2020
 
 
+class TestSearchMetadataComicVineFailover:
+    """ComicVine must never stall the search-metadata cascade.
+
+    A hung or failing ComicVine attempt must be bounded so the cascade falls
+    over to the next configured provider (gcd_api). See
+    routes.metadata._try_comicvine_single (wall-clock guard) and
+    models.comicvine._make_cv_client (per-request timeout).
+    """
+
+    def _configure(self, app, stack, *, search_volumes_side_effect):
+        """Apply the shared mock stack; return the gcd_api mock for assertions."""
+        app.config["COMICVINE_API_KEY"] = "test-key"
+
+        stack.enter_context(patch("models.metron.is_metron_configured", return_value=False))
+        stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+        stack.enter_context(patch("models.gcd.is_mysql_available", return_value=False))
+        stack.enter_context(patch("models.gcd.check_mysql_status",
+                                  return_value={"gcd_mysql_available": False}))
+        stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
+        stack.enter_context(patch("models.comicvine.is_simyan_available", return_value=True))
+        stack.enter_context(patch("models.comicvine.search_volumes",
+                                  side_effect=search_volumes_side_effect))
+        stack.enter_context(patch("core.database.get_library_providers", return_value=[]))
+        stack.enter_context(patch("core.database.get_provider_credentials",
+                                  return_value={"username": "u", "password": "p"}))
+        stack.enter_context(patch("core.database.set_has_comicinfo"))
+        stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+        stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+        gcd_api = stack.enter_context(patch(
+            "routes.metadata._try_gcd_api_single",
+            return_value=({"Series": "Batman", "Number": "1"}, "http://img", None),
+        ))
+        return gcd_api
+
+    def test_failover_when_comicvine_stalls(self, app, client):
+        """A ComicVine call that hangs past CV_ATTEMPT_TIMEOUT is abandoned and
+        the cascade falls over to gcd_api."""
+        import time
+        from contextlib import ExitStack
+
+        def _slow(*args, **kwargs):
+            time.sleep(0.5)  # outlives the patched timeout below
+            return []
+
+        with ExitStack() as stack:
+            gcd_api = self._configure(app, stack, search_volumes_side_effect=_slow)
+            stack.enter_context(patch("routes.metadata.CV_ATTEMPT_TIMEOUT", 0.15))
+
+            started = time.monotonic()
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+            elapsed = time.monotonic() - started
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source"] == "gcd_api"
+        gcd_api.assert_called_once()
+        # The hung ComicVine worker must not block the request: returning well
+        # before the 0.5s sleep proves shutdown(wait=False) didn't join it.
+        assert elapsed < 0.45
+
+    def test_failover_when_comicvine_raises(self, app, client):
+        """A ComicVine exception is swallowed and the cascade reaches gcd_api
+        (no 500)."""
+        from contextlib import ExitStack
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("comicvine exploded")
+
+        with ExitStack() as stack:
+            gcd_api = self._configure(app, stack, search_volumes_side_effect=_boom)
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source"] == "gcd_api"
+        gcd_api.assert_called_once()
+
+    def test_try_comicvine_single_returns_quickly_on_timeout(self, app):
+        """Unit-level: the wall-clock guard returns the empty tuple promptly
+        instead of blocking for the full ComicVine call."""
+        import time
+        from routes.metadata import _try_comicvine_single
+
+        app.config["COMICVINE_API_KEY"] = "test-key"
+
+        def _slow(*args, **kwargs):
+            time.sleep(1.0)
+            return []
+
+        with app.app_context(), \
+                patch("models.comicvine.is_simyan_available", return_value=True), \
+                patch("models.comicvine.search_volumes", side_effect=_slow), \
+                patch("routes.metadata.CV_ATTEMPT_TIMEOUT", 0.15):
+            started = time.monotonic()
+            result = _try_comicvine_single(None, "Batman", "1", None)
+            elapsed = time.monotonic() - started
+
+        assert result == (None, None, None, None)
+        assert elapsed < 0.9
+
+
 class TestBatchMetadataRenameUpdatesIndex:
     """Verify file_index is updated with new path/name after batch rename."""
 


### PR DESCRIPTION
## 📝 Description
Introduce a per-request ComicVine timeout (COMICVINE_TIMEOUT, default 20s) and centralize client creation via _make_cv_client to ensure all Simyan calls honor the timeout. Add a wall-clock attempt guard (CV_ATTEMPT_TIMEOUT, default COMICVINE_TIMEOUT+5s) and a threaded wrapper _try_comicvine_single to abandon hung ComicVine lookups (shutdown(wait=False)) so the search-metadata cascade can fail over to other providers (e.g. gcd_api). Update call sites to use the new client factory and add tests ensuring ComicVine timeouts/exceptions do not stall requests and correctly fall back to gcd_api.

## 🛠️ Changes Made
- [] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass