### PR TITLE
Guard config read and use CFG_TARGET

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,12 @@ done
 
 # Ensure new sub-folders inherit the share's group (NAS-friendly, avoids needing 777).
 # setgid is inherited by child dirs, so this propagates to future folders automatically.
-CFG_TARGET="$(awk -F= '/^TARGET/ {print $2}' /config/config.ini 2>/dev/null | tr -d '\r')"
+# Guard the read: on a fresh install /config/config.ini may not exist yet, and under
+# `set -euo pipefail` a failing awk (exit 2) would otherwise terminate the container.
+CFG_TARGET=""
+if [ -f /config/config.ini ]; then
+  CFG_TARGET="$(awk -F= '/^TARGET/ {print $2}' /config/config.ini 2>/dev/null | tr -d '\r' || true)"
+fi
 for p in /data /downloads "${CFG_TARGET}"; do
   [ -n "$p" ] || continue
   [ -d "$p" ] || continue
@@ -186,7 +191,7 @@ RUN_AS_ROOT=0
 can_write() { gosu "${TARGET_USER}" sh -c "touch \"$1\"/.writetest && rm -f \"$1\"/.writetest"; }
 
 NEED_ROOT=0
-for p in /downloads/temp /downloads/processed /data "$(awk -F= '/^TARGET/ {print $2}' /config/config.ini 2>/dev/null | tr -d '\r')" ; do
+for p in /downloads/temp /downloads/processed /data "${CFG_TARGET}" ; do
   [ -n "$p" ] || continue
   [ -d "$p" ] || continue
   if ! can_write "$p" 2>/dev/null ; then


### PR DESCRIPTION
## 📝 Description
Avoid failing when /config/config.ini is missing by checking for the file before running awk and defaulting CFG_TARGET to an empty string. Wrap the awk invocation with || true to prevent non-zero exits from killing the container under set -euo pipefail. Reuse the CFG_TARGET variable in subsequent for-loops instead of re-running awk, improving robustness on fresh installs.

Closes #359 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass