### PR TITLE
Support one-shot folders: skip sidecars & renames

### DIFF
--- a/app.py
+++ b/app.py
@@ -4183,8 +4183,14 @@ def auto_fetch_metron_metadata(destination_path):
             # Extract issue number from filename
             issue_number = extract_issue_number(os.path.basename(file_path))
             if not issue_number:
-                app_logger.warning(f"Could not extract issue number from {file_path}")
-                continue
+                # One-shot operations (a single target file) fall back to issue
+                # #1; multi-file folders skip un-numbered files.
+                if len(files_to_process) == 1:
+                    issue_number = "1"
+                    app_logger.info(f"No issue number in {os.path.basename(file_path)}; defaulting to #1 (one-shot)")
+                else:
+                    app_logger.warning(f"Could not extract issue number from {file_path}")
+                    continue
 
             # Fetch metadata from Metron
             issue_data = get_issue_metadata(api, series_id, issue_number)

--- a/core/bulk_metadata.py
+++ b/core/bulk_metadata.py
@@ -240,17 +240,13 @@ def _series_year_for_folder(folder_path: str, files: List[str]) -> Tuple[str, Op
 def _is_oneshot_folder(folder_path: str) -> bool:
     """True if the folder's base name is in the user's ONESHOT_FOLDERS list.
 
-    These are folders of unrelated single issues (e.g. ``/oneshots``). Files in
-    them are resolved individually from their own filename rather than against a
-    single folder-level series, and no cvinfo/series.json sidecar is written.
-    Matching is on the folder's base name, case-insensitive, ignoring any
-    leading slashes the user may have typed in the config value.
+    Thin wrapper over ``core.config.is_oneshot_folder`` (the single source of
+    truth) kept for existing callers. One-shot folders hold unrelated single
+    issues, so files are resolved individually and no cvinfo/series.json sidecar
+    is written for the folder.
     """
-    names = config.get("SETTINGS", "ONESHOT_FOLDERS",
-                       fallback="oneshots,one-shots,specials")
-    wanted = {n.strip().strip('/\\').lower() for n in names.split(',') if n.strip()}
-    base = os.path.basename(folder_path.rstrip('/\\')).lower()
-    return bool(base) and base in wanted
+    from core.config import is_oneshot_folder
+    return is_oneshot_folder(folder_path)
 
 
 def _try_cvinfo(folder_path: str) -> Optional[Tuple[str, str]]:
@@ -339,6 +335,11 @@ def ensure_folder_sidecars(folder_path: str, provider_name: str, series: Optiona
     provider.
     """
     if not series or not folder_path or not os.path.isdir(folder_path):
+        return
+
+    # One-shot folders hold unrelated singles — never drop folder-level sidecars.
+    if _is_oneshot_folder(folder_path):
+        app_logger.debug(f"Skipping folder sidecars in one-shot folder: {folder_path}")
         return
 
     try:

--- a/core/config.py
+++ b/core/config.py
@@ -20,6 +20,26 @@ def write_config():
     with open(CONFIG_FILE, "w") as configfile:
         config.write(configfile)
 
+
+def is_oneshot_folder(folder_path) -> bool:
+    """True when the folder's base name is in the ONESHOT_FOLDERS setting.
+
+    One-shot folders (default: oneshots, one-shots, specials) hold unrelated
+    single issues, so metadata writes must not drop folder-level sidecars
+    (cvinfo / series.json) that would wrongly bind every file to one series.
+    Matching is case-insensitive on the base name, ignoring stray slashes.
+    """
+    if not folder_path:
+        return False
+    try:
+        names = config.get("SETTINGS", "ONESHOT_FOLDERS",
+                            fallback="oneshots,one-shots,specials")
+    except Exception:
+        names = "oneshots,one-shots,specials"
+    wanted = {n.strip().strip('/\\').lower() for n in names.split(',') if n.strip()}
+    base = os.path.basename(str(folder_path).rstrip('/\\')).lower()
+    return bool(base) and base in wanted
+
 def load_config():
     """
     Loads or (if missing) creates the config file, ensuring

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -968,6 +968,10 @@ def write_cvinfo_fields(cvinfo_path: str, publisher_name: Optional[str], start_y
     Returns:
         True if successful, False otherwise
     """
+    from core.config import is_oneshot_folder
+    if is_oneshot_folder(os.path.dirname(cvinfo_path)):
+        app_logger.debug(f"Skipping cvinfo write in one-shot folder: {cvinfo_path}")
+        return False
     try:
         # Read existing content
         existing = read_cvinfo_fields(cvinfo_path)
@@ -1040,6 +1044,10 @@ def write_cvinfo_manga_fields(cvinfo_path: str, fields: Dict[str, str]) -> bool:
     Returns:
         True if successful, False otherwise
     """
+    from core.config import is_oneshot_folder
+    if is_oneshot_folder(os.path.dirname(cvinfo_path)):
+        app_logger.debug(f"Skipping cvinfo write in one-shot folder: {cvinfo_path}")
+        return False
     try:
         existing = read_cvinfo_manga_fields(cvinfo_path)
 
@@ -1358,10 +1366,16 @@ def auto_fetch_metadata_for_folder(folder_path: str, api_key: str, target_file: 
             # Extract issue number from filename
             issue_number = extract_issue_number(os.path.basename(file_path))
             if not issue_number:
-                app_logger.warning(f"Could not extract issue number from {file_path}")
-                result['errors'] += 1
-                result['details'].append({'file': file_path, 'status': 'error', 'reason': 'no issue number'})
-                continue
+                # One-shot operations (a single target file) fall back to issue
+                # #1; multi-file folders error rather than map every file to #1.
+                if len(comic_files) == 1:
+                    issue_number = "1"
+                    app_logger.info(f"No issue number in {os.path.basename(file_path)}; defaulting to #1 (one-shot)")
+                else:
+                    app_logger.warning(f"Could not extract issue number from {file_path}")
+                    result['errors'] += 1
+                    result['details'].append({'file': file_path, 'status': 'error', 'reason': 'no issue number'})
+                    continue
 
             # Fetch metadata from ComicVine (pass start_year + publisher_name
             # so Volume and Publisher fields are populated from cvinfo cache)

--- a/models/metron.py
+++ b/models/metron.py
@@ -243,6 +243,11 @@ def update_cvinfo_with_metron_id(cvinfo_path: str, series_id: int) -> bool:
     Returns:
         True if successful, False otherwise
     """
+    from os.path import dirname
+    from core.config import is_oneshot_folder
+    if is_oneshot_folder(dirname(cvinfo_path)):
+        app_logger.debug(f"Skipping cvinfo write in one-shot folder: {cvinfo_path}")
+        return False
     try:
         with open(cvinfo_path, "r", encoding="utf-8") as f:
             content = f.read()
@@ -311,6 +316,11 @@ def write_cvinfo_fields(
     Returns:
         True if successful, False otherwise
     """
+    from os.path import dirname
+    from core.config import is_oneshot_folder
+    if is_oneshot_folder(dirname(cvinfo_path)):
+        app_logger.debug(f"Skipping cvinfo write in one-shot folder: {cvinfo_path}")
+        return False
     try:
         existing = read_cvinfo_fields(cvinfo_path)
         lines_to_add = []
@@ -907,6 +917,11 @@ def add_cvinfo_url(cvinfo_path: str, cv_id: int) -> bool:
     Returns:
         True if successful, False otherwise
     """
+    from os.path import dirname
+    from core.config import is_oneshot_folder
+    if is_oneshot_folder(dirname(cvinfo_path)):
+        app_logger.debug(f"Skipping cvinfo write in one-shot folder: {cvinfo_path}")
+        return False
     try:
         cv_url = f"https://comicvine.gamespot.com/volume/4050-{cv_id}/"
 
@@ -960,6 +975,11 @@ def create_cvinfo_file(
     Returns:
         True if successful, False otherwise
     """
+    from os.path import dirname
+    from core.config import is_oneshot_folder
+    if is_oneshot_folder(dirname(cvinfo_path)):
+        app_logger.debug(f"Skipping cvinfo write in one-shot folder: {cvinfo_path}")
+        return False
     try:
         lines = []
 

--- a/routes/bulk_metadata.py
+++ b/routes/bulk_metadata.py
@@ -145,13 +145,21 @@ def _apply_series_to_folder(
     # the unfiltered directory.
     eligible = []
     skipped_existing = 0
-    for entry in sorted(os.listdir(folder_path)):
+    folder_comics = [
+        e for e in sorted(os.listdir(folder_path))
+        if os.path.isfile(os.path.join(folder_path, e)) and e.lower().endswith(('.cbz', '.zip'))
+    ]
+    is_one_shot = len(folder_comics) == 1
+    for entry in folder_comics:
         fp = os.path.join(folder_path, entry)
-        if not (os.path.isfile(fp) and entry.lower().endswith(('.cbz', '.zip'))):
-            continue
         issue_text = extract_issue_number(entry)
         if not issue_text:
-            continue
+            # One-shot folders (a single comic) fall back to issue #1; multi-file
+            # folders skip un-numbered files to avoid mapping them all to #1.
+            if is_one_shot:
+                issue_text = "1"
+            else:
+                continue
         norm = issue_text.lstrip('0') or '0'
         matches = issues_by_norm.get(norm, [])
         if len(matches) != 1:
@@ -486,9 +494,11 @@ def resolve_review(review_id):
             issues = provider.get_issues(series_id) or []
         except Exception as e:
             return _err(f"get_issues failed: {e}", status=502)
-        issue_text = extract_issue_number(os.path.basename(file_path))
-        if not issue_text:
-            return _err("could not parse issue number from filename")
+        # Fall back to issue #1 when the filename has no parseable number (e.g.
+        # a one-shot). The user has explicitly resolved this file to a series, so
+        # a best-effort #1 match — or the synthesised series-level metadata below
+        # — beats refusing to act.
+        issue_text = extract_issue_number(os.path.basename(file_path)) or "1"
         issue_obj = _pick_issue_for_number(issues, issue_text)
         if issue_obj is None:
             # User explicitly picked this series — synthesize an IssueResult so
@@ -782,9 +792,12 @@ def apply_cvinfo(review_id):
             )
         else:
             # CV-only: write the canonical URL line ourselves (mirrors
-            # routes/metadata.py:1123–1127 in the legacy SSE path).
-            with open(cvinfo_path, 'w', encoding='utf-8') as f:
-                f.write(f"https://comicvine.gamespot.com/volume/4050-{cv_volume_id}/")
+            # routes/metadata.py:1123–1127 in the legacy SSE path). One-shot
+            # folders never get a folder-level cvinfo.
+            from core.config import is_oneshot_folder
+            if not is_oneshot_folder(folder_path):
+                with open(cvinfo_path, 'w', encoding='utf-8') as f:
+                    f.write(f"https://comicvine.gamespot.com/volume/4050-{cv_volume_id}/")
             # Best-effort publisher + start_year append using the same helper.
             try:
                 from models import comicvine as cv_mod

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -1110,6 +1110,12 @@ def batch_metadata():
         cvinfo_publisher_name = None
         cv_id_missing_warning = False  # Track if CV ID is missing from Metron
 
+        # One-shot folders (oneshots/specials/...) hold unrelated single issues,
+        # so a folder-level cvinfo must never be read or created here — it would
+        # match every file to the same series. Each file is resolved from its own
+        # filename in the per-file loop below.
+        is_oneshot = _is_oneshot_folder_safe(directory)
+
         # Determine if manga providers have higher priority than comic providers
         manga_providers_set = {'mangadex', 'mangaupdates', 'anilist'}
         comic_providers_set = {'metron', 'comicvine'}
@@ -1124,7 +1130,9 @@ def batch_metadata():
                     elif ptype in comic_providers_set:
                         break
 
-        if not os.path.exists(cvinfo_path):
+        if is_oneshot:
+            app_logger.info("Batch metadata: one-shot folder — skipping folder-level cvinfo (per-file matching)")
+        elif not os.path.exists(cvinfo_path):
             # Extract series name from folder first
             series_name = os.path.basename(directory)
             series_name = re.sub(r'\s*\(\d{4}\).*$', '', series_name)  # Remove (1994) and everything after
@@ -1242,7 +1250,7 @@ def batch_metadata():
                     app_logger.warning(f"Series in Metron but no ComicVine ID available for series_id={series_id}")
 
         # Step 3: Add Metron series ID and details if not present in existing cvinfo
-        if metron_api and os.path.exists(cvinfo_path) and not series_id:
+        if metron_api and not is_oneshot and os.path.exists(cvinfo_path) and not series_id:
             cv_id = metron.parse_cvinfo_for_comicvine_id(cvinfo_path)
             if cv_id:
                 series_id = metron.get_series_id_by_comicvine_id(metron_api, cv_id)
@@ -1264,7 +1272,7 @@ def batch_metadata():
 
         # Step 4: Read start_year + publisher_name from cvinfo for ComicVine calls
         # (Volume and Publisher fields in ComicInfo.xml)
-        if (not cvinfo_start_year or not cvinfo_publisher_name) and os.path.exists(cvinfo_path):
+        if (not cvinfo_start_year or not cvinfo_publisher_name) and not is_oneshot and os.path.exists(cvinfo_path):
             cvinfo_fields = comicvine.read_cvinfo_fields(cvinfo_path)
             if not cvinfo_start_year:
                 cvinfo_start_year = cvinfo_fields.get('start_year')
@@ -1353,10 +1361,17 @@ def batch_metadata():
                         issue_number = volume_number
                         app_logger.info(f"Using volume number {volume_number} for manga: {filename}")
                     elif not issue_number:
-                        app_logger.warning(f"Could not extract issue number from {filename}")
-                        result['errors'] += 1
-                        result['details'].append({'file': filename, 'status': 'error', 'reason': 'no issue number'})
-                        continue
+                        # One-shot folders (a single comic) fall back to issue #1
+                        # so an un-numbered one-shot still matches; multi-file
+                        # folders error out rather than map every file to #1.
+                        if len(comic_files) == 1:
+                            issue_number = "1"
+                            app_logger.info(f"No issue number in {filename}; defaulting to #1 (one-shot)")
+                        else:
+                            app_logger.warning(f"Could not extract issue number from {filename}")
+                            result['errors'] += 1
+                            result['details'].append({'file': filename, 'status': 'error', 'reason': 'no issue number'})
+                            continue
 
                     app_logger.info(f"Processing {filename} (issue/vol #{issue_number})")
 
@@ -1672,11 +1687,16 @@ def batch_metadata():
                         xml_bytes = comicvine.generate_comicinfo_xml(metadata)
                         add_comicinfo_to_cbz(file_path, xml_bytes)
 
-                        # Auto-rename FIRST (before index update)
+                        # Auto-rename FIRST (before index update). Skipped in
+                        # one-shot folders so a guessed match doesn't silently
+                        # rename the file — the user reviews/renames it.
                         from cbz_ops.rename import rename_comic_from_metadata
                         old_filename = filename
                         old_path = file_path
-                        new_path, was_renamed = rename_comic_from_metadata(file_path, metadata)
+                        if is_oneshot:
+                            new_path, was_renamed = file_path, False
+                        else:
+                            new_path, was_renamed = rename_comic_from_metadata(file_path, metadata)
                         if was_renamed:
                             file_path = new_path
                             filename = os.path.basename(new_path)
@@ -3367,6 +3387,33 @@ def gcd_api_cover():
         return jsonify({"success": False, "error": str(e)})
 
 
+def _is_oneshot_folder_safe(folder_path):
+    """True when ``folder_path`` is a one-shot folder (oneshots/specials/...).
+
+    One-shot folders hold unrelated single issues, so a folder-level cvinfo must
+    not be applied across them and auto-rename should wait for confirmation.
+    """
+    try:
+        from core.bulk_metadata import _is_oneshot_folder
+        return bool(folder_path) and _is_oneshot_folder(folder_path)
+    except Exception:
+        return False
+
+
+def _rename_config_for(folder_path):
+    """Build the response's rename_config, suppressing auto-rename in one-shot
+    folders so a fetched match is applied but the rename waits for the user to
+    confirm (guards against a wrong one-shot guess silently renaming the file)."""
+    auto = current_app.config.get("ENABLE_AUTO_RENAME", False)
+    if _is_oneshot_folder_safe(folder_path):
+        auto = False
+    return {
+        "enabled": current_app.config.get("ENABLE_CUSTOM_RENAME", False),
+        "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
+        "auto_rename": auto,
+    }
+
+
 @metadata_bp.route('/api/search-metadata', methods=['POST'])
 def search_metadata():
     """
@@ -3448,6 +3495,12 @@ def search_metadata():
         if search_term_override:
             cvinfo_path = None
             app_logger.info("[search-metadata] Bypassing cvinfo (search_term override is set)")
+        elif _is_oneshot_folder_safe(folder_path):
+            # One-shot folders hold unrelated singles — a shared folder cvinfo
+            # would wrongly match every file to the same series. Search by the
+            # file's own parsed name instead.
+            cvinfo_path = None
+            app_logger.info("[search-metadata] Bypassing cvinfo (one-shot folder)")
         else:
             cvinfo_path = comicvine.find_cvinfo_in_folder(folder_path)
 
@@ -3547,11 +3600,7 @@ def search_metadata():
                 "source": provider,
                 "metadata": metadata,
                 "image_url": img_url,
-                "rename_config": {
-                    "enabled": current_app.config.get("ENABLE_CUSTOM_RENAME", False),
-                    "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
-                    "auto_rename": current_app.config.get("ENABLE_AUTO_RENAME", False)
-                }
+                "rename_config": _rename_config_for(folder_path)
             }
 
             if new_file_path:
@@ -3754,11 +3803,7 @@ def search_metadata():
                     "source": provider_type,
                     "metadata": metadata,
                     "image_url": img_url,
-                    "rename_config": {
-                        "enabled": current_app.config.get("ENABLE_CUSTOM_RENAME", False),
-                        "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
-                        "auto_rename": current_app.config.get("ENABLE_AUTO_RENAME", False)
-                    }
+                    "rename_config": _rename_config_for(folder_path)
                 }
 
                 if new_file_path:
@@ -3922,11 +3967,7 @@ def search_comicvine_metadata():
                             "name": volume_data.get('name', ''),
                             "start_year": volume_data.get('start_year')
                         },
-                        "rename_config": {
-                            "enabled": current_app.config.get("ENABLE_CUSTOM_RENAME", False),
-                            "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
-                            "auto_rename": current_app.config.get("ENABLE_AUTO_RENAME", False)
-                        }
+                        "rename_config": _rename_config_for(folder_path)
                     }
 
                     if new_file_path:
@@ -4082,11 +4123,7 @@ def search_comicvine_metadata():
                 "name": selected_volume['name'],
                 "start_year": selected_volume['start_year']
             },
-            "rename_config": {
-                "enabled": current_app.config.get("ENABLE_CUSTOM_RENAME", False),
-                "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
-                "auto_rename": current_app.config.get("ENABLE_AUTO_RENAME", False)
-            }
+            "rename_config": _rename_config_for(folder_path)
         }
 
         # Add new file path to response if file was moved
@@ -4195,11 +4232,7 @@ def search_comicvine_metadata_with_selection():
             "success": True,
             "metadata": comicinfo_data,
             "image_url": img_url,
-            "rename_config": {
-                "enabled": current_app.config.get("ENABLE_CUSTOM_RENAME", False),
-                "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
-                "auto_rename": current_app.config.get("ENABLE_AUTO_RENAME", False)
-            }
+            "rename_config": _rename_config_for(os.path.dirname(file_path))
         }
 
         # Add new file path to response if file was moved

--- a/tests/routes/test_bulk_metadata.py
+++ b/tests/routes/test_bulk_metadata.py
@@ -705,6 +705,33 @@ class TestApplyCvinfo:
         # The parsed issue number from the filename makes it into the XML.
         assert b'<Number>99</Number>' in xml
 
+    def test_resolve_defaults_to_issue_one_when_unparseable(self, bulk_client, tmp_path):
+        """A one-shot whose filename has no parseable issue number must fall back
+        to issue #1 instead of erroring with
+        'could not parse issue number from filename'."""
+        folder = tmp_path / "Demis Wild Kingdom"
+        folder.mkdir()
+        cbz = _make_cbz(folder / "Demis Wild Kingdom.cbz")  # no issue number
+        _, review_ids = self._seed_review_rows(folder, [cbz])
+
+        series = SearchResult(
+            provider=ProviderType.GCD_API, id='30644', title="Demi's Wild Kingdom", year=2009,
+        )
+        issues = [
+            IssueResult(provider=ProviderType.GCD_API, id='1', series_id='30644', issue_number='1'),
+        ]
+        with patch('core.bulk_metadata._instantiate_provider',
+                   return_value=self._provider_returning(series, issues)):
+            r = bulk_client.post(
+                f'/api/bulk-metadata/review/{review_ids[0]}/resolve',
+                json={'provider': 'gcd_api', 'series_id': '30644'},
+            )
+        assert r.status_code == 200, r.get_json()
+        assert r.get_json()['success'] is True
+        xml = _read_xml_from_cbz(cbz)
+        assert xml is not None
+        assert b'<Number>1</Number>' in xml
+
     def test_flips_file_index_has_comicinfo(self, bulk_client, tmp_path):
         """The bug fix: after applying metadata, file_index.has_comicinfo
         must flip to 1 so the file drops off the Missing XML view."""
@@ -1217,3 +1244,59 @@ class TestGroupCascade:
 
         r = bulk_client.post(f'/api/bulk-metadata/review/{rids[0]}/skip-series')
         assert r.status_code == 409
+
+
+class TestApplySeriesOneShotFallback:
+    """_apply_series_to_folder must fall back to issue #1 for an un-numbered
+    file ONLY when the folder is a one-shot (single comic), never for multi-file
+    folders (which would mis-map every file to #1)."""
+
+    def _provider(self, issues):
+        p = MagicMock()
+        p.get_issues.return_value = issues
+        return p
+
+    def _series_and_issues(self):
+        series = SearchResult(
+            provider=ProviderType.COMICVINE, id='1', title='One Shot', year=2020,
+        )
+        issues = [IssueResult(provider=ProviderType.COMICVINE, id='i1', series_id='1', issue_number='1')]
+        return series, issues
+
+    def test_one_shot_unnumbered_uses_issue_one(self, tmp_path):
+        from routes.bulk_metadata import _apply_series_to_folder
+        folder = tmp_path / 'One Shot'
+        folder.mkdir()
+        _make_cbz(folder / 'One Shot Special.cbz')  # no issue number
+        series, issues = self._series_and_issues()
+
+        with patch('core.bulk_metadata._has_existing_comicinfo', return_value=False), \
+             patch('core.bulk_metadata._write_metadata', return_value=True) as wm:
+            written, errors = _apply_series_to_folder(
+                job_id='j', folder_path=str(folder), provider_name='comicvine',
+                provider=self._provider(issues), series=series, series_id='1',
+                parsed_year=2020, matched_via='manual',
+            )
+        assert written == 1
+        assert errors == 0
+        # The single file was matched to issue #1.
+        assert wm.call_args.kwargs['issue'].issue_number == '1'
+
+    def test_multi_file_unnumbered_skips(self, tmp_path):
+        from routes.bulk_metadata import _apply_series_to_folder
+        folder = tmp_path / 'Multi'
+        folder.mkdir()
+        _make_cbz(folder / 'Multi One.cbz')  # no issue number
+        _make_cbz(folder / 'Multi Two.cbz')  # no issue number
+        series, issues = self._series_and_issues()
+
+        with patch('core.bulk_metadata._has_existing_comicinfo', return_value=False), \
+             patch('core.bulk_metadata._write_metadata', return_value=True) as wm:
+            written, errors = _apply_series_to_folder(
+                job_id='j', folder_path=str(folder), provider_name='comicvine',
+                provider=self._provider(issues), series=series, series_id='1',
+                parsed_year=2020, matched_via='manual',
+            )
+        # Neither un-numbered file is forced to #1 in a multi-file folder.
+        assert written == 0
+        assert not wm.called

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1017,3 +1017,156 @@ class TestBatchMetadataSkipProviders:
         assert '"type": "complete"' in body
         # ComicVine search must not run when comicvine is skipped.
         cv.assert_not_called()
+
+    def test_one_shot_unnumbered_falls_back_to_issue_one(self, app, client, tmp_path):
+        """A single un-numbered file (one-shot) must NOT error with 'no issue
+        number' — it falls back to issue #1 and is processed normally."""
+        from contextlib import ExitStack
+        folder = tmp_path / "One Shot Special"
+        folder.mkdir()
+        _make_cbz(str(folder / "One Shot Special.cbz"), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack)
+            stack.enter_context(patch("models.comicvine.search_volumes", return_value=[]))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+            body = resp.get_data(as_text=True)
+
+        assert resp.status_code == 200
+        assert 'text/event-stream' in resp.content_type
+        assert 'no issue number' not in body
+
+    def test_multi_file_unnumbered_still_errors(self, app, client, tmp_path):
+        """Multiple un-numbered files must NOT all be mapped to #1 — they still
+        report the 'no issue number' error."""
+        from contextlib import ExitStack
+        folder = tmp_path / "Mixed Folder"
+        folder.mkdir()
+        _make_cbz(str(folder / "Mixed Folder One.cbz"), with_comicinfo=False)
+        _make_cbz(str(folder / "Mixed Folder Two.cbz"), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack)
+            stack.enter_context(patch("models.comicvine.search_volumes", return_value=[]))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+            body = resp.get_data(as_text=True)
+
+        assert resp.status_code == 200
+        assert 'no issue number' in body
+
+
+class TestOneShotFolderHandling:
+    """One-shot folders (oneshots/specials/...) hold unrelated singles, so a
+    shared folder cvinfo must be ignored and auto-rename must be gated."""
+
+    def test_search_metadata_bypasses_cvinfo_and_gates_autorename(self, app, client, tmp_path):
+        from contextlib import ExitStack
+        app.config["COMICVINE_API_KEY"] = "k"
+        app.config["ENABLE_AUTO_RENAME"] = True
+        folder = tmp_path / "oneshots"
+        folder.mkdir()
+        # A poisoning cvinfo (volume 99999) that must be ignored here.
+        (folder / "cvinfo").write_text("https://comicvine.gamespot.com/x/4050-99999/")
+        cbz = folder / "Lilli Xene.cbz"
+        _make_cbz(str(cbz), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("core.database.get_library_providers", return_value=[
+                {"provider_type": "comicvine", "enabled": True}]))
+            stack.enter_context(patch("models.comicvine.is_simyan_available", return_value=True))
+            sv = stack.enter_context(patch("models.comicvine.search_volumes", return_value=[
+                {"id": 555, "name": "Lilli Xene", "publisher_name": "X", "start_year": 2007}]))
+            pcv = stack.enter_context(patch("models.comicvine.parse_cvinfo_volume_id", return_value=99999))
+            stack.enter_context(patch("models.comicvine.get_issue_by_number", return_value={
+                "volume_name": "Lilli Xene", "year": 2007, "image_url": "http://i"}))
+            stack.enter_context(patch("models.comicvine.map_to_comicinfo",
+                                      return_value={"Series": "Lilli Xene", "Number": "1"}))
+            stack.enter_context(patch("models.comicvine.auto_move_file", return_value=None))
+            stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+            stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+            stack.enter_context(patch("core.database.set_has_comicinfo"))
+            stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': str(cbz), 'file_name': 'Lilli Xene.cbz', 'library_id': 1,
+            })
+
+        data = resp.get_json()
+        assert data["success"] is True
+        # cvinfo was bypassed → matched by the file's own name, not volume 99999.
+        sv.assert_called()
+        pcv.assert_not_called()
+        # auto-rename gated off in one-shot folders despite ENABLE_AUTO_RENAME.
+        assert data["rename_config"]["auto_rename"] is False
+
+    def test_non_oneshot_uses_cvinfo_and_allows_autorename(self, app, client, tmp_path):
+        from contextlib import ExitStack
+        app.config["COMICVINE_API_KEY"] = "k"
+        app.config["ENABLE_AUTO_RENAME"] = True
+        folder = tmp_path / "Some Series (2007)"
+        folder.mkdir()
+        (folder / "cvinfo").write_text("https://comicvine.gamespot.com/x/4050-99999/")
+        cbz = folder / "Some Series 001.cbz"
+        _make_cbz(str(cbz), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("core.database.get_library_providers", return_value=[
+                {"provider_type": "comicvine", "enabled": True}]))
+            stack.enter_context(patch("models.comicvine.is_simyan_available", return_value=True))
+            stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder",
+                                      return_value=str(folder / "cvinfo")))
+            pcv = stack.enter_context(patch("models.comicvine.parse_cvinfo_volume_id", return_value=99999))
+            gibn = stack.enter_context(patch("models.comicvine.get_issue_by_number", return_value={
+                "volume_name": "Some Series", "year": 2007, "image_url": "http://i"}))
+            stack.enter_context(patch("models.comicvine.read_cvinfo_fields",
+                                      return_value={"start_year": 2007, "publisher_name": "X"}))
+            stack.enter_context(patch("models.comicvine.map_to_comicinfo",
+                                      return_value={"Series": "Some Series", "Number": "1"}))
+            stack.enter_context(patch("models.comicvine.auto_move_file", return_value=None))
+            stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+            stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+            stack.enter_context(patch("core.database.set_has_comicinfo"))
+            stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': str(cbz), 'file_name': 'Some Series 001.cbz', 'library_id': 1,
+            })
+
+        data = resp.get_json()
+        assert data["success"] is True
+        # Normal folder: cvinfo IS consulted and auto-rename stays enabled.
+        pcv.assert_called()
+        gibn.assert_called()
+        assert data["rename_config"]["auto_rename"] is True
+
+    def test_batch_oneshot_does_not_consult_cvinfo(self, app, client, tmp_path):
+        from contextlib import ExitStack
+        app.config["COMICVINE_API_KEY"] = "k"
+        folder = tmp_path / "oneshots"
+        folder.mkdir()
+        (folder / "cvinfo").write_text("https://comicvine.gamespot.com/x/4050-99999/")
+        _make_cbz(str(folder / "Lilli Xene.cbz"), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("routes.metadata.is_valid_library_path", return_value=True))
+            stack.enter_context(patch("app.get_target_dir_live", return_value="/nonexistent"))
+            stack.enter_context(patch("core.database.get_library_providers", return_value=[
+                {"provider_type": "comicvine", "enabled": True}]))
+            stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+            gmv = stack.enter_context(patch("models.comicvine.get_metadata_by_volume_id", return_value=None))
+            pcv = stack.enter_context(patch("models.comicvine.parse_cvinfo_volume_id", return_value=99999))
+
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+            body = resp.get_data(as_text=True)
+
+        assert resp.status_code == 200
+        # The folder's cvinfo (volume 99999) must never be consulted for a one-shot folder.
+        gmv.assert_not_called()
+        pcv.assert_not_called()
+        assert '"type": "complete"' in body

--- a/tests/unit/test_bulk_metadata_sidecars.py
+++ b/tests/unit/test_bulk_metadata_sidecars.py
@@ -109,3 +109,49 @@ class TestEnsureFolderSidecars:
         ensure_folder_sidecars(folder, 'metron', None)
         assert not os.path.exists(os.path.join(folder, 'cvinfo'))
         assert not os.path.exists(os.path.join(folder, 'series.json'))
+
+
+class TestOneShotFolderNoSidecars:
+    """One-shot folders (oneshots/specials/...) must never get folder sidecars,
+    on any metadata write — both via ensure_folder_sidecars and the low-level
+    cvinfo writers."""
+
+    def test_ensure_folder_sidecars_skips_oneshot(self, tmp_path):
+        folder = tmp_path / "oneshots"
+        folder.mkdir()
+        ensure_folder_sidecars(str(folder), 'metron', _series(ProviderType.METRON, id='100'))
+        assert not os.path.exists(os.path.join(str(folder), 'cvinfo'))
+        assert not os.path.exists(os.path.join(str(folder), 'series.json'))
+
+    def test_low_level_cvinfo_writers_noop_in_oneshot(self, tmp_path):
+        from models import metron, comicvine
+        folder = tmp_path / "specials"
+        folder.mkdir()
+        cvinfo = str(folder / "cvinfo")
+
+        assert metron.create_cvinfo_file(cvinfo, cv_id=1, series_id=2) is False
+        assert comicvine.write_cvinfo_fields(cvinfo, "DC Comics", 2016) is False
+        assert not os.path.exists(cvinfo)
+
+    def test_writers_still_work_in_normal_folder(self, tmp_path):
+        from models import metron
+        folder = tmp_path / "Batman (2016)"
+        folder.mkdir()
+        cvinfo = str(folder / "cvinfo")
+        assert metron.create_cvinfo_file(cvinfo, cv_id=1, series_id=2) is True
+        assert os.path.exists(cvinfo)
+
+
+class TestIsOneShotFolderPredicate:
+
+    def test_matches_default_names(self):
+        from core.config import is_oneshot_folder
+        assert is_oneshot_folder("/data/Adult/oneshots")
+        assert is_oneshot_folder("/x/specials")
+        assert is_oneshot_folder("/x/one-shots/")
+
+    def test_rejects_normal_and_empty(self):
+        from core.config import is_oneshot_folder
+        assert not is_oneshot_folder("/x/Batman (2016)")
+        assert not is_oneshot_folder("")
+        assert not is_oneshot_folder(None)


### PR DESCRIPTION
## 📝 Description

Introduce a single-source is_oneshot_folder predicate and use it to treat folders of unrelated single issues as special. One-shot folders now: skip creating or updating folder-level sidecars (cvinfo / series.json), bypass reading folder cvinfo for matching, avoid low-level cvinfo writes, and disable automatic renaming so matches require user confirmation. Also change per-file logic to fall back to issue #1 for single-file (one-shot) operations while keeping multi-file folders unchanged. Changes touch core.config, core.bulk_metadata, models.{comicvine,metron}, routes/{metadata,bulk_metadata}, app.py and add/adjust tests to cover these behaviors to prevent mis-binding unrelated singles to a single series and accidental silent renames.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass