### PR TITLE
Improve file search ranking and results UI

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -2683,16 +2683,26 @@ def search_file_index(query, limit=100):
 
         c = conn.cursor()
 
-        # Search with LIKE for partial matching (case-insensitive)
+        # Search with LIKE for partial matching (case-insensitive). The WHERE
+        # clause filters by substring; the ORDER BY ranks matches by relevance
+        # so that names beginning with the query (and shorter/tighter matches)
+        # rank above ones where the query appears mid-string. Ranking is
+        # computed only over the already-filtered, limited rows so cost is
+        # negligible.
         c.execute(
             """
             SELECT name, path, type, size, parent
             FROM file_index
             WHERE LOWER(name) LIKE LOWER(?)
-            ORDER BY type DESC, name ASC
+            ORDER BY
+                type DESC,
+                CASE WHEN LOWER(name) LIKE LOWER(? || '%') THEN 0 ELSE 1 END,
+                INSTR(LOWER(name), LOWER(?)),
+                LENGTH(name),
+                name ASC
             LIMIT ?
         """,
-            (f"%{query}%", limit),
+            (f"%{query}%", query, query, limit),
         )
 
         rows = c.fetchall()

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -3706,6 +3706,10 @@ function displaySearchResults(results, query) {
       resultsContainer.appendChild(resultItem);
     });
   }
+
+  // Reset scroll to the top whenever results are (re)rendered, so a new search
+  // or changed term doesn't leave the user scrolled into the previous results.
+  resultsContainer.scrollTop = 0;
 }
 
 function navigateToSearchResult(item) {

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -1034,11 +1034,13 @@ function searchFiles(retryWithoutFirstWord = false) {
                 const item = document.createElement('div');
                 item.className = 'list-group-item list-group-item-action search-result-item';
                 item.innerHTML = `
-                <div class="d-flex w-100 justify-content-between">
-                    <h6 class="mb-1 text-truncate">${file.name}</h6>
-                    <small class="text-muted">${file.path.split('/').slice(-2, -1)[0]}</small>
+                <div class="d-flex flex-column w-100">
+                    <div class="d-flex w-100 justify-content-between">
+                        <h6 class="mb-1 text-truncate">${file.name}</h6>
+                        <small class="text-muted">${file.path.split('/').slice(-2, -1)[0]}</small>
+                    </div>
+                    <small class="text-info-emphasis text-break font-monospace">${file.path}</small>
                 </div>
-                <small class="text-muted text-break">${file.path}</small>
             `;
                 item.onclick = () => selectFile(file.path, item);
                 resultsDiv.appendChild(item);
@@ -1220,11 +1222,13 @@ function searchFilesForAdd() {
                 const item = document.createElement('div');
                 item.className = 'list-group-item list-group-item-action search-result-item';
                 item.innerHTML = `
-                    <div class="d-flex w-100 justify-content-between">
-                        <h6 class="mb-1 text-truncate">${file.name}</h6>
-                        <small class="text-muted">${file.path.split('/').slice(-2, -1)[0]}</small>
+                    <div class="d-flex flex-column w-100">
+                        <div class="d-flex w-100 justify-content-between">
+                            <h6 class="mb-1 text-truncate">${file.name}</h6>
+                            <small class="text-muted">${file.path.split('/').slice(-2, -1)[0]}</small>
+                        </div>
+                        <small class="text-info-emphasis text-break font-monospace">${file.path}</small>
                     </div>
-                    <small class="text-muted text-break">${file.path}</small>
                 `;
                 item.onclick = () => {
                     selectedAddFilePath = file.path;

--- a/tests/integration/test_database_file_index.py
+++ b/tests/integration/test_database_file_index.py
@@ -177,6 +177,31 @@ class TestSearchFileIndex:
         assert "type" in r
         assert "parent" in r
 
+    def test_prefix_match_ranks_first(self, db_connection):
+        from core.database import search_file_index
+
+        create_file_index_entry(name="All-New X-Men 013 (2013).cbz")
+        create_file_index_entry(name="Astonishing X-Men 013 (2006).cbz")
+        create_file_index_entry(name="Uncanny X-Men 013 (2024).cbz")
+        create_file_index_entry(name="X-Men 013 (1992).cbz")
+
+        results = search_file_index("X-Men 013")
+        # The name that starts with the query ranks above mid-string matches.
+        assert results[0]["name"] == "X-Men 013 (1992).cbz"
+
+    def test_shorter_match_ranks_ahead_among_non_prefix(self, db_connection):
+        from core.database import search_file_index
+
+        create_file_index_entry(name="The Uncanny X-Men 013 (2024).cbz")
+        create_file_index_entry(name="Uncanny X-Men 013 (2024).cbz")
+
+        results = search_file_index("X-Men 013")
+        names = [r["name"] for r in results]
+        # Neither starts with the query; the earlier match position wins.
+        assert names.index("Uncanny X-Men 013 (2024).cbz") < names.index(
+            "The Uncanny X-Men 013 (2024).cbz"
+        )
+
 
 class TestGetDirectoryChildren:
 


### PR DESCRIPTION
## 📝 Description
Enhance file search relevance and result rendering:

- core/database.py: refine ORDER BY for file_index searches to prefer prefix matches, earlier match positions, and shorter names; updated SQL parameters and added comments explaining the ranking rationale.
- static/js/files.js: reset results container scrollTop when results are (re)rendered so new searches start at the top.
- static/js/reading_list.js: show the file path below each result in a monospace, wrapped line and adjust markup to a column layout so paths don't get truncated; applied to both search flows.
- tests/integration/test_database_file_index.py: add integration tests asserting prefix matches rank first and that earlier/shorter matches rank ahead among non-prefix hits.

These changes improve usability by surfacing more relevant matches and making full file paths visible in search results.

Closes #338 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass