### PR TITLE
Create Debug Package with Redacted Secrets

### DIFF
--- a/core/debug_package.py
+++ b/core/debug_package.py
@@ -19,6 +19,7 @@ import io
 import json
 import os
 import platform
+import re
 import sys
 import zipfile
 from collections import deque
@@ -28,13 +29,20 @@ from core.config import CONFIG_DIR, CONFIG_FILE
 from core.version import __version__
 from models.providers.crypto import mask_credential
 
-# Substrings that mark a config/preference key as sensitive (case-insensitive).
-# Matching on substrings keeps this future-proof as new secret settings are
-# added (anything with KEY / PASSWORD / TOKEN / SECRET in its name).
-_SENSITIVE_SUBSTRINGS = ("KEY", "PASSWORD", "TOKEN", "SECRET")
+# Substrings that mark a key as sensitive. Compared against a normalized key
+# (uppercased, separators stripped) so "CF-Access-Client-Id", "client_id" and
+# "ClientId" all match. Substring matching keeps this future-proof as new secret
+# settings appear (anything with KEY / PASSWORD / TOKEN / SECRET / CLIENTID).
+_SENSITIVE_SUBSTRINGS = ("KEY", "PASSWORD", "TOKEN", "SECRET", "CLIENTID", "CREDENTIAL")
 
-# Explicit keys that don't contain an obvious marker but are still sensitive.
-_SENSITIVE_EXPLICIT = {"METRON_USERNAME", "CLU_USERNAME"}
+# Explicit (normalized) keys that don't contain an obvious marker but are still sensitive.
+_SENSITIVE_EXPLICIT = {"METRONUSERNAME", "CLUUSERNAME"}
+
+# Matches a JSON/dict-style `"key": "value"` pair, tolerant of any level of
+# backslash-escaping (none for config.ini values, single/multiple for
+# JSON-encoded DB preferences). Used to mask secrets nested inside a value
+# whose own top-level key looks innocuous (e.g. custom_headers / HEADERS).
+_BLOB_KV_RE = re.compile(r'(\\*"([^"\\]+?)\\*"\s*:\s*\\*")([^"\\]*)(\\*")')
 
 # How many trailing lines of each log file to include.
 LOG_TAIL_LINES = 5000
@@ -44,17 +52,37 @@ def _is_sensitive_key(key: str) -> bool:
     """True when a config/preference key holds a secret that must be redacted."""
     if not key:
         return False
-    upper = key.upper()
-    if upper in _SENSITIVE_EXPLICIT:
+    norm = re.sub(r"[^A-Z0-9]", "", key.upper())
+    if norm in _SENSITIVE_EXPLICIT:
         return True
-    return any(marker in upper for marker in _SENSITIVE_SUBSTRINGS)
+    return any(marker in norm for marker in _SENSITIVE_SUBSTRINGS)
 
 
-def _redact_value(value):
-    """Mask a value if it is a non-empty string; pass through otherwise."""
-    if isinstance(value, str) and value:
-        return mask_credential(value)
-    return value
+def _redact_blob(value):
+    """Mask secrets nested inside a string value (JSON / header dict / etc.).
+
+    Scans for `"key": "value"` pairs and masks the value whenever the nested
+    key is sensitive, leaving the surrounding structure intact. No-op for
+    strings that contain no such pairs.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+
+    def _repl(m):
+        if _is_sensitive_key(m.group(2)) and m.group(3):
+            return m.group(1) + mask_credential(m.group(3)) + m.group(4)
+        return m.group(0)
+
+    return _BLOB_KV_RE.sub(_repl, value)
+
+
+def _sanitize_value(key, value):
+    """Mask the whole value when its key is sensitive, else scrub nested secrets."""
+    if not isinstance(value, str):
+        return value
+    if _is_sensitive_key(key):
+        return mask_credential(value) if value else value
+    return _redact_blob(value)
 
 
 def _redacted_config_ini(config_path: str = CONFIG_FILE) -> str:
@@ -71,8 +99,9 @@ def _redacted_config_ini(config_path: str = CONFIG_FILE) -> str:
 
     for section in parser.sections():
         for key, value in parser.items(section):
-            if _is_sensitive_key(key) and value:
-                parser.set(section, key, mask_credential(value))
+            sanitized = _sanitize_value(key, value)
+            if sanitized != value:
+                parser.set(section, key, sanitized)
 
     buf = io.StringIO()
     parser.write(buf)
@@ -96,12 +125,9 @@ def _db_settings_json() -> str:
         )
         for row in c.fetchall():
             key = row["key"]
-            value = row["value"]
-            if _is_sensitive_key(key):
-                value = _redact_value(value)
             data["user_preferences"].append({
                 "key": key,
-                "value": value,
+                "value": _sanitize_value(key, row["value"]),
                 "category": row["category"],
                 "updated_at": row["updated_at"],
             })

--- a/core/debug_package.py
+++ b/core/debug_package.py
@@ -1,0 +1,186 @@
+"""
+Debug Package builder.
+
+Bundles the most useful diagnostic data (config, settings, recent logs and
+system info) into a single in-memory ZIP so users can attach it to a support
+request. All secrets are redacted by default using the same masking the app
+uses elsewhere for credentials, so the package is safe to share publicly.
+
+Contents of the ZIP:
+    README.txt          -- what's inside + redaction notice
+    system_info.json    -- version, platform, python, key paths, flags
+    config.ini          -- copy of config.ini with secrets redacted
+    db_settings.json    -- user_preferences rows + table list (settings only)
+    logs/app.log        -- last N lines of app.log
+    logs/monitor.log    -- last N lines of monitor.log
+"""
+import configparser
+import io
+import json
+import os
+import platform
+import sys
+import zipfile
+from collections import deque
+
+from core.app_logging import APP_LOG, MONITOR_LOG, LOG_DIR, app_logger
+from core.config import CONFIG_DIR, CONFIG_FILE
+from core.version import __version__
+from models.providers.crypto import mask_credential
+
+# Substrings that mark a config/preference key as sensitive (case-insensitive).
+# Matching on substrings keeps this future-proof as new secret settings are
+# added (anything with KEY / PASSWORD / TOKEN / SECRET in its name).
+_SENSITIVE_SUBSTRINGS = ("KEY", "PASSWORD", "TOKEN", "SECRET")
+
+# Explicit keys that don't contain an obvious marker but are still sensitive.
+_SENSITIVE_EXPLICIT = {"METRON_USERNAME", "CLU_USERNAME"}
+
+# How many trailing lines of each log file to include.
+LOG_TAIL_LINES = 5000
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """True when a config/preference key holds a secret that must be redacted."""
+    if not key:
+        return False
+    upper = key.upper()
+    if upper in _SENSITIVE_EXPLICIT:
+        return True
+    return any(marker in upper for marker in _SENSITIVE_SUBSTRINGS)
+
+
+def _redact_value(value):
+    """Mask a value if it is a non-empty string; pass through otherwise."""
+    if isinstance(value, str) and value:
+        return mask_credential(value)
+    return value
+
+
+def _redacted_config_ini(config_path: str = CONFIG_FILE) -> str:
+    """Return config.ini as a string with all sensitive values masked."""
+    if not os.path.exists(config_path):
+        return f"# config.ini not found at {config_path}\n"
+
+    parser = configparser.RawConfigParser()
+    parser.optionxform = str  # preserve key case
+    try:
+        parser.read(config_path)
+    except configparser.Error as e:
+        return f"# Failed to parse config.ini: {e}\n"
+
+    for section in parser.sections():
+        for key, value in parser.items(section):
+            if _is_sensitive_key(key) and value:
+                parser.set(section, key, mask_credential(value))
+
+    buf = io.StringIO()
+    parser.write(buf)
+    return buf.getvalue()
+
+
+def _db_settings_json() -> str:
+    """Dump the user_preferences table + table list as JSON (secrets redacted)."""
+    from core.database import get_db_connection
+
+    data = {"user_preferences": [], "tables": []}
+    conn = None
+    try:
+        conn = get_db_connection()
+        if conn is None:
+            return json.dumps({"error": "database unavailable"}, indent=2)
+        c = conn.cursor()
+
+        c.execute(
+            "SELECT key, value, category, updated_at FROM user_preferences ORDER BY key"
+        )
+        for row in c.fetchall():
+            key = row["key"]
+            value = row["value"]
+            if _is_sensitive_key(key):
+                value = _redact_value(value)
+            data["user_preferences"].append({
+                "key": key,
+                "value": value,
+                "category": row["category"],
+                "updated_at": row["updated_at"],
+            })
+
+        c.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        data["tables"] = [r["name"] for r in c.fetchall()]
+    except Exception as e:
+        app_logger.error(f"Debug package: failed reading db settings: {e}")
+        data["error"] = str(e)
+    finally:
+        if conn is not None:
+            conn.close()
+
+    return json.dumps(data, indent=2, default=str)
+
+
+def _system_info_json() -> str:
+    """Return non-sensitive runtime/environment info as JSON."""
+    info = {
+        "version": __version__,
+        "platform": platform.platform(),
+        "python_version": sys.version,
+        "paths": {
+            "config_dir": CONFIG_DIR,
+            "log_dir": LOG_DIR,
+            "config_file": CONFIG_FILE,
+        },
+        "flags": {
+            "MONITOR": os.environ.get("MONITOR", ""),
+            "ENABLE_DEBUG_LOGGING": os.environ.get("ENABLE_DEBUG_LOGGING", ""),
+            "PUID": os.environ.get("PUID", ""),
+            "PGID": os.environ.get("PGID", ""),
+        },
+    }
+    return json.dumps(info, indent=2, default=str)
+
+
+def _tail(path: str, lines: int = LOG_TAIL_LINES) -> str:
+    """Return the last ``lines`` lines of a text file, or a placeholder."""
+    if not path or not os.path.exists(path):
+        return f"(log file not found: {path})\n"
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            tail = deque(f, maxlen=lines)
+        return "".join(tail)
+    except Exception as e:
+        return f"(failed to read log {path}: {e})\n"
+
+
+def _readme() -> str:
+    """Short explanation of the package contents and the redaction guarantee."""
+    return (
+        "CLU Debug Package\n"
+        "=================\n\n"
+        f"Generated by Comic Library Utilities v{__version__}.\n\n"
+        "Contents:\n"
+        "  system_info.json  - version, platform, python, key paths, flags\n"
+        "  config.ini        - your config with secrets masked\n"
+        "  db_settings.json  - user_preferences (settings) + table list\n"
+        "  logs/app.log      - last {n} lines of the application log\n"
+        "  logs/monitor.log  - last {n} lines of the monitor log\n\n"
+        "Redaction:\n"
+        "  API keys, passwords and tokens are masked (e.g. 'abcd...wxyz').\n"
+        "  No reading history, file paths or full database is included.\n"
+        "  This package is safe to attach to a public support request.\n"
+    ).format(n=LOG_TAIL_LINES)
+
+
+def build_debug_package() -> bytes:
+    """Build the debug package ZIP and return its raw bytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("README.txt", _readme())
+        zf.writestr("system_info.json", _system_info_json())
+        zf.writestr("config.ini", _redacted_config_ini())
+        zf.writestr("db_settings.json", _db_settings_json())
+        zf.writestr("logs/app.log", _tail(APP_LOG))
+        zf.writestr("logs/monitor.log", _tail(MONITOR_LOG))
+    buf.seek(0)
+    return buf.getvalue()

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -7,7 +7,7 @@ optional CLU_USERNAME/CLU_PASSWORD session gate). They are *not* under
 and the token managed here is the very thing it authenticates against.
 """
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, Response, jsonify, request
 
 from core.app_logging import app_logger
 from core.database import (
@@ -16,6 +16,8 @@ from core.database import (
     rotate_api_token,
     set_api_browse_mode,
 )
+from core.debug_package import build_debug_package
+from core.version import __version__
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/api/admin")
@@ -60,3 +62,21 @@ def put_browse_mode():
             "error": "mode must be 'metadata' or 'filesystem'",
         }), 400
     return jsonify({"success": True, "mode": get_api_browse_mode()})
+
+
+@admin_bp.route("/debug-package", methods=["GET"])
+def download_debug_package():
+    """Build and return a redacted debug package (config, settings, logs) as a ZIP."""
+    try:
+        data = build_debug_package()
+        return Response(
+            data,
+            mimetype="application/zip",
+            headers={
+                "Content-Disposition":
+                    f"attachment; filename=clu-debug-{__version__}.zip",
+            },
+        )
+    except Exception as e:
+        app_logger.error(f"Failed to build debug package: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -6,6 +6,14 @@
 <div class="container-lg">
     <h1 class="text-center mb-3">Logs</h1>
 
+    <!-- Debug Package -->
+    <div class="text-center mb-3">
+        <a href="/api/admin/debug-package" class="btn btn-outline-secondary btn-sm" download>
+            <i class="bi bi-bug"></i> Download Debug Package
+        </a>
+        <div class="text-muted small mt-1">Bundles config, settings &amp; recent logs for support. Secrets are redacted.</div>
+    </div>
+
     <!-- Nav Tabs -->
     <ul class="nav nav-tabs" id="logTabs" role="tablist">
         <li class="nav-item" role="presentation">

--- a/tests/routes/test_admin_routes.py
+++ b/tests/routes/test_admin_routes.py
@@ -1,5 +1,7 @@
 """Tests for routes/admin.py -- /api/admin/api-token endpoints used by the config page."""
+import io
 import json
+import zipfile
 
 from core.database import get_api_browse_mode, get_api_token, set_user_preference
 
@@ -81,6 +83,52 @@ class TestApiBrowseMode:
         assert resp.status_code == 400
         # Preference unchanged (still metadata)
         assert get_api_browse_mode() == "metadata"
+
+
+class TestDebugPackage:
+
+    def test_returns_zip_attachment(self, db_connection, client):
+        resp = client.get("/api/admin/debug-package")
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/zip"
+        assert "attachment" in resp.headers["Content-Disposition"]
+        assert "clu-debug-" in resp.headers["Content-Disposition"]
+
+    def test_zip_contains_expected_members(self, db_connection, client):
+        resp = client.get("/api/admin/debug-package")
+        with zipfile.ZipFile(io.BytesIO(resp.data)) as zf:
+            names = set(zf.namelist())
+        assert {
+            "README.txt",
+            "system_info.json",
+            "config.ini",
+            "db_settings.json",
+            "logs/app.log",
+            "logs/monitor.log",
+        } <= names
+
+    def test_db_settings_is_valid_json(self, db_connection, client):
+        resp = client.get("/api/admin/debug-package")
+        with zipfile.ZipFile(io.BytesIO(resp.data)) as zf:
+            payload = json.loads(zf.read("db_settings.json"))
+        assert "user_preferences" in payload
+        assert "tables" in payload
+
+    def test_secret_preference_is_redacted(self, db_connection, client):
+        # Seed a preference whose key marks it as sensitive.
+        set_user_preference(
+            "COMICVINE_API_KEY", "SECRET1234VALUE", category="providers"
+        )
+        resp = client.get("/api/admin/debug-package")
+        # Raw secret must not appear anywhere in the package bytes.
+        assert b"SECRET1234VALUE" not in resp.data
+        with zipfile.ZipFile(io.BytesIO(resp.data)) as zf:
+            payload = json.loads(zf.read("db_settings.json"))
+        entry = next(
+            p for p in payload["user_preferences"] if p["key"] == "COMICVINE_API_KEY"
+        )
+        assert "SECRET1234VALUE" not in str(entry["value"])
+        assert "..." in str(entry["value"])
 
     def test_put_missing_mode_400(self, db_connection, client):
         resp = client.put(

--- a/tests/routes/test_admin_routes.py
+++ b/tests/routes/test_admin_routes.py
@@ -130,6 +130,18 @@ class TestDebugPackage:
         assert "SECRET1234VALUE" not in str(entry["value"])
         assert "..." in str(entry["value"])
 
+    def test_nested_header_secrets_redacted(self, db_connection, client):
+        # An innocuous-keyed preference whose value carries nested secrets.
+        set_user_preference(
+            "custom_headers",
+            '{"CF-Access-Client-Id": "4tyjwrtyhjdtyj.access", '
+            '"CF-Access-Client-Secret": "e5yjthyjfghjsecret"}',
+            category="downloads",
+        )
+        resp = client.get("/api/admin/debug-package")
+        assert b"4tyjwrtyhjdtyj.access" not in resp.data
+        assert b"e5yjthyjfghjsecret" not in resp.data
+
     def test_put_missing_mode_400(self, db_connection, client):
         resp = client.put(
             "/api/admin/api-browse-mode",

--- a/tests/unit/test_debug_package.py
+++ b/tests/unit/test_debug_package.py
@@ -15,10 +15,48 @@ class TestIsSensitiveKey:
     def test_explicit_keys_match(self):
         assert dp._is_sensitive_key("METRON_USERNAME")
 
+    def test_client_id_variants_match(self):
+        # Separators are stripped before matching, so all of these are caught.
+        assert dp._is_sensitive_key("CF-Access-Client-Id")
+        assert dp._is_sensitive_key("client_id")
+        assert dp._is_sensitive_key("ClientId")
+        assert dp._is_sensitive_key("CF-Access-Client-Secret")
+
     def test_plain_keys_not_sensitive(self):
         assert not dp._is_sensitive_key("BOOTSTRAP_THEME")
         assert not dp._is_sensitive_key("AUTOCONVERT")
+        assert not dp._is_sensitive_key("custom_headers")
         assert not dp._is_sensitive_key("")
+
+
+class TestRedactBlob:
+
+    def test_masks_nested_header_dict_in_config_value(self):
+        # HEADERS-style value: top-level key is innocuous, secrets are nested.
+        value = ('{"CF-Access-Client-Id": "4tyjwrtyhjdtyj.access", '
+                 '"CF-Access-Client-Secret": "e5yjthyjfghjsecret"}')
+        out = dp._redact_blob(value)
+        assert "4tyjwrtyhjdtyj.access" not in out
+        assert "e5yjthyjfghjsecret" not in out
+        # Structure / key names are preserved.
+        assert "CF-Access-Client-Id" in out
+        assert "CF-Access-Client-Secret" in out
+
+    def test_masks_json_encoded_db_blob_with_escapes(self):
+        # Mirrors a JSON-encoded preference value (escaped inner quotes).
+        value = ('"{\\"CF-Access-Client-Id\\": \\"4tyjwrtyhjdtyj.access\\",'
+                 '\\"CF-Access-Client-Secret\\":\\"e5yjthyjfghjsecret\\"}"')
+        out = dp._redact_blob(value)
+        assert "4tyjwrtyhjdtyj.access" not in out
+        assert "e5yjthyjfghjsecret" not in out
+
+    def test_leaves_non_secret_pairs_untouched(self):
+        value = '{"theme": "darkly", "limit": "10"}'
+        assert dp._redact_blob(value) == value
+
+    def test_passthrough_non_string(self):
+        assert dp._redact_blob(None) is None
+        assert dp._redact_blob("") == ""
 
 
 class TestRedactedConfigIni:

--- a/tests/unit/test_debug_package.py
+++ b/tests/unit/test_debug_package.py
@@ -1,0 +1,69 @@
+"""Unit tests for core/debug_package.py helpers (no Flask, no DB)."""
+import json
+
+from core import debug_package as dp
+
+
+class TestIsSensitiveKey:
+
+    def test_marker_substrings_match(self):
+        assert dp._is_sensitive_key("COMICVINE_API_KEY")
+        assert dp._is_sensitive_key("METRON_PASSWORD")
+        assert dp._is_sensitive_key("api_token")
+        assert dp._is_sensitive_key("client_secret")
+
+    def test_explicit_keys_match(self):
+        assert dp._is_sensitive_key("METRON_USERNAME")
+
+    def test_plain_keys_not_sensitive(self):
+        assert not dp._is_sensitive_key("BOOTSTRAP_THEME")
+        assert not dp._is_sensitive_key("AUTOCONVERT")
+        assert not dp._is_sensitive_key("")
+
+
+class TestRedactedConfigIni:
+
+    def test_secrets_masked_others_preserved(self, tmp_path):
+        cfg = tmp_path / "config.ini"
+        cfg.write_text(
+            "[SETTINGS]\n"
+            "COMICVINE_API_KEY = SECRET1234VALUE\n"
+            "BOOTSTRAP_THEME = darkly\n"
+        )
+        out = dp._redacted_config_ini(str(cfg))
+        assert "SECRET1234VALUE" not in out
+        assert "BOOTSTRAP_THEME = darkly" in out
+        assert "..." in out  # masked value present
+
+    def test_empty_secret_left_alone(self, tmp_path):
+        cfg = tmp_path / "config.ini"
+        cfg.write_text("[SETTINGS]\nPIXELDRAIN_API_KEY = \n")
+        out = dp._redacted_config_ini(str(cfg))
+        # Empty value stays empty (nothing to mask)
+        assert "PIXELDRAIN_API_KEY" in out
+
+    def test_missing_file_placeholder(self, tmp_path):
+        out = dp._redacted_config_ini(str(tmp_path / "nope.ini"))
+        assert "not found" in out
+
+
+class TestTail:
+
+    def test_returns_last_n_lines(self, tmp_path):
+        log = tmp_path / "app.log"
+        log.write_text("".join(f"line {i}\n" for i in range(100)))
+        out = dp._tail(str(log), lines=10)
+        assert out.splitlines() == [f"line {i}" for i in range(90, 100)]
+
+    def test_missing_file_placeholder(self, tmp_path):
+        out = dp._tail(str(tmp_path / "missing.log"))
+        assert "not found" in out
+
+
+class TestSystemInfoJson:
+
+    def test_has_version_and_no_obvious_secret(self):
+        info = json.loads(dp._system_info_json())
+        assert "version" in info
+        assert "paths" in info
+        assert "flags" in info


### PR DESCRIPTION
## 📝 Description
Creates a download package with essential information for debugging issues

CLU Debug Package
=================

Generated by Comic Library Utilities v5.0.

Contents:
  system_info.json  - version, platform, python, key paths, flags
  config.ini        - your config with secrets masked
  db_settings.json  - user_preferences (settings) + table list
  logs/app.log      - last 5000 lines of the application log
  logs/monitor.log  - last 5000 lines of the monitor log

Redaction:
  API keys, passwords and tokens are masked (e.g. 'abcd...wxyz').
  No reading history, file paths or full database is included.
  This package is safe to attach to a public support request.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass