### PR TITLE
Add Oneshot-folder handling to bulk metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -6907,6 +6907,9 @@ def config_page():
         config["SETTINGS"]["VARIANT_TYPES"] = request.form.get(
             "variantTypes", "annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery,absolute"
         )
+        config["SETTINGS"]["ONESHOT_FOLDERS"] = request.form.get(
+            "oneshotFolders", "oneshots,one-shots,specials"
+        )
         config["SETTINGS"]["ENABLE_DEBUG_LOGGING"] = str(
             request.form.get("enableDebugLogging") == "on"
         )
@@ -7049,6 +7052,7 @@ def config_page():
         ),
         publicationTypes=settings.get("PUBLICATION_TYPES", "annual,quarterly"),
         variantTypes=settings.get("VARIANT_TYPES", "annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery"),
+        oneshotFolders=settings.get("ONESHOT_FOLDERS", "oneshots,one-shots,specials"),
         enableDebugLogging=settings.get("ENABLE_DEBUG_LOGGING", "False") == "True",
         bootstrapTheme=get_user_preference("bootstrap_theme", default="default"),
         timezone=get_user_preference("timezone", default="UTC"),

--- a/core/bulk_metadata.py
+++ b/core/bulk_metadata.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional, Tuple
 import core.app_state as app_state
 from core.app_logging import app_logger
 from core.comicinfo import find_comicinfo_in_zip
+from core.config import config
 from core.database import (
     add_review_item,
     complete_bulk_job,
@@ -234,6 +235,22 @@ def _series_year_for_folder(folder_path: str, files: List[str]) -> Tuple[str, Op
     if not year and files:
         year = extract_year_from_name(os.path.basename(files[0]))
     return series, year
+
+
+def _is_oneshot_folder(folder_path: str) -> bool:
+    """True if the folder's base name is in the user's ONESHOT_FOLDERS list.
+
+    These are folders of unrelated single issues (e.g. ``/oneshots``). Files in
+    them are resolved individually from their own filename rather than against a
+    single folder-level series, and no cvinfo/series.json sidecar is written.
+    Matching is on the folder's base name, case-insensitive, ignoring any
+    leading slashes the user may have typed in the config value.
+    """
+    names = config.get("SETTINGS", "ONESHOT_FOLDERS",
+                       fallback="oneshots,one-shots,specials")
+    wanted = {n.strip().strip('/\\').lower() for n in names.split(',') if n.strip()}
+    base = os.path.basename(folder_path.rstrip('/\\')).lower()
+    return bool(base) and base in wanted
 
 
 def _try_cvinfo(folder_path: str) -> Optional[Tuple[str, str]]:
@@ -560,6 +577,20 @@ def _process_folder(
     """Process a single folder bucket. Updates job counts and progress in place."""
     folder_name = os.path.basename(folder_path.rstrip(os.sep)) or folder_path
 
+    # Oneshots folders hold unrelated single issues — resolve each file on its
+    # own from its filename, and never write a folder-level series sidecar.
+    if _is_oneshot_folder(folder_path):
+        _process_oneshot_folder(
+            job_id=job_id,
+            op_id=op_id,
+            folder_path=folder_path,
+            files=files,
+            providers=providers,
+            overwrite_existing=overwrite_existing,
+            progress=progress,
+        )
+        return
+
     # Resolve series — cvinfo first, then provider search with the auto-accept gate.
     cvinfo = _try_cvinfo(folder_path)
     parsed_series, parsed_year = _series_year_for_folder(folder_path, files)
@@ -706,6 +737,146 @@ def _process_folder(
                 parsed_series=parsed_series,
                 parsed_issue=issue_text,
                 parsed_year=parsed_year,
+                reason='issue_no_match',
+                candidates=[],
+            )
+            update_bulk_job_counts(job_id, needs_review=1)
+
+
+def _process_oneshot_folder(
+    job_id: str,
+    op_id: str,
+    folder_path: str,
+    files: List[str],
+    providers: List[str],
+    overwrite_existing: bool,
+    progress: Dict[str, int],
+) -> None:
+    """Process a folder of unrelated single issues (a "oneshots" folder).
+
+    Unlike _process_folder, there is no single folder series: each file is
+    resolved independently from its own filename (series name + year), matched
+    to an issue, and written. No cvinfo/series.json sidecar is written. A file
+    with no parseable issue number is treated as issue ``#1`` (one-shots are a
+    single issue). Anything that can't be auto-resolved is queued for file-level
+    review.
+    """
+    # Small per-folder cache so repeated series in the same folder don't refetch.
+    series_cache: Dict[Tuple[str, Optional[int]], Tuple[Optional[str], Optional[SearchResult], Dict[str, List[IssueResult]]]] = {}
+
+    for file_path in files:
+        progress["done"] += 1
+        app_state.update_operation(op_id, current=progress["done"], detail=os.path.basename(file_path))
+
+        # Skip files that already have metadata (unless caller asked to overwrite).
+        if not overwrite_existing and _has_existing_comicinfo(file_path):
+            update_bulk_job_counts(job_id, skipped=1)
+            continue
+
+        base = os.path.basename(file_path)
+        file_series = extract_series_name_from_filename(base)
+        file_year = extract_year_from_name(base)
+        # One-shots are a single issue; default a missing issue number to #1.
+        issue_text = extract_issue_number(base) or "1"
+
+        cache_key = (file_series, file_year)
+        if cache_key in series_cache:
+            prov_name, series, issues_by_norm = series_cache[cache_key]
+        else:
+            prov_name, series, all_candidates = _resolve_series_auto(
+                providers, file_series, file_year
+            )
+            if series is None:
+                reason = 'series_ambiguous' if all_candidates else 'series_no_match'
+                add_review_item(
+                    job_id=job_id,
+                    folder_path=folder_path,
+                    file_path=file_path,
+                    parsed_series=file_series,
+                    parsed_issue=issue_text,
+                    parsed_year=file_year,
+                    reason=reason,
+                    candidates=_candidates_to_json(all_candidates),
+                )
+                update_bulk_job_counts(job_id, needs_review=1)
+                series_cache[cache_key] = (None, None, {})
+                continue
+
+            provider = _instantiate_provider(prov_name)
+            try:
+                all_issues = provider.get_issues(str(series.id)) if provider else []
+            except Exception as e:
+                app_logger.warning(f"get_issues failed for {file_path}: {e}")
+                all_issues = []
+            issues_by_norm = {}
+            for i in all_issues:
+                key = (i.issue_number or '').lstrip('0') or '0'
+                issues_by_norm.setdefault(key, []).append(i)
+            series_cache[cache_key] = (prov_name, series, issues_by_norm)
+
+        # A cached miss (unresolved series) still queues this file for review.
+        if series is None:
+            add_review_item(
+                job_id=job_id,
+                folder_path=folder_path,
+                file_path=file_path,
+                parsed_series=file_series,
+                parsed_issue=issue_text,
+                parsed_year=file_year,
+                reason='series_no_match',
+                candidates=[],
+            )
+            update_bulk_job_counts(job_id, needs_review=1)
+            continue
+
+        norm = issue_text.lstrip('0') or '0'
+        matches = issues_by_norm.get(norm, [])
+        if len(matches) == 1:
+            ok = _write_metadata(
+                job_id=job_id,
+                folder_path=folder_path,
+                file_path=file_path,
+                provider_name=prov_name,
+                series=series,
+                issue=matches[0],
+                matched_via='oneshot_filename',
+                parsed_year=file_year,
+            )
+            if ok:
+                update_bulk_job_counts(job_id, auto_accepted=1)
+            else:
+                update_bulk_job_counts(job_id, errors=1)
+        elif len(matches) > 1:
+            add_review_item(
+                job_id=job_id,
+                folder_path=folder_path,
+                file_path=file_path,
+                parsed_series=file_series,
+                parsed_issue=issue_text,
+                parsed_year=file_year,
+                reason='issue_ambiguous',
+                candidates=[
+                    {
+                        "provider": prov_name,
+                        "id": m.id,
+                        "issue_number": m.issue_number,
+                        "title": m.title,
+                        "cover_date": m.cover_date,
+                        "cover_url": m.cover_url,
+                        "series_id": m.series_id,
+                    }
+                    for m in matches[:8]
+                ],
+            )
+            update_bulk_job_counts(job_id, needs_review=1)
+        else:
+            add_review_item(
+                job_id=job_id,
+                folder_path=folder_path,
+                file_path=file_path,
+                parsed_series=file_series,
+                parsed_issue=issue_text,
+                parsed_year=file_year,
                 reason='issue_no_match',
                 candidates=[],
             )

--- a/core/config.py
+++ b/core/config.py
@@ -66,7 +66,8 @@ def load_config():
         "TRASH_MAX_SIZE_MB": "1024",
         "PUBLICATION_TYPES": "annual,quarterly",
         "VARIANT_TYPES": "annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery",
-        "SEQUEL_KEYWORDS": "season,volume,book,part,chapter"
+        "SEQUEL_KEYWORDS": "season,volume,book,part,chapter",
+        "ONESHOT_FOLDERS": "oneshots,one-shots,specials"
     }
 
     if not os.path.exists(CONFIG_FILE):

--- a/templates/config.html
+++ b/templates/config.html
@@ -699,6 +699,17 @@
                             </small>
                         </div>
                     </div>
+                    <div class="row mt-3">
+                        <div class="col-md-12">
+                            <label for="oneshotFolders" class="form-label">One-Shot Folders</label>
+                            <input type="text" name="oneshotFolders" id="oneshotFolders"
+                                value="{{ oneshotFolders }}" class="form-control"
+                                placeholder="oneshots,one-shots,specials">
+                            <small class="form-text text-muted">
+                                Folder names whose files are <strong>unrelated single issues</strong> (e.g., one-shots). In bulk metadata, each file in these folders is matched <strong>individually</strong> from its own filename and <strong>no cvinfo/series.json</strong> is written. Comma-separated, matched by folder name.
+                            </small>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- GetComics Wanted Issues Simulation -->

--- a/tests/unit/test_bulk_metadata_oneshots.py
+++ b/tests/unit/test_bulk_metadata_oneshots.py
@@ -1,0 +1,226 @@
+"""Unit tests for oneshots-folder handling in the bulk metadata orchestrator.
+
+A "oneshots" folder (configured via ONESHOT_FOLDERS) holds unrelated single
+issues. Unlike a normal folder, each file is resolved independently from its own
+filename and NO cvinfo/series.json sidecar is written. Providers are mocked at
+the module level so no real APIs are hit.
+"""
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from core import bulk_metadata as bm
+from core.database import create_bulk_job, get_bulk_job, get_review_queue
+from models.providers import ProviderType
+from models.providers.base import SearchResult, IssueResult
+
+
+def _make_search(provider, title, year, **kw):
+    return SearchResult(
+        provider=provider,
+        id=str(kw.get('id', '1')),
+        title=title,
+        year=year,
+        publisher=kw.get('publisher'),
+        issue_count=kw.get('issue_count'),
+        cover_url=None,
+        description=None,
+    )
+
+
+def _make_issue(provider, series_id, number, issue_id='1'):
+    return IssueResult(
+        provider=provider,
+        id=str(issue_id),
+        series_id=str(series_id),
+        issue_number=str(number),
+        title=None,
+        cover_date=None,
+        store_date=None,
+        cover_url=None,
+        summary=None,
+    )
+
+
+def _new_job():
+    import uuid
+    job_id = uuid.uuid4().hex
+    create_bulk_job(job_id, 'folder', [])
+    return job_id
+
+
+# ---------------------------------------------------------------------------
+# _is_oneshot_folder
+# ---------------------------------------------------------------------------
+class TestIsOneshotFolder:
+
+    def test_matches_configured_name_case_insensitive(self):
+        with patch.object(bm.config, 'get', return_value='oneshots,one-shots,specials'):
+            assert bm._is_oneshot_folder('/data/Comics/Oneshots') is True
+            assert bm._is_oneshot_folder('/data/Comics/ONESHOTS') is True
+            assert bm._is_oneshot_folder('/data/Comics/Specials/') is True
+
+    def test_ignores_leading_slash_in_config_value(self):
+        # User may type "/oneshots" in the config field.
+        with patch.object(bm.config, 'get', return_value='/oneshots, Standalone'):
+            assert bm._is_oneshot_folder('/data/Comics/oneshots') is True
+            assert bm._is_oneshot_folder('/data/Comics/standalone') is True
+
+    def test_unlisted_folder_is_false(self):
+        with patch.object(bm.config, 'get', return_value='oneshots,one-shots,specials'):
+            assert bm._is_oneshot_folder('/data/Comics/Batman (2016)') is False
+
+    def test_empty_config_is_false(self):
+        with patch.object(bm.config, 'get', return_value=''):
+            assert bm._is_oneshot_folder('/data/Comics/oneshots') is False
+
+
+# ---------------------------------------------------------------------------
+# _process_oneshot_folder — per-file resolution, no sidecars
+# ---------------------------------------------------------------------------
+class TestProcessOneshotFolder:
+
+    def _run(self, db_connection, tmp_path, files, resolve_results, issues):
+        """Run _process_oneshot_folder over `files`, mocking resolution + write.
+
+        Returns (job_id, write_mock).
+        """
+        folder = tmp_path / 'oneshots'
+        folder.mkdir()
+        file_paths = [str(folder / f) for f in files]
+
+        job_id = _new_job()
+        progress = {"done": 0}
+
+        provider = MagicMock()
+        provider.get_issues.return_value = issues
+
+        write_mock = MagicMock(return_value=True)
+
+        with patch.object(bm, '_resolve_series_auto', side_effect=resolve_results), \
+             patch.object(bm, '_instantiate_provider', return_value=provider), \
+             patch.object(bm, '_write_metadata', write_mock):
+            bm._process_oneshot_folder(
+                job_id=job_id,
+                op_id='op-test',
+                folder_path=str(folder),
+                files=file_paths,
+                providers=['metron', 'comicvine'],
+                overwrite_existing=True,  # skip the on-disk ComicInfo check
+                progress=progress,
+            )
+
+        return job_id, str(folder), write_mock
+
+    def test_two_unrelated_files_each_resolve_independently(self, db_connection, tmp_path):
+        series_a = _make_search(ProviderType.METRON, 'Batman - Damned', 2017, id='10')
+        series_b = _make_search(ProviderType.COMICVINE, 'Saga Special', 2014, id='20')
+        issues = [
+            _make_issue(ProviderType.METRON, '10', '1', issue_id='A1'),
+            _make_issue(ProviderType.COMICVINE, '20', '3', issue_id='B3'),
+        ]
+        job_id, folder, write_mock = self._run(
+            db_connection, tmp_path,
+            files=['Batman - Damned (2017).cbz', 'Saga Special 003 (2014).cbz'],
+            resolve_results=[('metron', series_a, []), ('comicvine', series_b, [])],
+            issues=issues,
+        )
+
+        # _write_metadata called once per file, with that file's own series.
+        assert write_mock.call_count == 2
+        written_series = {c.kwargs['series'].id for c in write_mock.call_args_list}
+        assert written_series == {'10', '20'}
+        assert all(c.kwargs['matched_via'] == 'oneshot_filename' for c in write_mock.call_args_list)
+
+        # No folder-level sidecars written.
+        assert not os.path.exists(os.path.join(folder, 'cvinfo'))
+        assert not os.path.exists(os.path.join(folder, 'series.json'))
+
+        job = get_bulk_job(job_id)
+        assert job['auto_accepted'] == 2
+        assert job['needs_review'] == 0
+
+    def test_file_without_issue_number_defaults_to_one(self, db_connection, tmp_path):
+        series_a = _make_search(ProviderType.METRON, 'Batman - Damned', 2017, id='10')
+        issues = [_make_issue(ProviderType.METRON, '10', '1', issue_id='A1')]
+        job_id, folder, write_mock = self._run(
+            db_connection, tmp_path,
+            files=['Batman - Damned (2017).cbz'],  # no issue number
+            resolve_results=[('metron', series_a, [])],
+            issues=issues,
+        )
+        # Treated as #1 -> matched + written, not queued.
+        assert write_mock.call_count == 1
+        assert write_mock.call_args.kwargs['issue'].id == 'A1'
+        assert get_review_queue(job_id=job_id) == []
+        assert not os.path.exists(os.path.join(folder, 'series.json'))
+
+    def test_unresolvable_file_queues_file_level_review_no_sidecar(self, db_connection, tmp_path):
+        job_id, folder, write_mock = self._run(
+            db_connection, tmp_path,
+            files=['Totally Unknown Comic (1999).cbz'],
+            resolve_results=[(None, None, [])],  # nothing matched
+            issues=[],
+        )
+        write_mock.assert_not_called()
+
+        queue = get_review_queue(job_id=job_id)
+        assert len(queue) == 1
+        # File-level review item -> file_path is populated.
+        assert queue[0]['file_path'] == os.path.join(folder, 'Totally Unknown Comic (1999).cbz')
+        assert queue[0]['reason'] == 'series_no_match'
+
+        assert not os.path.exists(os.path.join(folder, 'cvinfo'))
+        assert not os.path.exists(os.path.join(folder, 'series.json'))
+
+
+# ---------------------------------------------------------------------------
+# _process_folder routing — oneshot vs normal
+# ---------------------------------------------------------------------------
+class TestProcessFolderRouting:
+
+    def test_oneshot_folder_routes_to_per_file_and_skips_sidecars(self, db_connection, tmp_path):
+        folder = tmp_path / 'oneshots'
+        folder.mkdir()
+        files = [str(folder / 'Some Comic (2017).cbz')]
+
+        with patch.object(bm, '_is_oneshot_folder', return_value=True), \
+             patch.object(bm, '_process_oneshot_folder') as oneshot_mock, \
+             patch.object(bm, 'ensure_folder_sidecars') as sidecar_mock, \
+             patch.object(bm, '_resolve_series_auto') as resolve_mock:
+            bm._process_folder(
+                job_id=_new_job(), op_id='op', folder_path=str(folder),
+                files=files, providers=['metron'], overwrite_existing=True,
+                progress={"done": 0},
+            )
+
+        oneshot_mock.assert_called_once()
+        sidecar_mock.assert_not_called()
+        resolve_mock.assert_not_called()  # folder-level resolution skipped
+
+    def test_normal_folder_writes_sidecars(self, db_connection, tmp_path):
+        folder = tmp_path / 'Batman (2016)'
+        folder.mkdir()
+        files = [str(folder / 'Batman 001 (2016).cbz')]
+
+        series = _make_search(ProviderType.METRON, 'Batman', 2016, id='42')
+        provider = MagicMock()
+        provider.get_issues.return_value = [
+            _make_issue(ProviderType.METRON, '42', '1', issue_id='I1'),
+        ]
+
+        with patch.object(bm, '_is_oneshot_folder', return_value=False), \
+             patch.object(bm, '_process_oneshot_folder') as oneshot_mock, \
+             patch.object(bm, '_resolve_series_auto', return_value=('metron', series, [])), \
+             patch.object(bm, '_instantiate_provider', return_value=provider), \
+             patch.object(bm, '_write_metadata', return_value=True), \
+             patch.object(bm, 'ensure_folder_sidecars') as sidecar_mock:
+            bm._process_folder(
+                job_id=_new_job(), op_id='op', folder_path=str(folder),
+                files=files, providers=['metron'], overwrite_existing=True,
+                progress={"done": 0},
+            )
+
+        oneshot_mock.assert_not_called()
+        sidecar_mock.assert_called_once()


### PR DESCRIPTION
## 📝 Description
Introduce ONESHOT_FOLDERS configuration and UI support and change bulk metadata processing to treat configured folders as collections of unrelated one-shot files. app.py now reads/writes ONESHOT_FOLDERS and exposes it to the config template; templates/config.html adds a field for the setting. core/config.py adds the default ONESHOT_FOLDERS value. core/bulk_metadata.py adds _is_oneshot_folder and a new _process_oneshot_folder that resolves each file independently (defaults missing issue numbers to #1), avoids writing folder-level sidecars (cvinfo/series.json), queues file-level review items when unresolved or ambiguous, and updates job counts; _process_folder now routes oneshot folders to the per-file processor. Added unit tests (tests/unit/test_bulk_metadata_oneshots.py) covering detection, per-file resolution, sidecar behavior, and routing. The change enables treating folders like "oneshots"/"one-shots"/etc. as special-case per-file processing in bulk metadata runs.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass