### PR TITLE
Default Manual Search to Series Alias if Present

### DIFF
--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -3664,6 +3664,51 @@ def update_series_aliases(series_name: str, aliases: str) -> int:
     return updated
 
 
+def get_series_aliases(series_name: str) -> str:
+    """
+    Read the stored search aliases for a series.
+
+    Reads from getcomics_urls.search_aliases first (per scrape-index entry).
+    If no scrape-index row carries aliases — e.g. the series hasn't been
+    scraped yet — falls back to getcomics_series_aliases, which
+    update_series_aliases() always writes to. This keeps the series page in
+    sync with what was actually saved regardless of scrape coverage.
+
+    Args:
+        series_name: The series to look up
+
+    Returns:
+        Comma-separated alias string (normalized), or "" if none stored
+    """
+    from core.database import get_db_connection
+    _ensure_urls_table()
+    _ensure_alias_table()
+
+    norm_series, _ = normalize_series_name(series_name)
+    norm_series_lower = norm_series.lower().replace('-', ' ').replace('–', ' ').replace('—', ' ')
+
+    conn = get_db_connection()
+    try:
+        row = conn.execute("""
+            SELECT search_aliases FROM getcomics_urls
+            WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '–', ' ')) = ?
+              AND search_aliases IS NOT NULL AND search_aliases != ''
+            LIMIT 1
+        """, (norm_series_lower,)).fetchone()
+        if row and row[0]:
+            return row[0]
+
+        # Fallback: rebuild from the canonical alias table
+        alias_rows = conn.execute("""
+            SELECT alias FROM getcomics_series_aliases
+            WHERE canonical_norm = ?
+            ORDER BY rowid
+        """, (_normalize_alias(norm_series_lower),)).fetchall()
+        return ','.join(r[0] for r in alias_rows if r[0])
+    finally:
+        conn.close()
+
+
 def get_sitemap_subseries_aliases(series_name: str) -> list[str]:
     """
     Get candidate aliases for a series from the GetComics sitemap.

--- a/routes/series.py
+++ b/routes/series.py
@@ -889,28 +889,18 @@ def get_series_search_aliases(series_id):
         return jsonify({"success": False, "error": "Series name not found"}), 404
 
     from models.getcomics import (
+        get_series_aliases,
         get_sitemap_subseries_aliases,
-        normalize_series_name,
     )
-    from core.database import get_db_connection
 
-    # Get current aliases from scrape index
-    norm_series, _ = normalize_series_name(series_name)
-    norm_lower = norm_series.lower().replace('-', ' ').replace('\u2013', ' ').replace('\u2014', ' ')
-
-    conn = get_db_connection()
-    row = conn.execute("""
-        SELECT search_aliases FROM getcomics_urls
-        WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '\u2013', ' ')) = ?
-        LIMIT 1
-    """, (norm_lower,)).fetchone()
-    current = row[0] if row else ""
-    conn.close()
+    # Get current aliases (reads scrape index, falls back to alias table)
+    current = get_series_aliases(series_name)
 
     # Get pre-populated candidates from sitemap
     candidates = get_sitemap_subseries_aliases(series_name)
 
     return jsonify({
+        "success": True,
         "series_name": series_name,
         "current_aliases": current,
         "candidate_aliases": candidates,

--- a/templates/series.html
+++ b/templates/series.html
@@ -1103,11 +1103,21 @@
         currentSearchSeries = seriesName;
         currentSearchIssue = issueNumber;
 
-        const query = `${seriesName} ${issueNumber}`;
+        // Prefer the first configured alias over the series title for the query
+        const aliasName = getFirstAlias();
+        const queryName = aliasName || seriesName;
+
+        const query = `${queryName} ${issueNumber}`;
         document.getElementById('getcomicsQuery').value = query;
 
         getcomicsModal.show();
         doGetComicsSearch();
+    }
+
+    function getFirstAlias() {
+        if (!currentAliases) return '';
+        const list = currentAliases.split(',').map(a => a.trim()).filter(a => a);
+        return list.length ? list[0] : '';
     }
 
     async function doGetComicsSearch() {
@@ -1195,6 +1205,10 @@
                 btn.classList.add('btn-success');
                 showToastGC('Download queued successfully!', 'success');
 
+                // Reflect the queued download on the issue row:
+                // a wanted/not-found issue (table-danger) becomes table-warning
+                markIssueRowDownloading(currentSearchIssue);
+
                 setTimeout(() => {
                     getcomicsModal.hide();
                 }, 500);
@@ -1207,6 +1221,20 @@
             btn.disabled = false;
             btn.innerHTML = '<i class="bi bi-download"></i>';
             showToastGC('Error: ' + e.message, 'danger');
+        }
+    }
+
+    // When a download is queued for an issue, downgrade its row from
+    // "not found" (table-danger) to "downloading" (table-warning).
+    function markIssueRowDownloading(issueNumber) {
+        if (issueNumber === '' || issueNumber === null || issueNumber === undefined) return;
+        const row = document.querySelector(
+            `tr[data-issue-number="${CSS.escape(String(issueNumber))}"]`
+        );
+        if (!row) return;
+        if (row.classList.contains('table-danger')) {
+            row.classList.remove('table-danger');
+            row.classList.add('table-warning');
         }
     }
 

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -531,3 +531,53 @@ class TestPullListImport:
         assert data["imported_new"] == 1
         assert len(data["errors"]) == 1
         assert get_series_by_id(777) is not None
+
+
+class TestSearchAliases:
+    """GET/PUT /api/series/<id>/search-aliases."""
+
+    @patch("models.getcomics.get_sitemap_subseries_aliases", return_value=["2000ad"])
+    @patch("models.getcomics.get_series_aliases", return_value="2000ad")
+    @patch("routes.series.get_series_by_id", return_value={"name": "2000 AD"})
+    def test_get_returns_success_and_aliases(self, mock_series, mock_aliases, mock_cands, client):
+        resp = client.get("/api/series/100/search-aliases")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # The missing `success` flag was why the UI stayed stuck on "Loading..."
+        assert data["success"] is True
+        assert data["current_aliases"] == "2000ad"
+        assert data["candidate_aliases"] == ["2000ad"]
+
+    @patch("routes.series.get_series_by_id", return_value=None)
+    def test_get_series_not_found(self, mock_series, client):
+        resp = client.get("/api/series/999/search-aliases")
+        assert resp.status_code == 404
+        assert resp.get_json()["success"] is False
+
+    @patch("models.getcomics.update_series_aliases", return_value=2)
+    @patch("routes.series.get_series_by_id", return_value={"name": "2000 AD"})
+    def test_put_saves_aliases(self, mock_series, mock_update, client):
+        resp = client.put("/api/series/100/search-aliases",
+                           json={"aliases": "2000ad"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["entries_updated"] == 2
+        mock_update.assert_called_once_with("2000 AD", "2000ad")
+
+
+class TestGetSeriesAliasesPersistence:
+    """models.getcomics.get_series_aliases falls back to the alias table."""
+
+    def test_falls_back_to_alias_table_when_no_scrape_row(self, app):
+        from core.database import get_db_connection
+        from models.getcomics import (
+            update_series_aliases,
+            get_series_aliases,
+        )
+        # No getcomics_urls row exists for this series, so update touches 0
+        # scrape-index entries -- but the alias must still persist.
+        updated = update_series_aliases("2000 AD", "2000ad")
+        assert updated == 0
+        # Reading back must surface the alias via the canonical alias table.
+        assert "2000ad" in get_series_aliases("2000 AD")


### PR DESCRIPTION
## 📝 Description
Introduce get_series_aliases() in models/getcomics to read stored search aliases from getcomics_urls (with a fallback to getcomics_series_aliases). Update routes/series to use this helper when serving /api/series/<id>/search-aliases and include a success flag in the JSON response. Update series.html to prefer the first configured alias for GetComics queries and to mark issue rows as "downloading" when a download is queued. Add unit tests for the search-aliases endpoints and for alias persistence/fallback behavior. These changes ensure the UI shows correct alias data even when the scrape-index lacks entries and give immediate visual feedback when downloads are queued.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass