### PR TITLE
Migrate rename token {year} -> {volume_year}

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,17 @@ if get_user_preference("custom_rename_pattern") is None:
             "Migrated custom rename settings from config.ini to user_preferences DB"
         )
 
+# Migrate the legacy {year} rename token to {volume_year} (one-time, in-place).
+# Exact literal replace never touches {cover_year}/{store_year}/{issue_year}.
+_stored_rename_pattern = get_user_preference("custom_rename_pattern")
+if _stored_rename_pattern and "{year}" in _stored_rename_pattern:
+    set_user_preference(
+        "custom_rename_pattern",
+        _stored_rename_pattern.replace("{year}", "{volume_year}"),
+        category="file_processing",
+    )
+    app_logger.info("Migrated rename token {year} -> {volume_year} in user_preferences DB")
+
 # Migrate bootstrap_theme from config.ini to user_preferences DB
 if get_user_preference("bootstrap_theme") is None:
     _ini_theme = config.get("SETTINGS", "BOOTSTRAP_THEME", fallback="default")
@@ -722,18 +733,18 @@ def process_incoming_wanted_issues():
     # Load rename pattern
     enabled, pattern = load_custom_rename_config()
     if not enabled or not pattern:
-        pattern = "{series_name} {issue_number} ({year})"
+        pattern = "{series_name} {issue_number} ({volume_year})"
 
     # Create a matching pattern WITHOUT year (year can differ between sources)
-    # Replace {year} and surrounding parens/spaces with flexible match
+    # Replace {volume_year} and surrounding parens/spaces with flexible match
     match_pattern = pattern
     # Remove year placeholder and its common surrounding patterns
     match_pattern = re.sub(
-        r"\s*\(\s*\{year\}\s*\)", "", match_pattern
-    )  # " ({year})" -> ""
+        r"\s*\(\s*\{volume_year\}\s*\)", "", match_pattern
+    )  # " ({volume_year})" -> ""
     match_pattern = re.sub(
-        r"\s*\{year\}", "", match_pattern
-    )  # remaining "{year}" -> ""
+        r"\s*\{volume_year\}", "", match_pattern
+    )  # remaining "{volume_year}" -> ""
     match_pattern = match_pattern.strip()
     app_logger.debug(f"Using match pattern (no year): '{match_pattern}'")
 

--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -524,10 +524,14 @@ def load_custom_rename_config():
 
         enabled = get_user_preference("enable_custom_rename", default=False)
         pattern = get_user_preference("custom_rename_pattern", default="")
+        # Legacy normalization: {year} was renamed to {volume_year}. Rewrite on read
+        # so any not-yet-migrated stored pattern still resolves. Literal replace is
+        # exact and never touches {cover_year}/{store_year}/{issue_year}/{volume_year}.
+        pattern = (pattern or "").replace("{year}", "{volume_year}")
         app_logger.debug(
             f"Loaded custom rename config: enabled={enabled}, pattern={pattern}"
         )
-        return bool(enabled), pattern or ""
+        return bool(enabled), pattern
     except Exception as e:
         app_logger.warning(f"Failed to load custom rename config from DB: {e}")
         return False, ""
@@ -540,7 +544,7 @@ _TOKEN_REGEX = {
     "series_name": r"(?P<series_name>.+?)",
     "issue_number": r"(?P<issue_number>\d{1,4}(?:\.\w+)?)",
     "volume_number": r"(?P<volume_number>\d{1,4})",
-    "year": r"(?P<year>\d{4})",
+    "volume_year": r"(?P<year>\d{4})",
     "issue_year": r"(?P<issue_year>\d{4})",
     "cover_year": r"(?P<cover_year>\d{4})",
     "cover_month_m": r"(?P<cover_month_m>\d{2})",
@@ -1080,7 +1084,11 @@ def apply_custom_pattern(values, pattern):
     # Replace variables with extracted values
     result = result.replace("{series_name}", series_name)
     result = result.replace("{volume_number}", values.get("volume_number", ""))
-    result = result.replace("{year}", values.get("year", ""))
+    # {volume_year} resolves to the series/volume start year; fall back to the parsed
+    # year (reverse-parse from filename only fills "year").
+    result = result.replace(
+        "{volume_year}", values.get("volume_year") or values.get("year", "")
+    )
     result = result.replace("{issue_year}", values.get("issue_year", ""))
     result = result.replace("{cover_year}", values.get("cover_year", ""))
     result = result.replace("{cover_month_M}", values.get("cover_month_M", ""))
@@ -1140,9 +1148,17 @@ def rename_comic_from_metadata(file_path, metadata):
         cover_year, cover_month_M, cover_month_m = _format_date_parts(metadata.get("CoverDate"))
         store_year, store_month_M, store_month_m = _format_date_parts(metadata.get("StoreDate"))
 
+        # {volume_year} = series/volume start year (ComicInfo Volume field:
+        # ComicVine start_year / Metron year_began). GCD stores a volume *number*
+        # there, so guard to a 4-digit year and let apply_custom_pattern fall back
+        # to the issue year when it isn't one.
+        vol_raw = str(metadata.get("Volume", "") or "").strip()
+        volume_year = vol_raw if re.fullmatch(r"\d{4}", vol_raw) else ""
+
         values = {
             "series_name": series,
             "volume_number": "",
+            "volume_year": volume_year,
             "year": str(metadata.get("Year", "")),
             "issue_year": str(metadata.get("Year", "")),
             "cover_year": cover_year,
@@ -1195,7 +1211,7 @@ def validate_custom_pattern(pattern):
     valid_variables = [
         "{series_name}",
         "{volume_number}",
-        "{year}",
+        "{volume_year}",
         "{issue_year}",
         "{cover_year}",
         "{cover_month_M}",
@@ -2003,14 +2019,14 @@ def test_custom_rename():
     }
 
     test_patterns = [
-        ("{series_name} {issue_number} ({year})", "Spider-Man 2099 044 (1992)"),
-        ("{series_name} [{year}] {issue_number}", "Spider-Man 2099 [1992] 044"),
+        ("{series_name} {issue_number} ({volume_year})", "Spider-Man 2099 044 (1992)"),
+        ("{series_name} [{volume_year}] {issue_number}", "Spider-Man 2099 [1992] 044"),
         ("issue{issue_number}", "issue044"),
         ("{volume_number}_{issue_number}", "v2_044"),
-        ("{series_name} - {year}", "Spider-Man 2099 - 1992"),
+        ("{series_name} - {volume_year}", "Spider-Man 2099 - 1992"),
         ("{series_name} {volume_number} {issue_number}", "Spider-Man 2099 v2 044"),
         (
-            "{series_name} {issue_number} - {issue_title} ({year})",
+            "{series_name} {issue_number} - {issue_title} ({volume_year})",
             "Spider-Man 2099 044 - The Last Dance (1992)",
         ),
     ]

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -262,6 +262,8 @@ def _plan_file(
     values = {
         "series_name": _sanitize_series_name((metadata.get("name") or "").strip()),
         "volume_number": _format_volume(metadata.get("volume")),
+        # series.json "year" is the series/volume year -> feeds {volume_year}
+        "volume_year": _format_year(metadata.get("year")),
         "year": _format_year(metadata.get("year")),
         "issue_number": issue,
         "issue_title": "",

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -11,10 +11,10 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
     Pattern placeholders:
     - {series_name} -> matches the series name (flexible whitespace/case)
     - {issue_number} -> matches the issue number (with optional leading zeros)
-    - {year} -> matches any 4-digit year
+    - {volume_year} (and legacy {year}) -> matches any 4-digit year
 
     Args:
-        custom_pattern: The rename pattern from config (e.g., "{series_name} {issue_number} ({year})")
+        custom_pattern: The rename pattern from config (e.g., "{series_name} {issue_number} ({volume_year})")
         series_name: The series name to match
         issue_number: The issue number to match
 
@@ -27,14 +27,15 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
 
     try:
         # First, escape literal parentheses in the custom pattern BEFORE substituting
-        # This handles patterns like "{series_name} {issue_number} ({year})"
-        # The ( ) around {year} should become \( \) in the final regex
+        # This handles patterns like "{series_name} {issue_number} ({volume_year})"
+        # The ( ) around {volume_year} should become \( \) in the final regex
 
         # Use placeholders to protect our variable markers
         pattern = custom_pattern
         pattern = pattern.replace('{series_name}', '<<<SERIES>>>')
         pattern = pattern.replace('{issue_number}', '<<<ISSUE>>>')
-        pattern = pattern.replace('{year}', '<<<YEAR>>>')
+        pattern = pattern.replace('{volume_year}', '<<<YEAR>>>')
+        pattern = pattern.replace('{year}', '<<<YEAR>>>')  # legacy fallback
         pattern = pattern.replace('{volume_number}', '<<<VOLUME>>>')
         pattern = pattern.replace('{issue_title}', '<<<TITLE>>>')
 

--- a/models/cbl.py
+++ b/models/cbl.py
@@ -63,6 +63,7 @@ class CBLLoader:
         search_term = search_term.replace('{issue_number}', padded_number)
         search_term = search_term.replace('{issue}', padded_number)
         search_term = search_term.replace('{volume}', volume or '')
+        search_term = search_term.replace('{volume_year}', year or '')
         search_term = search_term.replace('{year}', year or '')
         search_term = search_term.replace('{start_year}', volume or year or '')
 

--- a/static/js/clu-metadata.js
+++ b/static/js/clu-metadata.js
@@ -979,6 +979,10 @@
       var year = metadata.Year || '';
       var volumeNumber = '';  // ComicVine uses year as Volume, not a volume number
       var issueYear = metadata.Year || '';
+      // {volume_year} = series/volume start year (ComicInfo Volume field). GCD stores
+      // a volume number there, so guard to a 4-digit year and fall back to issue year.
+      var volRaw = String(metadata.Volume || '').trim();
+      var volumeYear = /^\d{4}$/.test(volRaw) ? volRaw : '';
 
       var cover = CLU.parseDateParts(metadata.CoverDate);
       var store = CLU.parseDateParts(metadata.StoreDate);
@@ -1000,7 +1004,7 @@
       result = result.replace(/{store_month_M}/g, store.monthName);
       result = result.replace(/{store_month_m}/g, store.monthPadded);
       result = result.replace(/{store_year}/gi, store.year);
-      result = result.replace(/{year}/gi, year);
+      result = result.replace(/{volume_year}/gi, volumeYear || year);
       result = result.replace(/{YYYY}/g, year);
       result = result.replace(/{volume_number}/gi, volumeNumber);
       result = result.replace(/{issue_title}/gi, issueTitle);

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -959,6 +959,7 @@ function formatSearchTerm(series, number, volume, year) {
         .replace('{issue_number}', paddedNumber)
         .replace('{issue}', paddedNumber)
         .replace('{volume}', volume || '')
+        .replace('{volume_year}', year || '')
         .replace('{year}', year || '')
         .replace('{start_year}', volume || year || '');
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -390,11 +390,12 @@
                             <label for="customRenamePattern" class="form-label">Custom Rename Pattern:</label>
                             <input type="text" name="customRenamePattern" id="customRenamePattern"
                                 value="{{ customRenamePattern }}" class="form-control"
-                                placeholder="e.g., {series_name} {issue_number} ({year})">
+                                placeholder="e.g., {series_name} {issue_number} ({volume_year})">
                             <small class="form-text text-muted">
                                 Use variables to create your naming pattern. Available variables:
-                                <code>{series_name}</code>, <code>{volume_number}</code>, <code>{year}</code>,
-                                <code>{issue_year}</code>,
+                                <code>{series_name}</code>, <code>{volume_number}</code>,
+                                <code>{volume_year}</code> (series/volume start year),
+                                <code>{issue_year}</code> (this issue's year),
                                 <code>{issue_number}</code>, <code>{issue_title}</code>.
                                 Cover/store dates (from ComicVine/Metron):
                                 <code>{cover_year}</code>, <code>{cover_month_M}</code> (June), <code>{cover_month_m}</code> (06),
@@ -413,13 +414,13 @@
                         <div class="col-md-12">
                             <small class="text-muted">
                                 <strong>Examples:</strong><br>
-                                • <code>{series_name} {issue_number} ({year})</code> →
+                                • <code>{series_name} {issue_number} ({volume_year})</code> →
                                 <code>Spider-Man 2099 044 (1992).cbz</code><br>
-                                • <code>{series_name} [{year}] {issue_number}</code> →
+                                • <code>{series_name} [{volume_year}] {issue_number}</code> →
                                 <code>Spider-Man 2099 [1992] 044.cbz</code><br>
                                 • <code>issue{issue_number}</code> → <code>issue001.cbz</code><br>
                                 • <code>{volume_number}_{issue_number}</code> → <code>v2_044.cbz</code><br>
-                                • <code>{series_name} {issue_number} - {issue_title} ({year})</code> →
+                                • <code>{series_name} {issue_number} - {issue_title} ({volume_year})</code> →
                                 <code>Spider-Man 2099 044 - The Last Dance (1992).cbz</code><br>
                                 • <code>{series_name} {issue_number} ({cover_year}-{cover_month_m})</code> →
                                 <code>Spider-Man 2099 044 (1992-06).cbz</code>
@@ -2628,6 +2629,7 @@
             publisher: 'Marvel',
             series_name: 'Spider-Man 2099',
             volume_number: 'v2',
+            volume_year: '1992',
             year: '1992',
             issue_year: '1992',
             cover_year: '1992',
@@ -2656,7 +2658,8 @@
         result = result.replace(/\{publisher\}/g, values.publisher || '');
         result = result.replace(/\{series_name\}/g, values.series_name || '');
         result = result.replace(/\{volume_number\}/g, values.volume_number || '');
-        result = result.replace(/\{year\}/g, values.year || '');  // For rename patterns
+        result = result.replace(/\{volume_year\}/g, values.volume_year || values.year || '');  // For rename patterns
+        result = result.replace(/\{year\}/g, values.year || '');  // Legacy rename token
         result = result.replace(/\{start_year\}/g, values.start_year || '');  // For move patterns
         result = result.replace(/\{issue_year\}/g, values.issue_year || '');
         result = result.replace(/\{cover_year\}/g, values.cover_year || '');

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -199,6 +199,7 @@ class TestApplyCustomPattern:
         return {
             "series_name": "Spider-Man 2099",
             "volume_number": "v2",
+            "volume_year": "1992",
             "year": "1992",
             "issue_year": "1992",
             "cover_year": "1992",
@@ -212,14 +213,14 @@ class TestApplyCustomPattern:
         }
 
     @pytest.mark.parametrize("pattern,expected", [
-        ("{series_name} {issue_number} ({year})", "Spider-Man 2099 044 (1992)"),
-        ("{series_name} [{year}] {issue_number}", "Spider-Man 2099 [1992] 044"),
+        ("{series_name} {issue_number} ({volume_year})", "Spider-Man 2099 044 (1992)"),
+        ("{series_name} [{volume_year}] {issue_number}", "Spider-Man 2099 [1992] 044"),
         ("issue{issue_number}", "issue044"),
         ("{volume_number}_{issue_number}", "v2_044"),
-        ("{series_name} - {year}", "Spider-Man 2099 - 1992"),
+        ("{series_name} - {volume_year}", "Spider-Man 2099 - 1992"),
         ("{series_name} {volume_number} {issue_number}", "Spider-Man 2099 v2 044"),
         (
-            "{series_name} {issue_number} - {issue_title} ({year})",
+            "{series_name} {issue_number} - {issue_title} ({volume_year})",
             "Spider-Man 2099 044 - The Last Dance (1992)",
         ),
         (
@@ -267,6 +268,54 @@ class TestApplyCustomPattern:
         assert "/" not in result
         assert "\\" not in result
         assert '"' not in result
+
+    def test_volume_year_prefers_volume_year_value(self):
+        from cbz_ops.rename import apply_custom_pattern
+        values = {
+            "series_name": "X", "issue_number": "001",
+            "volume_year": "2016", "year": "2099",
+        }
+        assert apply_custom_pattern(values, "{series_name} {issue_number} ({volume_year})") \
+            == "X 001 (2016)"
+
+    def test_volume_year_falls_back_to_parsed_year(self):
+        # Reverse-parse path only fills "year"; {volume_year} should pick it up.
+        from cbz_ops.rename import apply_custom_pattern
+        values = {"series_name": "X", "issue_number": "001", "year": "2020"}
+        assert apply_custom_pattern(values, "{series_name} {issue_number} ({volume_year})") \
+            == "X 001 (2020)"
+
+
+# ===== load_custom_rename_config (legacy {year} migration) =====
+
+class TestLoadCustomRenameConfig:
+
+    def test_legacy_year_token_normalized_on_read(self):
+        from cbz_ops import rename as rename_mod
+
+        def fake_pref(key, default=None):
+            return {
+                "enable_custom_rename": True,
+                "custom_rename_pattern": "{series_name} {issue_number} ({year})",
+            }.get(key, default)
+
+        with patch("core.database.get_user_preference", side_effect=fake_pref):
+            enabled, pattern = rename_mod.load_custom_rename_config()
+        assert enabled is True
+        assert pattern == "{series_name} {issue_number} ({volume_year})"
+
+    def test_other_year_tokens_untouched(self):
+        from cbz_ops import rename as rename_mod
+
+        def fake_pref(key, default=None):
+            return {
+                "enable_custom_rename": True,
+                "custom_rename_pattern": "{series_name} ({cover_year}) {issue_year} {store_year}",
+            }.get(key, default)
+
+        with patch("core.database.get_user_preference", side_effect=fake_pref):
+            _, pattern = rename_mod.load_custom_rename_config()
+        assert pattern == "{series_name} ({cover_year}) {issue_year} {store_year}"
 
 
 # ===== _apply_filters =====
@@ -545,7 +594,7 @@ class TestRenameComicFromMetadata:
         assert result_path == str(f)
         assert was_renamed is False
 
-    @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number} ({year})'))
+    @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number} ({volume_year})'))
     def test_renames_with_pattern(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
@@ -578,7 +627,7 @@ class TestRenameComicFromMetadata:
         assert result_path == str(f)
         assert os.path.exists(str(f))
 
-    @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number} ({year})'))
+    @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number} ({volume_year})'))
     def test_renames_decimal_issue_number(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
@@ -597,7 +646,7 @@ class TestRenameComicFromMetadata:
         assert was_renamed is False
         assert result_path == str(f)
 
-    @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number} ({year})'))
+    @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number} ({volume_year})'))
     def test_renames_manga_volume_number(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
@@ -658,6 +707,32 @@ class TestRenameComicFromMetadata:
         assert name == "Batman 001.cbz"
         assert "-)" not in name and "(-" not in name and "()" not in name
 
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({volume_year})'))
+    def test_volume_year_uses_volume_field(self, mock_config, tmp_path):
+        # {volume_year} = series/volume start year (ComicInfo Volume), distinct from
+        # the issue Year. Volume 2016 should win over Year 2099.
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Spider-Man', 'Number': '1', 'Year': 2099, 'Volume': 2016})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "Spider-Man 001 (2016).cbz"
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({volume_year})'))
+    def test_volume_year_falls_back_to_issue_year_when_volume_not_a_year(self, mock_config, tmp_path):
+        # GCD stores a volume *number* in Volume; the 4-digit guard makes {volume_year}
+        # fall back to the issue Year.
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Volume': '1'})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "Batman 001 (2020).cbz"
+
 
 # ===== reverse_parse_pattern =====
 
@@ -667,7 +742,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Batman #001 V2021 (2021)",
-            "{series_name} #{issue_number} V{volume_number} ({year})"
+            "{series_name} #{issue_number} V{volume_number} ({volume_year})"
         )
         assert result is not None
         assert result["series_name"] == "Batman"
@@ -679,7 +754,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Miskatonic - Even Death May Die #001 V2021 (2021)",
-            "{series_name} #{issue_number} V{volume_number} ({year})"
+            "{series_name} #{issue_number} V{volume_number} ({volume_year})"
         )
         assert result is not None
         assert result["series_name"] == "Miskatonic - Even Death May Die"
@@ -691,7 +766,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Batman 042 (2020)",
-            "{series_name} {issue_number} ({year})"
+            "{series_name} {issue_number} ({volume_year})"
         )
         assert result is not None
         assert result["series_name"] == "Batman"
@@ -702,7 +777,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Batman 042 - Court of Owls (2020)",
-            "{series_name} {issue_number} - {issue_title} ({year})"
+            "{series_name} {issue_number} - {issue_title} ({volume_year})"
         )
         assert result is not None
         assert result["series_name"] == "Batman"
@@ -714,7 +789,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "totally different format",
-            "{series_name} #{issue_number} ({year})"
+            "{series_name} #{issue_number} ({volume_year})"
         )
         assert result is None
 
@@ -734,7 +809,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Batman  042  (2020)",
-            "{series_name} {issue_number} ({year})"
+            "{series_name} {issue_number} ({volume_year})"
         )
         assert result is not None
         assert result["series_name"] == "Batman"
@@ -744,7 +819,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Batman #001 v2021 (2021)",
-            "{series_name} #{issue_number} V{volume_number} ({year})"
+            "{series_name} #{issue_number} V{volume_number} ({volume_year})"
         )
         assert result is not None
         assert result["issue_number"] == "001"
@@ -753,7 +828,7 @@ class TestReverseParsePattern:
         from cbz_ops.rename import reverse_parse_pattern
         result = reverse_parse_pattern(
             "Avengers 012.1 (2011)",
-            "{series_name} {issue_number} ({year})"
+            "{series_name} {issue_number} ({volume_year})"
         )
         assert result is not None
         assert result["issue_number"] == "012.1"
@@ -767,7 +842,7 @@ class TestParseComicFilename:
         from cbz_ops.rename import parse_comic_filename
         result = parse_comic_filename(
             "Miskatonic - Even Death May Die #001 V2021 (2021).cbz",
-            custom_pattern="{series_name} #{issue_number} V{volume_number} ({year})"
+            custom_pattern="{series_name} #{issue_number} V{volume_number} ({volume_year})"
         )
         assert result["series_name"] == "Miskatonic - Even Death May Die"
         assert result["issue_number"] == "1"  # Stripped leading zeros
@@ -794,7 +869,7 @@ class TestParseComicFilename:
         from cbz_ops.rename import parse_comic_filename
         result = parse_comic_filename(
             "Batman 001 (2020).cbz",
-            custom_pattern="{series_name} #{issue_number} V{volume_number} ({year})"
+            custom_pattern="{series_name} #{issue_number} V{volume_number} ({volume_year})"
         )
         # Custom pattern won't match "Batman 001 (2020)" (missing #, V), falls back
         assert result["series_name"]
@@ -812,7 +887,7 @@ class TestParseComicFilename:
         from cbz_ops.rename import parse_comic_filename
         result = parse_comic_filename(
             "Batman #042 (2020).cbz",
-            custom_pattern="{series_name} #{issue_number} ({year})"
+            custom_pattern="{series_name} #{issue_number} ({volume_year})"
         )
         assert result["issue_number"] == "42"
 
@@ -820,7 +895,7 @@ class TestParseComicFilename:
         from cbz_ops.rename import parse_comic_filename
         result = parse_comic_filename(
             "Avengers 012.1 (2011).cbz",
-            custom_pattern="{series_name} {issue_number} ({year})"
+            custom_pattern="{series_name} {issue_number} ({volume_year})"
         )
         assert result["issue_number"] == "12.1"
 


### PR DESCRIPTION
## 📝 Description
Introduce a dedicated `{volume_year} `token for series/volume start year and migrate legacy {year} usage. Performs a one-time in-place DB migration of stored custom rename patterns, normalizes `{year} -> {volume_year}` on read, and updates pattern parsing/formatting throughout the codebase (rename logic, smart rename planning, filename pattern generation, JS UI/formatters, models, and templates). apply_custom_pattern now prefers volume_year and falls back to parsed year; smart metadata extraction guards volume->year mapping to 4-digit values so volume numbers are not treated as years. Tests were updated and new tests added to cover normalization, fallback behavior, and parsing changes.

Closes #345 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass