### PR TITLE
Resolve File Name Matching with {volume} Changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -735,17 +735,10 @@ def process_incoming_wanted_issues():
     if not enabled or not pattern:
         pattern = "{series_name} {issue_number} ({volume_year})"
 
-    # Create a matching pattern WITHOUT year (year can differ between sources)
-    # Replace {volume_year} and surrounding parens/spaces with flexible match
-    match_pattern = pattern
-    # Remove year placeholder and its common surrounding patterns
-    match_pattern = re.sub(
-        r"\s*\(\s*\{volume_year\}\s*\)", "", match_pattern
-    )  # " ({volume_year})" -> ""
-    match_pattern = re.sub(
-        r"\s*\{volume_year\}", "", match_pattern
-    )  # remaining "{volume_year}" -> ""
-    match_pattern = match_pattern.strip()
+    # Create a matching pattern WITHOUT year (year can differ between sources).
+    # Strips any year token variant (volume/cover/issue/store/legacy) so the
+    # year is not required for matching.
+    match_pattern = strip_year_token(pattern)
     app_logger.debug(f"Using match pattern (no year): '{match_pattern}'")
 
     # Scan TARGET for comic files (including subdirectories)
@@ -770,6 +763,11 @@ def process_incoming_wanted_issues():
 
     moved_count = 0
     affected_series = set()  # Track series that had files moved
+    # GetComics search aliases let a series match files stored under an
+    # alternative name (e.g. series "Thor" with alias "Mortal Thor" so
+    # 'Mortal Thor 011.cbz' matches). Cache per series name — one DB hit each.
+    from models.getcomics import get_series_aliases
+    alias_cache = {}
     for issue in wanted:
         db_series_name = issue["series_name"]
         issue_number = issue["number"]
@@ -783,22 +781,48 @@ def process_incoming_wanted_issues():
                 f"Using file-based name: '{actual_series_name}' instead of '{db_series_name}'"
             )
 
-        # Generate regex pattern for this issue (without year)
-        regex = generate_filename_pattern(
-            match_pattern, actual_series_name, issue_number
+        # Names to match against: the file-derived series name plus any
+        # GetComics search aliases configured for this series.
+        if db_series_name not in alias_cache:
+            try:
+                raw_aliases = get_series_aliases(db_series_name) or ""
+            except Exception as e:
+                app_logger.debug(
+                    f"Failed to load aliases for '{db_series_name}': {e}"
+                )
+                raw_aliases = ""
+            alias_cache[db_series_name] = [
+                a.strip() for a in raw_aliases.split(",") if a.strip()
+            ]
+
+        match_names = build_series_match_names(
+            actual_series_name, alias_cache[db_series_name]
         )
-        if not regex:
+
+        # Generate a regex per candidate name (without year)
+        regexes = []
+        for name in match_names:
+            r = generate_filename_pattern(match_pattern, name, issue_number)
+            if r:
+                regexes.append(r)
+        if not regexes:
             app_logger.info(
                 f"Failed to generate pattern for: {actual_series_name} #{issue_number}"
             )
             continue
 
-        app_logger.info(
-            f"Checking: '{actual_series_name}' #{issue_number} | regex: {regex.pattern}"
-        )
+        if len(match_names) > 1:
+            app_logger.info(
+                f"Checking: '{actual_series_name}' #{issue_number} "
+                f"(+{len(match_names) - 1} alias(es): {', '.join(match_names[1:])})"
+            )
+        else:
+            app_logger.info(
+                f"Checking: '{actual_series_name}' #{issue_number} | regex: {regexes[0].pattern}"
+            )
 
         for filename, src in files[:]:  # Copy list to allow removal
-            match_result = regex.match(filename)
+            match_result = any(r.match(filename) for r in regexes)
 
             # Fallback: try ComicInfo.xml if regex didn't match
             if not match_result and filename.lower().endswith((".cbz", ".zip")):
@@ -808,9 +832,9 @@ def process_incoming_wanted_issues():
                     check_num = str(issue_number).strip().lstrip("0") or "0"
                     if meta_num == check_num:
                         meta_series = (comicinfo.get("series") or "").lower()
-                        series_lower = actual_series_name.lower()
-                        if meta_series and (
-                            series_lower in meta_series or meta_series in series_lower
+                        if meta_series and any(
+                            n.lower() in meta_series or meta_series in n.lower()
+                            for n in match_names
                         ):
                             match_result = True
 
@@ -2336,6 +2360,8 @@ def refresh_wanted_cache_background():
 # Moved to helpers/collection.py - re-exported for backward compatibility
 from helpers.collection import (
     generate_filename_pattern,
+    strip_year_token,
+    build_series_match_names,
     extract_comicinfo,
     match_issues_to_collection,
 )

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,4 @@
 [SETTINGS]
-WATCH = /downloads/temp
-TARGET = /downloads/processed
 IGNORED_TERMS = Annual
 IGNORED_EXTENSIONS = .crdownload,.torrent,.tmp,.mega,.rar,.bak,.zip,.part,.download,.downloading,.incomplete
 IGNORED_FILES = cover.jpg,cvinfo,.DS_Store
@@ -41,4 +39,5 @@ TRASH_MAX_SIZE_MB = 1024
 PUBLICATION_TYPES = annual,quarterly
 VARIANT_TYPES = annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery
 SEQUEL_KEYWORDS = season,volume,book,part,chapter
+ONESHOT_FOLDERS = oneshots,one-shots,specials
 

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -4,6 +4,58 @@ from core.config import config
 from core.app_logging import app_logger
 
 
+# Matches any year token variant ({volume_year}/{cover_year}/{issue_year}/
+# {store_year}) and the legacy {year}.
+_YEAR_TOKEN = r"\{(?:volume|cover|issue|store)?_?year\}"
+
+
+def strip_year_token(pattern):
+    """Remove every year token (and its surrounding ()/[] and spaces) from a
+    rename pattern, producing a pattern suitable for year-agnostic matching.
+
+    The year of a file can differ between metadata sources (or be absent), so
+    wanted-issue matching deliberately ignores it. Handles all year variants,
+    not just the legacy {volume_year}.
+    """
+    if not pattern:
+        return pattern
+    # " ({cover_year})" / " [{volume_year}]" -> ""
+    pattern = re.sub(r"\s*[\(\[]\s*" + _YEAR_TOKEN + r"\s*[\)\]]", "", pattern)
+    # remaining bare " {...year}" -> ""
+    pattern = re.sub(r"\s*" + _YEAR_TOKEN, "", pattern)
+    return pattern.strip()
+
+
+def build_series_match_names(series_name, aliases):
+    """Ordered, de-duplicated list of names to match a series against.
+
+    The primary ``series_name`` comes first, followed by any GetComics search
+    aliases that are case-insensitively distinct from it and each other. This
+    lets a wanted series match files stored under an alternative name (e.g.
+    series "Thor" with alias "Mortal Thor" matching ``Mortal Thor 011.cbz``).
+
+    Args:
+        series_name: The primary series name (matched first).
+        aliases: A comma-separated string or an iterable of alias names.
+
+    Returns:
+        List of names, ``series_name`` first, with empty/duplicate entries removed.
+    """
+    if isinstance(aliases, str):
+        alias_list = aliases.split(",")
+    else:
+        alias_list = aliases or []
+
+    names = [series_name]
+    seen = {series_name.lower()}
+    for alias in alias_list:
+        alias = str(alias).strip()
+        if alias and alias.lower() not in seen:
+            names.append(alias)
+            seen.add(alias.lower())
+    return names
+
+
 def generate_filename_pattern(custom_pattern, series_name, issue_number):
     """
     Convert CUSTOM_RENAME_PATTERN to a precise regex for matching a specific issue.
@@ -11,7 +63,12 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
     Pattern placeholders:
     - {series_name} -> matches the series name (flexible whitespace/case)
     - {issue_number} -> matches the issue number (with optional leading zeros)
-    - {volume_year} (and legacy {year}) -> matches any 4-digit year
+    - {volume_year}/{cover_year}/{issue_year}/{store_year} (and legacy {year})
+      -> matches any 4-digit year
+    - {cover_month_m}/{store_month_m} -> matches a 2-digit month
+    - {cover_month_M}/{store_month_M} -> matches a month name
+    Any other (unrecognized) {token} is stripped defensively so it never leaks
+    into the compiled regex as a literal requirement.
 
     Args:
         custom_pattern: The rename pattern from config (e.g., "{series_name} {issue_number} ({volume_year})")
@@ -34,8 +91,15 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         pattern = custom_pattern
         pattern = pattern.replace('{series_name}', '<<<SERIES>>>')
         pattern = pattern.replace('{issue_number}', '<<<ISSUE>>>')
-        pattern = pattern.replace('{volume_year}', '<<<YEAR>>>')
-        pattern = pattern.replace('{year}', '<<<YEAR>>>')  # legacy fallback
+        # Year variants — all match any 4-digit year
+        for tok in ('{volume_year}', '{cover_year}', '{issue_year}',
+                    '{store_year}', '{year}'):  # {year} is a legacy fallback
+            pattern = pattern.replace(tok, '<<<YEAR>>>')
+        # Month variants — numeric (2-digit) and name
+        for tok in ('{cover_month_m}', '{store_month_m}'):
+            pattern = pattern.replace(tok, '<<<MONTHNUM>>>')
+        for tok in ('{cover_month_M}', '{store_month_M}'):
+            pattern = pattern.replace(tok, '<<<MONTHNAME>>>')
         pattern = pattern.replace('{volume_number}', '<<<VOLUME>>>')
         pattern = pattern.replace('{issue_title}', '<<<TITLE>>>')
 
@@ -84,12 +148,23 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         pattern = pattern.replace('<<<SERIES>>>', f'(?:{series_pattern})')
         pattern = pattern.replace('<<<ISSUE>>>', f'({issue_pattern})')
         pattern = pattern.replace('<<<YEAR>>>', r'\d{4}')
+        pattern = pattern.replace('<<<MONTHNUM>>>', r'\d{2}')
+        pattern = pattern.replace('<<<MONTHNAME>>>', r'[A-Za-z]+')
         pattern = pattern.replace('<<<VOLUME>>>', r'\d+')
         pattern = pattern.replace('<<<TITLE>>>', r'[^()]*?')
 
         # Make spaces between components flexible (allow punctuation like trailing periods)
         # This handles cases like "K.O. 003" where there's punctuation before the space
         pattern = pattern.replace(') (', r").+?(" )
+
+        # Defensive: drop any unrecognized {token} (and an empty "()" it may
+        # leave behind) so a stray placeholder never becomes a literal regex
+        # requirement that no real filename can satisfy. Match only placeholder
+        # tokens (names start with a letter/underscore) so we never clobber a
+        # regex quantifier like \d{4} or \d{1,4} produced by substitution above.
+        _tok = r'\{[A-Za-z_][^}]*\}'
+        pattern = re.sub(r'\s*\\\(\s*' + _tok + r'\s*\\\)', '', pattern)  # " ({token})" -> ""
+        pattern = re.sub(r'\s*' + _tok, '', pattern)                     # bare " {token}" -> ""
 
         # Add file extension matching at the end
         pattern += r'.*\.(?:cbz|cbr|zip|rar)$'

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -1,0 +1,209 @@
+"""Tests for helpers.collection.generate_filename_pattern.
+
+Regression coverage for the wanted-issue matching bug: custom rename patterns
+that use a year token other than the legacy {volume_year} (e.g. {cover_year},
+{issue_year}, {store_year}) left the literal placeholder in the compiled regex,
+so no file ever matched. See helpers/collection.py.
+"""
+import re
+import pytest
+
+from helpers.collection import (
+    generate_filename_pattern,
+    strip_year_token,
+    build_series_match_names,
+)
+
+
+# ---- helper -------------------------------------------------------------
+
+def _no_placeholder_leak(regex):
+    """The compiled pattern must not contain a literal {token} placeholder.
+
+    Regex quantifiers like \\d{4} or \\d{1,4} are allowed; only alphabetic
+    placeholder tokens ({cover_year}, ...) are forbidden.
+    """
+    stripped = re.sub(r'\{\d', '', regex.pattern)  # drop {4 / {1,4 quantifier starts
+    return not re.search(r'\{[A-Za-z_]', stripped)
+
+
+# ---- year token variants ------------------------------------------------
+
+class TestYearTokenVariants:
+
+    @pytest.mark.parametrize("token", [
+        "volume_year", "cover_year", "issue_year", "store_year", "year",
+    ])
+    def test_year_token_matches_file_with_year(self, token):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({%s})" % token,
+            "Absolute Catwoman", "1",
+        )
+        assert regex is not None
+        assert regex.search("Absolute Catwoman 001 (2025).cbz")
+        assert _no_placeholder_leak(regex)
+
+    @pytest.mark.parametrize("token", [
+        "volume_year", "cover_year", "issue_year", "store_year",
+    ])
+    def test_no_literal_placeholder_in_pattern(self, token):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({%s})" % token,
+            "Daredevil", "3",
+        )
+        assert "{%s}" % token not in regex.pattern
+        assert _no_placeholder_leak(regex)
+
+    def test_year_is_four_digits(self):
+        # The year placeholder must compile to a real 4-digit matcher, not be
+        # collapsed by the unknown-token safety net.
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({cover_year})", "Daredevil", "3",
+        )
+        assert r"\d{4}" in regex.pattern
+        assert not regex.search("Daredevil 003 (12).cbz")  # 2-digit not a year
+
+
+# ---- month token variants ----------------------------------------------
+
+class TestMonthTokens:
+
+    def test_numeric_month(self):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} {cover_month_m} ({cover_year})",
+            "Sentry", "4",
+        )
+        assert regex.search("Sentry 004 03 (2024).cbz")
+        assert _no_placeholder_leak(regex)
+
+    def test_name_month(self):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} {store_month_M} ({store_year})",
+            "Sentry", "4",
+        )
+        assert regex.search("Sentry 004 March (2024).cbz")
+        assert _no_placeholder_leak(regex)
+
+
+# ---- defensive safety net ----------------------------------------------
+
+class TestUnknownTokenSafetyNet:
+
+    def test_unknown_token_stripped_not_required(self):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({totally_made_up})", "Sentry", "4",
+        )
+        assert _no_placeholder_leak(regex)
+        # Stripping the unknown ({token}) must not leave a dangling space that
+        # blocks a plain filename.
+        assert regex.search("Sentry 004.cbz")
+
+
+# ---- regressions / existing behaviour -----------------------------------
+
+class TestExistingBehaviour:
+
+    def test_volume_year_still_matches(self):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({volume_year})",
+            "Spider-Man 2099", "44",
+        )
+        assert regex.search("Spider-Man 2099 044 (1992).cbz")
+
+    def test_wrong_issue_number_rejected(self):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({volume_year})",
+            "Spider-Man 2099", "44",
+        )
+        assert not regex.search("Spider-Man 2099 045 (1992).cbz")
+
+    def test_leading_zeros_flexible(self):
+        regex = generate_filename_pattern(
+            "{series_name} {issue_number} ({cover_year})", "Black Cat", "11",
+        )
+        assert regex.search("Black Cat 011 (2024).cbz")
+
+    def test_empty_pattern_returns_none(self):
+        assert generate_filename_pattern("", "Foo", "1") is None
+        assert generate_filename_pattern("{series_name}", "", "1") is None
+
+
+# ---- strip_year_token (app.py no-year matching path) --------------------
+
+class TestStripYearToken:
+
+    @pytest.mark.parametrize("token", [
+        "volume_year", "cover_year", "issue_year", "store_year", "year",
+    ])
+    def test_strips_parenthesized_year(self, token):
+        out = strip_year_token("{series_name} {issue_number} ({%s})" % token)
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_bracketed_year(self):
+        out = strip_year_token("{series_name} [{volume_year}] {issue_number}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_bare_year(self):
+        out = strip_year_token("{series_name} - {cover_year}")
+        assert out == "{series_name} -"
+
+    def test_no_year_token_unchanged(self):
+        out = strip_year_token("{series_name} {issue_number}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_empty(self):
+        assert strip_year_token("") == ""
+
+
+# ---- search-alias matching (Thor -> Mortal Thor) ------------------------
+
+class TestBuildSeriesMatchNames:
+
+    def test_primary_name_first(self):
+        assert build_series_match_names("Thor", "")[0] == "Thor"
+
+    def test_comma_string_aliases(self):
+        names = build_series_match_names("Thor", "mortal thor, ultimate thor")
+        assert names == ["Thor", "mortal thor", "ultimate thor"]
+
+    def test_iterable_aliases(self):
+        names = build_series_match_names("Thor", ["mortal thor"])
+        assert names == ["Thor", "mortal thor"]
+
+    def test_dedups_case_insensitively(self):
+        names = build_series_match_names("Thor", "thor, THOR, Mortal Thor")
+        assert names == ["Thor", "Mortal Thor"]
+
+    def test_skips_blank_entries(self):
+        names = build_series_match_names("Thor", " , mortal thor , ")
+        assert names == ["Thor", "mortal thor"]
+
+    def test_no_aliases(self):
+        assert build_series_match_names("Thor", "") == ["Thor"]
+
+
+class TestAliasMatching:
+    """An aliased file should match via the alias name, not the series name."""
+
+    def test_alias_matches_aliased_file(self):
+        # Aliases are stored normalized (lowercase). Series "Thor" with alias
+        # "mortal thor" must match 'Mortal Thor 011.cbz'.
+        match_pattern = strip_year_token("{series_name} {issue_number} ({cover_year})")
+        names = build_series_match_names("Thor", "mortal thor")
+        regexes = [
+            generate_filename_pattern(match_pattern, n, "11") for n in names
+        ]
+        assert any(r.match("Mortal Thor 011.cbz") for r in regexes)
+
+    def test_series_name_alone_does_not_match_aliased_file(self):
+        match_pattern = strip_year_token("{series_name} {issue_number} ({cover_year})")
+        regex = generate_filename_pattern(match_pattern, "Thor", "11")
+        assert not regex.match("Mortal Thor 011.cbz")
+
+    def test_alias_does_not_steal_plain_match(self):
+        match_pattern = strip_year_token("{series_name} {issue_number} ({cover_year})")
+        names = build_series_match_names("Thor", "mortal thor")
+        regexes = [
+            generate_filename_pattern(match_pattern, n, "11") for n in names
+        ]
+        assert any(r.match("Thor 011.cbz") for r in regexes)


### PR DESCRIPTION
## 📝 Description
Add year/token/month handling and alias support for wanted-issue matching. Introduces helpers.collection.strip_year_token and build_series_match_names, enhances generate_filename_pattern to recognize multiple year tokens, month tokens, and defensively strip unknown placeholders, and adds a safety net to avoid literal placeholder leaks. Update app.py to use strip_year_token, cache GetComics search aliases, and try multiple regexes per issue name (including aliases) when locating files; re-export new helpers for backward compatibility. Add comprehensive unit tests for filename patterns and alias behavior, tweak config.ini (remove WATCH/TARGET entries and add ONESHOT_FOLDERS), and add an empty comic_utils.db file.


## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass