### PR TITLE
Add status column and sorting support

### DIFF
--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -116,6 +116,7 @@
                     <tbody>
                         {% for series in series_list %}
                         <tr data-name="{{ series.name|lower }}"
+                            data-status="{{ (series.status or '')|lower }}"
                             data-publisher="{{ (series.publisher_name or '')|lower }}"
                             data-issues="{{ series.issue_count or 0 }}" data-synced="{{ series.last_synced_at or '' }}">
                             <td class="ps-4">
@@ -127,11 +128,13 @@
                                     {% endif %}
                                 </a>
                             </td>
-                            {% if series.status %}
                             <td>
+                                {% if series.status %}
                                 <small class="text-muted">{{ series.status }}</small>
+                                {% else %}
+                                <span class="text-muted">-</span>
+                                {% endif %}
                             </td>
-                            {% endif %}
                             <td>
                                 {% if series.publisher_name %}
                                 <span class="badge bg-secondary">{{ series.publisher_name }}</span>
@@ -398,6 +401,10 @@
                         case 'name':
                             aVal = a.dataset.name || '';
                             bVal = b.dataset.name || '';
+                            break;
+                        case 'status':
+                            aVal = a.dataset.status || '';
+                            bVal = b.dataset.status || '';
                             break;
                         case 'publisher':
                             aVal = a.dataset.publisher || '';


### PR DESCRIPTION
## 📝 Description
Always render a status cell for each series (showing the status or a dash when empty) and add a data-status attribute on the table row. Also extend the client-side sorting logic to read the status dataset so the table can be sorted by status.

Closes #375 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass