### PR TITLE
Replace cover/store date variables with issue_month

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -381,26 +381,6 @@ def _format_issue_month(month_raw):
     return "", ""
 
 
-def _format_date_parts(date_str):
-    """Parse a 'YYYY-MM-DD' (or 'YYYY') date string into display variants.
-
-    Returns a tuple (year, month_name, month_padded), e.g.
-    "2010-06-01" -> ("2010", "June", "06"). Returns ("", "", "") when blank or
-    unparseable. Month name/padded are empty when only a year is present.
-    """
-    if not date_str:
-        return "", "", ""
-    m = re.match(r"(\d{4})(?:-(\d{1,2}))?", str(date_str).strip())
-    if not m:
-        return "", "", ""
-    year = m.group(1)
-    if m.group(2):
-        month_name, month_padded = _format_issue_month(m.group(2))
-    else:
-        month_name, month_padded = "", ""
-    return year, month_name, month_padded
-
-
 _FILENAME_CLEANUP_DEFAULTS = {
     "spaces_enabled": False,
     "spaces_mode": "replace",
@@ -546,12 +526,8 @@ _TOKEN_REGEX = {
     "volume_number": r"(?P<volume_number>\d{1,4})",
     "volume_year": r"(?P<year>\d{4})",
     "issue_year": r"(?P<issue_year>\d{4})",
-    "cover_year": r"(?P<cover_year>\d{4})",
-    "cover_month_m": r"(?P<cover_month_m>\d{2})",
-    "cover_month_M": r"(?P<cover_month_M>[A-Za-z]+)",
-    "store_year": r"(?P<store_year>\d{4})",
-    "store_month_m": r"(?P<store_month_m>\d{2})",
-    "store_month_M": r"(?P<store_month_M>[A-Za-z]+)",
+    "issue_month_m": r"(?P<issue_month_m>\d{2})",
+    "issue_month_M": r"(?P<issue_month_M>[A-Za-z]+)",
     "issue_title": r"(?P<issue_title>.+?)",
 }
 
@@ -1118,17 +1094,8 @@ def apply_custom_pattern(values, pattern):
         "{volume_year}", values.get("volume_year") or values.get("year", "")
     )
     result = result.replace("{issue_year}", values.get("issue_year", ""))
-    # {cover_year} falls back to the year parsed from the filename when no
-    # metadata is available (cover dates only come from ComicInfo.xml or a
-    # live provider fetch).
-    result = result.replace(
-        "{cover_year}", values.get("cover_year") or values.get("year", "")
-    )
-    result = result.replace("{cover_month_M}", values.get("cover_month_M", ""))
-    result = result.replace("{cover_month_m}", values.get("cover_month_m", ""))
-    result = result.replace("{store_year}", values.get("store_year", ""))
-    result = result.replace("{store_month_M}", values.get("store_month_M", ""))
-    result = result.replace("{store_month_m}", values.get("store_month_m", ""))
+    result = result.replace("{issue_month_M}", values.get("issue_month_M", ""))
+    result = result.replace("{issue_month_m}", values.get("issue_month_m", ""))
     result = result.replace("{issue_number}", issue_number)
 
     # Replace issue_title with sanitization
@@ -1137,6 +1104,11 @@ def apply_custom_pattern(values, pattern):
     issue_title = re.sub(r"[\x00-\x1f]", "", issue_title)
     issue_title = issue_title.strip(". ")
     result = result.replace("{issue_title}", issue_title)
+
+    # Drop any leftover {token} we don't recognize (e.g. a retired cover/store
+    # token still saved in an old pattern) so it never leaks into the filename
+    # as a literal. Surrounding empty separators/parens are cleaned up below.
+    result = re.sub(r"\{[A-Za-z_][^}]*\}", "", result)
 
     # Clean up extra spaces and trim
     result = re.sub(r"\s+", " ", result).strip()
@@ -1177,10 +1149,6 @@ def rename_comic_from_metadata(file_path, metadata):
         series = re.sub(r'[<>"/\\|?*]', "", series)
         series = smart_title_case(series)
 
-        # Cover/store dates (live-fetch only; absent in ComicInfo-only re-renames)
-        cover_year, cover_month_M, cover_month_m = _format_date_parts(metadata.get("CoverDate"))
-        store_year, store_month_M, store_month_m = _format_date_parts(metadata.get("StoreDate"))
-
         # {volume_year} = series/volume start year (ComicInfo Volume field:
         # ComicVine start_year / Metron year_began). GCD stores a volume *number*
         # there, so guard to a 4-digit year and let apply_custom_pattern fall back
@@ -1188,18 +1156,18 @@ def rename_comic_from_metadata(file_path, metadata):
         vol_raw = str(metadata.get("Volume", "") or "").strip()
         volume_year = vol_raw if re.fullmatch(r"\d{4}", vol_raw) else ""
 
+        # {issue_month_M}/{issue_month_m} = ComicInfo Month (the cover month)
+        issue_month_M, issue_month_m = _format_issue_month(metadata.get("Month"))
+
         values = {
             "series_name": series,
             "volume_number": "",
             "volume_year": volume_year,
+            # {issue_year} = ComicInfo Year (the cover year written to the XML)
             "year": str(metadata.get("Year", "")),
             "issue_year": str(metadata.get("Year", "")),
-            "cover_year": cover_year,
-            "cover_month_M": cover_month_M,
-            "cover_month_m": cover_month_m,
-            "store_year": store_year,
-            "store_month_M": store_month_M,
-            "store_month_m": store_month_m,
+            "issue_month_M": issue_month_M,
+            "issue_month_m": issue_month_m,
             "issue_number": _pad_issue_number(str(metadata.get("Number", ""))),
             "issue_title": metadata.get("Title", "") or "",
         }
@@ -1246,12 +1214,8 @@ def validate_custom_pattern(pattern):
         "{volume_number}",
         "{volume_year}",
         "{issue_year}",
-        "{cover_year}",
-        "{cover_month_M}",
-        "{cover_month_m}",
-        "{store_year}",
-        "{store_month_M}",
-        "{store_month_m}",
+        "{issue_month_M}",
+        "{issue_month_m}",
         "{issue_number}",
         "{issue_title}",
     ]
@@ -1460,16 +1424,14 @@ def get_renamed_filename(filename, file_path=None):
             comic_values.setdefault("issue_year", comic_values.get("year", ""))
 
             # Tokens that require reading ComicInfo.xml for accurate values.
-            # ComicInfo Year/Month hold the cover date, so cover tokens read
-            # from there too; store dates exist only in live provider fetches.
+            # ComicInfo Year/Month hold the issue's (cover) year and month.
             needs_comicinfo = any(
                 token in custom_pattern
                 for token in (
                     "{issue_title}",
                     "{issue_year}",
-                    "{cover_year}",
-                    "{cover_month_M}",
-                    "{cover_month_m}",
+                    "{issue_month_M}",
+                    "{issue_month_m}",
                 )
             )
 
@@ -1487,13 +1449,12 @@ def get_renamed_filename(filename, file_path=None):
                         comic_values["issue_title"] = comicinfo["Title"]
                     if comicinfo.get("Year"):
                         comic_values["issue_year"] = str(comicinfo["Year"])
-                        comic_values["cover_year"] = str(comicinfo["Year"])
                     if comicinfo.get("Month"):
                         month_name, month_padded = _format_issue_month(
                             comicinfo["Month"]
                         )
-                        comic_values["cover_month_M"] = month_name
-                        comic_values["cover_month_m"] = month_padded
+                        comic_values["issue_month_M"] = month_name
+                        comic_values["issue_month_m"] = month_padded
                 except Exception:
                     pass
 

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -252,16 +252,15 @@ def _sanitize_series_name(name: str) -> str:
 def _read_issue_meta(file_path: str) -> Dict[str, str]:
     """Read issue-level tokens from a file's embedded ComicInfo.xml.
 
-    Returns a dict with cover_year, cover_month_M, cover_month_m, issue_year,
-    issue_title (any of which may be empty). ComicInfo Year/Month hold the
-    cover date. Only .cbz/.zip are supported (ComicInfo in a .cbr lives in a
-    RAR); anything else, or a read failure, yields empty values.
+    Returns a dict with issue_year/issue_month_M/issue_month_m (from ComicInfo
+    Year/Month, the cover date written to the XML) and issue_title (from
+    Title); any may be empty. Only .cbz/.zip are supported (ComicInfo in a
+    .cbr lives in a RAR); anything else, or a read failure, yields empty values.
     """
     empty = {
-        "cover_year": "",
-        "cover_month_M": "",
-        "cover_month_m": "",
         "issue_year": "",
+        "issue_month_M": "",
+        "issue_month_m": "",
         "issue_title": "",
     }
     if not file_path.lower().endswith((".cbz", ".zip")):
@@ -277,12 +276,9 @@ def _read_issue_meta(file_path: str) -> Dict[str, str]:
 
     out = dict(empty)
     if info.get("Year"):
-        out["cover_year"] = str(info["Year"])
         out["issue_year"] = str(info["Year"])
     if info.get("Month"):
-        month_name, month_padded = _format_issue_month(info["Month"])
-        out["cover_month_M"] = month_name
-        out["cover_month_m"] = month_padded
+        out["issue_month_M"], out["issue_month_m"] = _format_issue_month(info["Month"])
     if info.get("Title"):
         out["issue_title"] = info["Title"]
     return out
@@ -319,10 +315,9 @@ def _plan_file(
 
     issue = _pad_issue_number(raw_issue, width=3)
 
-    # Issue-level tokens (cover date, issue title/year) come from each file's
-    # embedded ComicInfo.xml, not series.json. Unknown tokens stay empty and
-    # drop cleanly. {cover_year} falls back to the issue year (never the
-    # series start year), so {volume_year} alone carries the series year.
+    # Issue-level tokens ({issue_year}, {issue_title}) come from each file's
+    # embedded ComicInfo.xml, not series.json. The series/volume year feeds
+    # {volume_year}; {issue_year} is the issue's own year from the XML.
     issue_meta = _read_issue_meta(file_path) if needs_issue_meta else {}
 
     values = {
@@ -330,15 +325,14 @@ def _plan_file(
         "volume_number": _format_volume(metadata.get("volume")),
         # series.json "year" is the series/volume year -> feeds {volume_year}
         "volume_year": _format_year(metadata.get("year")),
-        # "year" is only the {cover_year} fallback: use the issue's own year
-        # (from ComicInfo) if known, otherwise empty — not the series year.
+        # "year" is the {volume_year} fallback only; the issue's own year (from
+        # ComicInfo) feeds {issue_year}, never the series start year.
         "year": issue_meta.get("issue_year", ""),
         "issue_number": issue,
         "issue_title": issue_meta.get("issue_title", ""),
         "issue_year": issue_meta.get("issue_year", ""),
-        "cover_year": issue_meta.get("cover_year", ""),
-        "cover_month_M": issue_meta.get("cover_month_M", ""),
-        "cover_month_m": issue_meta.get("cover_month_m", ""),
+        "issue_month_M": issue_meta.get("issue_month_M", ""),
+        "issue_month_m": issue_meta.get("issue_month_m", ""),
     }
 
     new_stem = apply_custom_pattern(values, pattern)
@@ -397,15 +391,14 @@ def plan_smart_rename(
     exclude_terms = _load_exclude_terms()
 
     # Only crack open each archive for ComicInfo.xml when the pattern actually
-    # references an issue-level token (cover date / issue title / issue year).
+    # references an issue-level token (title / year / month).
     needs_issue_meta = bool(pattern) and any(
         tok in pattern
         for tok in (
-            "{cover_year}",
-            "{cover_month_M}",
-            "{cover_month_m}",
             "{issue_title}",
             "{issue_year}",
+            "{issue_month_M}",
+            "{issue_month_m}",
         )
     )
 

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -63,10 +63,9 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
     Pattern placeholders:
     - {series_name} -> matches the series name (flexible whitespace/case)
     - {issue_number} -> matches the issue number (with optional leading zeros)
-    - {volume_year}/{cover_year}/{issue_year}/{store_year} (and legacy {year})
-      -> matches any 4-digit year
-    - {cover_month_m}/{store_month_m} -> matches a 2-digit month
-    - {cover_month_M}/{store_month_M} -> matches a month name
+    - {volume_year}/{issue_year} (and legacy {year}) -> matches any 4-digit year
+    - {issue_month_m} -> matches a 2-digit month
+    - {issue_month_M} -> matches a month name
     Any other (unrecognized) {token} is stripped defensively so it never leaks
     into the compiled regex as a literal requirement.
 
@@ -92,14 +91,11 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         pattern = pattern.replace('{series_name}', '<<<SERIES>>>')
         pattern = pattern.replace('{issue_number}', '<<<ISSUE>>>')
         # Year variants — all match any 4-digit year
-        for tok in ('{volume_year}', '{cover_year}', '{issue_year}',
-                    '{store_year}', '{year}'):  # {year} is a legacy fallback
+        for tok in ('{volume_year}', '{issue_year}', '{year}'):  # {year} is a legacy fallback
             pattern = pattern.replace(tok, '<<<YEAR>>>')
         # Month variants — numeric (2-digit) and name
-        for tok in ('{cover_month_m}', '{store_month_m}'):
-            pattern = pattern.replace(tok, '<<<MONTHNUM>>>')
-        for tok in ('{cover_month_M}', '{store_month_M}'):
-            pattern = pattern.replace(tok, '<<<MONTHNAME>>>')
+        pattern = pattern.replace('{issue_month_m}', '<<<MONTHNUM>>>')
+        pattern = pattern.replace('{issue_month_M}', '<<<MONTHNAME>>>')
         pattern = pattern.replace('{volume_number}', '<<<VOLUME>>>')
         pattern = pattern.replace('{issue_title}', '<<<TITLE>>>')
 

--- a/models/metron.py
+++ b/models/metron.py
@@ -563,8 +563,10 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
         "Year": year,
         "Month": month,
         "Day": day,
-        # Raw provider dates (NOT written to ComicInfo.xml — generate_comicinfo_xml
-        # uses an explicit tag allowlist; consumed only by rename templating)
+        # Raw provider dates surfaced for display/API. NOT written to
+        # ComicInfo.xml (generate_comicinfo_xml uses an explicit tag allowlist)
+        # and no longer used by rename templating — the cover year is read from
+        # the ComicInfo Year tag via {issue_year}.
         "CoverDate": str(cover_date) if cover_date else None,
         "StoreDate": str(store_date) if store_date else None,
         "Writer": writer or None,

--- a/static/js/clu-metadata.js
+++ b/static/js/clu-metadata.js
@@ -1137,24 +1137,6 @@
     return numStr.padStart(width, '0');
   };
 
-  // Parse a "YYYY-MM-DD" (or "YYYY") date string into rename-template parts.
-  // Returns { year, monthName, monthPadded } with empty strings when unavailable.
-  CLU.parseDateParts = function (dateStr) {
-    var result = { year: '', monthName: '', monthPadded: '' };
-    if (!dateStr) return result;
-    var m = String(dateStr).trim().match(/^(\d{4})(?:-(\d{1,2}))?/);
-    if (!m) return result;
-    result.year = m[1];
-    if (m[2]) {
-      var monthNum = parseInt(m[2], 10);
-      if (monthNum >= 1 && monthNum <= 12) {
-        result.monthName = MONTH_NAMES[monthNum];
-        result.monthPadded = String(monthNum).padStart(2, '0');
-      }
-    }
-    return result;
-  };
-
   /**
    * Build the suggested filename from fetched metadata and the rename config.
    * @returns {string|null}  New filename, or null when it would not change.
@@ -1180,8 +1162,13 @@
       var volRaw = String(metadata.Volume || '').trim();
       var volumeYear = /^\d{4}$/.test(volRaw) ? volRaw : '';
 
-      var cover = CLU.parseDateParts(metadata.CoverDate);
-      var store = CLU.parseDateParts(metadata.StoreDate);
+      // {issue_month_M}/{issue_month_m} from ComicInfo Month (the cover month)
+      var monthNum = parseInt(metadata.Month, 10);
+      var issueMonthName = '', issueMonthPadded = '';
+      if (monthNum >= 1 && monthNum <= 12) {
+        issueMonthName = MONTH_NAMES[monthNum];
+        issueMonthPadded = String(monthNum).padStart(2, '0');
+      }
 
       var issueTitle = metadata.Title || '';
       issueTitle = issueTitle.replace(/:/g, ' -');
@@ -1194,22 +1181,21 @@
       result = result.replace(/{issue_number}/gi, issueNumber);
       result = result.replace(/{issue_year}/gi, issueYear);
       // Month variants are case-sensitive: {..._M} (name) vs {..._m} (padded)
-      result = result.replace(/{cover_month_M}/g, cover.monthName);
-      result = result.replace(/{cover_month_m}/g, cover.monthPadded);
-      result = result.replace(/{cover_year}/gi, cover.year);
-      result = result.replace(/{store_month_M}/g, store.monthName);
-      result = result.replace(/{store_month_m}/g, store.monthPadded);
-      result = result.replace(/{store_year}/gi, store.year);
+      result = result.replace(/{issue_month_M}/g, issueMonthName);
+      result = result.replace(/{issue_month_m}/g, issueMonthPadded);
       result = result.replace(/{volume_year}/gi, volumeYear || year);
       result = result.replace(/{YYYY}/g, year);
       result = result.replace(/{volume_number}/gi, volumeNumber);
       result = result.replace(/{issue_title}/gi, issueTitle);
 
+      // Drop any leftover {token} we don't recognize (mirrors apply_custom_pattern)
+      result = result.replace(/\{[A-Za-z_][^}]*\}/g, '');
+
       result = result.replace(/\s+/g, ' ').trim();
       // Remove a separator left dangling against a parenthesis boundary
-      // (e.g. "(2010-)" -> "(2010)") when a token resolved empty
-      result = result.replace(/\(\s*-\s*/g, '(');
-      result = result.replace(/\s*-\s*\)/g, ')');
+      // (e.g. "(2010-)" -> "(2010)", "(, 2026)" -> "(2026)") when a token resolved empty
+      result = result.replace(/\(\s*[-,]\s*/g, '(');
+      result = result.replace(/\s*[-,]\s*\)/g, ')');
       // Remove empty parentheses
       result = result.replace(/\s*\(\s*\)/g, '').trim();
       // Remove orphaned separators (e.g. trailing " - " when issue_title is empty)

--- a/templates/config.html
+++ b/templates/config.html
@@ -395,14 +395,9 @@
                                 Use variables to create your naming pattern. Available variables:
                                 <code>{series_name}</code>, <code>{volume_number}</code>,
                                 <code>{volume_year}</code> (series/volume start year),
-                                <code>{issue_year}</code> (this issue's year),
+                                <code>{issue_year}</code> (this issue's year, from ComicInfo.xml),
+                                <code>{issue_month_M}</code> (June), <code>{issue_month_m}</code> (06),
                                 <code>{issue_number}</code>, <code>{issue_title}</code>.
-                                Cover dates (from embedded ComicInfo.xml or a ComicVine/Metron fetch):
-                                <code>{cover_year}</code>, <code>{cover_month_M}</code> (June), <code>{cover_month_m}</code> (06).
-                                <code>{cover_year}</code> falls back to the year parsed from the filename
-                                when no metadata is available yet.
-                                Store dates (live ComicVine/Metron fetch only):
-                                <code>{store_year}</code>, <code>{store_month_M}</code>, <code>{store_month_m}</code>
                             </small>
                         </div>
                         <div class="col-md-4">
@@ -425,7 +420,9 @@
                                 • <code>{volume_number}_{issue_number}</code> → <code>v2_044.cbz</code><br>
                                 • <code>{series_name} {issue_number} - {issue_title} ({volume_year})</code> →
                                 <code>Spider-Man 2099 044 - The Last Dance (1992).cbz</code><br>
-                                • <code>{series_name} {issue_number} ({cover_year}-{cover_month_m})</code> →
+                                • <code>{series_name} {issue_number} ({issue_year})</code> →
+                                <code>Spider-Man 2099 044 (1992).cbz</code><br>
+                                • <code>{series_name} {issue_number} ({issue_year}-{issue_month_m})</code> →
                                 <code>Spider-Man 2099 044 (1992-06).cbz</code>
                             </small>
                         </div>
@@ -2646,12 +2643,8 @@
             volume_year: '1992',
             year: '1992',
             issue_year: '1992',
-            cover_year: '1992',
-            cover_month_M: 'June',
-            cover_month_m: '06',
-            store_year: '1992',
-            store_month_M: 'July',
-            store_month_m: '07',
+            issue_month_M: 'June',
+            issue_month_m: '06',
             issue_number: '044',
             issue_title: 'The Last Dance'
         };
@@ -2676,22 +2669,21 @@
         result = result.replace(/\{year\}/g, values.year || '');  // Legacy rename token
         result = result.replace(/\{start_year\}/g, values.start_year || '');  // For move patterns
         result = result.replace(/\{issue_year\}/g, values.issue_year || '');
-        result = result.replace(/\{cover_year\}/g, values.cover_year || '');
-        result = result.replace(/\{cover_month_M\}/g, values.cover_month_M || '');
-        result = result.replace(/\{cover_month_m\}/g, values.cover_month_m || '');
-        result = result.replace(/\{store_year\}/g, values.store_year || '');
-        result = result.replace(/\{store_month_M\}/g, values.store_month_M || '');
-        result = result.replace(/\{store_month_m\}/g, values.store_month_m || '');
+        result = result.replace(/\{issue_month_M\}/g, values.issue_month_M || '');
+        result = result.replace(/\{issue_month_m\}/g, values.issue_month_m || '');
         result = result.replace(/\{issue_number\}/g, values.issue_number || '');
         result = result.replace(/\{issue_title\}/g, values.issue_title || '');
+
+        // Drop any leftover {token} we don't recognize (mirrors apply_custom_pattern)
+        result = result.replace(/\{[A-Za-z_][^}]*\}/g, '');
 
         // Clean up extra spaces
         result = result.replace(/\s+/g, ' ').trim();
 
         // Remove a separator left dangling against a parenthesis boundary
-        // (e.g. "(2020-)" -> "(2020)") when a token resolved empty
-        result = result.replace(/\(\s*-\s*/g, '(');
-        result = result.replace(/\s*-\s*\)/g, ')');
+        // (e.g. "(2020-)" -> "(2020)", "(, 2026)" -> "(2026)") when a token resolved empty
+        result = result.replace(/\(\s*[-,]\s*/g, '(');
+        result = result.replace(/\s*[-,]\s*\)/g, ')');
 
         // Remove empty parentheses
         result = result.replace(/\s*\(\s*\)/g, '').trim();

--- a/templates/files.html
+++ b/templates/files.html
@@ -298,10 +298,9 @@
         <p class="text-muted small mb-2">
           Series tokens (<code>{series_name}</code>, <code>{volume_number}</code>,
           <code>{volume_year}</code>) come from <code>series.json</code>. Issue tokens
-          (<code>{cover_year}</code>, <code>{cover_month_M}</code>, <code>{issue_title}</code>,
-          <code>{issue_year}</code>) are read from each file's embedded ComicInfo.xml —
-          unavailable for <code>.cbr</code> files and dropped when absent. Store-date tokens
-          are not available in Smart Rename.
+          (<code>{issue_title}</code>, <code>{issue_year}</code>, <code>{issue_month_M}</code>,
+          <code>{issue_month_m}</code>) are read from each file's embedded ComicInfo.xml —
+          unavailable for <code>.cbr</code> files and dropped when absent.
         </p>
         <div style="max-height: 50vh; overflow-y: auto;">
           <table class="table table-sm table-hover small">

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -1,9 +1,9 @@
 """Tests for helpers.collection.generate_filename_pattern.
 
 Regression coverage for the wanted-issue matching bug: custom rename patterns
-that use a year token other than the legacy {volume_year} (e.g. {cover_year},
-{issue_year}, {store_year}) left the literal placeholder in the compiled regex,
-so no file ever matched. See helpers/collection.py.
+that use a year token other than the legacy {volume_year} (e.g. {issue_year})
+left the literal placeholder in the compiled regex, so no file ever matched.
+See helpers/collection.py.
 """
 import re
 import pytest
@@ -32,7 +32,7 @@ def _no_placeholder_leak(regex):
 class TestYearTokenVariants:
 
     @pytest.mark.parametrize("token", [
-        "volume_year", "cover_year", "issue_year", "store_year", "year",
+        "volume_year", "issue_year", "year",
     ])
     def test_year_token_matches_file_with_year(self, token):
         regex = generate_filename_pattern(
@@ -44,7 +44,7 @@ class TestYearTokenVariants:
         assert _no_placeholder_leak(regex)
 
     @pytest.mark.parametrize("token", [
-        "volume_year", "cover_year", "issue_year", "store_year",
+        "volume_year", "issue_year",
     ])
     def test_no_literal_placeholder_in_pattern(self, token):
         regex = generate_filename_pattern(
@@ -58,7 +58,7 @@ class TestYearTokenVariants:
         # The year placeholder must compile to a real 4-digit matcher, not be
         # collapsed by the unknown-token safety net.
         regex = generate_filename_pattern(
-            "{series_name} {issue_number} ({cover_year})", "Daredevil", "3",
+            "{series_name} {issue_number} ({issue_year})", "Daredevil", "3",
         )
         assert r"\d{4}" in regex.pattern
         assert not regex.search("Daredevil 003 (12).cbz")  # 2-digit not a year
@@ -70,7 +70,7 @@ class TestMonthTokens:
 
     def test_numeric_month(self):
         regex = generate_filename_pattern(
-            "{series_name} {issue_number} {cover_month_m} ({cover_year})",
+            "{series_name} {issue_number} {issue_month_m} ({issue_year})",
             "Sentry", "4",
         )
         assert regex.search("Sentry 004 03 (2024).cbz")
@@ -78,7 +78,7 @@ class TestMonthTokens:
 
     def test_name_month(self):
         regex = generate_filename_pattern(
-            "{series_name} {issue_number} {store_month_M} ({store_year})",
+            "{series_name} {issue_number} {issue_month_M} ({issue_year})",
             "Sentry", "4",
         )
         assert regex.search("Sentry 004 March (2024).cbz")

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -202,12 +202,8 @@ class TestApplyCustomPattern:
             "volume_year": "1992",
             "year": "1992",
             "issue_year": "1992",
-            "cover_year": "1992",
-            "cover_month_M": "June",
-            "cover_month_m": "06",
-            "store_year": "1992",
-            "store_month_M": "July",
-            "store_month_m": "07",
+            "issue_month_M": "June",
+            "issue_month_m": "06",
             "issue_number": "044",
             "issue_title": "The Last Dance",
         }
@@ -228,16 +224,12 @@ class TestApplyCustomPattern:
             "Spider-Man 2099 044 (1992)",
         ),
         (
-            "{series_name} ({cover_year}-{cover_month_m})",
-            "Spider-Man 2099 (1992-06)",
+            "{series_name} {issue_number} ({issue_year}-{issue_month_m})",
+            "Spider-Man 2099 044 (1992-06)",
         ),
         (
-            "{series_name} {issue_number} {cover_month_M} {cover_year}",
+            "{series_name} {issue_number} {issue_month_M} {issue_year}",
             "Spider-Man 2099 044 June 1992",
-        ),
-        (
-            "{series_name} {issue_number} [{store_month_M} {store_year}]",
-            "Spider-Man 2099 044 [July 1992]",
         ),
     ])
     def test_custom_patterns(self, sample_values, pattern, expected):
@@ -285,35 +277,22 @@ class TestApplyCustomPattern:
         assert apply_custom_pattern(values, "{series_name} {issue_number} ({volume_year})") \
             == "X 001 (2020)"
 
-    def test_cover_year_prefers_cover_value(self):
+    def test_retired_token_is_stripped(self):
+        # A retired cover/store token left in an old pattern must not leak into
+        # the filename as a literal; it (and its empty parens) drop cleanly.
         from cbz_ops.rename import apply_custom_pattern
-        values = {
-            "series_name": "X", "issue_number": "001",
-            "cover_year": "2025", "year": "2026",
-        }
-        assert apply_custom_pattern(values, "{series_name} {issue_number} ({cover_year})") \
-            == "X 001 (2025)"
-
-    def test_cover_year_falls_back_to_parsed_year(self):
-        # No metadata yet (fresh download): {cover_year} picks up the filename year.
-        from cbz_ops.rename import apply_custom_pattern
-        values = {"series_name": "X", "issue_number": "001", "year": "2026"}
-        assert apply_custom_pattern(values, "{series_name} {issue_number} ({cover_year})") \
-            == "X 001 (2026)"
-
-    def test_empty_month_drops_dangling_comma(self):
-        # "({cover_month_M}, {cover_year})" with no month -> "(2026)"
-        from cbz_ops.rename import apply_custom_pattern
-        values = {"series_name": "X", "issue_number": "001", "year": "2026"}
+        values = {"series_name": "X", "issue_number": "001", "issue_year": "2026"}
         assert apply_custom_pattern(
-            values, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"
+            values, "{series_name} {issue_number} ({cover_year})"
+        ) == "X 001"
+
+    def test_retired_token_keeps_remaining_year(self):
+        # The retired token drops but a real {issue_year} beside it survives.
+        from cbz_ops.rename import apply_custom_pattern
+        values = {"series_name": "X", "issue_number": "001", "issue_year": "2026"}
+        assert apply_custom_pattern(
+            values, "{series_name} - {issue_number} ({cover_month_M}, {issue_year})"
         ) == "X - 001 (2026)"
-
-    def test_month_and_year_present_keeps_comma(self, sample_values):
-        from cbz_ops.rename import apply_custom_pattern
-        assert apply_custom_pattern(
-            sample_values, "{series_name} {issue_number} ({cover_month_M}, {cover_year})"
-        ) == "Spider-Man 2099 044 (June, 1992)"
 
 
 # ===== load_custom_rename_config (legacy {year} migration) =====
@@ -560,7 +539,7 @@ class TestGetRenamedFilename:
 
 
 class TestGetRenamedFilenameCustomPattern:
-    """Custom-pattern path of get_renamed_filename, incl. cover-date tokens."""
+    """Custom-pattern path of get_renamed_filename, incl. {issue_year}."""
 
     def _make_cbz(self, tmp_path, name, comicinfo_xml=None):
         import zipfile
@@ -572,38 +551,49 @@ class TestGetRenamedFilenameCustomPattern:
         return str(path)
 
     @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"))
-    def test_cover_tokens_read_from_comicinfo(self, mock_config, tmp_path):
-        # ComicInfo Year/Month hold the cover date and must fill the cover tokens
+           return_value=(True, "{series_name} - {issue_number} ({issue_year})"))
+    def test_issue_year_read_from_comicinfo(self, mock_config, tmp_path):
+        # ComicInfo Year (the cover year) fills {issue_year}
         from cbz_ops.rename import get_renamed_filename
         xml = (b"<?xml version='1.0' encoding='utf-8'?><ComicInfo>"
                b"<Series>Civil War - Unmasked</Series><Number>2</Number>"
                b"<Year>2026</Year><Month>3</Month></ComicInfo>")
         path = self._make_cbz(tmp_path, "Civil War - Unmasked 002.cbz", xml)
         result = get_renamed_filename("Civil War - Unmasked 002.cbz", file_path=path)
-        assert result == "Civil War - Unmasked - 002 (March, 2026).cbz"
+        assert result == "Civil War - Unmasked - 002 (2026).cbz"
 
     @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
-    def test_cover_year_falls_back_to_filename_year(self, mock_config):
-        # Fresh download, no ComicInfo.xml: the year embedded in the filename
-        # must survive into {cover_year} instead of being dropped.
+           return_value=(True, "{series_name} - {issue_number} ({issue_year}-{issue_month_m})"))
+    def test_issue_month_read_from_comicinfo(self, mock_config, tmp_path):
+        # ComicInfo Month (the cover month) fills {issue_month_m}
+        from cbz_ops.rename import get_renamed_filename
+        xml = (b"<?xml version='1.0' encoding='utf-8'?><ComicInfo>"
+               b"<Series>Civil War - Unmasked</Series><Number>2</Number>"
+               b"<Year>2026</Year><Month>3</Month></ComicInfo>")
+        path = self._make_cbz(tmp_path, "Civil War - Unmasked 002.cbz", xml)
+        result = get_renamed_filename("Civil War - Unmasked 002.cbz", file_path=path)
+        assert result == "Civil War - Unmasked - 002 (2026-03).cbz"
+
+    @patch("cbz_ops.rename.load_custom_rename_config",
+           return_value=(True, "{series_name} {issue_number} ({issue_year})"))
+    def test_issue_year_from_filename(self, mock_config):
+        # No ComicInfo.xml: {issue_year} defaults to the year parsed from the filename.
         from cbz_ops.rename import get_renamed_filename
         result = get_renamed_filename(
             "Civil_War_-_Unmasked_002_2026_Digital_Shan-Empire.cbz")
         assert result == "Civil War - Unmasked 002 (2026).cbz"
 
     @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"))
-    def test_month_missing_drops_comma(self, mock_config):
-        # Only the year is known: "(March, 2026)" degrades to "(2026)"
+           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+    def test_retired_cover_token_dropped(self, mock_config):
+        # A retired {cover_year} left in a saved pattern is stripped, not leaked.
         from cbz_ops.rename import get_renamed_filename
         result = get_renamed_filename(
             "Civil_War_-_Unmasked_002_2026_Digital_Shan-Empire.cbz")
-        assert result == "Civil War - Unmasked - 002 (2026).cbz"
+        assert result == "Civil War - Unmasked 002.cbz"
 
     @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+           return_value=(True, "{series_name} {issue_number} ({issue_year})"))
     def test_rerename_clean_name_without_year_is_noop(self, mock_config):
         # Output of an earlier pass before metadata: must extract cleanly and
         # return the same name (monitor/wanted-issues passes stay quiet no-ops)
@@ -612,23 +602,14 @@ class TestGetRenamedFilenameCustomPattern:
         assert result == "Civil War - Unmasked 002.cbz"
 
     @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+           return_value=(True, "{series_name} {issue_number} ({issue_year})"))
     def test_rerename_final_name_is_noop(self, mock_config):
         from cbz_ops.rename import get_renamed_filename
         result = get_renamed_filename("Civil War - Unmasked 002 (2026).cbz")
         assert result == "Civil War - Unmasked 002 (2026).cbz"
 
     @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"))
-    def test_rerename_month_name_is_noop_without_comicinfo(self, mock_config):
-        # The metadata pass produced this name; a later pass must not strip
-        # the month it cannot re-derive from the filename alone.
-        from cbz_ops.rename import get_renamed_filename
-        result = get_renamed_filename("Civil War - Unmasked - 002 (March, 2026).cbz")
-        assert result == "Civil War - Unmasked - 002 (March, 2026).cbz"
-
-    @patch("cbz_ops.rename.load_custom_rename_config",
-           return_value=(True, "{series_name} {issue_number} ({cover_year})"))
+           return_value=(True, "{series_name} {issue_number} ({issue_year})"))
     def test_half_matching_messy_name_still_renames(self, mock_config):
         # A scene-style name that coincidentally half-matches the pattern's
         # reverse-parse regex must still be renamed (round-trip guard rejects)
@@ -780,34 +761,43 @@ class TestRenameComicFromMetadata:
         assert os.path.exists(result_path)
 
     @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
-    def test_renames_with_cover_date(self, mock_config, tmp_path):
+           return_value=(True, '{series_name} {issue_number} ({issue_year}-{issue_month_m})'))
+    def test_renames_with_issue_month(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
         result_path, was_renamed = rename_comic_from_metadata(
-            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 5,
-                     'CoverDate': '2010-03-01', 'StoreDate': '2010-05-01'})
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 5})
         assert was_renamed is True
-        # Cover month (March -> 03), distinct from store month
-        assert os.path.basename(result_path) == "Batman 001 (2010-03).cbz"
+        assert os.path.basename(result_path) == "Batman 001 (2020-05).cbz"
 
     @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} cover-{cover_month_M} store-{store_month_M}'))
-    def test_cover_and_store_months_differ(self, mock_config, tmp_path):
+           return_value=(True, '{series_name} {issue_number} {issue_month_M} {issue_year}'))
+    def test_issue_month_name_from_metadata(self, mock_config, tmp_path):
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
         result_path, was_renamed = rename_comic_from_metadata(
-            str(f), {'Series': 'Batman', 'Number': '1',
-                     'CoverDate': '2010-03-01', 'StoreDate': '2010-05-15'})
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020, 'Month': 5})
         assert was_renamed is True
-        assert os.path.basename(result_path) == "Batman 001 cover-March store-May.cbz"
+        assert os.path.basename(result_path) == "Batman 001 May 2020.cbz"
 
     @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
-    def test_missing_cover_date_falls_back_to_year(self, mock_config, tmp_path):
-        # No CoverDate -> {cover_year} falls back to Year, month drops cleanly
+           return_value=(True, '{series_name} {issue_number} ({issue_year}-{issue_month_m})'))
+    def test_missing_month_drops_cleanly(self, mock_config, tmp_path):
+        # No Month -> {issue_month_m} empty, separator drops, year survives
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "Batman 001 (2020).cbz"
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({cover_year})'))
+    def test_retired_cover_token_dropped(self, mock_config, tmp_path):
+        # A retired {cover_year} in a saved pattern is stripped, not leaked.
         f = tmp_path / "old.cbz"
         f.write_bytes(b"fake")
         from cbz_ops.rename import rename_comic_from_metadata
@@ -815,22 +805,8 @@ class TestRenameComicFromMetadata:
             str(f), {'Series': 'Batman', 'Number': '1', 'Year': 2020})
         assert was_renamed is True
         name = os.path.basename(result_path)
-        assert name == "Batman 001 (2020).cbz"
-        assert "-)" not in name and "(-" not in name and "()" not in name
-
-    @patch('cbz_ops.rename.load_custom_rename_config',
-           return_value=(True, '{series_name} {issue_number} ({cover_year}-{cover_month_m})'))
-    def test_missing_cover_date_and_year_drops_cleanly(self, mock_config, tmp_path):
-        # No CoverDate and no Year -> cover tokens resolve empty, no stray separators
-        f = tmp_path / "old.cbz"
-        f.write_bytes(b"fake")
-        from cbz_ops.rename import rename_comic_from_metadata
-        result_path, was_renamed = rename_comic_from_metadata(
-            str(f), {'Series': 'Batman', 'Number': '1'})
-        assert was_renamed is True
-        name = os.path.basename(result_path)
         assert name == "Batman 001.cbz"
-        assert "-)" not in name and "(-" not in name and "()" not in name
+        assert "{" not in name and "()" not in name
 
     @patch('cbz_ops.rename.load_custom_rename_config',
            return_value=(True, '{series_name} {issue_number} ({volume_year})'))

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -390,9 +390,9 @@ def _write_cbz_with_comicinfo(path, year=None, month=None, title=None):
 
 
 class TestSmartRenameIssueTokens:
-    """Issue-level tokens (cover date, issue title/year) read from ComicInfo."""
+    """Issue-level tokens ({issue_year}, {issue_title}) read from ComicInfo."""
 
-    def test_cover_tokens_from_comicinfo(self, tmp_path):
+    def test_issue_year_from_comicinfo(self, tmp_path):
         from cbz_ops.smart_rename import plan_smart_rename
         d = tmp_path / "Sandman"
         d.mkdir()
@@ -400,15 +400,16 @@ class TestSmartRenameIssueTokens:
         _write_series_json(d, name="Sandman", volume=2, year=1989)
         _write_cbz_with_comicinfo(d / "Sandman 5.cbz", year=2026, month=3, title="Passengers")
 
-        pattern = "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"
+        pattern = "{series_name} - {issue_number} ({issue_year})"
         with _enable_custom_rename(pattern=pattern):
             plan = plan_smart_rename(str(d), recursive=False)
 
         names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
-        assert names == ["Sandman - 005 (March, 2026).cbz"]
+        # {issue_year} = ComicInfo Year (2026), distinct from the series year (1989)
+        assert names == ["Sandman - 005 (2026).cbz"]
 
-    def test_missing_comicinfo_drops_cover_tokens_no_series_year(self, tmp_path):
-        # Decision 3: {cover_year} must NOT fall back to the series start year.
+    def test_missing_comicinfo_drops_issue_year_no_series_year(self, tmp_path):
+        # {issue_year} must NOT fall back to the series start year.
         from cbz_ops.smart_rename import plan_smart_rename
         d = tmp_path / "Sandman"
         d.mkdir()
@@ -416,13 +417,44 @@ class TestSmartRenameIssueTokens:
         _write_series_json(d, name="Sandman", volume=2, year=1989)
         (d / "Sandman 5.cbz").write_bytes(b"x")  # no ComicInfo.xml
 
+        pattern = "{series_name} - {issue_number} ({issue_year})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        # Year group drops cleanly; the series year (1989) must not appear.
+        assert names == ["Sandman - 005.cbz"]
+
+    def test_retired_cover_token_dropped(self, tmp_path):
+        # A retired {cover_year}/{cover_month_M} in a saved pattern is stripped.
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        _write_cbz_with_comicinfo(d / "Sandman 5.cbz", year=2026, month=3)
+
         pattern = "{series_name} - {issue_number} ({cover_month_M}, {cover_year})"
         with _enable_custom_rename(pattern=pattern):
             plan = plan_smart_rename(str(d), recursive=False)
 
         names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
-        # Date group drops cleanly; the series year (1989) must not appear.
         assert names == ["Sandman - 005.cbz"]
+
+    def test_issue_month_from_comicinfo(self, tmp_path):
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        _write_cbz_with_comicinfo(d / "Sandman 5.cbz", year=2026, month=3)
+
+        pattern = "{series_name} - {issue_number} ({issue_year}-{issue_month_m})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert names == ["Sandman - 005 (2026-03).cbz"]
 
     def test_issue_title_from_comicinfo(self, tmp_path):
         from cbz_ops.smart_rename import plan_smart_rename


### PR DESCRIPTION
## 📝 Description
Retire `cover_/store_ date` variables and treat ComicInfo Year/Month as the issue (cover) date. Removed _format_date_parts and renamed token usage to {issue_year}, {issue_month_M}, {issue_month_m} across Python, JS, templates and tests. apply_custom_pattern and front-end filename builder now defensively strip unknown {tokens} so old patterns don't leak literal placeholders, and cleanup of surrounding separators/parentheses/commas was tightened. Tests and filename-pattern generation were updated to match the new token names and behaviors. Also clarified Metron comment: provider CoverDate/StoreDate are kept for display/API but not used for rename templating.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass