### PR TITLE
Add Links for Writer and Penciller fields in XML Preview

### DIFF
--- a/static/js/clu-cbz-info.js
+++ b/static/js/clu-cbz-info.js
@@ -77,8 +77,8 @@
     {
       title: 'Creative Team',
       fields: [
-        { key: 'Writer', label: 'Writer' },
-        { key: 'Penciller', label: 'Penciller' },
+        { key: 'Writer', label: 'Writer', browse: 'writer' },
+        { key: 'Penciller', label: 'Penciller', browse: 'penciller' },
         { key: 'Inker', label: 'Inker' },
         { key: 'Colorist', label: 'Colorist' },
         { key: 'Letterer', label: 'Letterer' },
@@ -369,6 +369,16 @@
             else if (value !== 'Yes' && value !== 'No') value = 'Unknown';
           }
           if (field.key === 'CommunityRating' && value > 0) value = value + '/5';
+          if (field.browse) {
+            value = String(value).split(',')
+              .map(function (n) { return n.trim(); })
+              .filter(function (n) { return n; })
+              .map(function (n) {
+                return '<a href="/browse/' + field.browse + '/' +
+                  encodeURIComponent(n) + '">' + CLU.escapeHtml(n) + '</a>';
+              })
+              .join(', ');
+          }
           html += '<li><strong>' + field.label + ':</strong> ' + value + '</li>';
         }
       });


### PR DESCRIPTION
## 📝 Description
Add a `browse` property to the Writer and Penciller field definitions and render any field with a `browse` key as links to `/browse/<type>/<name>`. Comma-separated names are split, trimmed, filtered, URL-encoded for the href, and HTML-escaped for display, then joined with commas. This makes creative-team names clickable to their browse pages.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass