### PR TITLE
Improve Rename and Cover Date Handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -875,6 +875,23 @@ def process_incoming_wanted_issues():
                     moved_count += 1
                     affected_series.add(issue["series_id"])
 
+                    # Index the file right away so later rename/metadata steps
+                    # can update the entry instead of warning "not found"
+                    try:
+                        file_stat = os.stat(temp_dest)
+                        add_file_index_entry(
+                            name=filename,
+                            path=temp_dest,
+                            entry_type="file",
+                            size=file_stat.st_size,
+                            parent=dest_dir,
+                            modified_at=file_stat.st_mtime,
+                        )
+                    except Exception as e:
+                        app_logger.error(
+                            f"Failed to add {temp_dest} to file index: {e}"
+                        )
+
                     # Only rename if AUTO_RENAME_MONITOR is enabled
                     auto_rename_monitor = config.getboolean(
                         "SETTINGS", "AUTO_RENAME_MONITOR", fallback=True
@@ -888,13 +905,21 @@ def process_incoming_wanted_issues():
                             final_path = os.path.join(dest_dir, new_filename)
                             os.rename(temp_dest, final_path)
                             app_logger.info(f"Renamed: {filename} -> {new_filename}")
+                            update_file_index_entry(
+                                temp_dest,
+                                name=new_filename,
+                                new_path=final_path,
+                                parent=dest_dir,
+                            )
 
                     # Auto-fetch metadata (try Metron first, then ComicVine as fallback)
                     app_logger.info(f"Auto-fetching metadata for: {final_path}")
+                    pre_fetch_path = final_path
                     final_path = auto_fetch_metron_metadata(final_path)
                     final_path = auto_fetch_comicvine_metadata(final_path)
 
-                    # Add to file_index immediately so the file is searchable/visible
+                    # Refresh the index entry (upsert) — metadata injection
+                    # changes size, and the fetchers may have renamed the file
                     try:
                         file_stat = os.stat(final_path)
                         add_file_index_entry(
@@ -905,6 +930,12 @@ def process_incoming_wanted_issues():
                             parent=os.path.dirname(final_path),
                             modified_at=file_stat.st_mtime,
                         )
+                        # Drop a stale row left behind when a fetcher renamed
+                        # the file without updating the index (ComicVine path)
+                        if final_path != pre_fetch_path and not os.path.exists(
+                            pre_fetch_path
+                        ):
+                            delete_file_index_entry(pre_fetch_path)
                     except Exception as e:
                         app_logger.error(
                             f"Failed to add {final_path} to file index: {e}"

--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -605,10 +605,13 @@ def reverse_parse_pattern(filename, pattern):
         "year": "",
         "issue_title": "",
     }
-    for key in result:
-        val = match.groupdict().get(key)
+    # Copy every named group that matched, including cover/store date tokens,
+    # so a conforming filename can be round-tripped through the pattern.
+    for key, val in match.groupdict().items():
         if val is not None:
             result[key] = val.strip()
+        elif key not in result:
+            result[key] = ""
 
     return result
 
@@ -992,6 +995,31 @@ def extract_comic_values(filename):
             values["issue_number"] = f"{int(issue_num):03d}"
         return values
 
+    # Handle already-clean "Series Issue.ext" names with no year, e.g.
+    # "Civil War - Unmasked 002.cbz" (output of an earlier rename pass before
+    # metadata is available). Keeps re-renames idempotent instead of failing
+    # extraction and falling back with warnings.
+    series_issue_no_year_match = re.match(
+        r"^(?P<series>.+?)\s+(?P<issue>\d{1,4}(?:\.\d+)?)(?P<ext>\.\w+)$",
+        filename,
+    )
+    if series_issue_no_year_match:
+        series_name = series_issue_no_year_match.group("series")
+        issue_num = series_issue_no_year_match.group("issue")
+
+        series_name = series_name.replace("_", " ").strip()
+        series_name = re.sub(r"[#\-\s]+$", "", series_name).strip()
+        values["series_name"] = smart_title_case(series_name)
+        if "." in issue_num:
+            parts = issue_num.split(".", 1)
+            values["issue_number"] = f"{int(parts[0]):03d}.{parts[1]}"
+        else:
+            values["issue_number"] = f"{int(issue_num):03d}"
+        app_logger.info(
+            f"Matched series/issue (no year) pattern: series={values['series_name']}, issue={values['issue_number']}"
+        )
+        return values
+
     # Extract year from parentheses (most reliable fallback)
     year_match = re.search(r"\((\d{4})\)", filename)
     if year_match:
@@ -1090,7 +1118,12 @@ def apply_custom_pattern(values, pattern):
         "{volume_year}", values.get("volume_year") or values.get("year", "")
     )
     result = result.replace("{issue_year}", values.get("issue_year", ""))
-    result = result.replace("{cover_year}", values.get("cover_year", ""))
+    # {cover_year} falls back to the year parsed from the filename when no
+    # metadata is available (cover dates only come from ComicInfo.xml or a
+    # live provider fetch).
+    result = result.replace(
+        "{cover_year}", values.get("cover_year") or values.get("year", "")
+    )
     result = result.replace("{cover_month_M}", values.get("cover_month_M", ""))
     result = result.replace("{cover_month_m}", values.get("cover_month_m", ""))
     result = result.replace("{store_year}", values.get("store_year", ""))
@@ -1109,9 +1142,9 @@ def apply_custom_pattern(values, pattern):
     result = re.sub(r"\s+", " ", result).strip()
 
     # Remove a separator left dangling against a parenthesis boundary when a
-    # token resolved empty (e.g. "(2020-)" -> "(2020)", "(-06)" -> "(06)")
-    result = re.sub(r"\(\s*-\s*", "(", result)
-    result = re.sub(r"\s*-\s*\)", ")", result)
+    # token resolved empty (e.g. "(2020-)" -> "(2020)", "(, 2026)" -> "(2026)")
+    result = re.sub(r"\(\s*[-,]\s*", "(", result)
+    result = re.sub(r"\s*[-,]\s*\)", ")", result)
 
     # Remove empty parentheses and space before them
     result = re.sub(r"\s*\(\s*\)", "", result).strip()
@@ -1406,6 +1439,19 @@ def get_renamed_filename(filename, file_path=None):
         if custom_enabled and custom_pattern:
             app_logger.info(f"Custom rename pattern enabled: {custom_pattern}")
 
+            # If the filename already conforms to the custom pattern, leave it
+            # alone. Later rename passes (monitor, wanted-issues) would
+            # otherwise strip tokens they cannot re-derive from the filename
+            # (e.g. a cover month that came from metadata). The round-trip
+            # check guards against names that only coincidentally half-match.
+            stem, _ = os.path.splitext(filename)
+            conforming = reverse_parse_pattern(stem, custom_pattern)
+            if conforming and apply_custom_pattern(conforming, custom_pattern) == stem:
+                app_logger.info(
+                    f"Filename already matches custom pattern, no rename needed: {filename}"
+                )
+                return filename
+
             # Extract comic values from the filename
             comic_values = extract_comic_values(filename)
 
@@ -1413,9 +1459,18 @@ def get_renamed_filename(filename, file_path=None):
             # ComicInfo.xml (read below) takes precedence when available.
             comic_values.setdefault("issue_year", comic_values.get("year", ""))
 
-            # Tokens that require reading ComicInfo.xml for accurate values
-            needs_comicinfo = (
-                "{issue_title}" in custom_pattern or "{issue_year}" in custom_pattern
+            # Tokens that require reading ComicInfo.xml for accurate values.
+            # ComicInfo Year/Month hold the cover date, so cover tokens read
+            # from there too; store dates exist only in live provider fetches.
+            needs_comicinfo = any(
+                token in custom_pattern
+                for token in (
+                    "{issue_title}",
+                    "{issue_year}",
+                    "{cover_year}",
+                    "{cover_month_M}",
+                    "{cover_month_m}",
+                )
             )
 
             # Read issue title / publication year from ComicInfo.xml if needed
@@ -1432,6 +1487,13 @@ def get_renamed_filename(filename, file_path=None):
                         comic_values["issue_title"] = comicinfo["Title"]
                     if comicinfo.get("Year"):
                         comic_values["issue_year"] = str(comicinfo["Year"])
+                        comic_values["cover_year"] = str(comicinfo["Year"])
+                    if comicinfo.get("Month"):
+                        month_name, month_padded = _format_issue_month(
+                            comicinfo["Month"]
+                        )
+                        comic_values["cover_month_M"] = month_name
+                        comic_values["cover_month_m"] = month_padded
                 except Exception:
                     pass
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -397,8 +397,11 @@
                                 <code>{volume_year}</code> (series/volume start year),
                                 <code>{issue_year}</code> (this issue's year),
                                 <code>{issue_number}</code>, <code>{issue_title}</code>.
-                                Cover/store dates (from ComicVine/Metron):
-                                <code>{cover_year}</code>, <code>{cover_month_M}</code> (June), <code>{cover_month_m}</code> (06),
+                                Cover dates (from embedded ComicInfo.xml or a ComicVine/Metron fetch):
+                                <code>{cover_year}</code>, <code>{cover_month_M}</code> (June), <code>{cover_month_m}</code> (06).
+                                <code>{cover_year}</code> falls back to the year parsed from the filename
+                                when no metadata is available yet.
+                                Store dates (live ComicVine/Metron fetch only):
                                 <code>{store_year}</code>, <code>{store_month_M}</code>, <code>{store_month_m}</code>
                             </small>
                         </div>

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -285,6 +285,36 @@ class TestApplyCustomPattern:
         assert apply_custom_pattern(values, "{series_name} {issue_number} ({volume_year})") \
             == "X 001 (2020)"
 
+    def test_cover_year_prefers_cover_value(self):
+        from cbz_ops.rename import apply_custom_pattern
+        values = {
+            "series_name": "X", "issue_number": "001",
+            "cover_year": "2025", "year": "2026",
+        }
+        assert apply_custom_pattern(values, "{series_name} {issue_number} ({cover_year})") \
+            == "X 001 (2025)"
+
+    def test_cover_year_falls_back_to_parsed_year(self):
+        # No metadata yet (fresh download): {cover_year} picks up the filename year.
+        from cbz_ops.rename import apply_custom_pattern
+        values = {"series_name": "X", "issue_number": "001", "year": "2026"}
+        assert apply_custom_pattern(values, "{series_name} {issue_number} ({cover_year})") \
+            == "X 001 (2026)"
+
+    def test_empty_month_drops_dangling_comma(self):
+        # "({cover_month_M}, {cover_year})" with no month -> "(2026)"
+        from cbz_ops.rename import apply_custom_pattern
+        values = {"series_name": "X", "issue_number": "001", "year": "2026"}
+        assert apply_custom_pattern(
+            values, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"
+        ) == "X - 001 (2026)"
+
+    def test_month_and_year_present_keeps_comma(self, sample_values):
+        from cbz_ops.rename import apply_custom_pattern
+        assert apply_custom_pattern(
+            sample_values, "{series_name} {issue_number} ({cover_month_M}, {cover_year})"
+        ) == "Spider-Man 2099 044 (June, 1992)"
+
 
 # ===== load_custom_rename_config (legacy {year} migration) =====
 
@@ -403,6 +433,9 @@ class TestExtractComicValues:
         ("Legion of Super-Heroes, 1985-07-00 (#14) (digital) (Glorith-Novus-HD).cbz", "Legion of Super-Heroes", "014", "1985"),
         # Series (YYYY-MM) ### pattern
         ("Justice League (1987-09) 05 (DobisP.R.-Novus-HD).cbz", "Justice League", "005", "1987"),
+        # Already-clean "Series Issue.ext" name with no year (output of an
+        # earlier rename pass before metadata is available)
+        ("Civil War - Unmasked 002.cbz", "Civil War - Unmasked", "002", ""),
     ])
     def test_value_extraction(self, filename, expected_series, expected_issue, expected_year):
         from cbz_ops.rename import extract_comic_values
@@ -524,6 +557,84 @@ class TestGetRenamedFilename:
         assert "2008" in result
         # Should not include "Digital4K"
         assert "Digital" not in result
+
+
+class TestGetRenamedFilenameCustomPattern:
+    """Custom-pattern path of get_renamed_filename, incl. cover-date tokens."""
+
+    def _make_cbz(self, tmp_path, name, comicinfo_xml=None):
+        import zipfile
+        path = tmp_path / name
+        with zipfile.ZipFile(path, "w") as z:
+            z.writestr("page01.jpg", b"fake")
+            if comicinfo_xml:
+                z.writestr("ComicInfo.xml", comicinfo_xml)
+        return str(path)
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"))
+    def test_cover_tokens_read_from_comicinfo(self, mock_config, tmp_path):
+        # ComicInfo Year/Month hold the cover date and must fill the cover tokens
+        from cbz_ops.rename import get_renamed_filename
+        xml = (b"<?xml version='1.0' encoding='utf-8'?><ComicInfo>"
+               b"<Series>Civil War - Unmasked</Series><Number>2</Number>"
+               b"<Year>2026</Year><Month>3</Month></ComicInfo>")
+        path = self._make_cbz(tmp_path, "Civil War - Unmasked 002.cbz", xml)
+        result = get_renamed_filename("Civil War - Unmasked 002.cbz", file_path=path)
+        assert result == "Civil War - Unmasked - 002 (March, 2026).cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+    def test_cover_year_falls_back_to_filename_year(self, mock_config):
+        # Fresh download, no ComicInfo.xml: the year embedded in the filename
+        # must survive into {cover_year} instead of being dropped.
+        from cbz_ops.rename import get_renamed_filename
+        result = get_renamed_filename(
+            "Civil_War_-_Unmasked_002_2026_Digital_Shan-Empire.cbz")
+        assert result == "Civil War - Unmasked 002 (2026).cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"))
+    def test_month_missing_drops_comma(self, mock_config):
+        # Only the year is known: "(March, 2026)" degrades to "(2026)"
+        from cbz_ops.rename import get_renamed_filename
+        result = get_renamed_filename(
+            "Civil_War_-_Unmasked_002_2026_Digital_Shan-Empire.cbz")
+        assert result == "Civil War - Unmasked - 002 (2026).cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+    def test_rerename_clean_name_without_year_is_noop(self, mock_config):
+        # Output of an earlier pass before metadata: must extract cleanly and
+        # return the same name (monitor/wanted-issues passes stay quiet no-ops)
+        from cbz_ops.rename import get_renamed_filename
+        result = get_renamed_filename("Civil War - Unmasked 002.cbz")
+        assert result == "Civil War - Unmasked 002.cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+    def test_rerename_final_name_is_noop(self, mock_config):
+        from cbz_ops.rename import get_renamed_filename
+        result = get_renamed_filename("Civil War - Unmasked 002 (2026).cbz")
+        assert result == "Civil War - Unmasked 002 (2026).cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"))
+    def test_rerename_month_name_is_noop_without_comicinfo(self, mock_config):
+        # The metadata pass produced this name; a later pass must not strip
+        # the month it cannot re-derive from the filename alone.
+        from cbz_ops.rename import get_renamed_filename
+        result = get_renamed_filename("Civil War - Unmasked - 002 (March, 2026).cbz")
+        assert result == "Civil War - Unmasked - 002 (March, 2026).cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+    def test_half_matching_messy_name_still_renames(self, mock_config):
+        # A scene-style name that coincidentally half-matches the pattern's
+        # reverse-parse regex must still be renamed (round-trip guard rejects)
+        from cbz_ops.rename import get_renamed_filename
+        result = get_renamed_filename("Batman 046 52p ctc 04-05 (1948).cbz")
+        assert result == "Batman 046 (1948).cbz"
 
 
 # ===== try_rule_engine =====
@@ -695,13 +806,27 @@ class TestRenameComicFromMetadata:
 
     @patch('cbz_ops.rename.load_custom_rename_config',
            return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
-    def test_missing_cover_date_drops_cleanly(self, mock_config, tmp_path):
-        # No CoverDate -> cover tokens resolve empty, no stray separators
+    def test_missing_cover_date_falls_back_to_year(self, mock_config, tmp_path):
+        # No CoverDate -> {cover_year} falls back to Year, month drops cleanly
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
         result_path, was_renamed = rename_comic_from_metadata(
             str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020})
+        assert was_renamed is True
+        name = os.path.basename(result_path)
+        assert name == "Batman 001 (2020).cbz"
+        assert "-)" not in name and "(-" not in name and "()" not in name
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
+    def test_missing_cover_date_and_year_drops_cleanly(self, mock_config, tmp_path):
+        # No CoverDate and no Year -> cover tokens resolve empty, no stray separators
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1'})
         assert was_renamed is True
         name = os.path.basename(result_path)
         assert name == "Batman 001.cbz"


### PR DESCRIPTION
## 📝 Description
Index moved files immediately and refresh entries after renames/metadata: add file index entry when a file is moved into place, call update_file_index_entry after auto-rename, and delete stale index rows if a fetcher renamed the file. Enhance rename parsing and custom-pattern behavior: copy all named regex groups from reverse_parse_pattern, add handling for already-clean "Series Issue.ext" filenames so re-renames are idempotent, and guard custom-pattern renames with a round-trip check to avoid stripping metadata-only tokens. Improve cover/store date handling: make {cover_year} fall back to the filename-parsed year when no metadata is available, populate cover month/year from ComicInfo.xml, and better remove dangling commas/ dashes when date tokens are empty. Update user docs and add unit tests covering cover-year fallbacks, empty-month behavior, ComicInfo-driven cover tokens, idempotent re-renames, and related edge cases.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass