### PR TITLE
Highlight Subscribed Series in Search Results

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -8092,6 +8092,27 @@ def get_all_mapped_series():
         return []
 
 
+def get_mapped_series_ids():
+    """Return a set of Metron series ids that have a mapped local folder (subscribed)."""
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return set()
+
+        c = conn.cursor()
+        c.execute(
+            "SELECT id FROM series WHERE mapped_path IS NOT NULL AND mapped_path != ''"
+        )
+        rows = c.fetchall()
+        conn.close()
+
+        return {row["id"] for row in rows}
+
+    except Exception as e:
+        app_logger.error(f"Failed to get mapped series ids: {e}")
+        return set()
+
+
 def normalize_series_name(name):
     """
     Normalize a series name for matching purposes.

--- a/routes/series.py
+++ b/routes/series.py
@@ -734,6 +734,7 @@ def series_view(slug):
 def api_search_series():
     """Search Metron API for series by name."""
     from app import generate_series_slug
+    from core.database import get_mapped_series_ids
 
     query = request.args.get("q", "").strip()
     if not query:
@@ -759,6 +760,10 @@ def api_search_series():
                 pass  # ignore non-numeric publisher filter
 
         results = api.series_list(filters)
+
+        # Series the user is subscribed to (have a mapped local folder) so the
+        # frontend can highlight already-tracked results.
+        mapped_ids = get_mapped_series_ids()
 
         series_list = []
         for series in results:
@@ -786,6 +791,7 @@ def api_search_series():
                     "issue_count": issue_count,
                     "status": status,
                     "slug": slug,
+                    "subscribed": series_id in mapped_ids,
                 }
             )
 

--- a/templates/series_search.html
+++ b/templates/series_search.html
@@ -237,6 +237,11 @@
                 row.dataset.year = series.year_began || '';
                 row.dataset.issues = series.issue_count || 0;
 
+                if (series.subscribed) {
+                    row.classList.add('table-success');
+                    row.dataset.subscribed = '1';
+                }
+
                 const slug = generateSeriesSlug(series.name, series.id, series.volume);
                 row.innerHTML = `
                 <td class="ps-4">
@@ -244,6 +249,7 @@
                         ${escapeHtml(series.name)}
                     </a>
                     ${series.volume ? `<span class="text-muted fw-normal ms-1">Vol. ${series.volume}</span>` : ''}
+                    ${series.subscribed ? `<span class="badge bg-success ms-2"><i class="bi bi-check-circle me-1"></i>Subscribed</span>` : ''}
                 </td>
                 <td class="text-center">
                     ${series.issue_count

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -46,6 +46,44 @@ class TestSeriesSearch:
         data = resp.get_json()
         assert data["success"] is True
         assert data["count"] == 1
+        # Not subscribed (no mapped folder) -> flagged False for row highlighting
+        assert data["series"][0]["subscribed"] is False
+
+    @patch("core.database.get_mapped_series_ids")
+    @patch("routes.series.metron")
+    def test_search_flags_subscribed_series(
+        self, mock_metron, mock_mapped_ids, client, app
+    ):
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+
+        mock_series = MagicMock()
+        mock_series.id = 100
+        mock_series.display_name = "Batman"
+        mock_series.name = "Batman"
+        mock_series.volume = 2020
+        mock_series.year_began = 2020
+        mock_series.issue_count = 50
+        mock_series.status = "Ongoing"
+        mock_series.publisher = MagicMock()
+        mock_series.publisher.name = "DC Comics"
+
+        mock_api = MagicMock()
+        mock_api.series_list.return_value = [mock_series]
+        mock_metron.get_flask_api.return_value = mock_api
+        mock_metron.is_connection_error.return_value = False
+
+        # Series id 100 has a mapped folder -> subscribed
+        mock_mapped_ids.return_value = {100}
+
+        mock_app = MagicMock()
+        mock_app.generate_series_slug.return_value = "batman-v2020-100"
+        with patch.dict("sys.modules", {"app": mock_app}):
+            resp = client.get("/api/series/search?q=batman")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["series"][0]["subscribed"] is True
 
     @patch("routes.series.metron")
     def test_search_with_publisher_id(self, mock_metron, client, app):


### PR DESCRIPTION
## 📝 Description
Add functionality to identify and visually distinguish subscribed series (those with a mapped local folder) in the series search results. Backend now queries mapped series IDs and includes a 'subscribed' flag in search responses. Frontend highlights subscribed series with a green badge and row highlighting for better UX.

Closes #307 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="1078" height="1102" alt="Screenshot 2026-06-30 213659" src="https://github.com/user-attachments/assets/c2a05ba9-2e7a-4682-8b67-95a58284b514" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass