### PR TITLE
Refactor download link parsing for older post format

### DIFF
--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -633,6 +633,93 @@ def search_getcomics(query: str, max_pages: int = 3) -> list:
     return results
 
 
+def _extract_download_links(root) -> dict:
+    """Extract supported download links from a BeautifulSoup node.
+
+    Handles both the modern getcomics layout (buttons carry a ``title``
+    attribute or an ``aio-red``/``aio-blue`` class) and older posts where the
+    provider name lives in inner ``<span>`` text of a class-less, title-less
+    ``<a>`` (e.g. ``<strong><a ...><span>PIXELDRAIN</span></a> | ...</strong>``).
+
+    Only providers CLU can download are captured: pixeldrain, mega, and
+    download_now (which includes "Mirror Download" / "Download Now" buttons).
+    Terabox/Mediafire labels are deliberately ignored — there is no downloader
+    for them. Each tier only fills slots still empty, so earlier (more reliable)
+    tiers win.
+
+    Args:
+        root: a BeautifulSoup ``soup`` or container element.
+
+    Returns:
+        Dict with keys: pixeldrain, download_now, mega (values are URLs or None)
+    """
+    links = {"pixeldrain": None, "download_now": None, "mega": None}
+
+    # Tier 1: title attribute
+    for a in root.find_all("a"):
+        title = (a.get("title") or "").upper()
+        href = a.get("href", "") or ""
+        if not href:
+            continue
+        if "PIXELDRAIN" in title and not links["pixeldrain"]:
+            links["pixeldrain"] = href
+            logger.info(f"Found PIXELDRAIN link: {href}")
+        elif "DOWNLOAD NOW" in title and not links["download_now"]:
+            links["download_now"] = href
+            logger.info(f"Found DOWNLOAD NOW link: {href}")
+        elif "MEGA" in title and not links["mega"]:
+            links["mega"] = href
+            logger.info(f"Found MEGA link: {href}")
+
+    # Tier 2: aio-red/aio-blue button text
+    for a in root.find_all("a", class_=lambda c: c and ('aio-red' in c or 'aio-blue' in c)):
+        text = a.get_text(strip=True).upper()
+        href = a.get("href", "") or ""
+        if not href:
+            continue
+        if "PIXELDRAIN" in text and not links["pixeldrain"]:
+            links["pixeldrain"] = href
+            logger.info(f"Found PIXELDRAIN link (by button text): {href}")
+        elif "MEGA" in text and not links["mega"]:
+            links["mega"] = href
+            logger.info(f"Found MEGA link (by button text): {href}")
+        elif "DOWNLOAD" in text and not links["download_now"]:
+            links["download_now"] = href
+            logger.info(f"Found DOWNLOAD link (by button text): {href}")
+
+    # Tier 3: visible link text across all <a> (older strong/span format).
+    # Restrict to short labels to avoid matching unrelated body links.
+    for a in root.find_all("a"):
+        text = a.get_text(strip=True).upper()
+        href = a.get("href", "") or ""
+        if not href or len(text) > 40:
+            continue
+        if "PIXELDRAIN" in text and not links["pixeldrain"]:
+            links["pixeldrain"] = href
+            logger.info(f"Found PIXELDRAIN link (by text): {href}")
+        elif "MEGA" in text and not links["mega"]:
+            links["mega"] = href
+            logger.info(f"Found MEGA link (by text): {href}")
+        elif ("MIRROR DOWNLOAD" in text or "DOWNLOAD NOW" in text) and not links["download_now"]:
+            links["download_now"] = href
+            logger.info(f"Found DOWNLOAD link (by text): {href}")
+
+    # Tier 4: href-domain backstop for still-empty slots
+    for a in root.find_all("a"):
+        href = a.get("href", "") or ""
+        if not href:
+            continue
+        low = href.lower()
+        if "pixeldrain.com" in low and not links["pixeldrain"]:
+            links["pixeldrain"] = href
+            logger.info(f"Found PIXELDRAIN link (by href): {href}")
+        elif ("mega.nz" in low or "mega.co.nz" in low) and not links["mega"]:
+            links["mega"] = href
+            logger.info(f"Found MEGA link (by href): {href}")
+
+    return links
+
+
 def get_download_links(page_url: str) -> dict:
     """
     Fetch a getcomics page and extract download links.
@@ -650,47 +737,7 @@ def get_download_links(page_url: str) -> dict:
         resp.raise_for_status()
 
         soup = BeautifulSoup(resp.text, 'html.parser')
-
-        links = {"pixeldrain": None, "download_now": None, "mega": None}
-
-        # Search for download links by title attribute
-        for a in soup.find_all("a"):
-            title = (a.get("title") or "").upper()
-            href = a.get("href", "")
-
-            if not href:
-                continue
-
-            if "PIXELDRAIN" in title and not links["pixeldrain"]:
-                links["pixeldrain"] = href
-                logger.info(f"Found PIXELDRAIN link: {href}")
-            elif "DOWNLOAD NOW" in title and not links["download_now"]:
-                links["download_now"] = href
-                logger.info(f"Found DOWNLOAD NOW link: {href}")
-            elif "MEGA" in title and not links["mega"]:
-                links["mega"] = href
-                logger.info(f"Found MEGA link: {href}")
-
-        # If no links found by title, try button text content
-        if not links["pixeldrain"] and not links["download_now"] and not links["mega"]:
-            for a in soup.find_all("a", class_="aio-red"):
-                text = a.get_text(strip=True).upper()
-                href = a.get("href", "")
-
-                if not href:
-                    continue
-
-                if "PIXELDRAIN" in text and not links["pixeldrain"]:
-                    links["pixeldrain"] = href
-                    logger.info(f"Found PIXELDRAIN link (by text): {href}")
-                elif "DOWNLOAD" in text and not links["download_now"]:
-                    links["download_now"] = href
-                    logger.info(f"Found DOWNLOAD link (by text): {href}")
-                elif "MEGA" in text and not links["mega"]:
-                    links["mega"] = href
-                    logger.info(f"Found MEGA link (by text): {href}")
-
-        return links
+        return _extract_download_links(soup)
 
     except Exception as e:
         logger.error(f"Error fetching/parsing page: {e}")
@@ -2385,32 +2432,7 @@ def scrape_and_score_candidate(
 
         def _extract_links(container) -> dict:
             """Extract download links from a soup container."""
-            links = {"pixeldrain": None, "download_now": None, "mega": None}
-            for a in container.find_all("a", class_=lambda c: c and ('aio-red' in c or 'aio-blue' in c)):
-                text = a.get_text(strip=True).upper()
-                href = a.get("href", "") or ""
-                if not href:
-                    continue
-                if "PIXELDRAIN" in text and not links["pixeldrain"]:
-                    links["pixeldrain"] = href
-                elif "DOWNLOAD" in text and not links["download_now"]:
-                    links["download_now"] = href
-                elif "MEGA" in text and not links["mega"]:
-                    links["mega"] = href
-            # Fallback: title attribute
-            if not any(links.values()):
-                for a in container.find_all("a"):
-                    link_title = (a.get("title") or "").upper()
-                    href = a.get("href", "") or ""
-                    if not href:
-                        continue
-                    if "PIXELDRAIN" in link_title and not links["pixeldrain"]:
-                        links["pixeldrain"] = href
-                    elif "DOWNLOAD NOW" in link_title and not links["download_now"]:
-                        links["download_now"] = href
-                    elif "MEGA" in link_title and not links["mega"]:
-                        links["mega"] = href
-            return links
+            return _extract_download_links(container)
 
         best_score = -999
         best_result = None
@@ -2997,6 +3019,48 @@ def get_all_aliases() -> list[dict]:
     return [dict(r) for r in rows]
 
 
+def _extract_content_li_entries(soup) -> list[tuple[str, str | None]]:
+    """Extract <li>-based comic entries from a getcomics post page.
+
+    Older getcomics pages list each issue as an ``<li>`` containing the title
+    text followed by inline-styled download links. We must only look inside the
+    post content container — iterating the whole page would pick up the site's
+    nav/header/footer/sidebar ``<li>`` menu items (e.g. the "AI Girlfriend"
+    advertising link in the header nav), which would then be stored as bogus
+    series titles/aliases.
+
+    Args:
+        soup: BeautifulSoup of the full page.
+
+    Returns:
+        List of (title_text, download_url) tuples, in document order, deduped.
+    """
+    entries: list[tuple[str, str | None]] = []
+    seen_li: set[int] = set()
+    # Same content containers trusted by the other listing-page variants.
+    for root in soup.select('article, div.post-content, div.entry-content'):
+        for li in root.find_all('li'):
+            if id(li) in seen_li:
+                continue
+            seen_li.add(id(li))
+            # Title is the direct text content before the first " :" / links
+            li_text = li.get_text(separator=' ', strip=True)
+            if not li_text or len(li_text) < 10:
+                continue
+            title_text = li_text.split(' :')[0].strip() if ' :' in li_text else li_text
+            if not title_text or len(title_text) < 5:
+                continue
+            # Get download URL — first non-getcomics http href in an <a> tag
+            download_url = None
+            for a in li.find_all('a', href=True):
+                href = a.get('href', '')
+                if href.startswith('http') and 'getcomics' not in href:
+                    download_url = href
+                    break
+            entries.append((title_text, download_url))
+    return entries
+
+
 def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", lastmod: str = "", search_aliases: str = "") -> list[dict] | None:
     """
     Scrape a GetComics URL and store parsed results in the scrape index.
@@ -3218,22 +3282,10 @@ def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", la
         # Structure: each comic entry is a <li> containing title text followed by
         # download links in <strong><a href="..."><span style="color: #ff0000;">...
         # Links use inline styles (color: #ff0000 for Main Server) not CSS classes.
-        for li in soup.find_all('li'):
-            # Title is the direct text content before the first <strong> or <br>
-            li_text = li.get_text(separator=' ', strip=True)
-            if not li_text or len(li_text) < 10:
-                continue
-            # Extract title: text before the first " :" pattern or download links
-            title_text = li_text.split(' :')[0].strip() if ' :' in li_text else li_text
-            if not title_text or len(title_text) < 5:
-                continue
-            # Get download URL — first http href in an <a> tag
-            download_url = None
-            for a in li.find_all('a', href=True):
-                href = a.get('href', '')
-                if href.startswith('http') and 'getcomics' not in href:
-                    download_url = href
-                    break
+        # Scoped to the post content container by _extract_content_li_entries so
+        # site nav/header/footer menu items (e.g. advertising links) are never
+        # mistaken for comic titles.
+        for title_text, download_url in _extract_content_li_entries(soup):
             entry_slug = _slugify(title_text)
             entry_url = f"{url}#{entry_slug}"
             _parse_and_store(title_text, download_url, entry_url)

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -633,6 +633,23 @@ def search_getcomics(query: str, max_pages: int = 3) -> list:
     return results
 
 
+def _host_matches(url: str, *domains: str) -> bool:
+    """Return True if the URL's host equals or is a sub-domain of any *domains*.
+
+    Parses the URL and matches against the host so we never treat a hostile
+    URL like ``https://pixeldrain.com.evil.com/`` or
+    ``https://evil.com/?x=pixeldrain.com`` as belonging to the real provider
+    (a plain substring check would). Matching is case-insensitive and ignores
+    any ``user:pass@`` / ``:port`` parts.
+    """
+    from urllib.parse import urlparse
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    return any(host == d or host.endswith("." + d) for d in domains)
+
+
 def _extract_download_links(root) -> dict:
     """Extract supported download links from a BeautifulSoup node.
 
@@ -709,11 +726,10 @@ def _extract_download_links(root) -> dict:
         href = a.get("href", "") or ""
         if not href:
             continue
-        low = href.lower()
-        if "pixeldrain.com" in low and not links["pixeldrain"]:
+        if _host_matches(href, "pixeldrain.com") and not links["pixeldrain"]:
             links["pixeldrain"] = href
             logger.info(f"Found PIXELDRAIN link (by href): {href}")
-        elif ("mega.nz" in low or "mega.co.nz" in low) and not links["mega"]:
+        elif _host_matches(href, "mega.nz", "mega.co.nz") and not links["mega"]:
             links["mega"] = href
             logger.info(f"Found MEGA link (by href): {href}")
 

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -79,6 +79,16 @@ DOWNLOAD_LINKS_SPAN_HTML = """\
 </body></html>
 """
 
+# Tier-4 href backstop: provider name only appears as the URL host, plus a
+# look-alike host that must NOT be matched as a real provider.
+DOWNLOAD_LINKS_HREF_HOST_HTML = """\
+<html><body>
+<a rel="nofollow" href="https://pixeldrain.com.evil.com/u/spoof">Click</a>
+<a rel="nofollow" href="https://evil.com/?ref=mega.nz">Click</a>
+<a rel="nofollow" href="https://cdn.pixeldrain.com/api/file/real123">Download</a>
+</body></html>
+"""
+
 # Older getcomics layout: aio-red "Download Now" + aio-blue "Mirror Download"
 # (Supergirl Vol 2 style).
 DOWNLOAD_LINKS_MIRROR_HTML = """\
@@ -299,6 +309,18 @@ class TestGetDownloadLinks:
         # and the aio-blue "Mirror Download" /dls/ link is recognised.
         assert links["download_now"] == "https://light.getcomics.info/Comics/Supergirl.zip"
         assert links["pixeldrain"] is None
+        assert links["mega"] is None
+
+    @patch("models.getcomics.scraper")
+    def test_href_backstop_matches_real_host_rejects_lookalikes(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_LINKS_HREF_HOST_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/dc/supergirl")
+
+        # A real cdn.pixeldrain.com sub-domain link is matched...
+        assert links["pixeldrain"] == "https://cdn.pixeldrain.com/api/file/real123"
+        # ...but pixeldrain.com.evil.com and ?ref=mega.nz are NOT treated as providers.
         assert links["mega"] is None
 
     @patch("models.getcomics.scraper")

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -66,6 +66,28 @@ DOWNLOAD_NO_LINKS_HTML = """\
 </body></html>
 """
 
+# Older getcomics layout: provider names live in inner <span> text of
+# class-less, title-less <a> tags wrapped in <strong> (Supergirl Vol 4 style).
+DOWNLOAD_LINKS_SPAN_HTML = """\
+<html><body>
+<strong>
+<a rel="nofollow" href="https://getcomics.org/dls/terabox123"><span style="color: #008000;">TERABOX</span></a> |
+<a rel="nofollow" href="https://getcomics.org/dls/mega456"><span style="color: #800077;">Mega</span></a> |
+<a rel="nofollow" href="https://getcomics.org/dls/mediafire789"><span style="color: #808080;">Mediafire</span></a> |
+<a rel="nofollow" href="https://getcomics.org/dls/pixeldrain000"><span style="color: #ff9900;">PIXELDRAIN</span></a>
+</strong>
+</body></html>
+"""
+
+# Older getcomics layout: aio-red "Download Now" + aio-blue "Mirror Download"
+# (Supergirl Vol 2 style).
+DOWNLOAD_LINKS_MIRROR_HTML = """\
+<html><body>
+<a rel="nofollow" href="https://light.getcomics.info/Comics/Supergirl.zip" class="aio-red" title="Download Now"><i></i>Download Now</a>
+<a rel="nofollow" href="https://getcomics.org/dls/mirror999" class="aio-blue" title="Mirror Download"><i></i>Mirror Download</a>
+</body></html>
+"""
+
 HOMEPAGE_WITH_WEEKLY_PACK_HTML = """\
 <html><body>
 <div class="cover-blog-posts">
@@ -254,6 +276,32 @@ class TestGetDownloadLinks:
         assert links["mega"] == "https://mega.nz/file/textmega"
 
     @patch("models.getcomics.scraper")
+    def test_extracts_links_from_span_label_format(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_LINKS_SPAN_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/dc/supergirl-vol-4")
+
+        # Supported providers captured from inner <span> labels...
+        assert links["pixeldrain"] == "https://getcomics.org/dls/pixeldrain000"
+        assert links["mega"] == "https://getcomics.org/dls/mega456"
+        # ...while unsupported Terabox/Mediafire are ignored.
+        assert links["download_now"] is None
+
+    @patch("models.getcomics.scraper")
+    def test_extracts_mirror_download_aio_blue(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_LINKS_MIRROR_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/dc/supergirl-vol-2")
+
+        # aio-red "Download Now" wins the download_now slot (title tier first),
+        # and the aio-blue "Mirror Download" /dls/ link is recognised.
+        assert links["download_now"] == "https://light.getcomics.info/Comics/Supergirl.zip"
+        assert links["pixeldrain"] is None
+        assert links["mega"] is None
+
+    @patch("models.getcomics.scraper")
     def test_returns_none_values_when_no_links(self, mock_scraper):
         mock_scraper.get.return_value = _mock_response(DOWNLOAD_NO_LINKS_HTML)
 
@@ -270,6 +318,65 @@ class TestGetDownloadLinks:
         links = get_download_links("https://getcomics.org/fail")
 
         assert links == {"pixeldrain": None, "download_now": None, "mega": None}
+
+
+# ===================================================================
+# _extract_content_li_entries (variant-3 <li> scraping)
+# ===================================================================
+
+# Real-world shape: an advertising link lives in the site header nav (a <ul>
+# of <li> outside any <article>), while the actual comic entries are <li> items
+# inside the post content. Scraping must ignore the nav ad.
+LI_PAGE_WITH_NAV_AD_HTML = """\
+<html><body>
+<header>
+  <nav><ul class="menu">
+    <li><a href="https://ads.example.com/aigf">\U0001f497AI Girlfriend\U0001f497</a></li>
+    <li><a href="https://getcomics.org/dc/">DC</a></li>
+  </ul></nav>
+</header>
+<article class="post-body">
+  <div class="entry-content">
+    <ul>
+      <li>Supergirl Vol. 4 #1 : <strong><a href="https://pixeldrain.com/u/abc123">Main Server</a></strong></li>
+      <li>Supergirl Vol. 4 #2 : <strong><a href="https://pixeldrain.com/u/def456">Main Server</a></strong></li>
+    </ul>
+  </div>
+</article>
+<footer><ul><li><a href="https://ads.example.com/promo">Buy Premium Now Today</a></li></ul></footer>
+</body></html>
+"""
+
+
+class TestExtractContentLiEntries:
+
+    def test_ignores_nav_and_footer_li_keeps_comic_entries(self):
+        from bs4 import BeautifulSoup
+        from models.getcomics import _extract_content_li_entries
+
+        soup = BeautifulSoup(LI_PAGE_WITH_NAV_AD_HTML, "html.parser")
+        entries = _extract_content_li_entries(soup)
+
+        titles = [t for t, _ in entries]
+        # The header-nav advertising link and the footer promo are excluded...
+        assert not any("AI Girlfriend" in t for t in titles)
+        assert not any("Buy Premium" in t for t in titles)
+        # ...while the real in-content comic entries are captured.
+        assert titles == ["Supergirl Vol. 4 #1", "Supergirl Vol. 4 #2"]
+        assert entries[0][1] == "https://pixeldrain.com/u/abc123"
+
+    def test_returns_empty_when_no_content_container(self):
+        from bs4 import BeautifulSoup
+        from models.getcomics import _extract_content_li_entries
+
+        # <li> items exist only in nav — no article/post-content/entry-content.
+        soup = BeautifulSoup(
+            "<html><body><nav><ul>"
+            "<li><a href='https://ads.example.com'>\U0001f497AI Girlfriend\U0001f497</a></li>"
+            "</ul></nav></body></html>",
+            "html.parser",
+        )
+        assert _extract_content_li_entries(soup) == []
 
 
 # ===================================================================


### PR DESCRIPTION
## 📝 Description
Introduce `_extract_download_links` to centralize and robustly parse download links (pixeldrain, mega, download_now) across multiple getcomics layouts: title attributes, aio-red/aio-blue button text, inner <span> labels, and href-domain backstops. Replace duplicated parsing logic in get_download_links and internal _extract_links with calls to the new helper. Add _extract_content_li_entries to safely extract <li>-based comic entries scoped to article/post-content/entry-content containers, avoiding nav/footer menu items. Add tests for older span-label link format, aio-blue mirror/download-now behavior, and <li> extraction that ensures nav ads are ignored and content items are captured.

Closes #277 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass