### PR TITLE
Ensure sidecars inherit parent permissions

### DIFF
--- a/core/bulk_metadata.py
+++ b/core/bulk_metadata.py
@@ -297,6 +297,8 @@ def _write_cvinfo(cvinfo_path: str, provider_name: str, series: SearchResult) ->
     else:  # comicvine
         with open(cvinfo_path, 'w', encoding='utf-8') as f:
             f.write(f"https://comicvine.gamespot.com/volume/4050-{series_id}/")
+        from helpers import match_parent_permissions
+        match_parent_permissions(cvinfo_path)
         from models import comicvine as cv_mod
         cv_mod.write_cvinfo_fields(cvinfo_path, publisher, start_year)
 

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -64,6 +64,35 @@ def is_hidden(filepath):
     return False
 
 #########################
+#   Sidecar Permissions #
+#########################
+
+def match_parent_permissions(path):
+    """Best-effort: make a freshly written sidecar inherit its parent folder's
+    accessibility (group + rwx bits minus execute) so shared/NAS accounts can
+    read and write files CLU creates (cvinfo, series.json, ...).
+
+    Files are otherwise created with the process umask and, for series.json,
+    a 0o600 temp file from mkstemp — leaving sidecars unwritable for NAS users
+    even when the containing folder is group-writable. We mirror the parent
+    folder's mode (dropping the execute bits, which only matter on directories)
+    and set the group to the parent's, so the file is as accessible as its
+    folder. Silently ignored where unsupported (Windows-backed mounts, files
+    CLU does not own).
+    """
+    try:
+        parent = os.path.dirname(os.path.abspath(path)) or "."
+        pst = os.stat(parent)
+        os.chmod(path, stat.S_IMODE(pst.st_mode) & ~0o111)  # drop x for files
+        if hasattr(os, "chown"):                            # absent on Windows
+            try:
+                os.chown(path, -1, pst.st_gid)              # group only; keep owner
+            except (PermissionError, OSError):
+                pass
+    except OSError:
+        pass
+
+#########################
 #   Folder Thumbnails   #
 #########################
 

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -991,6 +991,9 @@ def write_cvinfo_fields(cvinfo_path: str, publisher_name: Optional[str], start_y
             for line in lines_to_add:
                 f.write(f"\n{line}")
 
+        from helpers import match_parent_permissions
+        match_parent_permissions(cvinfo_path)
+
         app_logger.debug(f"Added to cvinfo: {', '.join(lines_to_add)}")
         return True
 

--- a/models/metron.py
+++ b/models/metron.py
@@ -337,6 +337,9 @@ def write_cvinfo_fields(
             for line in lines_to_add:
                 f.write(f"\n{line}")
 
+        from helpers import match_parent_permissions
+        match_parent_permissions(cvinfo_path)
+
         app_logger.debug(f"Added to cvinfo: {', '.join(lines_to_add)}")
         return True
     except Exception as e:
@@ -999,6 +1002,9 @@ def create_cvinfo_file(
         # Write to file
         with open(cvinfo_path, "w", encoding="utf-8") as f:
             f.write("\n".join(lines))
+
+        from helpers import match_parent_permissions
+        match_parent_permissions(cvinfo_path)
 
         app_logger.info(f"Created cvinfo file: {cvinfo_path}")
         return True

--- a/models/series_json.py
+++ b/models/series_json.py
@@ -236,6 +236,11 @@ def write_series_json(folder_path, series, issues=None, api=None, preserve_exist
 
         target = os.path.join(folder_path, SERIES_JSON_FILENAME)
         _atomic_write(target, {"metadata": metadata})
+        # mkstemp creates the temp file 0o600 and os.replace preserves that mode,
+        # so series.json would otherwise be owner-only. Match the parent folder
+        # so shared/NAS accounts can read and edit it.
+        from helpers import match_parent_permissions
+        match_parent_permissions(target)
         app_logger.info(f"Wrote series.json at {target}")
         return True
 

--- a/routes/bulk_metadata.py
+++ b/routes/bulk_metadata.py
@@ -798,6 +798,8 @@ def apply_cvinfo(review_id):
             if not is_oneshot_folder(folder_path):
                 with open(cvinfo_path, 'w', encoding='utf-8') as f:
                     f.write(f"https://comicvine.gamespot.com/volume/4050-{cv_volume_id}/")
+                from helpers import match_parent_permissions
+                match_parent_permissions(cvinfo_path)
             # Best-effort publisher + start_year append using the same helper.
             try:
                 from models import comicvine as cv_mod

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -562,6 +562,9 @@ def save_cvinfo():
         with open(cvinfo_path, 'w', encoding='utf-8') as f:
             f.write(content.strip())
 
+        from helpers import match_parent_permissions
+        match_parent_permissions(cvinfo_path)
+
         app_logger.info(f"Saved cvinfo to {cvinfo_path}")
         return jsonify({"success": True, "path": cvinfo_path})
     except Exception as e:
@@ -1217,6 +1220,8 @@ def batch_metadata():
                         url = f"https://comicvine.gamespot.com/volume/4050-{cv_volume_id}/"
                         with open(cvinfo_path, 'w', encoding='utf-8') as f:
                             f.write(url)
+                        from helpers import match_parent_permissions
+                        match_parent_permissions(cvinfo_path)
                         cvinfo_created = True
                         app_logger.info(f"Created cvinfo with ComicVine volume ID: {cv_volume_id}")
 

--- a/tests/unit/test_bulk_metadata_sidecars.py
+++ b/tests/unit/test_bulk_metadata_sidecars.py
@@ -6,6 +6,9 @@ and without clobbering existing files.
 """
 import json
 import os
+import stat
+
+import pytest
 
 from core.bulk_metadata import ensure_folder_sidecars, _try_cvinfo
 from models.providers import ProviderType
@@ -109,6 +112,18 @@ class TestEnsureFolderSidecars:
         ensure_folder_sidecars(folder, 'metron', None)
         assert not os.path.exists(os.path.join(folder, 'cvinfo'))
         assert not os.path.exists(os.path.join(folder, 'series.json'))
+
+    @pytest.mark.skipif(os.name == 'nt', reason='POSIX chmod/group semantics')
+    def test_sidecars_are_group_writable(self, tmp_path):
+        """cvinfo and series.json must be group-writable so shared/NAS accounts
+        can edit them. Guards against the series.json mkstemp 0o600 regression."""
+        folder = str(tmp_path)
+        os.chmod(folder, 0o775)
+        ensure_folder_sidecars(folder, 'metron', _series(ProviderType.METRON, id='100'))
+
+        for name in ('cvinfo', 'series.json'):
+            mode = stat.S_IMODE(os.stat(os.path.join(folder, name)).st_mode)
+            assert mode & 0o060 == 0o060, f"{name} not group rw: {oct(mode)}"
 
 
 class TestOneShotFolderNoSidecars:

--- a/tests/unit/test_sidecar_permissions.py
+++ b/tests/unit/test_sidecar_permissions.py
@@ -1,0 +1,59 @@
+"""Unit tests for helpers.match_parent_permissions.
+
+CLU writes sidecars (cvinfo, series.json) with a plain open()/mkstemp, leaving
+them unwritable for shared/NAS accounts even when the containing folder is
+group-writable. match_parent_permissions makes a freshly written file inherit
+its parent folder's accessibility (group + rwx minus execute), best-effort.
+"""
+import os
+import stat
+
+import pytest
+
+from helpers import match_parent_permissions
+
+
+@pytest.mark.skipif(os.name == 'nt', reason='POSIX chmod/group semantics')
+class TestMatchParentPermissions:
+
+    def test_file_inherits_parent_mode_minus_execute(self, tmp_path):
+        folder = tmp_path
+        os.chmod(folder, 0o775)
+        f = folder / 'cvinfo'
+        f.write_text('x')
+        os.chmod(f, 0o600)  # start owner-only, like mkstemp output
+
+        match_parent_permissions(str(f))
+
+        mode = stat.S_IMODE(os.stat(f).st_mode)
+        assert mode == 0o664  # 775 dir -> 664 file (execute dropped)
+
+    def test_world_writable_folder_yields_666(self, tmp_path):
+        folder = tmp_path
+        os.chmod(folder, 0o777)
+        f = folder / 'series.json'
+        f.write_text('{}')
+        os.chmod(f, 0o600)
+
+        match_parent_permissions(str(f))
+
+        assert stat.S_IMODE(os.stat(f).st_mode) == 0o666
+
+    def test_file_inherits_parent_group(self, tmp_path):
+        f = tmp_path / 'cvinfo'
+        f.write_text('x')
+
+        match_parent_permissions(str(f))
+
+        assert os.stat(f).st_gid == os.stat(tmp_path).st_gid
+
+
+class TestMatchParentPermissionsBestEffort:
+    """Must never raise — it is a best-effort cosmetic step."""
+
+    def test_missing_path_is_silent_noop(self, tmp_path):
+        # Parent exists, file does not: chmod fails, helper swallows it.
+        match_parent_permissions(str(tmp_path / 'does-not-exist'))
+
+    def test_missing_parent_is_silent_noop(self, tmp_path):
+        match_parent_permissions(str(tmp_path / 'no' / 'such' / 'cvinfo'))


### PR DESCRIPTION
## 📝 Description
Add a best-effort helper (`helpers.match_parent_permissions`) that makes newly written sidecar files (`cvinfo, series.json`, etc.) inherit their parent folder's group and rw bits (dropping execute). Call this helper after creating/updating sidecars across core.bulk_metadata, routes.metadata, routes.bulk_metadata, models.comicvine, models.metron and models.series_json to avoid mkstemp/umask creating owner-only files that break shared/NAS workflows. Add unit tests (including a new tests/unit/test_sidecar_permissions.py) to verify group-writable behavior and that the helper is a silent noop on unsupported platforms; Windows tests are skipped.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass