### PR TITLE
Strip issue/title tokens for matching and Auto-Move

### DIFF
--- a/app.py
+++ b/app.py
@@ -574,57 +574,6 @@ def scheduled_series_sync():
         app_logger.error(f"Scheduled series sync failed: {e}")
 
 
-def get_series_name_from_files(mapped_path, db_series_name):
-    """
-    Extract actual series name used in existing files.
-    Falls back to database series name if no files exist.
-
-    This helps match files when the database has "The Ultimates" but
-    files are named "Ultimates 001.cbz".
-    """
-    if not mapped_path or not os.path.exists(mapped_path):
-        app_logger.debug(
-            f"get_series_name_from_files: path doesn't exist: {mapped_path}"
-        )
-        return db_series_name
-
-    comic_extensions = (".cbz", ".cbr", ".zip", ".rar")
-    try:
-        files = [
-            f for f in os.listdir(mapped_path) if f.lower().endswith(comic_extensions)
-        ]
-    except Exception:
-        return db_series_name
-
-    if not files:
-        app_logger.debug(
-            f"get_series_name_from_files: no files in {mapped_path}, using DB name: {db_series_name}"
-        )
-        return db_series_name
-
-    # Try to extract series name from first file
-    # Pattern: "Series Name 001 (2024).cbz" -> "Series Name"
-    first_file = files[0]
-    # Remove extension
-    name = os.path.splitext(first_file)[0]
-    # Remove all parenthetical groups: "(2024)", "(1)", "(digital)", etc.
-    name = re.sub(r"\s*\([^)]*\)", "", name)
-    # Remove issue number at end, including "001 of 5" and "#001" forms.
-    # Renamed files can use a "NNN of M" count (see cbz_ops/rename.py); without
-    # the "of M" branch only " M" is stripped, leaving "Series 001 of" as the name.
-    name = re.sub(r"\s+#?\d+(?:\s+of\s+\d+)?\s*$", "", name, flags=re.IGNORECASE)
-
-    if name:
-        extracted = name.strip()
-        if extracted != db_series_name:
-            app_logger.info(
-                f"get_series_name_from_files: extracted '{extracted}' from '{first_file}' (DB: '{db_series_name}')"
-            )
-        return extracted
-
-    return db_series_name
-
-
 def process_incoming_wanted_issues():
     """
     Scan TARGET folder for wanted issues and move to series folders.
@@ -2397,6 +2346,7 @@ from helpers.collection import (
     strip_year_token,
     strip_title_token,
     build_series_match_names,
+    get_series_name_from_files,
     extract_comicinfo,
     match_issues_to_collection,
 )

--- a/app.py
+++ b/app.py
@@ -609,8 +609,10 @@ def get_series_name_from_files(mapped_path, db_series_name):
     name = os.path.splitext(first_file)[0]
     # Remove all parenthetical groups: "(2024)", "(1)", "(digital)", etc.
     name = re.sub(r"\s*\([^)]*\)", "", name)
-    # Remove issue number at end: " 001" or " 1"
-    name = re.sub(r"\s+\d+\s*$", "", name)
+    # Remove issue number at end, including "001 of 5" and "#001" forms.
+    # Renamed files can use a "NNN of M" count (see cbz_ops/rename.py); without
+    # the "of M" branch only " M" is stripped, leaving "Series 001 of" as the name.
+    name = re.sub(r"\s+#?\d+(?:\s+of\s+\d+)?\s*$", "", name, flags=re.IGNORECASE)
 
     if name:
         extracted = name.strip()
@@ -739,7 +741,8 @@ def process_incoming_wanted_issues():
     # Strips any year token variant (volume/cover/issue/store/legacy) so the
     # year is not required for matching.
     match_pattern = strip_year_token(pattern)
-    app_logger.debug(f"Using match pattern (no year): '{match_pattern}'")
+    match_pattern = strip_title_token(match_pattern)
+    app_logger.debug(f"Using match pattern (no year/title): '{match_pattern}'")
 
     # Scan TARGET for comic files (including subdirectories)
     comic_extensions = (".cbz", ".cbr", ".zip", ".rar")
@@ -2392,6 +2395,7 @@ def refresh_wanted_cache_background():
 from helpers.collection import (
     generate_filename_pattern,
     strip_year_token,
+    strip_title_token,
     build_series_match_names,
     extract_comicinfo,
     match_issues_to_collection,

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -76,6 +76,57 @@ def build_series_match_names(series_name, aliases):
     return names
 
 
+def get_series_name_from_files(mapped_path, db_series_name):
+    """
+    Extract actual series name used in existing files.
+    Falls back to database series name if no files exist.
+
+    This helps match files when the database has "The Ultimates" but
+    files are named "Ultimates 001.cbz".
+    """
+    if not mapped_path or not os.path.exists(mapped_path):
+        app_logger.debug(
+            f"get_series_name_from_files: path doesn't exist: {mapped_path}"
+        )
+        return db_series_name
+
+    comic_extensions = (".cbz", ".cbr", ".zip", ".rar")
+    try:
+        files = [
+            f for f in os.listdir(mapped_path) if f.lower().endswith(comic_extensions)
+        ]
+    except Exception:
+        return db_series_name
+
+    if not files:
+        app_logger.debug(
+            f"get_series_name_from_files: no files in {mapped_path}, using DB name: {db_series_name}"
+        )
+        return db_series_name
+
+    # Try to extract series name from first file
+    # Pattern: "Series Name 001 (2024).cbz" -> "Series Name"
+    first_file = files[0]
+    # Remove extension
+    name = os.path.splitext(first_file)[0]
+    # Remove all parenthetical groups: "(2024)", "(1)", "(digital)", etc.
+    name = re.sub(r"\s*\([^)]*\)", "", name)
+    # Remove issue number at end, including "001 of 5" and "#001" forms.
+    # Renamed files can use a "NNN of M" count (see cbz_ops/rename.py); without
+    # the "of M" branch only " M" is stripped, leaving "Series 001 of" as the name.
+    name = re.sub(r"\s+#?\d+(?:\s+of\s+\d+)?\s*$", "", name, flags=re.IGNORECASE)
+
+    if name:
+        extracted = name.strip()
+        if extracted != db_series_name:
+            app_logger.info(
+                f"get_series_name_from_files: extracted '{extracted}' from '{first_file}' (DB: '{db_series_name}')"
+            )
+        return extracted
+
+    return db_series_name
+
+
 def generate_filename_pattern(custom_pattern, series_name, issue_number):
     """
     Convert CUSTOM_RENAME_PATTERN to a precise regex for matching a specific issue.

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -26,6 +26,26 @@ def strip_year_token(pattern):
     return pattern.strip()
 
 
+_TITLE_TOKEN = r"\{issue_title\}"
+
+
+def strip_title_token(pattern):
+    """Remove the {issue_title} token (and its surrounding separators/brackets)
+    from a rename pattern for title-agnostic matching.
+
+    A file's title can differ between sources or be absent (the renamer drops the
+    " - " separator for untitled issues), so wanted-issue matching must not
+    require it.
+    """
+    if not pattern:
+        return pattern
+    # " ({issue_title})" / " [{issue_title}]" -> ""
+    pattern = re.sub(r"\s*[\(\[]\s*" + _TITLE_TOKEN + r"\s*[\)\]]", "", pattern)
+    # " - {issue_title}" / " : {issue_title}" / bare " {issue_title}" -> ""
+    pattern = re.sub(r"\s*[-:_]*\s*" + _TITLE_TOKEN, "", pattern)
+    return pattern.strip()
+
+
 def build_series_match_names(series_name, aliases):
     """Ordered, de-duplicated list of names to match a series against.
 

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -11,6 +11,7 @@ import pytest
 from helpers.collection import (
     generate_filename_pattern,
     strip_year_token,
+    strip_title_token,
     build_series_match_names,
 )
 
@@ -153,6 +154,55 @@ class TestStripYearToken:
 
     def test_empty(self):
         assert strip_year_token("") == ""
+
+
+# ---- strip_title_token (title-agnostic matching path) -------------------
+
+class TestStripTitleToken:
+
+    def test_strips_parenthesized_title(self):
+        out = strip_title_token("{series_name} {issue_number} ({issue_title})")
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_bracketed_title(self):
+        out = strip_title_token("{series_name} {issue_number} [{issue_title}]")
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_dash_separated_title(self):
+        out = strip_title_token("{series_name} {issue_number} - {issue_title}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_bare_title(self):
+        out = strip_title_token("{series_name} {issue_number} {issue_title}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_no_title_token_unchanged(self):
+        out = strip_title_token("{series_name} {issue_number}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_empty(self):
+        assert strip_title_token("") == ""
+
+
+class TestTitleAgnosticMatching:
+    """A title in the rename pattern must not be required for matching: both
+    untitled and titled files for the same issue must match, and a wrong issue
+    is still rejected. Regression for 'Hidden Springs 001.cbz' -> no match."""
+
+    def _regex(self):
+        match_pattern = strip_title_token(
+            strip_year_token("{series_name} {issue_number} - {issue_title} ({volume_year})")
+        )
+        return generate_filename_pattern(match_pattern, "Hidden Springs", "1")
+
+    def test_untitled_file_matches(self):
+        assert self._regex().match("Hidden Springs 001.cbz")
+
+    def test_titled_file_matches(self):
+        assert self._regex().match("Hidden Springs 001 - The Dawn.cbz")
+
+    def test_wrong_issue_rejected(self):
+        assert not self._regex().match("Hidden Springs 002.cbz")
 
 
 # ---- search-alias matching (Thor -> Mortal Thor) ------------------------

--- a/tests/unit/test_series_name_from_files.py
+++ b/tests/unit/test_series_name_from_files.py
@@ -1,0 +1,47 @@
+"""Tests for app.get_series_name_from_files.
+
+Regression coverage for the wanted-issue matching bug: a series stored with
+"NNN of M" filenames (e.g. 'Is Ted Ok 001 of 5.cbz') had only the trailing
+" M" stripped, leaving 'Is Ted Ok 001 of' as the derived series name — which
+was then baked into the match regex as a literal and never matched the wanted
+file. See app.get_series_name_from_files.
+
+The ``app`` module pulls in optional runtime deps (e.g. rarfile) that aren't
+installed in every dev environment; skip cleanly when it can't be imported.
+"""
+import pytest
+
+app = pytest.importorskip("app", reason="app requires optional runtime deps")
+
+
+def _make_comic(dir_path, filename):
+    f = dir_path / filename
+    f.write_bytes(b"PK\x03\x04")  # minimal zip-ish header; contents are irrelevant
+    return f
+
+
+def test_strips_issue_of_total_count(tmp_path):
+    _make_comic(tmp_path, "Is Ted Ok 001 of 5.cbz")
+    assert app.get_series_name_from_files(str(tmp_path), "Is Ted OK?") == "Is Ted Ok"
+
+
+def test_plain_issue_with_year(tmp_path):
+    _make_comic(tmp_path, "Hidden Springs 001 (2026).cbz")
+    assert app.get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
+
+
+def test_preserves_of_within_series_name(tmp_path):
+    _make_comic(tmp_path, "Crisis of Infinite Earths 001.cbz")
+    assert (
+        app.get_series_name_from_files(str(tmp_path), "Crisis of Infinite Earths")
+        == "Crisis of Infinite Earths"
+    )
+
+
+def test_empty_folder_falls_back_to_db_name(tmp_path):
+    assert app.get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
+
+
+def test_missing_path_falls_back_to_db_name(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    assert app.get_series_name_from_files(str(missing), "Hidden Springs") == "Hidden Springs"

--- a/tests/unit/test_series_name_from_files.py
+++ b/tests/unit/test_series_name_from_files.py
@@ -1,17 +1,12 @@
-"""Tests for app.get_series_name_from_files.
+"""Tests for helpers.collection.get_series_name_from_files.
 
 Regression coverage for the wanted-issue matching bug: a series stored with
 "NNN of M" filenames (e.g. 'Is Ted Ok 001 of 5.cbz') had only the trailing
 " M" stripped, leaving 'Is Ted Ok 001 of' as the derived series name — which
 was then baked into the match regex as a literal and never matched the wanted
-file. See app.get_series_name_from_files.
-
-The ``app`` module pulls in optional runtime deps (e.g. rarfile) that aren't
-installed in every dev environment; skip cleanly when it can't be imported.
+file. See helpers/collection.py.
 """
-import pytest
-
-app = pytest.importorskip("app", reason="app requires optional runtime deps")
+from helpers.collection import get_series_name_from_files
 
 
 def _make_comic(dir_path, filename):
@@ -22,26 +17,26 @@ def _make_comic(dir_path, filename):
 
 def test_strips_issue_of_total_count(tmp_path):
     _make_comic(tmp_path, "Is Ted Ok 001 of 5.cbz")
-    assert app.get_series_name_from_files(str(tmp_path), "Is Ted OK?") == "Is Ted Ok"
+    assert get_series_name_from_files(str(tmp_path), "Is Ted OK?") == "Is Ted Ok"
 
 
 def test_plain_issue_with_year(tmp_path):
     _make_comic(tmp_path, "Hidden Springs 001 (2026).cbz")
-    assert app.get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
+    assert get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
 
 
 def test_preserves_of_within_series_name(tmp_path):
     _make_comic(tmp_path, "Crisis of Infinite Earths 001.cbz")
     assert (
-        app.get_series_name_from_files(str(tmp_path), "Crisis of Infinite Earths")
+        get_series_name_from_files(str(tmp_path), "Crisis of Infinite Earths")
         == "Crisis of Infinite Earths"
     )
 
 
 def test_empty_folder_falls_back_to_db_name(tmp_path):
-    assert app.get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
+    assert get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
 
 
 def test_missing_path_falls_back_to_db_name(tmp_path):
     missing = tmp_path / "does-not-exist"
-    assert app.get_series_name_from_files(str(missing), "Hidden Springs") == "Hidden Springs"
+    assert get_series_name_from_files(str(missing), "Hidden Springs") == "Hidden Springs"


### PR DESCRIPTION
## 📝 Description
Fix filename/series parsing to handle various issue-number forms and make matching title-agnostic. app.get_series_name_from_files now removes trailing forms like "#001" and "NNN of M" (case-insensitive) so renamed files don't leave a dangling "of" in derived series names. Introduce strip_title_token() in helpers/collection.py to remove the {issue_title} token and surrounding separators from rename patterns, and use it when building match patterns in process_incoming_wanted_issues. Add unit tests for strip_title_token and a new test suite covering series name extraction (including the regression for "NNN of M"). Also update imports to include strip_title_token.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass