### PR TITLE
Fix CBZ info/edit/script actions on series page

### DIFF
--- a/static/js/series.js
+++ b/static/js/series.js
@@ -640,8 +640,16 @@ function editIssueFile(filePath) {
  * @param {string} filePath - Full path to the file
  */
 function executeIssueScript(scriptType, filePath) {
-    // Call files.js function with 'source' panel (doesn't matter for single file ops)
-    executeScriptOnFile(scriptType, filePath, 'source');
+    // Drive the shared streaming op directly so completion reloads the series
+    // page (refreshing the issue's found-state and actions). The files.js
+    // wrapper instead refreshes the file-browser panels, which don't exist here.
+    window._cluStreaming = {
+        onComplete: function () {
+            setTimeout(function () { window.location.reload(); }, 1500);
+        },
+        onError: function () {}
+    };
+    CLU.executeStreamingOp(scriptType, filePath);
 }
 
 /**

--- a/templates/series.html
+++ b/templates/series.html
@@ -468,41 +468,8 @@
 
 <!-- Modals -->
 
-<!-- CBZ Info Modal -->
-<div class="modal fade" id="cbzInfoModal" tabindex="-1" aria-labelledby="cbzInfoModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="cbzInfoModalLabel">CBZ Information</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <!-- Navigation buttons row -->
-                <div id="cbzNavButtons" class="d-flex justify-content-between mb-3" style="display: none !important;">
-                    <button type="button" id="cbzPrevBtn" class="btn btn-outline-primary" style="visibility: hidden;">
-                        <i class="bi bi-arrow-left"></i> Prev
-                    </button>
-                    <button type="button" id="cbzNextBtn" class="btn btn-outline-primary" style="visibility: hidden;">
-                        Next <i class="bi bi-arrow-right"></i>
-                    </button>
-                </div>
-
-                <div id="cbzInfoContent">
-                    <div class="text-center">
-                        <div class="spinner-border" role="status">
-                            <span class="visually-hidden">Loading...</span>
-                        </div>
-                        <p class="mt-2">Loading CBZ information...</p>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- End of CBZ Info Modal -->
+<!-- CBZ Info Modal (shared partial – driven by clu-cbz-info.js) -->
+{% include 'partials/modal_cbz_info.html' %}
 
 <!-- Mark Issue Modal -->
 <div class="modal fade" id="markIssueModal" tabindex="-1" aria-labelledby="markIssueModalLabel" aria-hidden="true">
@@ -634,61 +601,11 @@
     </div>
 </div>
 
-<!-- Edit CBZ Modal -->
-<div class="modal fade" id="editCBZModal" tabindex="-1" aria-labelledby="editCBZModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-fullscreen">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="editCBZModalLabel">Editing CBZ File</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div id="editInlineContainer" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
-                    <!-- Inline editing content (cards) will be dynamically loaded here -->
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary" id="saveEditBtn" onclick="saveEditedCBZ()">
-                    <i class="bi bi-floppy2-fill"></i> Save
-                </button>
-                <form action="/save" method="post" id="editInlineSaveForm" style="display: none;">
-                    <input type="hidden" name="folder_name" id="editInlineFolderName">
-                    <input type="hidden" name="zip_file_path" id="editInlineZipFilePath">
-                    <input type="hidden" name="original_file_path" id="editInlineOriginalFilePath">
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- Free Form Crop Modal -->
-<div class="modal fade" id="freeFormCropModal" tabindex="-1" aria-labelledby="freeFormCropModalLabel" aria-hidden="true"
-    data-bs-backdrop="static">
-    <div class="modal-dialog modal-fullscreen">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="freeFormCropModalLabel">Free Form Crop - Click and drag to select area</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body d-flex justify-content-center align-items-center bg-dark"
-                style="overflow: hidden; position: relative;">
-                <div id="cropImageContainer"
-                    style="position: relative; display: inline-block; max-width: 100%; max-height: 100%; cursor: crosshair;">
-                    <img id="cropImage" src="" alt="Image to crop"
-                        style="max-width: 100%; max-height: 90vh; display: block; user-select: none;">
-                    <div id="cropSelection"
-                        style="position: absolute; border: 3px dashed #ff0000; background-color: rgba(255, 0, 0, 0.1); display: none; pointer-events: none;">
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-primary" id="confirmCropBtn" onclick="confirmFreeFormCrop()"
-                    disabled>Confirm Crop</button>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- End of Free Form Crop Modal -->
+<!-- Edit CBZ Modal (shared partial – driven by clu-cbz-edit.js) -->
+{% include 'partials/modal_cbz_edit.html' %}
+
+<!-- Free Form Crop Modal (shared partial – driven by clu-cbz-crop.js) -->
+{% include 'partials/modal_freeform_crop.html' %}
 
 <!-- ComicVine URL Modal -->
 <div class="modal fade" id="cvInfoModal" tabindex="-1" aria-labelledby="cvInfoModalLabel" aria-hidden="true">
@@ -1376,6 +1293,11 @@
     // Load aliases on page load
     document.addEventListener('DOMContentLoaded', loadAliases);
 </script>
+<script src="{{ url_for('static', filename='js/clu-utils.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-streaming.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-cbz-crop.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-cbz-edit.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-cbz-info.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/files.js') }}?v={{ range(1000, 9999) | random }}&t=202502"></script>
 <script src="{{ url_for('static', filename='js/series.js') }}?v={{ range(1, 10000) | random }}"></script>
 {% endblock %}


### PR DESCRIPTION
## 📝 Description
The series page issue-row controls (View CBZ Info, Edit CBZ, and the Crop/Remove/Rebuild/Enhance/Add dropdown) silently failed because series.html only loaded files.js + series.js, never the clu-* modules those handlers delegate into. It also carried stale, hand-rolled copies of the CBZ-info, edit, and freeform-crop modals that had drifted out of sync with the shared partials
 templates/series.html:

- Replace the inline CBZ Info, Edit CBZ, and Free Form Crop modals with the shared partials (modal_cbz_info / modal_cbz_edit / modal_freeform_crop). The inline edit modal was missing #editCBZModalText and the pending-deletes/order inputs; the crop modal called a non-existent global confirmFreeFormCrop().

- Load clu-utils, clu-streaming, clu-cbz-crop, clu-cbz-edit, and clu-cbz-info before files.js so CLU.showCBZInfo, executeStreamingOp, and the edit modal helpers are defined.

static/js/series.js:
- Rewrite executeIssueScript() to set its own _cluStreaming contract and call CLU.executeStreamingOp directly, reloading the page on completion instead of routing through the files-browser refresh that doesn't exist on this page.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass