### PR TITLE
Handle issue-less Manga Volume Renames

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -523,7 +523,7 @@ def load_custom_rename_config():
 _TOKEN_REGEX = {
     "series_name": r"(?P<series_name>.+?)",
     "issue_number": r"(?P<issue_number>\d{1,4}(?:\.\w+)?)",
-    "volume_number": r"(?P<volume_number>\d{1,4})",
+    "volume_number": r"(?P<volume_number>v?\d{1,4})",
     "volume_year": r"(?P<year>\d{4})",
     "issue_year": r"(?P<issue_year>\d{4})",
     "issue_month_m": r"(?P<issue_month_m>\d{2})",
@@ -1071,15 +1071,18 @@ def apply_custom_pattern(values, pattern):
     if not pattern:
         return ""
 
-    # Validate that we have the required fields
+    # Validate required fields, but only for tokens the pattern actually uses.
+    # A volume-only manga pattern like "{series_name} {volume_number} [{volume_year}]"
+    # legitimately carries no issue number, so requiring one would drop the pattern
+    # and fall back to the default (wrong-bracket) rename.
     series_name = values.get("series_name", "").strip()
     issue_number = values.get("issue_number", "").strip()
 
-    if not series_name:
+    if "{series_name}" in pattern and not series_name:
         app_logger.warning(f"Missing series_name in extracted values: {values}")
         return ""
 
-    if not issue_number:
+    if "{issue_number}" in pattern and not issue_number:
         app_logger.warning(f"Missing issue_number in extracted values: {values}")
         return ""
 
@@ -1428,6 +1431,17 @@ def get_renamed_filename(filename, file_path=None):
 
             # Extract comic values from the filename
             comic_values = extract_comic_values(filename)
+
+            # Manga volume names ("Series vNN (YYYY) ...") have no issue number, so
+            # extract_comic_values fills volume/year but leaves series empty. Recover
+            # the series as the text preceding the volume token; preserve the
+            # filename's casing (the default path does — don't smart_title_case and
+            # flatten manga titles).
+            if not comic_values.get("series_name") and comic_values.get("volume_number"):
+                vol = comic_values["volume_number"]  # e.g. "v03"
+                m = re.match(rf"^(.+?)\s+{re.escape(vol)}\b", filename, re.IGNORECASE)
+                if m:
+                    comic_values["series_name"] = m.group(1).replace("_", " ").strip()
 
             # Default issue_year to the year parsed from the filename;
             # ComicInfo.xml (read below) takes precedence when available.

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -320,10 +320,24 @@ def _plan_file(
 
     extracted = extract_comic_values(stem)
     raw_issue = (extracted.get("issue_number") or "").strip()
-    if not raw_issue:
+    # Manga volume files ("Series vNN (YYYY)") carry no issue number. Only skip when
+    # the pattern actually needs one; otherwise rename on volume/series alone.
+    pattern_needs_issue = "{issue_number}" in pattern
+    if not raw_issue and pattern_needs_issue:
         return {"old_path": file_path, "old_name": old_name, "status": "no_issue"}
 
-    issue = _pad_issue_number(raw_issue, width=3)
+    issue = _pad_issue_number(raw_issue, width=3) if raw_issue else ""
+
+    # series.json holds one series-level volume for the whole series, but a manga
+    # volume file's number ("v03") is per-file and lives only in the filename. When
+    # there's no issue number, take {volume_number} from the filename; otherwise the
+    # metadata volume stays authoritative.
+    if raw_issue:
+        volume_number = _format_volume(metadata.get("volume"))
+    else:
+        volume_number = (extracted.get("volume_number") or "").strip() or _format_volume(
+            metadata.get("volume")
+        )
 
     # Issue-level tokens ({issue_year}, {issue_title}) come from each file's
     # embedded ComicInfo.xml, not series.json. The series/volume year feeds
@@ -332,7 +346,7 @@ def _plan_file(
 
     values = {
         "series_name": _sanitize_series_name((metadata.get("name") or "").strip()),
-        "volume_number": _format_volume(metadata.get("volume")),
+        "volume_number": volume_number,
         # series.json "year" is the series/volume year -> feeds {volume_year}
         "volume_year": _format_year(metadata.get("year")),
         # "year" is the {volume_year} fallback only; the issue's own year (from

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -244,9 +244,21 @@ class TestApplyCustomPattern:
         from cbz_ops.rename import apply_custom_pattern
         assert apply_custom_pattern({"series_name": "", "issue_number": "001"}, "{series_name}") == ""
 
-    def test_missing_issue_returns_empty(self):
+    def test_missing_issue_returns_empty_when_pattern_needs_issue(self):
+        # A pattern that references {issue_number} still requires one.
         from cbz_ops.rename import apply_custom_pattern
-        assert apply_custom_pattern({"series_name": "X", "issue_number": ""}, "{series_name}") == ""
+        assert apply_custom_pattern(
+            {"series_name": "X", "issue_number": ""}, "{series_name} {issue_number}"
+        ) == ""
+
+    def test_issueless_pattern_allows_missing_issue(self):
+        # Volume-only manga patterns don't reference {issue_number}, so a missing
+        # issue number must not drop the pattern (regression: brackets -> parens).
+        from cbz_ops.rename import apply_custom_pattern
+        assert apply_custom_pattern(
+            {"series_name": "Frieren", "volume_number": "v03", "year": "2022"},
+            "{series_name} {volume_number} [{volume_year}]",
+        ) == "Frieren v03 [2022]"
 
     def test_sanitises_issue_title(self):
         from cbz_ops.rename import apply_custom_pattern
@@ -293,6 +305,54 @@ class TestApplyCustomPattern:
         assert apply_custom_pattern(
             values, "{series_name} - {issue_number} ({cover_month_M}, {issue_year})"
         ) == "X - 001 (2026)"
+
+
+# ===== reverse_parse_pattern (volume token with 'v' prefix) =====
+
+class TestReverseParseVolume:
+
+    @pytest.mark.parametrize("stem,expected_vol", [
+        ("Sandman v2 001 (1989)", "v2"),
+        ("Frieren v03 001 (2022)", "v03"),
+    ])
+    def test_volume_token_captures_v_prefix(self, stem, expected_vol):
+        from cbz_ops.rename import reverse_parse_pattern
+        parsed = reverse_parse_pattern(
+            stem, "{series_name} {volume_number} {issue_number} ({volume_year})"
+        )
+        assert parsed is not None
+        assert parsed["volume_number"] == expected_vol
+
+
+# ===== get_renamed_filename (manga volume custom rename) =====
+
+class TestGetRenamedFilenameManga:
+
+    def _enable(self, pattern):
+        return patch(
+            "core.database.get_user_preference",
+            side_effect=lambda key, default=None: {
+                "enable_custom_rename": True,
+                "custom_rename_pattern": pattern,
+                "rename_clean_spaces_enabled": False,
+                "rename_clean_specials_enabled": False,
+            }.get(key, default),
+        )
+
+    def test_manga_volume_uses_bracket_pattern(self):
+        from cbz_ops.rename import get_renamed_filename
+        pattern = "{series_name} {volume_number} [{volume_year}]"
+        src = "Frieren - Beyond Journey's End v03 (2022) (Digital) (1r0n).cbz"
+        expected = "Frieren - Beyond Journey's End v03 [2022].cbz"
+        with self._enable(pattern):
+            assert get_renamed_filename(src) == expected
+
+    def test_manga_volume_rename_is_idempotent(self):
+        from cbz_ops.rename import get_renamed_filename
+        pattern = "{series_name} {volume_number} [{volume_year}]"
+        renamed = "Frieren - Beyond Journey's End v03 [2022].cbz"
+        with self._enable(pattern):
+            assert get_renamed_filename(renamed) == renamed
 
 
 # ===== load_custom_rename_config (legacy {year} migration) =====

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -117,6 +117,27 @@ class TestPlanSmartRenameSeriesJsonPath:
         assert "Sandman v2 001 (1989).cbz" in names
         assert "Sandman v2 012 (1989).cbz" in names
 
+    def test_manga_volume_renamed_when_pattern_has_no_issue(self, tmp_path):
+        # Volume-only manga (no issue number) must rename when the pattern doesn't
+        # reference {issue_number}; the per-file volume ("v03") comes from the
+        # filename, series/year from series.json.
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Frieren"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Frieren - Beyond Journey's End", year=2022)
+        (d / "Frieren - Beyond Journey's End v03 (2022) (Digital).cbz").write_bytes(b"x")
+
+        with _enable_custom_rename(
+            pattern="{series_name} {volume_number} [{volume_year}]"
+        ):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        files = plan["directories"][0]["files"]
+        assert len(files) == 1
+        assert files[0]["status"] == "ok"
+        assert files[0]["new_name"] == "Frieren - Beyond Journey's End v03 [2022].cbz"
+
     def test_file_with_no_issue_number_is_skipped(self, tmp_path):
         from cbz_ops.smart_rename import plan_smart_rename
         d = tmp_path / "Sandman"


### PR DESCRIPTION
## 📝 Description
Fix custom and smart rename flows for manga-style volume files that have no issue number. The rename logic now only requires fields referenced by the active pattern, supports `v`-prefixed volume parsing, recovers missing series names from filenames like `Series v03 (...)`, and uses per-file volume tokens when issue data is absent. Added unit tests for pattern behavior, `v` volume parsing, manga rename output/idempotence, and smart-rename planning with issue-less patterns.

Closes #373 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass