### PR TITLE
Preserve Series Casing and Allow Case-only Renames

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -1147,7 +1147,9 @@ def rename_comic_from_metadata(file_path, metadata):
         series = metadata.get("Series", "")
         series = series.replace(":", " -")
         series = re.sub(r'[<>"/\\|?*]', "", series)
-        series = smart_title_case(series)
+        # Metadata Series casing is authoritative (provider/ComicInfo.xml) — preserve
+        # it verbatim. Don't title-case here (that flattens acronyms like "AVX" -> "Avx");
+        # smart_title_case is only for series names parsed out of messy filenames.
 
         # {volume_year} = series/volume start year (ComicInfo Volume field:
         # ComicVine start_year / Metron year_began). GCD stores a volume *number*
@@ -1185,11 +1187,19 @@ def rename_comic_from_metadata(file_path, metadata):
             return file_path, False
 
         new_path = os.path.join(os.path.dirname(file_path), new_name)
+        # On case-insensitive filesystems a case-only rename (e.g. "Avx" -> "AVX")
+        # makes new_path resolve to the source file itself, so os.path.exists reports
+        # a false collision. Permit it — os.rename applies the case change in place.
         if os.path.exists(new_path):
-            app_logger.warning(
-                f"Target file already exists, skipping rename: {new_path}"
-            )
-            return file_path, False
+            try:
+                same_file = os.path.samefile(file_path, new_path)
+            except OSError:
+                same_file = False
+            if not same_file:
+                app_logger.warning(
+                    f"Target file already exists, skipping rename: {new_path}"
+                )
+                return file_path, False
 
         os.rename(file_path, new_path)
         app_logger.info(f"Auto-renamed: {old_name} -> {new_name}")

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -249,6 +249,16 @@ def _sanitize_series_name(name: str) -> str:
     return name
 
 
+def _same_file(a: str, b: str) -> bool:
+    """True if both paths resolve to the same file. On case-insensitive
+    filesystems this catches a case-only rename (e.g. "Avx" -> "AVX") where the
+    target path points back at the source file rather than a real collision."""
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        return False
+
+
 def _read_issue_meta(file_path: str) -> Dict[str, str]:
     """Read issue-level tokens from a file's embedded ComicInfo.xml.
 
@@ -347,7 +357,7 @@ def _plan_file(
 
     directory = os.path.dirname(file_path)
     candidate = os.path.join(directory, new_name)
-    if candidate != file_path and (candidate in used_targets or os.path.exists(candidate)):
+    if not _same_file(candidate, file_path) and (candidate in used_targets or os.path.exists(candidate)):
         base, ext_final = os.path.splitext(new_name)
         suffix = 2
         while True:

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -705,7 +705,35 @@ class TestRenameComicFromMetadata:
         result_path, was_renamed = rename_comic_from_metadata(str(f), {'Series': 'Batman: The Dark Knight', 'Number': '5', 'Year': 2020})
         assert was_renamed is True
         assert ':' not in os.path.basename(result_path)
-        assert 'Batman - the Dark Knight 005' in os.path.basename(result_path)
+        # Metadata casing is authoritative — "The" stays capitalized, not title-cased down.
+        assert 'Batman - The Dark Knight 005' in os.path.basename(result_path)
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({volume_year})'))
+    def test_preserves_metadata_series_casing(self, mock_config, tmp_path):
+        # Regression: metadata Series casing (acronyms) must be preserved verbatim.
+        # "AVX Vs" must NOT be flattened to "Avx Vs".
+        f = tmp_path / "old.cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'AVX Vs', 'Number': '1', 'Year': 2012, 'Volume': 2012})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "AVX Vs 001 (2012).cbz"
+
+    @patch('cbz_ops.rename.load_custom_rename_config',
+           return_value=(True, '{series_name} {issue_number} ({issue_year})'))
+    def test_case_only_rename_not_blocked_as_collision(self, mock_config, tmp_path):
+        # A case-only re-case ("Avx" -> "AVX") must not be skipped as a false
+        # collision: on case-insensitive filesystems the target resolves back to
+        # the source file itself.
+        f = tmp_path / "Avx Vs 006 (2012).cbz"
+        f.write_bytes(b"fake")
+        from cbz_ops.rename import rename_comic_from_metadata
+        result_path, was_renamed = rename_comic_from_metadata(
+            str(f), {'Series': 'AVX Vs', 'Number': '6', 'Year': 2012})
+        assert was_renamed is True
+        assert os.path.basename(result_path) == "AVX Vs 006 (2012).cbz"
 
     @patch('cbz_ops.rename.load_custom_rename_config', return_value=(True, '{series_name} {issue_number}'))
     def test_skips_when_target_exists(self, mock_config, tmp_path):


### PR DESCRIPTION
## 📝 Description
Do not force title-casing on Series metadata — preserve the provider/ComicInfo.xml casing verbatim (prevents acronyms like "AVX" becoming "Avx").

Fix false-positive collisions on case-insensitive filesystems by allowing case-only renames: use os.path.samefile (wrapped in a _same_file helper with OSError fallback) to detect when the candidate path resolves to the same file and avoid skipping the rename. Adjusted _plan_file to use this helper and updated rename_comic_from_metadata to perform the same-file check before treating a target as an existing collision.

Added/updated unit tests to cover preserving metadata series casing and ensuring case-only recasing is not blocked as a collision.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass