### PR TITLE
Support skipping providers and Metron selection

### DIFF
--- a/models/metron.py
+++ b/models/metron.py
@@ -788,6 +788,65 @@ def search_series_by_name(
     return _api_call(_call, f"searching for series '{series_name}'")
 
 
+def search_series_list(
+    api, series_name: str, year: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """
+    Search Metron for a series by name and return *all* candidate matches.
+
+    Unlike search_series_by_name (which returns the single best match for the
+    auto-tag path), this returns every result shaped for the selection modal so
+    the user can pick when there are multiple ambiguous matches.
+
+    Args:
+        api: Mokkari API client
+        series_name: Series name to search for
+        year: Optional year to rank results by year_began proximity
+
+    Returns:
+        List of dicts with id, name, start_year, publisher_name, image_url,
+        description, count_of_issues. Empty list if nothing found.
+    """
+    if not api or not series_name:
+        return []
+
+    def _call():
+        app_logger.info(f"Searching Metron (list) for series: '{series_name}' (year: {year})")
+        results = api.series_list({"name": series_name})
+        if not results:
+            return []
+
+        series_list = list(results)
+
+        if year and len(series_list) > 1:
+
+            def year_distance(s):
+                s_year = getattr(s, "year_began", None)
+                return abs(s_year - year) if s_year is not None else 9999
+
+            series_list = sorted(series_list, key=year_distance)
+
+        matches = []
+        for series in series_list:
+            publisher = getattr(series, "publisher", None)
+            publisher_name = getattr(publisher, "name", None) if publisher else None
+            image = getattr(series, "image", None)
+            image_url = str(image) if image else None
+            matches.append({
+                "id": getattr(series, "id", None),
+                "name": getattr(series, "name", "") or getattr(series, "display_name", ""),
+                "start_year": getattr(series, "year_began", None),
+                "publisher_name": publisher_name or "",
+                "image_url": image_url,
+                "description": getattr(series, "desc", "") or "",
+                "count_of_issues": getattr(series, "issue_count", None),
+            })
+        app_logger.info(f"Found {len(matches)} Metron series matches (list)")
+        return matches
+
+    return _api_call(_call, f"listing series '{series_name}'") or []
+
+
 def get_series_details(api, series_id: int) -> Optional[Dict[str, Any]]:
     """
     Get full details for a Metron series including cv_id, publisher, year_began.

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -991,6 +991,9 @@ def batch_metadata():
         directory = data.get('directory')
         selected_volume_id = data.get('volume_id')  # Optional: pre-selected ComicVine volume ID
         library_id = data.get('library_id')  # Optional: library ID for provider lookup
+        # Providers the user skipped via "Skip to next provider" on the batch
+        # ComicVine modal — excluded from both cvinfo creation and the per-file loop.
+        skip_providers = data.get('skip_providers') or []
 
         if not directory:
             return jsonify({"error": "Missing directory parameter"}), 400
@@ -1032,6 +1035,36 @@ def batch_metadata():
             mangaupdates_available = False
 
         app_logger.info(f"Batch metadata: CV={comicvine_available}, Metron={metron_available}, GCD={gcd_available}, AniList={anilist_available}, MangaDex={mangadex_available}, MU={mangaupdates_available}")
+
+        # Resolved provider order (used by the frontend skip button to know what
+        # comes after the current provider). Library order when available,
+        # otherwise a sensible default of the available providers.
+        if library_id:
+            provider_order = list(enabled_providers)
+        else:
+            provider_order = [p for p, avail in (
+                ('metron', metron_available),
+                ('comicvine', comicvine_available),
+                ('gcd', gcd_available),
+                ('gcd_api', True),  # gcd_api has no availability flag; gated per-file
+            ) if avail]
+
+        # Honor user-skipped providers: drop them from availability so neither
+        # cvinfo creation nor the per-file loop consults them.
+        if skip_providers:
+            app_logger.info(f"Batch metadata: skipping providers {skip_providers}")
+            if 'metron' in skip_providers:
+                metron_available = False
+            if 'comicvine' in skip_providers:
+                comicvine_available = False
+            if 'gcd' in skip_providers:
+                gcd_available = False
+            if 'anilist' in skip_providers:
+                anilist_available = False
+            if 'mangadex' in skip_providers:
+                mangadex_available = False
+            if 'mangaupdates' in skip_providers:
+                mangaupdates_available = False
 
         # Initialize Metron API early (needed for cvinfo creation)
         metron_api = metron.get_flask_api() if metron_available else None
@@ -1159,6 +1192,8 @@ def batch_metadata():
                                 app_logger.info(f"Found {len(volumes)} volumes - returning for user selection")
                                 return jsonify({
                                     "requires_selection": True,
+                                    "provider": "comicvine",
+                                    "provider_order": provider_order,
                                     "directory": directory,
                                     "parsed_filename": {
                                         "series_name": series_name,
@@ -1617,13 +1652,18 @@ def batch_metadata():
                     if library_id and library_providers:
                         # Use library-configured priority order
                         for provider_config in library_providers:
+                            ptype = provider_config['provider_type']
+                            if ptype in skip_providers:
+                                continue
                             if provider_config.get('enabled', True):
-                                try_fn = provider_try_fns.get(provider_config['provider_type'])
+                                try_fn = provider_try_fns.get(ptype)
                                 if try_fn and try_fn():
                                     break
                     else:
                         # Fallback for no library_id: try all available providers
                         for name, try_fn in provider_try_fns.items():
+                            if name in skip_providers:
+                                continue
                             if try_fn():
                                 break
 
@@ -2919,11 +2959,15 @@ def search_gcd_metadata_with_selection():
 # =============================================================================
 
 def _try_metron_single(cvinfo_path, series_name, issue_number, year):
-    """Try Metron provider for a single file. Returns (metadata_dict, image_url) or (None, None)."""
+    """Try Metron provider for a single file.
+    Returns (metadata_dict, image_url, None) on success,
+    or (None, None, selection_data) when user selection is needed,
+    or (None, None, None) when nothing found.
+    """
     try:
         metron_api = metron.get_flask_api()
         if not metron_api:
-            return None, None
+            return None, None, None
 
         series_id = None
 
@@ -2931,18 +2975,36 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
         if cvinfo_path:
             series_id = metron.parse_cvinfo_for_metron_id(cvinfo_path)
 
-        # Fall back to searching by series name
+        # Fall back to searching by series name. When more than one candidate
+        # matches and none is a confident (exact) title match, pause for the
+        # user to pick rather than silently auto-tagging the wrong series.
         if not series_id and series_name:
-            series_result = metron.search_series_by_name(metron_api, series_name, year)
-            if series_result:
-                series_id = series_result.get("id")
+            candidates = metron.search_series_list(metron_api, series_name, year)
+            if not candidates:
+                return None, None, None
+
+            search_lower = series_name.lower().strip()
+            confident = next(
+                (c for c in candidates if (c.get('name') or '').lower().strip() == search_lower),
+                None
+            )
+            if confident:
+                series_id = confident.get("id")
+            elif len(candidates) > 1:
+                return None, None, {
+                    "requires_selection": True,
+                    "provider": "metron",
+                    "possible_matches": candidates,
+                }
+            else:
+                series_id = candidates[0].get("id")
 
         if not series_id:
-            return None, None
+            return None, None, None
 
         issue_data = metron.get_issue_metadata(metron_api, series_id, issue_number)
         if not issue_data:
-            return None, None
+            return None, None, None
 
         metadata = metron.map_to_comicinfo(issue_data)
 
@@ -2953,10 +3015,10 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
             if image:
                 img_url = str(image) if not isinstance(image, str) else image
 
-        return metadata, img_url
+        return metadata, img_url, None
     except Exception as e:
         app_logger.warning(f"[search-metadata] Metron lookup failed: {e}")
-        return None, None
+        return None, None, None
 
 
 def _try_comicvine_single(cvinfo_path, series_name, issue_number, year):
@@ -3325,6 +3387,11 @@ def search_metadata():
         search_term_override = data.get('search_term')
         search_year_override = data.get('search_year')  # User-provided series start year (manual search)
         gcd_api_start_year = data.get('gcd_api_start_year')  # User-provided series start year for GCD API (legacy)
+        # Providers the user has already skipped (via "Skip to next provider").
+        skip_providers = data.get('skip_providers') or []
+        # Restrict the cascade to a single provider (used by per-provider inline
+        # refine so refining inside the Metron modal re-searches Metron only).
+        only_provider = data.get('only_provider')
 
         if not file_path or not file_name:
             return jsonify({"success": False, "error": "Missing file_path or file_name"}), 400
@@ -3393,7 +3460,19 @@ def search_metadata():
             img_url = None
             volume_data = None
 
-            if provider == 'comicvine':
+            if provider == 'metron':
+                series_id = selected_match.get('series_id')
+                metron_api = metron.get_flask_api()
+                if series_id and metron_api:
+                    issue_data = metron.get_issue_metadata(metron_api, series_id, issue_number)
+                    if issue_data:
+                        metadata = metron.map_to_comicinfo(issue_data)
+                        if isinstance(issue_data, dict):
+                            image = issue_data.get('image')
+                            if image:
+                                img_url = str(image) if not isinstance(image, str) else image
+
+            elif provider == 'comicvine':
                 volume_id = selected_match.get('volume_id')
                 api_key = current_app.config.get("COMICVINE_API_KEY", "").strip()
                 if volume_id and api_key:
@@ -3508,6 +3587,14 @@ def search_metadata():
             except Exception:
                 pass
 
+        # Restrict to a single provider when requested (per-provider refine).
+        if only_provider:
+            provider_order = [p for p in provider_order if p == only_provider]
+
+        # Drop providers the user has explicitly skipped.
+        if skip_providers:
+            provider_order = [p for p in provider_order if p not in skip_providers]
+
         app_logger.info(f"[search-metadata] Provider order: {provider_order}")
 
         # Try each provider in priority order
@@ -3520,7 +3607,18 @@ def search_metadata():
             selection_data = None
 
             if provider_type == 'metron':
-                metadata, img_url = _try_metron_single(cvinfo_path, series_name, issue_number, year)
+                metadata, img_url, selection_data = _try_metron_single(
+                    cvinfo_path, series_name, issue_number, year
+                )
+                if selection_data:
+                    selection_data["parsed_filename"] = {
+                        "series_name": series_name,
+                        "issue_number": issue_number,
+                        "year": year
+                    }
+                    selection_data["provider_order"] = provider_order
+                    app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
+                    return jsonify(selection_data)
 
             elif provider_type == 'comicvine':
                 metadata, img_url, volume_data, selection_data = _try_comicvine_single(
@@ -3533,6 +3631,7 @@ def search_metadata():
                         "issue_number": issue_number,
                         "year": year
                     }
+                    selection_data["provider_order"] = provider_order
                     app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
                     return jsonify(selection_data)
 
@@ -3544,6 +3643,7 @@ def search_metadata():
                         "issue_number": issue_number,
                         "year": year
                     }
+                    selection_data["provider_order"] = provider_order
                     app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
                     return jsonify(selection_data)
 
@@ -3558,6 +3658,7 @@ def search_metadata():
                         "issue_number": issue_number,
                         "year": year
                     }
+                    selection_data["provider_order"] = provider_order
                     app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
                     return jsonify(selection_data)
 
@@ -3614,7 +3715,8 @@ def search_metadata():
                                     "series_name": series_name,
                                     "issue_number": issue_number,
                                     "year": year
-                                }
+                                },
+                                "provider_order": provider_order
                             }
                             app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
                             return jsonify(selection_data)

--- a/static/js/clu-metadata.js
+++ b/static/js/clu-metadata.js
@@ -34,6 +34,58 @@
     return typeof c.getLibraryId === 'function' ? c.getLibraryId() : null;
   }
 
+  // ── Skip-to-next-provider helpers ─────────────────────────────────────
+
+  /**
+   * Providers that remain to be tried after the current one.
+   * providerOrder is the (already skip-filtered) order returned by the backend.
+   */
+  function _remainingProviders(providerOrder, currentProvider, skipProviders) {
+    if (!Array.isArray(providerOrder)) return [];
+    var skip = (skipProviders || []).slice();
+    if (currentProvider) skip.push(currentProvider);
+    var idx = providerOrder.indexOf(currentProvider);
+    var rest = idx >= 0 ? providerOrder.slice(idx + 1) : providerOrder.slice();
+    return rest.filter(function (p) { return skip.indexOf(p) === -1; });
+  }
+
+  /**
+   * Show/hide and wire a modal's "Skip to next provider" button.
+   * Hides it when no further providers remain. Clicking it closes the
+   * containing modal and asks the backend for the next provider.
+   */
+  function _wireSkipButton(btnId, data, filePath, fileName, skipProviders, onSkip) {
+    var btn = document.getElementById(btnId);
+    if (!btn) return;
+
+    var remaining = _remainingProviders(data.provider_order, data.provider, skipProviders);
+    if (!remaining.length) {
+      btn.style.display = 'none';
+      return;
+    }
+    btn.style.display = '';
+
+    // Replace-clone to clear any listener from a previous open.
+    var newBtn = btn.cloneNode(true);
+    btn.parentNode.replaceChild(newBtn, btn);
+    newBtn.addEventListener('click', function () {
+      var modalEl = newBtn.closest('.modal');
+      if (modalEl) {
+        var m = bootstrap.Modal.getInstance(modalEl);
+        if (m) m.hide();
+      }
+      if (typeof onSkip === 'function') {
+        onSkip();
+      } else {
+        CLU.skipToNextProvider(filePath, fileName, data.provider, skipProviders);
+      }
+    });
+  }
+
+  // Exposed so page-level modals (files.js: GCD MySQL, Manga) can wire their
+  // own "Skip to next provider" buttons with the same logic.
+  CLU.wireSkipButton = _wireSkipButton;
+
   // ── Progress toast builder ────────────────────────────────────────────
 
   function _buildProgressToast() {
@@ -316,7 +368,70 @@
     _gcdApiLangFilter = '';
   }
 
-  function _showCVVolumeModal(data, filePath, fileName) {
+  /**
+   * Wire the inline "Refine" row (cvRefineSearchInput/cvRefineSearchBtn) to
+   * re-search a single provider with a revised series name. Shared by the
+   * ComicVine/Metron modals and the GCD API results modal so the user can fix
+   * a mis-parsed series name (e.g. "Demis" → "Demi's") rather than only the year.
+   */
+  function _wireInlineRefine(provider, filePath, fileName, skipProviders, parsedSeries, extraBody) {
+    var refineRow = document.getElementById('cvRefineSearchRow');
+    if (refineRow) refineRow.style.display = '';
+    var input = document.getElementById('cvRefineSearchInput');
+    var btn = document.getElementById('cvRefineSearchBtn');
+    if (input) input.value = parsedSeries || '';
+    if (!btn) return;
+
+    // Replace-clone to clear any listener from a previous open.
+    var newBtn = btn.cloneNode(true);
+    btn.parentNode.replaceChild(newBtn, btn);
+    newBtn.addEventListener('click', function () {
+      var term = (document.getElementById('cvRefineSearchInput').value || '').trim();
+      if (!term) return;
+      newBtn.disabled = true;
+      newBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Searching...';
+
+      var requestBody = {
+        file_path: filePath,
+        file_name: fileName,
+        search_term: term,
+        only_provider: provider
+      };
+      var libraryId = _getLibraryId();
+      if (libraryId) requestBody.library_id = libraryId;
+      if (skipProviders && skipProviders.length) requestBody.skip_providers = skipProviders;
+      if (extraBody) {
+        Object.keys(extraBody).forEach(function (k) { requestBody[k] = extraBody[k]; });
+      }
+
+      fetch('/api/search-metadata', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody)
+      })
+        .then(function (response) { return response.json(); })
+        .then(function (newData) {
+          newBtn.disabled = false;
+          newBtn.innerHTML = '<i class="bi bi-search me-1"></i>Refine';
+          if (newData.success) {
+            var m = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+            if (m) m.hide();
+          }
+          _handleSearchResponse(newData, filePath, fileName, skipProviders);
+        })
+        .catch(function (error) {
+          newBtn.disabled = false;
+          newBtn.innerHTML = '<i class="bi bi-search me-1"></i>Refine';
+          CLU.showToast('Search Error', error.message || 'Failed to refine search', 'error');
+        });
+    });
+  }
+
+  /**
+   * Shared renderer for providers that use the ComicVine volume modal UI
+   * (ComicVine and Metron). config = { provider, titlePrefix, unit, onSelect }.
+   */
+  function _showCVStyleModal(data, filePath, fileName, skipProviders, config) {
     _removeGCDApiLangFilter();
     // Show the inline refine row for single-file context
     var refineRow = document.getElementById('cvRefineSearchRow');
@@ -324,7 +439,8 @@
 
     var modalTitle = document.getElementById('comicVineVolumeModalLabel');
     if (modalTitle) {
-      modalTitle.textContent = 'Select correct match (via ComicVine) - ' + data.possible_matches.length + ' Volume(s)';
+      modalTitle.textContent = 'Select correct match (via ' + config.titlePrefix + ') - ' +
+        data.possible_matches.length + ' ' + config.unit + '(s)';
     }
 
     // Populate parsed info
@@ -340,71 +456,48 @@
     _cvClickHandler = function (volume) {
       var modal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
       modal.hide();
-
-      CLU.searchMetadataWithSelection(filePath, fileName, {
-        provider: 'comicvine',
-        volume_id: volume.id,
-        publisher_name: volume.publisher_name
-      });
+      config.onSelect(volume);
     };
 
     _wireCVSortAndFilter();
     _renderCVVolumeList(_cvVolumes);
+    _wireSkipButton('cvSkipProviderBtn', data, filePath, fileName, skipProviders);
 
-    // Wire up inline refine search
-    var cvRefineInput = document.getElementById('cvRefineSearchInput');
-    var cvRefineBtn = document.getElementById('cvRefineSearchBtn');
-    if (cvRefineInput && data.parsed_filename) {
-      cvRefineInput.value = data.parsed_filename.series_name || '';
-    }
-    if (cvRefineBtn) {
-      var newRefineBtn = cvRefineBtn.cloneNode(true);
-      cvRefineBtn.parentNode.replaceChild(newRefineBtn, cvRefineBtn);
-      newRefineBtn.addEventListener('click', function () {
-        var refinedTerm = (document.getElementById('cvRefineSearchInput').value || '').trim();
-        if (!refinedTerm) return;
-        newRefineBtn.disabled = true;
-        newRefineBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Searching...';
-
-        var requestBody = { file_path: filePath, file_name: fileName, search_term: refinedTerm };
-        var libraryId = _getLibraryId();
-        if (libraryId) requestBody.library_id = libraryId;
-
-        fetch('/api/search-metadata', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody)
-        })
-          .then(function (response) { return response.json(); })
-          .then(function (newData) {
-            newRefineBtn.disabled = false;
-            newRefineBtn.innerHTML = '<i class="bi bi-search me-1"></i>Refine';
-
-            if (newData.requires_selection && newData.provider === 'comicvine') {
-              // Re-populate volume list in-place
-              _showCVVolumeModal(newData, filePath, fileName);
-            } else if (newData.success) {
-              var modal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
-              if (modal) modal.hide();
-              CLU.showToast('Metadata Found', 'Metadata found via ' + newData.source, 'success');
-              var contract = _getContract();
-              if (typeof contract.onMetadataFound === 'function') {
-                contract.onMetadataFound(filePath, newData);
-              }
-            } else {
-              CLU.showToast('No Results', newData.error || 'No metadata found for refined search', 'warning');
-            }
-          })
-          .catch(function (error) {
-            newRefineBtn.disabled = false;
-            newRefineBtn.innerHTML = '<i class="bi bi-search me-1"></i>Refine';
-            CLU.showToast('Search Error', error.message || 'Failed to refine search', 'error');
-          });
-      });
-    }
+    // Wire up inline refine search (scoped to this provider via only_provider)
+    var parsedSeries = (data.parsed_filename && data.parsed_filename.series_name) || '';
+    _wireInlineRefine(config.provider, filePath, fileName, skipProviders, parsedSeries);
 
     var modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
     modal.show();
+  }
+
+  function _showCVVolumeModal(data, filePath, fileName, skipProviders) {
+    _showCVStyleModal(data, filePath, fileName, skipProviders, {
+      provider: 'comicvine',
+      titlePrefix: 'ComicVine',
+      unit: 'Volume',
+      onSelect: function (volume) {
+        CLU.searchMetadataWithSelection(filePath, fileName, {
+          provider: 'comicvine',
+          volume_id: volume.id,
+          publisher_name: volume.publisher_name
+        });
+      }
+    });
+  }
+
+  function _showMetronVolumeModal(data, filePath, fileName, skipProviders) {
+    _showCVStyleModal(data, filePath, fileName, skipProviders, {
+      provider: 'metron',
+      titlePrefix: 'Metron',
+      unit: 'Series',
+      onSelect: function (volume) {
+        CLU.searchMetadataWithSelection(filePath, fileName, {
+          provider: 'metron',
+          series_id: volume.id
+        });
+      }
+    });
   }
 
   // ── GCD API series modal (reuses ComicVine volume modal UI) ───────────
@@ -412,10 +505,11 @@
   // Track active GCD API language/country filter
   var _gcdApiLangFilter = '';
 
-  function _showGCDApiVolumeModal(data, filePath, fileName) {
-    // Hide the inline refine row (not applicable for GCD API)
+  function _showGCDApiVolumeModal(data, filePath, fileName, skipProviders) {
+    // The inline refine row lets the user fix a mis-parsed series name and
+    // re-search GCD API (wired below).
     var refineRow = document.getElementById('cvRefineSearchRow');
-    if (refineRow) refineRow.style.display = 'none';
+    if (refineRow) refineRow.style.display = '';
 
     // Populate parsed info
     var cvSeries = document.getElementById('cvParsedSeries');
@@ -489,6 +583,11 @@
     }
 
     _renderCVVolumeList(_cvVolumes);
+    _wireSkipButton('cvSkipProviderBtn', data, filePath, fileName, skipProviders);
+
+    // Allow revising the series name and re-searching GCD API.
+    var gcdParsedSeries = (data.parsed_filename && data.parsed_filename.series_name) || '';
+    _wireInlineRefine('gcd_api', filePath, fileName, skipProviders, gcdParsedSeries);
 
     var modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
     modal.show();
@@ -509,7 +608,7 @@
 
   // ── GCD API start year prompt ─────────────────────────────────────────
 
-  function _showGCDApiStartYearPrompt(data, filePath, fileName) {
+  function _showGCDApiStartYearPrompt(data, filePath, fileName, skipProviders) {
     var seriesName = (data.parsed_filename && data.parsed_filename.series_name) || 'Unknown';
     var message = data.message || ('No series found for "' + seriesName + '". Enter the year the series started.');
 
@@ -534,8 +633,12 @@
     volumeList.innerHTML =
       '<div class="p-3">' +
         '<p class="text-muted">' + CLU.escapeHtml(message) + '</p>' +
-        '<p class="text-muted small">The GCD API filters by the year a series <strong>started</strong>, ' +
-          'not the issue publication year. For example, a 2026 issue may belong to a series that started in 2025.</p>' +
+        '<label class="form-label small mb-1">Series name</label>' +
+        '<input type="text" id="gcdApiSeriesInput" class="form-control mb-2" placeholder="Series name">' +
+        '<p class="text-muted small mb-1">If the name was mis-parsed (e.g. a missing apostrophe), correct it ' +
+          'above. The GCD API filters by the year a series <strong>started</strong>, not the issue ' +
+          'publication year — leave the year blank to search by name only.</p>' +
+        '<label class="form-label small mb-1">Series start year <span class="text-muted">(optional)</span></label>' +
         '<div class="input-group mb-2">' +
           '<input type="number" id="gcdApiStartYearInput" class="form-control" placeholder="e.g. 2025" min="1900" max="2100">' +
           '<button class="btn btn-primary" type="button" id="gcdApiStartYearSearchBtn">' +
@@ -551,8 +654,11 @@
     var searchBtn = document.getElementById('gcdApiStartYearSearchBtn');
     var yearInput = document.getElementById('gcdApiStartYearInput');
     var noYearBtn = document.getElementById('gcdApiNoYearSearchBtn');
+    var seriesInput = document.getElementById('gcdApiSeriesInput');
+    if (seriesInput && seriesName && seriesName !== 'Unknown') seriesInput.value = seriesName;
 
     function doSearch(startYear) {
+      var currentSeries = (seriesInput && seriesInput.value.trim()) || seriesName;
       searchBtn.disabled = true;
       noYearBtn.disabled = true;
       searchBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Searching...';
@@ -560,9 +666,11 @@
       var requestBody = {
         file_path: filePath,
         file_name: fileName,
-        search_term: seriesName,
+        search_term: currentSeries,
+        only_provider: 'gcd_api',
         gcd_api_start_year: startYear || null
       };
+      if (skipProviders && skipProviders.length) requestBody.skip_providers = skipProviders;
       var libraryId = _getLibraryId();
       if (libraryId) requestBody.library_id = libraryId;
 
@@ -581,7 +689,7 @@
             // Got results — close and show selection modal
             var cvModal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
             if (cvModal) cvModal.hide();
-            _showGCDApiVolumeModal(newData, filePath, fileName);
+            _showGCDApiVolumeModal(newData, filePath, fileName, skipProviders);
           } else if (newData.success) {
             var cvModal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
             if (cvModal) cvModal.hide();
@@ -619,23 +727,39 @@
       }
     });
 
+    if (seriesInput) {
+      seriesInput.addEventListener('keydown', function (e) {
+        // Enter with no year → search by name only; with a year → use it.
+        if (e.key === 'Enter') {
+          var yr = parseInt(yearInput.value, 10);
+          if (yr && yr >= 1900 && yr <= 2100) doSearch(yr);
+          else doSearch(null);
+        }
+      });
+    }
+
     noYearBtn.addEventListener('click', function () {
       doSearch(null);
     });
 
+    // Allow skipping straight to the next provider instead of supplying a year.
+    _wireSkipButton('cvSkipProviderBtn', data, filePath, fileName, skipProviders);
+
     var modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
     modal.show();
 
-    // Focus the year input after modal is shown
+    // Focus the series-name input after modal is shown (correcting the name is
+    // the common case when GCD API returns nothing).
     document.getElementById('comicVineVolumeModal').addEventListener('shown.bs.modal', function handler() {
-      yearInput.focus();
+      if (seriesInput) seriesInput.focus(); else yearInput.focus();
       document.getElementById('comicVineVolumeModal').removeEventListener('shown.bs.modal', handler);
     });
   }
 
   // ── ComicVine volume modal (batch/directory context) ──────────────────
 
-  function _showBatchCVVolumeModal(data, dirPath, dirName) {
+  function _showBatchCVVolumeModal(data, dirPath, dirName, skipProviders) {
+    skipProviders = skipProviders || [];
     _removeGCDApiLangFilter();
     // Hide refine row for batch context
     var refineRow = document.getElementById('cvRefineSearchRow');
@@ -674,8 +798,80 @@
     _wireCVSortAndFilter();
     _renderCVVolumeList(_cvVolumes);
 
+    // Skip-to-next-provider for batch: re-run the folder fetch excluding the
+    // current provider so the remaining providers (e.g. GCD API) process the
+    // folder per-file.
+    _wireSkipButton('cvSkipProviderBtn', data, dirPath, dirName, skipProviders, function () {
+      var newSkip = skipProviders.slice();
+      if (data.provider && newSkip.indexOf(data.provider) === -1) {
+        newSkip.push(data.provider);
+      }
+      CLU.showToast('Skipping Provider', 'Trying the next metadata provider for this folder...', 'info');
+      CLU.fetchDirectoryMetadata(dirPath, dirName, newSkip);
+    });
+
     var modal = new bootstrap.Modal(document.getElementById('comicVineVolumeModal'));
     modal.show();
+  }
+
+  // ── Shared response router ────────────────────────────────────────────
+
+  /**
+   * Route a /api/search-metadata response to the right modal/handler.
+   * Shared by the initial search, the skip-to-next-provider flow, and the
+   * inline refine. skipProviders carries the providers already skipped so the
+   * selection modals can decide whether more remain.
+   */
+  function _handleSearchResponse(data, filePath, fileName, skipProviders) {
+    var contract = _getContract();
+    var libraryId = _getLibraryId();
+    skipProviders = skipProviders || [];
+
+    if (data.requires_selection) {
+      if (data.provider === 'metron') {
+        _showMetronVolumeModal(data, filePath, fileName, skipProviders);
+      } else if (data.provider === 'comicvine') {
+        _showCVVolumeModal(data, filePath, fileName, skipProviders);
+      } else if (data.provider === 'gcd') {
+        // Use page-level GCD modal if available, otherwise show info
+        if (typeof showGCDSeriesSelectionModal === 'function') {
+          showGCDSeriesSelectionModal(data, filePath, fileName, skipProviders);
+          window._cascadeGCDSelection = { filePath: filePath, fileName: fileName, libraryId: libraryId };
+        } else {
+          CLU.showToast('GCD Selection', 'GCD series selection requires the Files page', 'warning');
+        }
+      } else if (data.provider === 'gcd_api') {
+        if (data.requires_start_year) {
+          _showGCDApiStartYearPrompt(data, filePath, fileName, skipProviders);
+        } else {
+          _showGCDApiVolumeModal(data, filePath, fileName, skipProviders);
+        }
+      } else if (['mangadex', 'mangaupdates', 'anilist'].indexOf(data.provider) !== -1) {
+        if (typeof showMangaSeriesSelectionModal === 'function') {
+          showMangaSeriesSelectionModal(data, filePath, fileName, libraryId, skipProviders);
+        } else {
+          CLU.showToast('Series Selection', 'Series selection requires the Files page', 'warning');
+        }
+      }
+      return;
+    }
+
+    if (data.success) {
+      CLU.showToast('Metadata Found', 'Metadata found via ' + data.source, 'success');
+      if (typeof contract.onMetadataFound === 'function') {
+        contract.onMetadataFound(filePath, data);
+      }
+      return;
+    }
+
+    if (data.parsed_filename) {
+      _showRefineSearchModal(data, filePath, fileName);
+    } else {
+      CLU.showToast('No Metadata', data.error || 'No metadata found from any provider', 'warning');
+    }
+    if (typeof contract.onMetadataError === 'function') {
+      contract.onMetadataError(filePath, data.error || 'No metadata found');
+    }
   }
 
   // ── Public API: Single-file metadata search ───────────────────────────
@@ -706,50 +902,7 @@
     })
       .then(function (response) { return response.json(); })
       .then(function (data) {
-        if (data.requires_selection) {
-          if (data.provider === 'comicvine') {
-            _showCVVolumeModal(data, filePath, fileName);
-          } else if (data.provider === 'gcd') {
-            // Use page-level GCD modal if available, otherwise show info
-            if (typeof showGCDSeriesSelectionModal === 'function') {
-              showGCDSeriesSelectionModal(data, filePath, fileName);
-              window._cascadeGCDSelection = { filePath: filePath, fileName: fileName, libraryId: libraryId };
-            } else {
-              CLU.showToast('GCD Selection', 'GCD series selection requires the Files page', 'warning');
-            }
-          } else if (data.provider === 'gcd_api') {
-            if (data.requires_start_year) {
-              _showGCDApiStartYearPrompt(data, filePath, fileName);
-            } else {
-              _showGCDApiVolumeModal(data, filePath, fileName);
-            }
-          } else if (['mangadex', 'mangaupdates', 'anilist'].indexOf(data.provider) !== -1) {
-            if (typeof showMangaSeriesSelectionModal === 'function') {
-              showMangaSeriesSelectionModal(data, filePath, fileName, libraryId);
-            } else {
-              CLU.showToast('Series Selection', 'Series selection requires the Files page', 'warning');
-            }
-          }
-          return;
-        }
-
-        if (data.success) {
-          CLU.showToast('Metadata Found', 'Metadata found via ' + data.source, 'success');
-
-          if (typeof contract.onMetadataFound === 'function') {
-            contract.onMetadataFound(filePath, data);
-          }
-          return;
-        }
-
-        if (data.parsed_filename) {
-          _showRefineSearchModal(data, filePath, fileName);
-        } else {
-          CLU.showToast('No Metadata', data.error || 'No metadata found from any provider', 'warning');
-        }
-        if (typeof contract.onMetadataError === 'function') {
-          contract.onMetadataError(filePath, data.error || 'No metadata found');
-        }
+        _handleSearchResponse(data, filePath, fileName, []);
       })
       .catch(function (error) {
         console.error('Metadata search error:', error);
@@ -757,6 +910,45 @@
         if (typeof contract.onMetadataError === 'function') {
           contract.onMetadataError(filePath, error.message);
         }
+      });
+  };
+
+  // ── Public API: Skip to next provider ─────────────────────────────────
+
+  /**
+   * Re-run the metadata search excluding the providers already shown/skipped.
+   * Called from the "Skip to next provider" button on the selection modals.
+   * @param {string} filePath
+   * @param {string} fileName
+   * @param {string} currentProvider  Provider whose modal was just dismissed
+   * @param {string[]} skipProviders  Providers skipped before this one
+   */
+  CLU.skipToNextProvider = function (filePath, fileName, currentProvider, skipProviders) {
+    var libraryId = _getLibraryId();
+    var newSkip = (skipProviders || []).slice();
+    if (currentProvider && newSkip.indexOf(currentProvider) === -1) {
+      newSkip.push(currentProvider);
+    }
+
+    CLU.showToast('Skipping Provider', 'Trying the next metadata provider...', 'info');
+
+    var requestBody = { file_path: filePath, file_name: fileName, skip_providers: newSkip };
+    if (libraryId) {
+      requestBody.library_id = libraryId;
+    }
+
+    fetch('/api/search-metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody)
+    })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        _handleSearchResponse(data, filePath, fileName, newSkip);
+      })
+      .catch(function (error) {
+        console.error('Skip provider error:', error);
+        CLU.showToast('Metadata Error', error.message || 'Failed to search next provider', 'error');
       });
   };
 
@@ -819,14 +1011,18 @@
    * @param {string} dirPath   Full path to the directory
    * @param {string} dirName   Display name of the directory
    */
-  CLU.fetchDirectoryMetadata = function (dirPath, dirName) {
+  CLU.fetchDirectoryMetadata = function (dirPath, dirName, skipProviders) {
     var libraryId = _getLibraryId();
     var contract = _getContract();
     var progressToast = _buildProgressToast();
+    skipProviders = skipProviders || [];
 
     var requestBody = { directory: dirPath };
     if (libraryId) {
       requestBody.library_id = libraryId;
+    }
+    if (skipProviders.length) {
+      requestBody.skip_providers = skipProviders;
     }
 
     fetch('/api/batch-metadata', {
@@ -840,7 +1036,7 @@
           return response.json().then(function (data) {
             if (data.requires_selection) {
               _removeToast(progressToast);
-              _showBatchCVVolumeModal(data, dirPath, dirName);
+              _showBatchCVVolumeModal(data, dirPath, dirName, skipProviders);
               return;
             }
             if (data.error) {

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -4818,7 +4818,7 @@ function processBulkGCDMetadata(directoryPath, directoryName, seriesId, comicFil
 }
 
 // Function to show GCD series selection modal
-function showGCDSeriesSelectionModal(data, filePath, fileName) {
+function showGCDSeriesSelectionModal(data, filePath, fileName, skipProviders) {
   // Populate the parsed filename information
   document.getElementById('gcdParsedSeries').textContent = data.parsed_filename.series_name;
   document.getElementById('gcdParsedIssue').textContent = data.parsed_filename.issue_number;
@@ -4838,6 +4838,11 @@ function showGCDSeriesSelectionModal(data, filePath, fileName) {
 
   // Render the series list with initial order
   renderSeriesList(currentSeriesData);
+
+  // Wire the "Skip to next provider" button (shared logic from clu-metadata.js)
+  if (window.CLU && typeof CLU.wireSkipButton === 'function') {
+    CLU.wireSkipButton('gcdSkipProviderBtn', data, filePath, fileName, skipProviders || []);
+  }
 
   // Show the modal
   const modal = new bootstrap.Modal(document.getElementById('gcdSeriesModal'));
@@ -5593,7 +5598,7 @@ function showGCDApiStartYearPrompt(data, filePath, fileName) {
 
 // showBatchVolumeSelectionModal, fetchAllMetadataWithVolume – delegated to clu-metadata.js
 
-function showMangaSeriesSelectionModal(data, filePath, fileName, libraryId) {
+function showMangaSeriesSelectionModal(data, filePath, fileName, libraryId, skipProviders) {
   console.log('Showing manga series selection modal', data);
 
   const provider = data.provider;
@@ -5654,6 +5659,11 @@ function showMangaSeriesSelectionModal(data, filePath, fileName, libraryId) {
 
     seriesList.appendChild(seriesItem);
   });
+
+  // Wire the "Skip to next provider" button (shared logic from clu-metadata.js)
+  if (window.CLU && typeof CLU.wireSkipButton === 'function') {
+    CLU.wireSkipButton('mangaSkipProviderBtn', data, filePath, fileName, skipProviders || []);
+  }
 
   const modal = new bootstrap.Modal(document.getElementById('mangaSeriesModal'));
   modal.show();

--- a/templates/partials/modal_metadata_select.html
+++ b/templates/partials/modal_metadata_select.html
@@ -35,6 +35,9 @@
         </div>
       </div>
       <div class="modal-footer">
+        <button type="button" class="btn btn-outline-warning me-auto" id="gcdSkipProviderBtn" style="display:none;">
+          <i class="bi bi-skip-forward me-1"></i>Skip to next provider
+        </button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
       </div>
     </div>
@@ -90,6 +93,9 @@
         </div>
       </div>
       <div class="modal-footer">
+        <button type="button" class="btn btn-outline-warning me-auto" id="cvSkipProviderBtn" style="display:none;">
+          <i class="bi bi-skip-forward me-1"></i>Skip to next provider
+        </button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
       </div>
     </div>
@@ -122,6 +128,9 @@
         </div>
       </div>
       <div class="modal-footer">
+        <button type="button" class="btn btn-outline-warning me-auto" id="mangaSkipProviderBtn" style="display:none;">
+          <i class="bi bi-skip-forward me-1"></i>Skip to next provider
+        </button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
       </div>
     </div>

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -131,6 +131,59 @@ class TestSearchSeriesByName:
         assert search_series_by_name(None, "Batman") is None
 
 
+class TestSearchSeriesList:
+
+    def _make(self, **kwargs):
+        s = make_mock_series(**kwargs)
+        # MagicMock auto-creates truthy attrs; pin the optional ones so the
+        # mapped dict has clean values.
+        s.image = None
+        s.desc = ""
+        s.issue_count = 12
+        return s
+
+    def test_returns_all_candidates(self):
+        from models.metron import search_series_list
+
+        mock_api = MagicMock()
+        mock_api.series_list.return_value = [
+            self._make(id=1, name="Batman", year_began=1940),
+            self._make(id=2, name="Batman Beyond", year_began=1999),
+        ]
+
+        results = search_series_list(mock_api, "Batman")
+        assert len(results) == 2
+        assert {r["id"] for r in results} == {1, 2}
+        first = next(r for r in results if r["id"] == 1)
+        assert first["name"] == "Batman"
+        assert first["start_year"] == 1940
+        assert first["publisher_name"] == "DC Comics"
+        assert first["count_of_issues"] == 12
+
+    def test_year_ranking(self):
+        from models.metron import search_series_list
+
+        mock_api = MagicMock()
+        mock_api.series_list.return_value = [
+            self._make(id=1, name="Batman", year_began=1940),
+            self._make(id=2, name="Batman", year_began=2016),
+        ]
+
+        results = search_series_list(mock_api, "Batman", year=2016)
+        assert results[0]["id"] == 2  # closest year first
+
+    def test_no_results(self):
+        from models.metron import search_series_list
+
+        mock_api = MagicMock()
+        mock_api.series_list.return_value = []
+        assert search_series_list(mock_api, "Nonexistent") == []
+
+    def test_no_api(self):
+        from models.metron import search_series_list
+        assert search_series_list(None, "Batman") == []
+
+
 class TestGetSeriesDetails:
 
     def test_returns_details(self):

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -779,3 +779,241 @@ class TestRemoveComicInfoUpdatesFileIndex:
         row = cur.fetchone()
         assert row is not None
         assert row[0] == 0
+
+
+class TestSearchMetadataSkipProviders:
+    """skip_providers / only_provider control which providers the cascade tries,
+    and selection responses expose provider_order for the skip button."""
+
+    def _fallback_two_providers(self, app, stack):
+        """Configure the fallback order to be [metron, comicvine]."""
+        app.config["COMICVINE_API_KEY"] = "test-key"
+        stack.enter_context(patch("models.metron.is_metron_configured", return_value=True))
+        stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+        stack.enter_context(patch("models.gcd.is_mysql_available", return_value=False))
+        stack.enter_context(patch("models.gcd.check_mysql_status",
+                                  return_value={"gcd_mysql_available": False}))
+        stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
+        stack.enter_context(patch("models.comicvine.extract_issue_number", return_value=None))
+        stack.enter_context(patch("core.database.get_library_providers", return_value=[]))
+        stack.enter_context(patch("core.database.get_provider_credentials", return_value=None))
+        stack.enter_context(patch("core.database.set_has_comicinfo"))
+        stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+        stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+
+    def test_skip_providers_excludes_provider(self, app, client):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            self._fallback_two_providers(app, stack)
+            metron = stack.enter_context(patch(
+                "routes.metadata._try_metron_single", return_value=(None, None, None)))
+            cv = stack.enter_context(patch(
+                "routes.metadata._try_comicvine_single",
+                return_value=({"Series": "Batman", "Number": "1"}, "http://img", None, None)))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+                'skip_providers': ['metron'],
+            })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source"] == "comicvine"
+        metron.assert_not_called()
+        cv.assert_called_once()
+
+    def test_only_provider_restricts_cascade(self, app, client):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            self._fallback_two_providers(app, stack)
+            metron = stack.enter_context(patch(
+                "routes.metadata._try_metron_single", return_value=(None, None, None)))
+            cv = stack.enter_context(patch(
+                "routes.metadata._try_comicvine_single",
+                return_value=({"Series": "Batman", "Number": "1"}, "http://img", None, None)))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+                'only_provider': 'comicvine',
+            })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source"] == "comicvine"
+        metron.assert_not_called()
+        cv.assert_called_once()
+
+    def test_selection_response_includes_provider_order(self, app, client):
+        from contextlib import ExitStack
+        selection = {
+            "requires_selection": True,
+            "provider": "comicvine",
+            "possible_matches": [{"id": 1, "name": "Batman"}, {"id": 2, "name": "Batman Inc"}],
+        }
+        with ExitStack() as stack:
+            self._fallback_two_providers(app, stack)
+            stack.enter_context(patch(
+                "routes.metadata._try_metron_single", return_value=(None, None, None)))
+            stack.enter_context(patch(
+                "routes.metadata._try_comicvine_single",
+                return_value=(None, None, None, selection)))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+
+        data = resp.get_json()
+        assert data["requires_selection"] is True
+        assert data["provider"] == "comicvine"
+        assert data["provider_order"] == ["metron", "comicvine"]
+
+
+class TestSearchMetadataMetronSelection:
+    """Metron now shows a selection modal when matches are ambiguous and
+    supports the selected_match follow-up."""
+
+    def _metron_only(self, app, stack):
+        app.config["COMICVINE_API_KEY"] = ""
+        stack.enter_context(patch("models.metron.is_metron_configured", return_value=True))
+        stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+        stack.enter_context(patch("models.gcd.is_mysql_available", return_value=False))
+        stack.enter_context(patch("models.gcd.check_mysql_status",
+                                  return_value={"gcd_mysql_available": False}))
+        stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
+        stack.enter_context(patch("models.comicvine.extract_issue_number", return_value=None))
+        stack.enter_context(patch("core.database.get_library_providers", return_value=[]))
+        stack.enter_context(patch("core.database.get_provider_credentials", return_value=None))
+        stack.enter_context(patch("core.database.set_has_comicinfo"))
+        stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+        stack.enter_context(patch("models.metron.get_flask_api", return_value=MagicMock()))
+        stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+
+    def test_ambiguous_matches_require_selection(self, app, client):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            self._metron_only(app, stack)
+            stack.enter_context(patch("models.metron.search_series_list", return_value=[
+                {"id": 1, "name": "The Batman", "start_year": 1940},
+                {"id": 2, "name": "Batman Beyond", "start_year": 1999},
+            ]))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+
+        data = resp.get_json()
+        assert data["requires_selection"] is True
+        assert data["provider"] == "metron"
+        assert len(data["possible_matches"]) == 2
+        assert data["provider_order"] == ["metron"]
+
+    def test_confident_single_match_auto_applies(self, app, client):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            self._metron_only(app, stack)
+            stack.enter_context(patch("models.metron.search_series_list", return_value=[
+                {"id": 5, "name": "Batman", "start_year": 2016},
+            ]))
+            stack.enter_context(patch("models.metron.get_issue_metadata",
+                                      return_value={"image": "http://cover"}))
+            stack.enter_context(patch("models.metron.map_to_comicinfo",
+                                      return_value={"Series": "Batman", "Number": "1"}))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source"] == "metron"
+
+    def test_metron_selection_followup_applies(self, app, client):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            self._metron_only(app, stack)
+            stack.enter_context(patch("models.metron.get_issue_metadata",
+                                      return_value={"image": "http://cover"}))
+            stack.enter_context(patch("models.metron.map_to_comicinfo",
+                                      return_value={"Series": "Batman", "Number": "1"}))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+                'selected_match': {'provider': 'metron', 'series_id': 5},
+            })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source"] == "metron"
+
+
+class TestBatchMetadataSkipProviders:
+    """The folder/batch flow (/api/batch-metadata) must expose provider_order on
+    its ComicVine selection and honor skip_providers so the user can fall through
+    to the next provider (e.g. GCD API) for the whole folder."""
+
+    def _batch_stack(self, app, stack):
+        app.config["COMICVINE_API_KEY"] = "k"
+        stack.enter_context(patch("routes.metadata.is_valid_library_path", return_value=True))
+        stack.enter_context(patch("app.get_target_dir_live", return_value="/nonexistent_target"))
+        stack.enter_context(patch("core.database.get_library_providers", return_value=[
+            {"provider_type": "metron", "enabled": True},
+            {"provider_type": "comicvine", "enabled": True},
+            {"provider_type": "gcd_api", "enabled": True},
+        ]))
+        stack.enter_context(patch("models.metron.get_flask_api", return_value=MagicMock()))
+        stack.enter_context(patch("models.metron.search_series_by_name", return_value=None))
+        stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+
+    def test_comicvine_selection_includes_provider_order(self, app, client, tmp_path):
+        from contextlib import ExitStack
+        folder = tmp_path / "Batman (2020)"
+        folder.mkdir()
+        _make_cbz(str(folder / "Batman 001 (2020).cbz"), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack)
+            stack.enter_context(patch("models.comicvine.search_volumes", return_value=[
+                {"id": 1, "name": "Batman"},
+                {"id": 2, "name": "Batman Inc"},
+            ]))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+
+        data = resp.get_json()
+        assert data["requires_selection"] is True
+        assert data["provider"] == "comicvine"
+        assert data["provider_order"] == ["metron", "comicvine", "gcd_api"]
+
+    def test_skip_providers_bypasses_comicvine_halt(self, app, client, tmp_path):
+        """With comicvine skipped, the ComicVine multi-volume selection must NOT
+        halt the batch — it streams (SSE) and lets later providers run per-file."""
+        from contextlib import ExitStack
+        folder = tmp_path / "Batman (2020)"
+        folder.mkdir()
+        # File already has metadata (Notes) so it's skipped — keeps the per-file
+        # loop from making real provider calls during the stream.
+        cbz = str(folder / "Batman 001 (2020).cbz")
+        with zipfile.ZipFile(cbz, 'w') as zf:
+            zf.writestr("page_001.png", b"x")
+            zf.writestr("ComicInfo.xml", "<ComicInfo><Series>B</Series><Notes>has</Notes></ComicInfo>")
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack)
+            cv = stack.enter_context(patch("models.comicvine.search_volumes", return_value=[
+                {"id": 1, "name": "Batman"},
+                {"id": 2, "name": "Batman Inc"},
+            ]))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+                'skip_providers': ['comicvine'],
+            })
+            body = resp.get_data(as_text=True)
+
+        assert resp.status_code == 200
+        assert 'text/event-stream' in resp.content_type
+        assert '"type": "complete"' in body
+        # ComicVine search must not run when comicvine is skipped.
+        cv.assert_not_called()


### PR DESCRIPTION
## 📝 Description
Add skip-to-next-provider flow and improve Metron multi-match handling. Introduces models.metron.search_series_list to return all candidate series and rank by year; _try_metron_single now prompts a selection when ambiguous and accepts metron selection follow-ups. Routes accept skip_providers and only_provider to restrict provider cascades and expose provider_order in selection responses; batch flow honors skipped providers. Frontend: add shared inline-refine, skip button wiring, unified ComicVine/Metron selection UI, per-provider refine/skip APIs, and template buttons. Tests updated to cover skip/only-provider behavior and Metron selection paths.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass