### PR TITLE
Read per-file ComicInfo.xml for issue-level Naming Variables

### DIFF
--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -20,9 +20,10 @@ from cbz_ops.rename import (
     extract_comic_values,
     load_custom_rename_config,
     load_filename_cleanup_config,
+    _format_issue_month,
     _pad_issue_number,
 )
-from models.series_json import read_series_json, write_series_json
+from models.series_json import build_metadata, read_series_json, write_series_json
 from models import comicvine as cv_mod
 
 COMIC_EXTS = (".cbz", ".cbr", ".zip")
@@ -182,14 +183,33 @@ def _ensure_series_json(directory: str, library_id: Optional[int]) -> Dict:
     if not series_obj:
         return {"status": "series_json_failed", "reason": "no provider returned series data"}
 
-    ok = write_series_json(directory, series_obj, api=metron_api)
-    if not ok:
-        return {"status": "series_json_failed", "reason": "write_series_json returned False"}
+    # Build the metadata we need for the rename in memory first. This is what
+    # the plan actually consumes, so a failure to persist the series.json
+    # sidecar (e.g. read-only mount) should not block the rename.
+    try:
+        metadata = build_metadata(series_obj, api=metron_api)
+    except Exception as e:
+        return {"status": "series_json_failed", "reason": f"could not build metadata: {e}"}
+    if not metadata.get("name"):
+        return {"status": "series_json_failed", "reason": "provider series has no name"}
 
+    ok, reason = write_series_json(directory, series_obj, api=metron_api, return_reason=True)
+    if not ok:
+        app_logger.warning(
+            f"smart_rename: series.json not persisted in {directory}: {reason}"
+        )
+        return {
+            "status": "ok",
+            "metadata": metadata,
+            "warning": f"series.json not saved: {reason}",
+        }
+
+    # Persisted — re-read so preserved/merged fields win, but fall back to the
+    # in-memory metadata if the re-read comes back empty.
     refreshed = read_series_json(directory) or {}
     md = refreshed.get("metadata") if isinstance(refreshed, dict) else None
     if not md or not md.get("name"):
-        return {"status": "series_json_failed", "reason": "series.json missing 'name' after write"}
+        md = metadata
     return {"status": "ok", "metadata": md}
 
 
@@ -229,6 +249,45 @@ def _sanitize_series_name(name: str) -> str:
     return name
 
 
+def _read_issue_meta(file_path: str) -> Dict[str, str]:
+    """Read issue-level tokens from a file's embedded ComicInfo.xml.
+
+    Returns a dict with cover_year, cover_month_M, cover_month_m, issue_year,
+    issue_title (any of which may be empty). ComicInfo Year/Month hold the
+    cover date. Only .cbz/.zip are supported (ComicInfo in a .cbr lives in a
+    RAR); anything else, or a read failure, yields empty values.
+    """
+    empty = {
+        "cover_year": "",
+        "cover_month_M": "",
+        "cover_month_m": "",
+        "issue_year": "",
+        "issue_title": "",
+    }
+    if not file_path.lower().endswith((".cbz", ".zip")):
+        return empty
+    try:
+        from core.comicinfo import read_comicinfo_from_zip
+
+        info = read_comicinfo_from_zip(file_path)
+    except Exception:
+        return empty
+    if not info:
+        return empty
+
+    out = dict(empty)
+    if info.get("Year"):
+        out["cover_year"] = str(info["Year"])
+        out["issue_year"] = str(info["Year"])
+    if info.get("Month"):
+        month_name, month_padded = _format_issue_month(info["Month"])
+        out["cover_month_M"] = month_name
+        out["cover_month_m"] = month_padded
+    if info.get("Title"):
+        out["issue_title"] = info["Title"]
+    return out
+
+
 def _plan_file(
     file_path: str,
     metadata: Dict,
@@ -236,6 +295,7 @@ def _plan_file(
     cleanup_cfg: Dict,
     used_targets: set,
     exclude_terms: Optional[List[str]] = None,
+    needs_issue_meta: bool = False,
 ) -> Dict:
     """Build the rename plan entry for a single file."""
     old_name = os.path.basename(file_path)
@@ -259,14 +319,26 @@ def _plan_file(
 
     issue = _pad_issue_number(raw_issue, width=3)
 
+    # Issue-level tokens (cover date, issue title/year) come from each file's
+    # embedded ComicInfo.xml, not series.json. Unknown tokens stay empty and
+    # drop cleanly. {cover_year} falls back to the issue year (never the
+    # series start year), so {volume_year} alone carries the series year.
+    issue_meta = _read_issue_meta(file_path) if needs_issue_meta else {}
+
     values = {
         "series_name": _sanitize_series_name((metadata.get("name") or "").strip()),
         "volume_number": _format_volume(metadata.get("volume")),
         # series.json "year" is the series/volume year -> feeds {volume_year}
         "volume_year": _format_year(metadata.get("year")),
-        "year": _format_year(metadata.get("year")),
+        # "year" is only the {cover_year} fallback: use the issue's own year
+        # (from ComicInfo) if known, otherwise empty — not the series year.
+        "year": issue_meta.get("issue_year", ""),
         "issue_number": issue,
-        "issue_title": "",
+        "issue_title": issue_meta.get("issue_title", ""),
+        "issue_year": issue_meta.get("issue_year", ""),
+        "cover_year": issue_meta.get("cover_year", ""),
+        "cover_month_M": issue_meta.get("cover_month_M", ""),
+        "cover_month_m": issue_meta.get("cover_month_m", ""),
     }
 
     new_stem = apply_custom_pattern(values, pattern)
@@ -324,6 +396,19 @@ def plan_smart_rename(
     cleanup_cfg = load_filename_cleanup_config()
     exclude_terms = _load_exclude_terms()
 
+    # Only crack open each archive for ComicInfo.xml when the pattern actually
+    # references an issue-level token (cover date / issue title / issue year).
+    needs_issue_meta = bool(pattern) and any(
+        tok in pattern
+        for tok in (
+            "{cover_year}",
+            "{cover_month_M}",
+            "{cover_month_m}",
+            "{issue_title}",
+            "{issue_year}",
+        )
+    )
+
     result = {
         "root": root_dir,
         "recursive": recursive,
@@ -358,6 +443,8 @@ def plan_smart_rename(
 
         metadata = sj["metadata"]
         dir_entry["status"] = "ok"
+        if sj.get("warning"):
+            dir_entry["warning"] = sj["warning"]
         dir_entry["metadata"] = {
             "name": metadata.get("name"),
             "volume": metadata.get("volume"),
@@ -387,6 +474,7 @@ def plan_smart_rename(
                     cleanup_cfg,
                     used_targets,
                     exclude_terms=exclude_terms,
+                    needs_issue_meta=needs_issue_meta,
                 )
             )
 

--- a/models/series_json.py
+++ b/models/series_json.py
@@ -205,7 +205,8 @@ def _atomic_write(path, payload):
         raise
 
 
-def write_series_json(folder_path, series, issues=None, api=None, preserve_existing=True):
+def write_series_json(folder_path, series, issues=None, api=None, preserve_existing=True,
+                      return_reason=False):
     """Create or update the series.json file in `folder_path`.
 
     Args:
@@ -215,15 +216,22 @@ def write_series_json(folder_path, series, issues=None, api=None, preserve_exist
         api: Optional Metron API client; used to backfill missing cv_id.
         preserve_existing: When True, copy user-editable fields from any
             existing series.json into the new one (Mylar behavior).
+        return_reason: When True, return a ``(ok, reason)`` tuple where
+            ``reason`` is None on success or a human-readable cause on
+            failure. Default False preserves the bare-bool return for
+            existing callers.
 
     Returns:
-        True on success, False otherwise.
+        True on success, False otherwise. When ``return_reason`` is True,
+        a ``(bool, reason_or_None)`` tuple instead.
     """
+    def _result(ok, reason):
+        return (ok, reason) if return_reason else ok
+
     if not folder_path or not os.path.isdir(folder_path):
-        app_logger.warning(
-            f"Cannot write series.json: folder does not exist: {folder_path}"
-        )
-        return False
+        reason = f"folder does not exist: {folder_path}"
+        app_logger.warning(f"Cannot write series.json: {reason}")
+        return _result(False, reason)
 
     try:
         metadata = build_metadata(series, issues=issues, api=api)
@@ -242,8 +250,8 @@ def write_series_json(folder_path, series, issues=None, api=None, preserve_exist
         from helpers import match_parent_permissions
         match_parent_permissions(target)
         app_logger.info(f"Wrote series.json at {target}")
-        return True
+        return _result(True, None)
 
     except Exception as e:
         app_logger.error(f"Failed to write series.json in {folder_path}: {e}")
-        return False
+        return _result(False, str(e))

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -6061,6 +6061,9 @@ function showSmartRenameModal(plan, panel) {
       issues.push(`<li><code>${escapeHtml(dir.dir)}</code>: ${escapeHtml(dir.status)}${escapeHtml(reason)}</li>`);
       continue;
     }
+    if (dir.warning) {
+      issues.push(`<li><code>${escapeHtml(dir.dir)}</code>: ${escapeHtml(dir.warning)}</li>`);
+    }
     for (const f of (dir.files || [])) {
       if (f.status === 'ok') {
         okCount++;

--- a/templates/files.html
+++ b/templates/files.html
@@ -295,6 +295,14 @@
       </div>
       <div class="modal-body">
         <p id="smartRenameSummary" class="text-muted small mb-2"></p>
+        <p class="text-muted small mb-2">
+          Series tokens (<code>{series_name}</code>, <code>{volume_number}</code>,
+          <code>{volume_year}</code>) come from <code>series.json</code>. Issue tokens
+          (<code>{cover_year}</code>, <code>{cover_month_M}</code>, <code>{issue_title}</code>,
+          <code>{issue_year}</code>) are read from each file's embedded ComicInfo.xml —
+          unavailable for <code>.cbr</code> files and dropped when absent. Store-date tokens
+          are not available in Smart Rename.
+        </p>
         <div style="max-height: 50vh; overflow-y: auto;">
           <table class="table table-sm table-hover small">
             <thead>

--- a/tests/unit/test_series_json.py
+++ b/tests/unit/test_series_json.py
@@ -342,6 +342,26 @@ class TestWriteSeriesJson:
         leftovers = [p for p in os.listdir(tmp_path) if p.startswith(".series.json.")]
         assert leftovers == []
 
+    def test_return_reason_success(self, tmp_path, series):
+        from models.series_json import write_series_json
+        ok, reason = write_series_json(str(tmp_path), series, return_reason=True)
+        assert ok is True
+        assert reason is None
+
+    def test_return_reason_missing_folder(self, tmp_path, series):
+        from models.series_json import write_series_json
+        missing = tmp_path / "does-not-exist"
+        ok, reason = write_series_json(str(missing), series, return_reason=True)
+        assert ok is False
+        assert "does not exist" in reason
+
+    def test_return_reason_surfaces_exception(self, tmp_path, series):
+        from models import series_json as sj
+        with patch("models.series_json.json.dump", side_effect=RuntimeError("disk full")):
+            ok, reason = sj.write_series_json(str(tmp_path), series, return_reason=True)
+        assert ok is False
+        assert "disk full" in reason
+
 
 # ===== read_series_json =====
 

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -310,6 +310,135 @@ class TestPlanSmartRenameAutoCreateSeriesJson:
 
         assert plan["directories"][0]["status"] == "series_json_failed"
 
+    def _metron_patches(self, cv_id=999, **series_overrides):
+        """Build the standard Metron provider patches for these tests."""
+        series_fields = dict(
+            id=42, cv_id=cv_id, name="Sandman", volume=1, year_began=1989,
+            year_end=1996, publisher=SimpleNamespace(name="Vertigo"),
+            imprint=None, desc="", issue_count=75, status="Ended",
+            cover_image=None, image=None,
+        )
+        series_fields.update(series_overrides)
+        series_obj = SimpleNamespace(**series_fields)
+        fake_api = MagicMock()
+        fake_api.series.return_value = series_obj
+        fake_metron = MagicMock()
+        fake_metron.is_metron_configured.return_value = True
+        fake_metron.get_flask_api.return_value = fake_api
+        fake_metron.get_series_id.return_value = 42
+        return fake_metron
+
+    def test_persist_failure_still_renames_with_warning(self, tmp_path):
+        """When the provider resolves but series.json can't be written, the
+        rename still proceeds from in-memory metadata and surfaces the reason."""
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d, cv_id=999)
+        (d / "Sandman 5.cbz").write_bytes(b"x")
+
+        fake_metron = self._metron_patches()
+
+        with _enable_custom_rename(), \
+             patch("cbz_ops.smart_rename._get_metron_mod", return_value=fake_metron), \
+             patch("cbz_ops.smart_rename.write_series_json",
+                   return_value=(False, "Permission denied")), \
+             patch("core.database.get_library_providers",
+                   return_value=[{"provider_type": "metron", "enabled": True}]):
+            plan = plan_smart_rename(str(d), recursive=False, library_id=1)
+
+        dir_entry = plan["directories"][0]
+        assert dir_entry["status"] == "ok"
+        assert "Permission denied" in dir_entry["warning"]
+        renames = [f for f in dir_entry["files"] if f["status"] == "ok"]
+        assert renames[0]["new_name"] == "Sandman v1 005 (1989).cbz"
+
+    def test_provider_series_without_name_fails(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d, cv_id=999)
+        (d / "Sandman 5.cbz").write_bytes(b"x")
+
+        fake_metron = self._metron_patches(name=None)
+
+        with _enable_custom_rename(), \
+             patch("cbz_ops.smart_rename._get_metron_mod", return_value=fake_metron), \
+             patch("core.database.get_library_providers",
+                   return_value=[{"provider_type": "metron", "enabled": True}]):
+            plan = plan_smart_rename(str(d), recursive=False, library_id=1)
+
+        dir_entry = plan["directories"][0]
+        assert dir_entry["status"] == "series_json_failed"
+        assert "no name" in dir_entry["reason"]
+
+
+def _write_cbz_with_comicinfo(path, year=None, month=None, title=None):
+    """Write a minimal .cbz containing a ComicInfo.xml with the given fields."""
+    import zipfile
+    parts = ["<?xml version='1.0' encoding='utf-8'?>", "<ComicInfo>"]
+    if title is not None:
+        parts.append(f"<Title>{title}</Title>")
+    if year is not None:
+        parts.append(f"<Year>{year}</Year>")
+    if month is not None:
+        parts.append(f"<Month>{month}</Month>")
+    parts.append("</ComicInfo>")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("page01.jpg", b"fake")
+        z.writestr("ComicInfo.xml", "".join(parts))
+
+
+class TestSmartRenameIssueTokens:
+    """Issue-level tokens (cover date, issue title/year) read from ComicInfo."""
+
+    def test_cover_tokens_from_comicinfo(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        _write_cbz_with_comicinfo(d / "Sandman 5.cbz", year=2026, month=3, title="Passengers")
+
+        pattern = "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert names == ["Sandman - 005 (March, 2026).cbz"]
+
+    def test_missing_comicinfo_drops_cover_tokens_no_series_year(self, tmp_path):
+        # Decision 3: {cover_year} must NOT fall back to the series start year.
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        (d / "Sandman 5.cbz").write_bytes(b"x")  # no ComicInfo.xml
+
+        pattern = "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        # Date group drops cleanly; the series year (1989) must not appear.
+        assert names == ["Sandman - 005.cbz"]
+
+    def test_issue_title_from_comicinfo(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        _write_cbz_with_comicinfo(d / "Sandman 5.cbz", year=2026, title="The Sound of Her Wings")
+
+        pattern = "{series_name} {issue_number} - {issue_title}"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert names == ["Sandman 005 - The Sound of Her Wings.cbz"]
+
 
 class TestApplySmartRename:
 


### PR DESCRIPTION
## 📝 Description
Read per-file ComicInfo.xml for issue-level tokens (cover date, issue title/year) and use those values in smart rename patterns. Add _read_issue_meta and only extract ComicInfo when the custom pattern references issue tokens. Change smart_rename to build metadata in-memory first (via build_metadata) so renames can proceed even if persisting series.json fails; write_series_json now supports return_reason to surface human-friendly failure causes. When series.json write fails, return an OK plan with metadata plus a warning and re-read the persisted file (falling back to in-memory metadata if necessary). Surface directory-level warnings to the UI and add explanatory text in the Smart Rename modal. Update tests to cover write_series_json return_reason, persistence-failure behavior, provider-without-name failure, and ComicInfo-driven issue token handling.

Closes #355 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass