### PR TITLE
Add Publisher filter and sync Publishers from Metron

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -2,4 +2,4 @@
 Version information for Comic Library Utilities (CLU)
 """
 
-__version__ = "5.2"
+__version__ = "5.4"

--- a/routes/series.py
+++ b/routes/series.py
@@ -739,6 +739,8 @@ def api_search_series():
     if not query:
         return jsonify({"success": False, "error": "Search query required"}), 400
 
+    publisher_id = request.args.get("publisher_id", "").strip()
+
     try:
         api = metron.get_flask_api()
         if not api:
@@ -749,7 +751,14 @@ def api_search_series():
                 }
             ), 400
 
-        results = api.series_list({"name": query})
+        filters = {"name": query}
+        if publisher_id:
+            try:
+                filters["publisher_id"] = int(publisher_id)
+            except (TypeError, ValueError):
+                pass  # ignore non-numeric publisher filter
+
+        results = api.series_list(filters)
 
         series_list = []
         for series in results:
@@ -1715,6 +1724,46 @@ def api_search_publishers():
                 }
             ), 503
         app_logger.error(f"Error searching Metron publishers: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@series_bp.route("/api/publishers/sync", methods=["POST"])
+def api_sync_publishers():
+    """Fetch all publishers from Metron and store them in the database."""
+    from core.database import save_publisher
+
+    try:
+        api = metron.get_flask_api()
+        if not api:
+            return jsonify(
+                {
+                    "success": False,
+                    "error": "Metron credentials not configured or API unavailable",
+                }
+            ), 400
+
+        results = api.publishers_list({})
+
+        count = 0
+        for pub in results:
+            pub_id = pub.id if hasattr(pub, "id") else pub.get("id")
+            pub_name = pub.name if hasattr(pub, "name") else pub.get("name")
+            if pub_id is None or not pub_name:
+                continue
+            if save_publisher(pub_id, pub_name):
+                count += 1
+
+        return jsonify({"success": True, "count": count})
+    except Exception as e:
+        if metron.is_connection_error(e):
+            app_logger.warning(f"Metron unavailable during publisher sync: {e}")
+            return jsonify(
+                {
+                    "success": False,
+                    "error": "Metron is currently unavailable. Please try again later.",
+                }
+            ), 503
+        app_logger.error(f"Error syncing Metron publishers: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
 
 

--- a/templates/publishers.html
+++ b/templates/publishers.html
@@ -11,6 +11,9 @@
             <p class="text-muted lead mb-0">Manage publishers from Metron or add custom ones</p>
         </div>
         <div class="d-flex gap-2">
+            <button class="btn btn-outline-secondary" id="syncAllBtn" onclick="syncAllPublishers()">
+                <i class="bi bi-arrow-repeat me-1"></i>Sync All from Metron
+            </button>
             <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#searchMetronModal">
                 <i class="bi bi-search me-1"></i>Search Metron
             </button>
@@ -345,6 +348,29 @@
             if (e.key === 'Enter') searchMetron();
         });
     });
+
+    async function syncAllPublishers() {
+        const btn = document.getElementById('syncAllBtn');
+        const original = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Syncing...';
+
+        try {
+            const response = await fetch('/api/publishers/sync', { method: 'POST' });
+            const data = await response.json();
+            if (!data.success) {
+                alert('Error: ' + data.error);
+                btn.disabled = false;
+                btn.innerHTML = original;
+                return;
+            }
+            location.reload();
+        } catch (error) {
+            alert('Error: ' + error.message);
+            btn.disabled = false;
+            btn.innerHTML = original;
+        }
+    }
 
     async function searchMetron() {
         const query = document.getElementById('metronSearchInput').value.trim();

--- a/templates/series_search.html
+++ b/templates/series_search.html
@@ -30,8 +30,8 @@
     <!-- Search Card -->
     <div class="card border-0 shadow-sm mb-4">
         <div class="card-body">
-            <div class="row align-items-center">
-                <div class="col-md-8">
+            <div class="row align-items-center g-3">
+                <div class="col-md-6">
                     <div class="input-group">
                         <span class="input-group-text bg-white"><i class="bi bi-search"></i></span>
                         <input type="text" class="form-control" id="searchInput" placeholder="Enter series name..."
@@ -41,7 +41,12 @@
                         </button>
                     </div>
                 </div>
-                <div class="col-md-4 text-md-end mt-3 mt-md-0">
+                <div class="col-md-3">
+                    <select class="form-select" id="publisherFilter" title="Filter by publisher">
+                        <option value="">All Publishers</option>
+                    </select>
+                </div>
+                <div class="col-md-3 text-md-end">
                     <span class="text-muted" id="resultCount"></span>
                 </div>
             </div>
@@ -126,10 +131,55 @@
         let allResults = [];
         let currentSort = { column: null, ascending: true };
 
+        // Populate the publisher filter dropdown from the local DB,
+        // auto-syncing from Metron the first time when the table is empty.
+        async function loadPublishers() {
+            const select = document.getElementById('publisherFilter');
+            if (!select) return;
+
+            const fillOptions = (publishers) => {
+                const selected = select.value;
+                select.innerHTML = '<option value="">All Publishers</option>';
+                publishers.forEach(pub => {
+                    const opt = document.createElement('option');
+                    opt.value = pub.id;
+                    opt.textContent = pub.name;
+                    select.appendChild(opt);
+                });
+                select.value = selected;
+            };
+
+            try {
+                let resp = await fetch('/api/publishers');
+                let data = await resp.json();
+                let publishers = (data.success && data.publishers) ? data.publishers : [];
+
+                // Auto-sync from Metron the first time (empty table)
+                if (publishers.length === 0) {
+                    select.disabled = true;
+                    select.innerHTML = '<option value="">Loading publishers…</option>';
+                    await fetch('/api/publishers/sync', { method: 'POST' });
+                    resp = await fetch('/api/publishers');
+                    data = await resp.json();
+                    publishers = (data.success && data.publishers) ? data.publishers : [];
+                    select.disabled = false;
+                }
+
+                fillOptions(publishers);
+            } catch (e) {
+                select.disabled = false;
+                fillOptions([]);
+            }
+        }
+
+        loadPublishers();
+
         // Search function
         window.doSeriesSearch = async function () {
             const query = document.getElementById('searchInput').value.trim();
             if (!query) return;
+
+            const publisherId = document.getElementById('publisherFilter').value;
 
             // Show loading, hide other states
             document.getElementById('loadingState').style.display = 'block';
@@ -140,7 +190,11 @@
             document.getElementById('resultCount').textContent = '';
 
             try {
-                const response = await fetch(`/api/series/search?q=${encodeURIComponent(query)}`);
+                let searchUrl = `/api/series/search?q=${encodeURIComponent(query)}`;
+                if (publisherId) {
+                    searchUrl += `&publisher_id=${encodeURIComponent(publisherId)}`;
+                }
+                const response = await fetch(searchUrl);
                 const data = await response.json();
 
                 document.getElementById('loadingState').style.display = 'none';

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -47,6 +47,44 @@ class TestSeriesSearch:
         assert data["success"] is True
         assert data["count"] == 1
 
+    @patch("routes.series.metron")
+    def test_search_with_publisher_id(self, mock_metron, client, app):
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+
+        mock_api = MagicMock()
+        mock_api.series_list.return_value = []
+        mock_metron.get_flask_api.return_value = mock_api
+        mock_metron.is_connection_error.return_value = False
+
+        mock_app = MagicMock()
+        mock_app.generate_series_slug.return_value = "x"
+        with patch.dict("sys.modules", {"app": mock_app}):
+            resp = client.get("/api/series/search?q=spider-man&publisher_id=20")
+
+        assert resp.status_code == 200
+        mock_api.series_list.assert_called_once_with(
+            {"name": "spider-man", "publisher_id": 20}
+        )
+
+    @patch("routes.series.metron")
+    def test_search_ignores_non_numeric_publisher_id(self, mock_metron, client, app):
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+
+        mock_api = MagicMock()
+        mock_api.series_list.return_value = []
+        mock_metron.get_flask_api.return_value = mock_api
+        mock_metron.is_connection_error.return_value = False
+
+        mock_app = MagicMock()
+        mock_app.generate_series_slug.return_value = "x"
+        with patch.dict("sys.modules", {"app": mock_app}):
+            resp = client.get("/api/series/search?q=batman&publisher_id=abc")
+
+        assert resp.status_code == 200
+        mock_api.series_list.assert_called_once_with({"name": "batman"})
+
 
 class TestMapSeries:
 
@@ -324,6 +362,38 @@ class TestPublishersApi:
     def test_delete_negative_publisher(self, mock_del, client):
         resp = client.delete("/api/publishers/-1")
         assert resp.status_code == 200
+
+    @patch("routes.series.metron")
+    @patch("core.database.save_publisher", return_value=True)
+    def test_sync_publishers_from_metron(self, mock_save, mock_metron, client, app):
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+
+        pub1 = MagicMock()
+        pub1.id = 1
+        pub1.name = "DC Comics"
+        pub2 = MagicMock()
+        pub2.id = 2
+        pub2.name = "Marvel"
+
+        mock_api = MagicMock()
+        mock_api.publishers_list.return_value = [pub1, pub2]
+        mock_metron.get_flask_api.return_value = mock_api
+        mock_metron.is_connection_error.return_value = False
+
+        resp = client.post("/api/publishers/sync")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["count"] == 2
+        assert mock_save.call_count == 2
+
+    @patch("routes.series.metron")
+    def test_sync_publishers_no_metron(self, mock_metron, client):
+        mock_metron.get_flask_api.return_value = None
+        resp = client.post("/api/publishers/sync")
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
 
 
 class TestSeriesSubscription:


### PR DESCRIPTION
## 📝 Description
Bump version to 5.4 and add publisher filtering and sync support. The series search API now accepts an optional publisher_id query parameter (numeric values applied, non-numeric ignored). Added POST /api/publishers/sync to fetch publishers from Metron and save them to the local DB with error handling for Metron connection issues. Updated publishers and series search templates to add a "Sync All from Metron" button, a publisher dropdown filter (auto-syncs if local list is empty), and client-side logic to include publisher_id in searches. Added tests covering publisher filtering in series search and publisher sync behavior.

Closes #370 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1381" height="761" alt="image" src="https://github.com/user-attachments/assets/ebf58dc9-13e5-48d3-8005-7ef6a9bd489d" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass