### PR TITLE
Migrate GCD integration from MySQL to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ CLAUDE.md
 .venv
 *.log
 .claude/settings.local.json
+*.db

--- a/app.py
+++ b/app.py
@@ -7604,10 +7604,10 @@ def gcd_status():
         return jsonify({"error": str(e)}), 500
 
 
-@app.route("/gcd-mysql-status")
-def gcd_mysql_status():
-    """Check if GCD MySQL database is configured"""
-    return jsonify(gcd.check_mysql_status())
+@app.route("/gcd-db-status")
+def gcd_db_status():
+    """Check if the GCD SQLite database is configured and present"""
+    return jsonify(gcd.check_database_status())
 
 
 @app.route("/gcd-import", methods=["POST"])

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,13 +40,10 @@ services:
             ## so a second account (e.g. your NAS file browser) can write into CLU-created folders
             ## without needing 777. Set PGID to your NAS share group. Use 022 for owner-only writes.
             # - UMASK=002
-            # GCD Database Additions: Uncomment everything below and update values
-            # if you're using a local GCD database for Metadata
-            #- GCD_MYSQL_HOST=mysql-gcd
-            #- GCD_MYSQL_PORT=3306
-            #- GCD_MYSQL_DATABASE=gcd_data
-            #- GCD_MYSQL_USER=clu
-            #- GCD_MYSQL_PASSWORD=strong-user-password
+            # GCD Database: download the SQLite dump from https://www.comics.org/download/,
+            # mount it into the container, and point CLU at it (or set the path in
+            # Config -> Metadata Providers instead of using this env var).
+            #- GCD_DATABASE_PATH=/config/gcd.db
             - CLU_USERNAME=[USERNAME]
             - CLU_PASSWORD=[PASSWORD]
         #networks:

--- a/models/gcd.py
+++ b/models/gcd.py
@@ -1,18 +1,17 @@
 """
 GCD (Grand Comics Database) integration for comic metadata retrieval.
+
+Reads a user-provided SQLite export of the GCD database (downloaded from
+https://www.comics.org/download/). The dump shares identical table/column names
+with the historical MySQL schema, so only the connection + SQL-dialect layer is
+SQLite-specific here.
 """
 import os
 import re
+import sqlite3
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Tuple, Set
 from core.app_logging import app_logger
-
-# Check if mysql.connector is available
-try:
-    import mysql.connector
-    MYSQL_AVAILABLE = True
-except ImportError:
-    MYSQL_AVAILABLE = False
 
 # =============================================================================
 # Constants
@@ -21,7 +20,7 @@ except ImportError:
 STOPWORDS = {"the", "a", "an", "of", "and", "vol", "volume", "season", "series"}
 
 # Full set of GCD tables CLU touches across all code paths. Used to detect
-# which auxiliary tables a particular MySQL dump excludes — the public dump
+# which auxiliary tables a particular dump excludes — the public dump
 # from comics.org periodically drops tables (e.g. gcd_creator, gcd_issue_credit)
 # while GCD restructures schemas.
 EXPECTED_GCD_TABLES = frozenset({
@@ -120,9 +119,35 @@ def generate_search_variations(series_name: str, year: str = None):
 # Database Connection
 # =============================================================================
 
-def is_mysql_available() -> bool:
-    """Check if MySQL connector is available."""
-    return MYSQL_AVAILABLE
+def _regexp(pattern: Optional[str], value: Optional[str]) -> int:
+    """SQLite REGEXP implementation.
+
+    SQLite calls this as ``regexp(Y, X)`` for the expression ``X REGEXP Y``, so
+    the pattern is the first argument. Returns 1/0 and treats NULL values as
+    non-matching so the existing MySQL-style REGEXP SQL keeps working.
+    """
+    if value is None or pattern is None:
+        return 0
+    try:
+        return 1 if re.search(pattern, str(value)) else 0
+    except re.error:
+        return 0
+
+
+def _dict_factory(cursor, row):
+    """Row factory returning plain dicts.
+
+    Used instead of sqlite3.Row because callers rely on ``row.get(...)`` which
+    sqlite3.Row does not provide.
+    """
+    return {col[0]: row[idx] for idx, col in enumerate(cursor.description)}
+
+
+def is_database_available() -> bool:
+    """Check whether a configured GCD SQLite file exists on disk."""
+    params = get_connection_params()
+    path = params.get('database_path') if params else None
+    return bool(path and os.path.exists(path))
 
 
 def _get_saved_credentials() -> Optional[Dict[str, Any]]:
@@ -136,89 +161,75 @@ def _get_saved_credentials() -> Optional[Dict[str, Any]]:
 
 def get_connection_params() -> Optional[Dict[str, Any]]:
     """
-    Get GCD MySQL connection parameters.
-    Checks saved credentials first, then falls back to environment variables.
+    Get GCD SQLite connection parameters.
+    Checks saved credentials first, then falls back to the GCD_DATABASE_PATH
+    environment variable.
 
     Returns:
-        Dict with host, port, database, username, password or None if not configured
+        Dict with database_path, or None if not configured
     """
     # First try saved credentials from UI
     saved_creds = _get_saved_credentials()
-    if saved_creds and saved_creds.get('host'):
-        return {
-            'host': saved_creds.get('host'),
-            'port': int(saved_creds.get('port', 3306)),
-            'database': saved_creds.get('database'),
-            'username': saved_creds.get('username'),
-            'password': saved_creds.get('password', '')
-        }
+    if saved_creds and saved_creds.get('database_path'):
+        return {'database_path': saved_creds.get('database_path')}
 
-    # Fall back to environment variables
-    gcd_host = os.environ.get('GCD_MYSQL_HOST')
-    if gcd_host:
-        return {
-            'host': gcd_host,
-            'port': int(os.environ.get('GCD_MYSQL_PORT', 3306)),
-            'database': os.environ.get('GCD_MYSQL_DATABASE'),
-            'username': os.environ.get('GCD_MYSQL_USER'),
-            'password': os.environ.get('GCD_MYSQL_PASSWORD', '')
-        }
+    # Fall back to environment variable (Docker/headless setups)
+    env_path = os.environ.get('GCD_DATABASE_PATH')
+    if env_path:
+        return {'database_path': env_path}
 
     return None
 
 
-def check_mysql_status() -> Dict[str, Any]:
-    """Check if GCD MySQL database is configured."""
+def check_database_status() -> Dict[str, Any]:
+    """Check if the GCD SQLite database is configured and present on disk."""
     try:
         params = get_connection_params()
-        gcd_available = params is not None and bool(params.get('host'))
+        path = params.get('database_path') if params else None
+        available = bool(path and os.path.exists(path))
 
         return {
-            "gcd_mysql_available": gcd_available,
-            "gcd_host_configured": gcd_available
+            "gcd_available": available,
+            "gcd_path_configured": bool(path),
         }
     except Exception as e:
         return {
-            "gcd_mysql_available": False,
-            "gcd_host_configured": False,
+            "gcd_available": False,
+            "gcd_path_configured": False,
             "error": str(e)
         }
 
 
 def get_connection():
     """
-    Create and return a MySQL connection to the GCD database.
-    Uses saved credentials from UI first, falls back to environment variables.
+    Open and return a read-only SQLite connection to the GCD database.
+    Uses saved credentials from the UI first, falls back to GCD_DATABASE_PATH.
 
     Returns:
-        MySQL connection object or None if connection fails
+        sqlite3.Connection (dict rows, REGEXP registered) or None on failure
     """
-    if not MYSQL_AVAILABLE:
-        app_logger.error("MySQL connector not available")
-        return None
-
     try:
         params = get_connection_params()
-        if not params:
-            app_logger.error("GCD MySQL not configured (no saved credentials or environment variables)")
+        if not params or not params.get('database_path'):
+            app_logger.error("GCD database not configured (no saved path or GCD_DATABASE_PATH)")
             return None
 
-        if not all([params.get('host'), params.get('database'), params.get('username')]):
-            app_logger.error("GCD MySQL configuration incomplete (missing host, database, or username)")
+        path = params['database_path']
+        if not os.path.exists(path):
+            app_logger.error(f"GCD database file not found: {path}")
             return None
 
-        conn = mysql.connector.connect(
-            host=params['host'],
-            port=params['port'],
-            database=params['database'],
-            user=params['username'],
-            password=params['password'],
-            charset='utf8mb4',
-            collation='utf8mb4_unicode_ci'
-        )
+        # Read-only URI: never creates an empty DB on a bad path and never writes
+        # -wal/-shm/journal files next to the (large) dump.
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.row_factory = _dict_factory
+        conn.create_function("regexp", 2, _regexp)
         return conn
+    except sqlite3.Error as e:
+        app_logger.error(f"Failed to open GCD SQLite database: {e}")
+        return None
     except Exception as e:
-        app_logger.error(f"Failed to connect to GCD MySQL database: {e}")
+        app_logger.error(f"Failed to open GCD SQLite database: {e}")
         return None
 
 
@@ -230,7 +241,7 @@ def get_available_gcd_tables(conn=None, *, force_refresh: bool = False) -> Set[s
     """
     Return the set of expected GCD tables actually present in the connected database.
 
-    Caches at module level — first call queries information_schema, subsequent
+    Caches at module level — first call queries sqlite_master, subsequent
     calls return the cached set. Pass force_refresh=True to re-query (e.g. after
     credentials change). If `conn` is provided, reuses it; otherwise opens a
     short-lived connection. Returns an empty set on any failure so callers fall
@@ -251,13 +262,13 @@ def get_available_gcd_tables(conn=None, *, force_refresh: bool = False) -> Set[s
 
         cursor = conn.cursor()
         expected = sorted(EXPECTED_GCD_TABLES)
-        placeholders = ','.join(['%s'] * len(expected))
+        placeholders = ','.join(['?'] * len(expected))
         cursor.execute(
-            f"SELECT TABLE_NAME FROM information_schema.TABLES "
-            f"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ({placeholders})",
+            f"SELECT name FROM sqlite_master "
+            f"WHERE type = 'table' AND name IN ({placeholders})",
             expected,
         )
-        present = {row[0] for row in cursor.fetchall()}
+        present = {row['name'] for row in cursor.fetchall()}
         cursor.close()
 
         _AVAILABLE_TABLES_CACHE = present
@@ -285,7 +296,7 @@ def get_available_gcd_tables(conn=None, *, force_refresh: bool = False) -> Set[s
 
 
 def invalidate_gcd_table_cache() -> None:
-    """Reset the cached set so the next call re-queries information_schema."""
+    """Reset the cached set so the next call re-queries sqlite_master."""
     global _AVAILABLE_TABLES_CACHE, _AVAILABLE_TABLES_LOGGED
     _AVAILABLE_TABLES_CACHE = None
     _AVAILABLE_TABLES_LOGGED = False
@@ -296,7 +307,7 @@ def invalidate_gcd_table_cache() -> None:
 # =============================================================================
 
 def get_database_stats() -> Optional[Dict[str, Any]]:
-    """Get row counts for key GCD database tables via information_schema."""
+    """Get row counts for key GCD database tables via COUNT(*)."""
     conn = get_connection()
     if not conn:
         return None
@@ -311,23 +322,19 @@ def get_database_stats() -> Optional[Dict[str, Any]]:
             'gcd_creator': 'creators',
         }
 
-        # Build IN clause from tables we actually want stats on AND that exist.
+        # Count only the tables we care about AND that exist. Table names come
+        # from the trusted mapping above (never user input), so inlining them is
+        # safe — SQLite cannot parameterize table names anyway.
         stats = {friendly: 0 for friendly in mapping.values()}
         wanted = [t for t in mapping.keys() if t in available]
 
         if wanted:
             cursor = conn.cursor()
-            placeholders = ','.join(['%s'] * len(wanted))
-            cursor.execute(
-                f"SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.TABLES "
-                f"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ({placeholders})",
-                wanted,
-            )
-            rows = cursor.fetchall()
+            for table_name in wanted:
+                cursor.execute(f"SELECT COUNT(*) AS c FROM {table_name}")
+                row = cursor.fetchone()
+                stats[mapping[table_name]] = (row['c'] if row else 0) or 0
             cursor.close()
-            for table_name, row_count in rows:
-                if table_name in mapping:
-                    stats[mapping[table_name]] = row_count or 0
 
         stats['table_count'] = len(available)
         stats['available_tables'] = sorted(available)
@@ -362,12 +369,6 @@ def validate_issue(series_id: int, issue_number: str) -> Dict[str, Any]:
             "error": "Missing series_id or issue_number"
         }
 
-    if not MYSQL_AVAILABLE:
-        return {
-            "success": False,
-            "error": "MySQL connector not available"
-        }
-
     try:
         conn = get_connection()
         if not conn:
@@ -376,14 +377,14 @@ def validate_issue(series_id: int, issue_number: str) -> Dict[str, Any]:
                 "error": "Failed to connect to GCD database"
             }
 
-        cursor = conn.cursor(dictionary=True)
+        cursor = conn.cursor()
 
         # Query to find the issue
         validation_query = """
             SELECT id, title, number
             FROM gcd_issue
-            WHERE series_id = %s
-            AND (number = %s OR number = CONCAT('[', %s, ']') OR number LIKE CONCAT(%s, ' (%'))
+            WHERE series_id = ?
+            AND (number = ? OR number = '[' || ? || ']' OR number LIKE ? || ' (%')
             AND deleted = 0
             LIMIT 1
         """
@@ -410,7 +411,7 @@ def validate_issue(series_id: int, issue_number: str) -> Dict[str, Any]:
                 "message": f"Issue #{issue_number} not found in series {series_id}"
             }
 
-    except mysql.connector.Error as db_error:
+    except sqlite3.Error as db_error:
         app_logger.error(f"Database error in validate_issue: {db_error}")
         return {
             "success": False,
@@ -436,9 +437,6 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
     Returns:
         Best matching series dict with id, name, year_began, publisher_name, or None if not found
     """
-    if not MYSQL_AVAILABLE:
-        return None
-
     if language_codes is None:
         language_codes = ['en']
 
@@ -447,10 +445,10 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
         if not conn:
             return None
 
-        cursor = conn.cursor(dictionary=True)
+        cursor = conn.cursor()
 
         # Build language IN clause
-        lang_placeholders = ','.join(['%s'] * len(language_codes))
+        lang_placeholders = ','.join(['?'] * len(language_codes))
 
         # Generate search variations
         variations = generate_search_variations(series_name, str(year) if year else None)
@@ -459,7 +457,7 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
 
         for search_type, search_pattern in variations:
             try:
-                # lang_placeholders is validated above (only %s tokens)
+                # lang_placeholders is validated above (only ? tokens)
                 base_select = (
                     'SELECT s.id, s.name, s.year_began, s.year_ended,'
                     '       p.name AS publisher_name'
@@ -473,21 +471,21 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                 if search_type == "tokenized":
                     # REGEXP search
                     query = (base_select
-                             + ' WHERE LOWER(s.name) REGEXP %s'
+                             + ' WHERE LOWER(s.name) REGEXP ?'
                              + lang_filter + order_suffix)
                     cursor.execute(query, (search_pattern.lower(), *language_codes))
                 elif year and search_type in ["exact", "no_issue", "no_year", "no_dash"]:
                     # Year-constrained LIKE search
                     query = (base_select
-                             + ' WHERE s.name LIKE %s'
-                             + ' AND s.year_began <= %s'
-                             + ' AND (s.year_ended IS NULL OR s.year_ended >= %s)'
+                             + ' WHERE s.name LIKE ?'
+                             + ' AND s.year_began <= ?'
+                             + ' AND (s.year_ended IS NULL OR s.year_ended >= ?)'
                              + lang_filter + order_suffix)
                     cursor.execute(query, (search_pattern, year, year, *language_codes))
                 else:
                     # Regular LIKE search
                     query = (base_select
-                             + ' WHERE s.name LIKE %s'
+                             + ' WHERE s.name LIKE ?'
                              + lang_filter + order_suffix)
                     cursor.execute(query, (search_pattern, *language_codes))
 
@@ -523,22 +521,19 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
     Returns:
         Dict with ComicInfo-compatible metadata, or None if not found
     """
-    if not MYSQL_AVAILABLE:
-        return None
-
     try:
         conn = get_connection()
         if not conn:
             return None
 
-        cursor = conn.cursor(dictionary=True)
+        cursor = conn.cursor()
 
         # Get series info first
         series_query = """
             SELECT s.id, s.name, s.year_began, p.name as publisher_name
             FROM gcd_series s
             LEFT JOIN gcd_publisher p ON s.publisher_id = p.id
-            WHERE s.id = %s
+            WHERE s.id = ?
         """
         cursor.execute(series_query, (series_id,))
         series = cursor.fetchone()
@@ -570,17 +565,17 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
                 CASE
                     WHEN COALESCE(i.key_date, i.on_sale_date) IS NOT NULL
                          AND LENGTH(COALESCE(i.key_date, i.on_sale_date)) >= 4
-                    THEN CAST(SUBSTRING(COALESCE(i.key_date, i.on_sale_date), 1, 4) AS UNSIGNED)
+                    THEN CAST(substr(COALESCE(i.key_date, i.on_sale_date), 1, 4) AS INTEGER)
                 END AS year,
                 CASE
                     WHEN COALESCE(i.key_date, i.on_sale_date) IS NOT NULL
                          AND LENGTH(COALESCE(i.key_date, i.on_sale_date)) >= 7
-                    THEN CAST(SUBSTRING(COALESCE(i.key_date, i.on_sale_date), 6, 2) AS UNSIGNED)
+                    THEN CAST(substr(COALESCE(i.key_date, i.on_sale_date), 6, 2) AS INTEGER)
                 END AS month
             FROM gcd_issue i
-            WHERE i.series_id = %s
+            WHERE i.series_id = ?
               AND i.deleted = 0
-              AND (i.number = %s OR i.number = CONCAT('[', %s, ']') OR i.number LIKE CONCAT(%s, ' (%%'))
+              AND (i.number = ? OR i.number = '[' || ? || ']' OR i.number LIKE ? || ' (%')
             LIMIT 1
         """
         cursor.execute(issue_query, (series_id, issue_number, issue_number, issue_number))
@@ -614,7 +609,7 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
                 JOIN gcd_story_credit sc ON sc.story_id = s.id
                 JOIN gcd_credit_type ct ON ct.id = sc.credit_type_id
                 LEFT JOIN gcd_creator c ON c.id = sc.creator_id
-                WHERE s.issue_id = %s
+                WHERE s.issue_id = ?
                   AND (sc.deleted = 0 OR sc.deleted IS NULL)
             """
             cursor.execute(credits_query, (issue['id'],))
@@ -627,7 +622,7 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
             legacy_query = """
                 SELECT script, pencils, inks, colors, letters, editing
                 FROM gcd_story
-                WHERE issue_id = %s
+                WHERE issue_id = ?
                 LIMIT 1
             """
             cursor.execute(legacy_query, (issue['id'],))
@@ -713,7 +708,7 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
         app_logger.info(f"GCD get_issue_metadata: Found metadata for {series['name']} #{issue_number}")
         return metadata
 
-    except mysql.connector.Error as db_error:
+    except sqlite3.Error as db_error:
         app_logger.error(f"Database error in get_issue_metadata: {db_error}")
         return None
     except Exception as e:

--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -89,6 +89,7 @@ class ProviderCredentials:
     host: Optional[str] = None
     port: Optional[int] = None
     database: Optional[str] = None
+    database_path: Optional[str] = None  # GCD: path to the local SQLite dump
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary, excluding None values."""
@@ -98,7 +99,8 @@ class ProviderCredentials:
             "password": self.password,
             "host": self.host,
             "port": self.port,
-            "database": self.database
+            "database": self.database,
+            "database_path": self.database_path
         }.items() if v is not None}
 
     @classmethod
@@ -110,7 +112,8 @@ class ProviderCredentials:
             password=data.get("password"),
             host=data.get("host"),
             port=data.get("port"),
-            database=data.get("database")
+            database=data.get("database"),
+            database_path=data.get("database_path")
         )
 
 

--- a/models/providers/crypto.py
+++ b/models/providers/crypto.py
@@ -159,9 +159,15 @@ def mask_credentials_dict(credentials: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         Dictionary with masked values
     """
+    # Fields that are not secrets and should be shown in full so the user can
+    # see/confirm what they configured (e.g. a local database file path).
+    non_secret_keys = {"database_path"}
+
     masked = {}
     for key, value in credentials.items():
-        if isinstance(value, str):
+        if key in non_secret_keys:
+            masked[key] = value
+        elif isinstance(value, str):
             masked[key] = mask_credential(value)
         elif value is None:
             masked[key] = None

--- a/models/providers/gcd_provider.py
+++ b/models/providers/gcd_provider.py
@@ -1,7 +1,8 @@
 """
 GCD (Grand Comics Database) Provider Adapter.
 
-Wraps the existing GCD MySQL implementation to conform to the BaseProvider interface.
+Wraps the GCD SQLite implementation (a user-provided database file downloaded
+from comics.org) to conform to the BaseProvider interface.
 """
 from typing import Optional, List, Dict, Any
 
@@ -12,38 +13,38 @@ from . import register_provider
 
 @register_provider
 class GCDProvider(BaseProvider):
-    """GCD metadata provider using MySQL database connection."""
+    """GCD metadata provider using a local SQLite database file."""
 
     provider_type = ProviderType.GCD
     display_name = "Grand Comics Database"
     requires_auth = True
-    auth_fields = ["host", "port", "database", "username", "password"]
+    auth_fields = ["database_path"]
     rate_limit = 1000  # Local database, high rate limit
 
     def __init__(self, credentials: Optional[ProviderCredentials] = None):
         super().__init__(credentials)
 
     def _is_configured(self) -> bool:
-        """Check if GCD database connection is configured."""
+        """Check if the GCD SQLite database is configured and present."""
         from models import gcd as gcd_module
-        if not gcd_module.is_mysql_available():
-            return False
-
-        status = gcd_module.check_mysql_status()
-        return status.get('gcd_mysql_available', False)
+        status = gcd_module.check_database_status()
+        return status.get('gcd_available', False)
 
     def test_connection(self) -> bool:
-        """Test connection to GCD MySQL database."""
+        """Test the GCD SQLite database — open it and verify the core tables."""
         try:
             if not self._is_configured():
                 return False
 
             from models import gcd as gcd_module
             conn = gcd_module.get_connection()
-            if conn:
+            if not conn:
+                return False
+            try:
+                available = gcd_module.get_available_gcd_tables(conn=conn)
+                return gcd_module.GCD_CORE_TABLES.issubset(available)
+            finally:
                 conn.close()
-                return True
-            return False
         except Exception as e:
             app_logger.error(f"GCD connection test failed: {e}")
             return False
@@ -87,7 +88,7 @@ class GCDProvider(BaseProvider):
                 return None
 
             try:
-                cursor = conn.cursor(dictionary=True)
+                cursor = conn.cursor()
                 cursor.execute('''
                     SELECT
                         s.id,
@@ -98,7 +99,7 @@ class GCDProvider(BaseProvider):
                         (SELECT COUNT(*) FROM gcd_issue i WHERE i.series_id = s.id) AS issue_count
                     FROM gcd_series s
                     LEFT JOIN gcd_publisher p ON s.publisher_id = p.id
-                    WHERE s.id = %s
+                    WHERE s.id = ?
                 ''', (int(series_id),))
 
                 row = cursor.fetchone()
@@ -135,7 +136,7 @@ class GCDProvider(BaseProvider):
                 return []
 
             try:
-                cursor = conn.cursor(dictionary=True)
+                cursor = conn.cursor()
                 cursor.execute('''
                     SELECT
                         i.id,
@@ -144,10 +145,10 @@ class GCDProvider(BaseProvider):
                         i.key_date,
                         i.on_sale_date
                     FROM gcd_issue i
-                    WHERE i.series_id = %s AND i.deleted = 0
+                    WHERE i.series_id = ? AND i.deleted = 0
                     ORDER BY
                         CASE
-                            WHEN i.number REGEXP '^[0-9]+$' THEN LPAD(i.number, 10, '0')
+                            WHEN i.number REGEXP '^[0-9]+$' THEN printf('%010d', CAST(i.number AS INTEGER))
                             ELSE i.number
                         END
                 ''', (int(series_id),))
@@ -193,7 +194,7 @@ class GCDProvider(BaseProvider):
                 return None
 
             try:
-                cursor = conn.cursor(dictionary=True)
+                cursor = conn.cursor()
                 cursor.execute('''
                     SELECT
                         i.id,
@@ -203,7 +204,7 @@ class GCDProvider(BaseProvider):
                         i.key_date,
                         i.on_sale_date
                     FROM gcd_issue i
-                    WHERE i.id = %s AND i.deleted = 0
+                    WHERE i.id = ? AND i.deleted = 0
                 ''', (int(issue_id),))
 
                 row = cursor.fetchone()

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -20,7 +20,7 @@ import zipfile
 import threading
 import traceback
 import xml.etree.ElementTree as ET
-import mysql.connector
+import sqlite3
 from datetime import datetime
 from flask import (Blueprint, request, jsonify, Response,
                    stream_with_context, current_app)
@@ -1031,7 +1031,7 @@ def batch_metadata():
             # Fallback to global API credential availability checks
             comicvine_available = bool(comicvine_api_key and comicvine_api_key.strip())
             metron_available = metron.is_metron_configured()
-            gcd_available = gcd.is_mysql_available() and gcd.check_mysql_status().get('gcd_mysql_available', False)
+            gcd_available = gcd.check_database_status().get('gcd_available', False)
             anilist_available = False
             bedetheque_available = False
             mangadex_available = False
@@ -1911,31 +1911,17 @@ def search_gcd_metadata():
             }), 400
 
         app_logger.debug(f"DEBUG: About to connect to database...")
-        # Connect to GCD MySQL database
+        # Connect to the GCD SQLite database
         try:
-            # Get database connection details (checks saved credentials first, then env vars)
-            from models.gcd import get_connection_params
-            params = get_connection_params()
-            if not params:
+            connection = gcd.get_connection()
+            if not connection:
                 return jsonify({
                     "success": False,
-                    "error": "GCD MySQL not configured. Set credentials in Config or use environment variables."
+                    "error": "GCD database not configured or file not found. Set the database path in Config or GCD_DATABASE_PATH."
                 }), 500
 
-            connection = mysql.connector.connect(
-                host=params['host'],
-                port=params['port'],
-                database=params['database'],
-                user=params['username'],
-                password=params['password'],
-                charset='utf8mb4',
-                connection_timeout=30,  # 30 second connection timeout
-                autocommit=True
-            )
             app_logger.debug(f"DEBUG: Database connection successful!")
-            cursor = connection.cursor(dictionary=True)
-            # Set query timeout to 30 seconds
-            cursor.execute("SET SESSION MAX_EXECUTION_TIME=30000")  # 30000 milliseconds = 30 seconds
+            cursor = connection.cursor()
 
             # Detect which GCD tables this dump actually contains so we can
             # skip credit/character/story-type joins when their tables are absent
@@ -1948,7 +1934,7 @@ def search_gcd_metadata():
                 codes = list(codes or [])
                 if not codes:
                     return 'NULL', []            # produces "IN (NULL)" -> matches nothing
-                return ','.join(['%s'] * len(codes)), codes
+                return ','.join(['?'] * len(codes)), codes
 
             # Progressive search strategy for GCD database
             app_logger.debug(f"DEBUG: Starting progressive search for series: '{series_name}' with year: {year}")
@@ -1972,7 +1958,7 @@ def search_gcd_metadata():
             app_logger.debug(f"DEBUG: IN clause built: {in_clause}, params: {in_params}")
 
             # Base queries for LIKE and REGEXP matching
-            # in_clause contains only %s placeholders from build_in_clause()
+            # in_clause contains only ? placeholders from build_in_clause()
             base_select = (
                 'SELECT s.id, s.name, s.year_began, s.year_ended, s.publisher_id,'
                 ' l.code AS language, p.name AS publisher_name,'
@@ -1985,17 +1971,17 @@ def search_gcd_metadata():
             order_suffix = ' ORDER BY s.year_began DESC'
 
             like_query = (base_select
-                          + ' WHERE s.name LIKE %s'
+                          + ' WHERE s.name LIKE ?'
                           + lang_filter + order_suffix)
 
             like_query_with_year = (base_select
-                                    + ' WHERE s.name LIKE %s'
-                                    + ' AND s.year_began <= %s'
-                                    + ' AND (s.year_ended IS NULL OR s.year_ended >= %s)'
+                                    + ' WHERE s.name LIKE ?'
+                                    + ' AND s.year_began <= ?'
+                                    + ' AND (s.year_ended IS NULL OR s.year_ended >= ?)'
                                     + lang_filter + order_suffix)
 
             regexp_query = (base_select
-                            + ' WHERE LOWER(s.name) REGEXP %s'
+                            + ' WHERE LOWER(s.name) REGEXP ?'
                             + lang_filter + order_suffix)
 
             # Try each search variation progressively
@@ -2154,7 +2140,7 @@ def search_gcd_metadata():
                     JOIN stddata_language l ON l.id = sr.language_id
                     LEFT JOIN gcd_publisher p ON p.id = sr.publisher_id
                     LEFT JOIN gcd_indicia_publisher ip ON ip.id = i.indicia_publisher_id
-                    WHERE i.series_id = %s AND (i.number = %s OR i.number = CONCAT('[', %s, ']') OR i.number LIKE CONCAT(%s, ' (%') OR i.number = '[nn]')
+                    WHERE i.series_id = ? AND (i.number = ? OR i.number = '[' || ? || ']' OR i.number LIKE ? || ' (%' OR i.number = '[nn]')
                     LIMIT 1
                 """
             else:
@@ -2179,7 +2165,7 @@ def search_gcd_metadata():
                     JOIN stddata_language l ON l.id = sr.language_id
                     LEFT JOIN gcd_publisher p ON p.id = sr.publisher_id
                     LEFT JOIN gcd_indicia_publisher ip ON ip.id = i.indicia_publisher_id
-                    WHERE i.series_id = %s AND (i.number = %s OR i.number = CONCAT('[', %s, ']') OR i.number LIKE CONCAT(%s, ' (%'))
+                    WHERE i.series_id = ? AND (i.number = ? OR i.number = '[' || ? || ']' OR i.number LIKE ? || ' (%')
                     LIMIT 1
                 """
 
@@ -2198,7 +2184,7 @@ def search_gcd_metadata():
                     app_logger.debug(f"DEBUG: Checking if this is a single-issue series...")
 
                     # Count total issues in this series
-                    count_query = "SELECT COUNT(*) as total FROM gcd_issue WHERE series_id = %s AND deleted = 0"
+                    count_query = "SELECT COUNT(*) as total FROM gcd_issue WHERE series_id = ? AND deleted = 0"
                     cursor.execute(count_query, (best_series['id'],))
                     count_result = cursor.fetchone()
                     total_issues = count_result['total'] if count_result else 0
@@ -2230,7 +2216,7 @@ def search_gcd_metadata():
                             JOIN stddata_language l ON l.id = sr.language_id
                             LEFT JOIN gcd_publisher p ON p.id = sr.publisher_id
                             LEFT JOIN gcd_indicia_publisher ip ON ip.id = i.indicia_publisher_id
-                            WHERE i.series_id = %s AND i.deleted = 0
+                            WHERE i.series_id = ? AND i.deleted = 0
                             LIMIT 1
                         """
 
@@ -2281,7 +2267,7 @@ def search_gcd_metadata():
                     JOIN gcd_story_credit sc ON sc.story_id = s.id
                     JOIN gcd_credit_type ct ON ct.id = sc.credit_type_id
                     LEFT JOIN gcd_creator c ON c.id = sc.creator_id
-                    WHERE s.issue_id = %s
+                    WHERE s.issue_id = ?
                         AND (sc.deleted = 0 OR sc.deleted IS NULL)
                         AND NULLIF(TRIM(COALESCE(NULLIF(sc.credited_as,''), NULLIF(sc.credit_name,''), c.gcd_official_name)), '') IS NOT NULL
                 """
@@ -2293,7 +2279,7 @@ def search_gcd_metadata():
                     FROM gcd_issue_credit ic
                     JOIN gcd_credit_type ct ON ct.id = ic.credit_type_id
                     LEFT JOIN gcd_creator c ON c.id = ic.creator_id
-                    WHERE ic.issue_id = %s
+                    WHERE ic.issue_id = ?
                         AND (ic.deleted = 0 OR ic.deleted IS NULL)
                         AND NULLIF(TRIM(COALESCE(NULLIF(ic.credited_as,''), NULLIF(ic.credit_name,''), c.gcd_official_name)), '') IS NOT NULL
                 """
@@ -2331,7 +2317,7 @@ def search_gcd_metadata():
                                 st.name AS story_type
                             FROM gcd_story s
                             LEFT JOIN gcd_story_type st ON st.id = s.type_id
-                            WHERE s.issue_id = %s
+                            WHERE s.issue_id = ?
                             ORDER BY
                                 CASE WHEN s.sequence_number = 0 THEN 1 ELSE 0 END,
                                 CASE
@@ -2353,7 +2339,7 @@ def search_gcd_metadata():
                                 s.sequence_number,
                                 NULL AS story_type
                             FROM gcd_story s
-                            WHERE s.issue_id = %s
+                            WHERE s.issue_id = ?
                             ORDER BY CASE WHEN s.sequence_number = 0 THEN 1 ELSE 0 END, s.sequence_number
                         """
                     cursor.execute(story_query, (issue_id,))
@@ -2367,7 +2353,7 @@ def search_gcd_metadata():
                         FROM gcd_story s
                         LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
                         LEFT JOIN gcd_character c ON c.id = sc.character_id
-                        WHERE s.issue_id = %s AND c.name IS NOT NULL
+                        WHERE s.issue_id = ? AND c.name IS NOT NULL
                     """
                     cursor.execute(characters_query, (issue_id,))
                     character_results = cursor.fetchall()
@@ -2608,16 +2594,19 @@ def search_gcd_metadata():
                     "matches_found": matches_found
                 }), 404
 
-        except mysql.connector.Error as db_error:
-            app_logger.debug(f"MySQL Error: {str(db_error)}")
-            app_logger.debug(f"MySQL Error Traceback: {traceback.format_exc()}")
+        except sqlite3.Error as db_error:
+            app_logger.debug(f"GCD database error: {str(db_error)}")
+            app_logger.debug(f"GCD database error traceback: {traceback.format_exc()}")
             return jsonify({
                 "success": False,
                 "error": f"Database connection error: {str(db_error)}"
             }), 500
         finally:
-            if 'connection' in locals() and connection.is_connected():
-                cursor.close()
+            if 'connection' in locals() and connection is not None:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
                 connection.close()
 
     except Exception as e:
@@ -2657,26 +2646,16 @@ def search_gcd_metadata_with_selection():
                 "error": "Missing required parameters"
             }), 400
 
-        # Connect to GCD MySQL database
+        # Connect to the GCD SQLite database
         try:
-            # Get database connection details (checks saved credentials first, then env vars)
-            from models.gcd import get_connection_params
-            params = get_connection_params()
-            if not params:
+            connection = gcd.get_connection()
+            if not connection:
                 return jsonify({
                     "success": False,
-                    "error": "GCD MySQL not configured"
+                    "error": "GCD database not configured or file not found"
                 }), 500
 
-            connection = mysql.connector.connect(
-                host=params['host'],
-                port=params['port'],
-                database=params['database'],
-                user=params['username'],
-                password=params['password'],
-                charset='utf8mb4'
-            )
-            cursor = connection.cursor(dictionary=True)
+            cursor = connection.cursor()
 
             # Detect available GCD tables so we can compose the credits / genre /
             # characters subqueries against whatever tables this dump contains.
@@ -2689,7 +2668,7 @@ def search_gcd_metadata_with_selection():
                        p.name as publisher_name
                 FROM gcd_series s
                 LEFT JOIN gcd_publisher p ON s.publisher_id = p.id
-                WHERE s.id = %s
+                WHERE s.id = ?
             """
             cursor.execute(series_query, (series_id,))
             series_result = cursor.fetchone()
@@ -2743,10 +2722,16 @@ def search_gcd_metadata_with_selection():
                 if not halves:
                     return "NULL"
                 inner = "\nUNION\n".join(halves)
+                # SQLite cannot combine GROUP_CONCAT(DISTINCT ...) with a custom
+                # separator or ORDER BY, so dedupe/sort in a subquery first.
                 return f"""(
-                    SELECT GROUP_CONCAT(DISTINCT name ORDER BY name SEPARATOR ', ')
-                    FROM ({inner}) x
-                    WHERE NULLIF(name,'') IS NOT NULL
+                    SELECT group_concat(name, ', ')
+                    FROM (
+                        SELECT DISTINCT name
+                        FROM ({inner}) x
+                        WHERE NULLIF(name,'') IS NOT NULL
+                        ORDER BY name
+                    )
                 )"""
 
             non_zero_seq = "(s.sequence_number IS NULL OR s.sequence_number <> 0)"
@@ -2765,13 +2750,12 @@ def search_gcd_metadata_with_selection():
             # Genre uses only gcd_story.genre text column.
             if 'gcd_story' in gcd_tables:
                 genre_expr = """(
-                    SELECT TRIM(BOTH ', ' FROM
-                           REPLACE(
-                             GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.genre), '') SEPARATOR ', '),
-                             ';', ','
-                           ))
-                    FROM gcd_story s
-                    WHERE s.issue_id = i.id
+                    SELECT REPLACE(group_concat(g, ', '), ';', ',')
+                    FROM (
+                        SELECT DISTINCT NULLIF(TRIM(s.genre), '') AS g
+                        FROM gcd_story s
+                        WHERE s.issue_id = i.id AND NULLIF(TRIM(s.genre), '') IS NOT NULL
+                    )
                 )"""
             else:
                 genre_expr = "NULL"
@@ -2783,31 +2767,32 @@ def search_gcd_metadata_with_selection():
             if story_char_ok and story_text_ok:
                 characters_expr = """COALESCE(
                     (
-                      SELECT NULLIF(GROUP_CONCAT(DISTINCT c.name SEPARATOR ', '), '')
-                      FROM gcd_story s
-                      LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
-                      LEFT JOIN gcd_character c ON c.id = sc.character_id
-                      WHERE s.issue_id = i.id
+                      SELECT NULLIF(group_concat(nm, ', '), '')
+                      FROM (
+                        SELECT DISTINCT c.name AS nm
+                        FROM gcd_story s
+                        LEFT JOIN gcd_story_character sc ON sc.story_id = s.id
+                        LEFT JOIN gcd_character c ON c.id = sc.character_id
+                        WHERE s.issue_id = i.id AND c.name IS NOT NULL
+                      )
                     ),
                     (
-                      SELECT TRIM(BOTH ', ' FROM
-                             REPLACE(
-                               GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.characters), '') SEPARATOR ', '),
-                               ';', ','
-                             ))
-                      FROM gcd_story s
-                      WHERE s.issue_id = i.id
+                      SELECT REPLACE(group_concat(g, ', '), ';', ',')
+                      FROM (
+                        SELECT DISTINCT NULLIF(TRIM(s.characters), '') AS g
+                        FROM gcd_story s
+                        WHERE s.issue_id = i.id AND NULLIF(TRIM(s.characters), '') IS NOT NULL
+                      )
                     )
                 )"""
             elif story_text_ok:
                 characters_expr = """(
-                    SELECT TRIM(BOTH ', ' FROM
-                           REPLACE(
-                             GROUP_CONCAT(DISTINCT NULLIF(TRIM(s.characters), '') SEPARATOR ', '),
-                             ';', ','
-                           ))
-                    FROM gcd_story s
-                    WHERE s.issue_id = i.id
+                    SELECT REPLACE(group_concat(g, ', '), ';', ',')
+                    FROM (
+                        SELECT DISTINCT NULLIF(TRIM(s.characters), '') AS g
+                        FROM gcd_story s
+                        WHERE s.issue_id = i.id AND NULLIF(TRIM(s.characters), '') IS NOT NULL
+                    )
                 )"""
             else:
                 characters_expr = "NULL"
@@ -2859,19 +2844,19 @@ def search_gcd_metadata_with_selection():
                     SELECT COUNT(*)
                     FROM gcd_issue i2
                     WHERE i2.series_id = i.series_id AND i2.deleted = 0
-                  )                                                   AS `Count`,
+                  )                                                   AS "Count",
                   i.volume                                            AS Volume,
                   {summary_expr}                                       AS Summary,
                   CASE
                     WHEN COALESCE(i.key_date, i.on_sale_date) IS NOT NULL
                          AND LENGTH(COALESCE(i.key_date, i.on_sale_date)) >= 4
-                      THEN CAST(SUBSTRING(COALESCE(i.key_date, i.on_sale_date), 1, 4) AS UNSIGNED)
-                  END AS `Year`,
+                      THEN CAST(substr(COALESCE(i.key_date, i.on_sale_date), 1, 4) AS INTEGER)
+                  END AS "Year",
                   CASE
                     WHEN COALESCE(i.key_date, i.on_sale_date) IS NOT NULL
                          AND LENGTH(COALESCE(i.key_date, i.on_sale_date)) >= 7
-                      THEN CAST(SUBSTRING(COALESCE(i.key_date, i.on_sale_date), 6, 2) AS UNSIGNED)
-                  END AS `Month`,
+                      THEN CAST(substr(COALESCE(i.key_date, i.on_sale_date), 6, 2) AS INTEGER)
+                  END AS "Month",
                   {writer_expr}                                        AS Writer,
                   {penciller_expr}                                     AS Penciller,
                   {inker_expr}                                         AS Inker,
@@ -2889,7 +2874,7 @@ def search_gcd_metadata_with_selection():
                 JOIN stddata_language l            ON sr.language_id = l.id
                 LEFT JOIN gcd_publisher p          ON p.id = sr.publisher_id
                 LEFT JOIN gcd_indicia_publisher ip ON ip.id = i.indicia_publisher_id
-                WHERE i.series_id = %s AND (i.number = %s OR i.number = CONCAT('[', %s, ']') OR i.number LIKE CONCAT(%s, ' (%'))
+                WHERE i.series_id = ? AND (i.number = ? OR i.number = '[' || ? || ']' OR i.number LIKE ? || ' (%')
                 LIMIT 1
             """
 
@@ -2958,16 +2943,19 @@ def search_gcd_metadata_with_selection():
                     "error": f"Issue #{issue_number} not found for series '{series_result['name']}'"
                 }), 404
 
-        except mysql.connector.Error as db_error:
-            app_logger.error(f"MySQL Error in search_gcd_metadata_with_selection: {str(db_error)}")
-            app_logger.debug(f"MySQL Error Traceback:\n{traceback.format_exc()}")
+        except sqlite3.Error as db_error:
+            app_logger.error(f"GCD database error in search_gcd_metadata_with_selection: {str(db_error)}")
+            app_logger.debug(f"GCD database error traceback:\n{traceback.format_exc()}")
             return jsonify({
                 "success": False,
                 "error": f"Database connection error: {str(db_error)}"
             }), 500
         finally:
-            if 'connection' in locals() and connection.is_connected():
-                cursor.close()
+            if 'connection' in locals() and connection is not None:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
                 connection.close()
 
     except Exception as e:
@@ -3176,7 +3164,7 @@ def _try_gcd_single(series_name, issue_number, year):
     or (None, None, None) when nothing found.
     """
     try:
-        if not (gcd.is_mysql_available() and gcd.check_mysql_status().get('gcd_mysql_available', False)):
+        if not gcd.check_database_status().get('gcd_available', False):
             return None, None, None
 
         if not series_name:
@@ -3630,7 +3618,7 @@ def search_metadata():
                 provider_order.append('metron')
             if current_app.config.get("COMICVINE_API_KEY", "").strip():
                 provider_order.append('comicvine')
-            if gcd.is_mysql_available() and gcd.check_mysql_status().get('gcd_mysql_available', False):
+            if gcd.check_database_status().get('gcd_available', False):
                 provider_order.append('gcd')
             # Check if GCD API credentials are configured
             try:

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -38,7 +38,7 @@ let sourceScrollHistory = {};  // { path: scrollTop }
 let destinationScrollHistory = {};
 
 // Global variable to track GCD MySQL availability (legacy - kept for backwards compatibility)
-let gcdMysqlAvailable = false;
+let gcdAvailable = false;
 
 // Global variable to track ComicVine API availability (legacy - kept for backwards compatibility)
 let comicVineAvailable = false;
@@ -76,15 +76,15 @@ function encodeFilePathForReader(path) {
 
 // Function to check GCD MySQL availability
 function checkGCDAvailability() {
-  fetch('/gcd-mysql-status')
+  fetch('/gcd-db-status')
     .then(response => response.json())
     .then(data => {
-      gcdMysqlAvailable = data.gcd_mysql_available || false;
-      console.log('GCD MySQL availability checked:', gcdMysqlAvailable);
+      gcdAvailable = data.gcd_available || false;
+      console.log('GCD availability checked:', gcdAvailable);
     })
     .catch(error => {
       console.warn('Error checking GCD availability:', error);
-      gcdMysqlAvailable = false;
+      gcdAvailable = false;
     });
 }
 
@@ -436,8 +436,8 @@ function createListItem(itemName, fullPath, type, panel, isDraggable) {
     }
 
     // Fallback: if no providers but legacy availability flags are set, show legacy buttons
-    if (!hasAnyProvider && (gcdMysqlAvailable || comicVineAvailable)) {
-      if (gcdMysqlAvailable) {
+    if (!hasAnyProvider && (gcdAvailable || comicVineAvailable)) {
+      if (gcdAvailable) {
         const gcdBtn = document.createElement("button");
         gcdBtn.className = "btn btn-sm btn-outline-success";
         gcdBtn.innerHTML = '<i class="bi bi-cloud-download"></i>';
@@ -541,7 +541,7 @@ function createListItem(itemName, fullPath, type, panel, isDraggable) {
     }
 
     // Fallback: if no providers but legacy availability flags are set, show legacy button
-    if (fileData.name !== "Parent" && !hasAnyProvider && (gcdMysqlAvailable || comicVineAvailable || metronAvailable)) {
+    if (fileData.name !== "Parent" && !hasAnyProvider && (gcdAvailable || comicVineAvailable || metronAvailable)) {
       const metadataBtn = document.createElement("button");
       metadataBtn.className = "btn btn-sm btn-outline-success";
       metadataBtn.innerHTML = '<i class="bi bi-cloud-download"></i>';
@@ -1646,7 +1646,7 @@ function loadRecentFiles(panel) {
 
           // Fallback to legacy buttons if no providers configured
           if (!hasAnyProvider) {
-            if (typeof gcdMysqlAvailable !== 'undefined' && gcdMysqlAvailable) {
+            if (typeof gcdAvailable !== 'undefined' && gcdAvailable) {
               const gcdBtn = document.createElement('button');
               gcdBtn.className = 'btn btn-sm btn-outline-success';
               gcdBtn.innerHTML = '<i class="bi bi-cloud-download"></i>';

--- a/templates/config.html
+++ b/templates/config.html
@@ -3219,6 +3219,14 @@
                 const isComingSoon = provider.type === 'bedetheque';
 
                 const gcdExtra = provider.type === 'gcd' ? `
+                    <div class="mt-2">
+                        <small class="form-text text-muted">
+                            Download the SQLite database dump from
+                            <a href="https://www.comics.org/download/" target="_blank" rel="noopener">comics.org</a>,
+                            place it on disk, and enter its full path above (e.g. <code>/config/gcd.db</code>).
+                            The file is large (~6&nbsp;GB) and is read directly from disk, not uploaded.
+                        </small>
+                    </div>
                     <div class="mt-3 pt-3 border-top">
                         <label for="gcdLanguages" class="form-label">Metadata Languages</label>
                         <div class="input-group input-group-sm">
@@ -3266,7 +3274,7 @@
                                 ${provider.type === 'gcd' && provider.is_valid
                                     ? '<span class="spinner-border spinner-border-sm me-1"></span>Loading database stats...'
                                     : provider.type === 'gcd'
-                                        ? 'Local MySQL database'
+                                        ? 'Local SQLite database'
                                         : `Rate limit: ${provider.rate_limit} requests/minute`}
                             </div>
                         </div>
@@ -3335,7 +3343,7 @@
                 }
                 footer.innerHTML = html;
             } else {
-                footer.textContent = 'Local MySQL database';
+                footer.textContent = 'Local SQLite database';
             }
         } catch (e) {
             footer.textContent = 'Local MySQL database';

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -35,11 +35,144 @@ def comicvine_creds():
 
 
 @pytest.fixture
-def gcd_creds():
-    return ProviderCredentials(
-        host="localhost", port="3306", database="gcd",
-        username="root", password="pass",
+def gcd_creds(gcd_db_path):
+    return ProviderCredentials(database_path=str(gcd_db_path))
+
+
+# ---------------------------------------------------------------------------
+# GCD SQLite test database
+#
+# The GCD provider now reads a user-supplied SQLite dump. Rather than mock
+# cursors, these fixtures build a tiny real SQLite file with the GCD schema and
+# a handful of rows, so the ported SQL is exercised end to end.
+# ---------------------------------------------------------------------------
+
+def build_gcd_sqlite(path, *, core_only=False):
+    """Create a minimal GCD SQLite database at `path`.
+
+    Contains a Batman series (id 200) published by DC Comics with English
+    language, issues #1/#2/#10 (plus a bracketed variant), a story with a
+    writer credit and a character. When `core_only` is True, only the core
+    tables are created (to exercise missing-table handling).
+    """
+    import sqlite3
+    conn = sqlite3.connect(str(path))
+    cur = conn.cursor()
+
+    cur.executescript(
+        """
+        CREATE TABLE stddata_language (id INTEGER PRIMARY KEY, code TEXT);
+        CREATE TABLE gcd_publisher (id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE gcd_series (
+            id INTEGER PRIMARY KEY, name TEXT, year_began INTEGER,
+            year_ended INTEGER, publisher_id INTEGER, language_id INTEGER
+        );
+        CREATE TABLE gcd_issue (
+            id INTEGER PRIMARY KEY, number TEXT, volume TEXT, series_id INTEGER,
+            indicia_publisher_id INTEGER, key_date TEXT, on_sale_date TEXT,
+            title TEXT, rating TEXT, page_count INTEGER,
+            page_count_uncertain INTEGER, deleted INTEGER DEFAULT 0
+        );
+        CREATE TABLE gcd_story (
+            id INTEGER PRIMARY KEY, issue_id INTEGER, title TEXT, synopsis TEXT,
+            notes TEXT, genre TEXT, characters TEXT, page_count INTEGER,
+            sequence_number INTEGER, type_id INTEGER, script TEXT, pencils TEXT,
+            inks TEXT, colors TEXT, letters TEXT, editing TEXT,
+            deleted INTEGER DEFAULT 0
+        );
+        """
     )
+
+    cur.executemany("INSERT INTO stddata_language (id, code) VALUES (?, ?)",
+                    [(1, "en")])
+    cur.executemany("INSERT INTO gcd_publisher (id, name) VALUES (?, ?)",
+                    [(10, "DC Comics")])
+    cur.executemany(
+        "INSERT INTO gcd_series (id, name, year_began, year_ended, publisher_id, language_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [(200, "Batman", 1940, None, 10, 1)],
+    )
+    cur.executemany(
+        "INSERT INTO gcd_issue (id, number, volume, series_id, indicia_publisher_id, "
+        "key_date, on_sale_date, title, rating, page_count, page_count_uncertain, deleted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (500, "1", "1", 200, None, "1940-04-01", "1940-03-01", "The Beginning", "", 64, 0, 0),
+            (502, "2", "1", 200, None, "1940-05-01", "1940-04-01", "", "", 64, 0, 0),
+            (510, "10", "1", 200, None, "1941-01-01", "1940-12-01", "", "", 64, 0, 0),
+            (511, "[nn]", "1", 200, None, "1941-02-01", "1941-01-01", "", "", 64, 0, 0),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO gcd_story (id, issue_id, title, synopsis, notes, genre, characters, "
+        "page_count, sequence_number, type_id, script, pencils, inks, colors, letters, editing, deleted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [(900, 500, "Story One", "A synopsis", "", "superhero", "Batman; Robin",
+          64, 1, 1, "", "", "", "", "", "", 0)],
+    )
+
+    if not core_only:
+        cur.executescript(
+            """
+            CREATE TABLE gcd_credit_type (id INTEGER PRIMARY KEY, name TEXT);
+            CREATE TABLE gcd_creator (id INTEGER PRIMARY KEY, gcd_official_name TEXT, sort_name TEXT);
+            CREATE TABLE gcd_story_credit (
+                id INTEGER PRIMARY KEY, story_id INTEGER, creator_id INTEGER,
+                credit_type_id INTEGER, credited_as TEXT, credit_name TEXT,
+                deleted INTEGER DEFAULT 0
+            );
+            CREATE TABLE gcd_issue_credit (
+                id INTEGER PRIMARY KEY, issue_id INTEGER, creator_id INTEGER,
+                credit_type_id INTEGER, credited_as TEXT, credit_name TEXT,
+                deleted INTEGER DEFAULT 0
+            );
+            CREATE TABLE gcd_indicia_publisher (id INTEGER PRIMARY KEY, name TEXT);
+            CREATE TABLE gcd_story_type (id INTEGER PRIMARY KEY, name TEXT, sort_code INTEGER);
+            CREATE TABLE gcd_story_character (story_id INTEGER, character_id INTEGER);
+            CREATE TABLE gcd_character (id INTEGER PRIMARY KEY, name TEXT);
+            """
+        )
+        cur.executemany("INSERT INTO gcd_credit_type (id, name) VALUES (?, ?)",
+                        [(1, "script"), (2, "pencils")])
+        cur.executemany("INSERT INTO gcd_creator (id, gcd_official_name, sort_name) VALUES (?, ?, ?)",
+                        [(700, "Bob Kane", "Kane, Bob")])
+        cur.executemany(
+            "INSERT INTO gcd_story_credit (id, story_id, creator_id, credit_type_id, "
+            "credited_as, credit_name, deleted) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [(800, 900, 700, 1, "", "", 0)],
+        )
+        cur.executemany("INSERT INTO gcd_story_type (id, name, sort_code) VALUES (?, ?, ?)",
+                        [(1, "comic story", 1)])
+        cur.executemany("INSERT INTO gcd_character (id, name) VALUES (?, ?)",
+                        [(600, "Batman")])
+        cur.executemany("INSERT INTO gcd_story_character (story_id, character_id) VALUES (?, ?)",
+                        [(900, 600)])
+
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+@pytest.fixture
+def gcd_db_path(tmp_path):
+    """Path to a fully-populated GCD SQLite test database."""
+    return build_gcd_sqlite(tmp_path / "gcd.db")
+
+
+@pytest.fixture
+def gcd_core_only_db_path(tmp_path):
+    """Path to a GCD SQLite database missing the optional/auxiliary tables."""
+    return build_gcd_sqlite(tmp_path / "gcd_core.db", core_only=True)
+
+
+@pytest.fixture
+def gcd_configured(gcd_db_path, monkeypatch):
+    """Point models.gcd at the full test database via saved credentials."""
+    monkeypatch.setattr(
+        "models.gcd._get_saved_credentials",
+        lambda: {"database_path": str(gcd_db_path)},
+    )
+    return str(gcd_db_path)
 
 
 # ---------------------------------------------------------------------------
@@ -150,15 +283,3 @@ def make_mock_cv_issue(*, id=1001, issue_number="1", name="Rebirth",
     return i
 
 
-# ---------------------------------------------------------------------------
-# Mock MySQL cursor/connection
-# ---------------------------------------------------------------------------
-
-def make_mock_mysql_connection(rows=None, fetchone_result=None):
-    """Create a mock MySQL connection and cursor."""
-    conn = MagicMock()
-    cursor = MagicMock()
-    cursor.fetchall.return_value = rows or []
-    cursor.fetchone.return_value = fetchone_result
-    conn.cursor.return_value = cursor
-    return conn, cursor

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -1,173 +1,153 @@
-"""Tests for models/gcd.py -- mocked MySQL connection."""
+"""Tests for models/gcd.py -- runs the ported SQL against a real temp SQLite DB."""
+import sqlite3
 import pytest
 from unittest.mock import patch, MagicMock
-from tests.mocked.conftest import make_mock_mysql_connection
 
-from models.gcd import EXPECTED_GCD_TABLES
-
-
-class TestIsMysqlAvailable:
-
-    def test_returns_bool(self):
-        from models.gcd import is_mysql_available
-        assert isinstance(is_mysql_available(), bool)
+from models.gcd import EXPECTED_GCD_TABLES, GCD_CORE_TABLES
+from tests.mocked.conftest import build_gcd_sqlite
 
 
-class TestCheckMysqlStatus:
+@pytest.fixture
+def not_configured(monkeypatch):
+    """No saved credentials and no env var -> GCD is unconfigured."""
+    monkeypatch.setattr("models.gcd._get_saved_credentials", lambda: None)
+    monkeypatch.delenv("GCD_DATABASE_PATH", raising=False)
 
-    @patch("models.gcd.get_connection_params",
-           return_value={"host": "localhost", "port": 3306,
-                         "database": "gcd", "username": "root", "password": ""})
-    def test_available(self, mock_params):
-        from models.gcd import check_mysql_status
 
-        status = check_mysql_status()
-        assert status["gcd_mysql_available"] is True
+class TestDatabaseStatus:
 
-    @patch("models.gcd.get_connection_params", return_value=None)
-    def test_not_available(self, mock_params):
-        from models.gcd import check_mysql_status
+    def test_available_when_file_exists(self, gcd_configured):
+        from models.gcd import check_database_status, is_database_available
+        status = check_database_status()
+        assert status["gcd_available"] is True
+        assert status["gcd_path_configured"] is True
+        assert is_database_available() is True
 
-        status = check_mysql_status()
-        assert status["gcd_mysql_available"] is False
+    def test_not_available_when_unconfigured(self, not_configured):
+        from models.gcd import check_database_status, is_database_available
+        status = check_database_status()
+        assert status["gcd_available"] is False
+        assert status["gcd_path_configured"] is False
+        assert is_database_available() is False
+
+    def test_not_available_when_path_missing(self, tmp_path, monkeypatch):
+        from models.gcd import check_database_status
+        missing = tmp_path / "nope.db"
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(missing)})
+        status = check_database_status()
+        assert status["gcd_available"] is False
+        # Path is configured but the file is absent.
+        assert status["gcd_path_configured"] is True
+
+    def test_env_var_fallback(self, gcd_db_path, monkeypatch):
+        from models.gcd import get_connection_params
+        monkeypatch.setattr("models.gcd._get_saved_credentials", lambda: None)
+        monkeypatch.setenv("GCD_DATABASE_PATH", str(gcd_db_path))
+        params = get_connection_params()
+        assert params == {"database_path": str(gcd_db_path)}
+
+
+class TestGetConnection:
+
+    def test_opens_read_only(self, gcd_configured):
+        from models.gcd import get_connection
+        conn = get_connection()
+        assert conn is not None
+        try:
+            # Read-only: writes must fail.
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("CREATE TABLE should_fail (x INTEGER)")
+        finally:
+            conn.close()
+
+    def test_regexp_registered(self, gcd_configured):
+        from models.gcd import get_connection
+        conn = get_connection()
+        try:
+            cur = conn.cursor()
+            # Case-sensitive by design (search_series lowercases both operands).
+            cur.execute("SELECT 'Batman' REGEXP ? AS m", ("Bat",))
+            assert cur.fetchone()["m"] == 1
+            cur.execute("SELECT 'Batman' REGEXP ? AS m", ("^zzz",))
+            assert cur.fetchone()["m"] == 0
+        finally:
+            conn.close()
+
+    def test_none_when_unconfigured(self, not_configured):
+        from models.gcd import get_connection
+        assert get_connection() is None
 
 
 class TestSearchSeries:
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_connection")
-    def test_finds_series(self, mock_conn):
+    def test_finds_series(self, gcd_configured):
         from models.gcd import search_series
-
-        conn, cursor = make_mock_mysql_connection(rows=[
-            {"id": 200, "name": "Batman", "year_began": 1940,
-             "year_ended": None, "publisher_id": 10, "publisher_name": "DC Comics"},
-        ])
-        mock_conn.return_value = conn
-
         result = search_series("Batman")
         assert result is not None
         assert result["name"] == "Batman"
+        assert result["year_began"] == 1940
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_connection")
-    def test_no_match(self, mock_conn):
+    def test_finds_series_with_year(self, gcd_configured):
         from models.gcd import search_series
+        result = search_series("Batman", year=1945)
+        assert result is not None
+        assert result["name"] == "Batman"
 
-        conn, cursor = make_mock_mysql_connection(rows=[])
-        mock_conn.return_value = conn
-
+    def test_no_match(self, gcd_configured):
+        from models.gcd import search_series
         assert search_series("NonexistentSeries") is None
 
-    @patch("models.gcd.MYSQL_AVAILABLE", False)
-    def test_mysql_unavailable(self):
+    def test_not_configured(self, not_configured):
         from models.gcd import search_series
         assert search_series("Batman") is None
 
 
 class TestGetIssueMetadata:
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_available_gcd_tables", return_value=set(EXPECTED_GCD_TABLES))
-    @patch("models.gcd.get_connection")
-    def test_returns_metadata(self, mock_conn, mock_tables):
+    def test_returns_metadata(self, gcd_configured):
         from models.gcd import get_issue_metadata
-
-        # get_issue_metadata uses a single cursor for three sequential queries:
-        # 1. series query → fetchone (series info)
-        # 2. issue query  → fetchone (issue info)
-        # 3. credits query → fetchall (credits list)
-        conn = MagicMock()
-        cursor = MagicMock()
-        cursor.fetchone.side_effect = [
-            # Series query result
-            {"id": 200, "name": "Batman", "year_began": 1940, "publisher_name": "DC Comics"},
-            # Issue query result
-            {"id": 1, "number": "1", "volume": "1", "title": "Origin",
-             "summary": "The origin of Batman", "year": 1940, "month": 4},
-        ]
-        cursor.fetchall.return_value = [
-            {"credit_type": "pencils", "creator_name": "Bob Kane"},
-            {"credit_type": "script", "creator_name": "Bill Finger"},
-        ]
-        conn.cursor.return_value = cursor
-        mock_conn.return_value = conn
-
         result = get_issue_metadata(200, "1")
         assert result is not None
         assert result["Series"] == "Batman"
         assert result["Number"] == "1"
-        assert result["Writer"] == "Bill Finger"
+        assert result["Publisher"] == "DC Comics"
+        assert result["Title"] == "The Beginning"
+        assert result["Year"] == 1940
+        assert result["Month"] == 4
+        # Normalized credit: Bob Kane credited as 'script' -> Writer.
+        assert result["Writer"] == "Bob Kane"
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_available_gcd_tables", return_value=set(EXPECTED_GCD_TABLES))
-    @patch("models.gcd.get_connection")
-    def test_issue_not_found(self, mock_conn, mock_tables):
+    def test_issue_not_found(self, gcd_configured):
         from models.gcd import get_issue_metadata
-
-        conn, cursor = make_mock_mysql_connection(fetchone_result=None)
-        mock_conn.return_value = conn
-
         assert get_issue_metadata(200, "999") is None
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_connection")
-    def test_falls_back_to_legacy_when_story_credit_missing(self, mock_conn):
-        """When gcd_story_credit is absent the normalized query is skipped and
-        the legacy text-column fallback runs against gcd_story."""
+    def test_core_only_db_has_no_credits(self, gcd_core_only_db_path, monkeypatch):
+        """A dump missing the credit tables still returns core fields."""
         from models.gcd import get_issue_metadata
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(gcd_core_only_db_path)})
+        result = get_issue_metadata(200, "1")
+        assert result is not None
+        assert result["Series"] == "Batman"
+        assert "Writer" not in result  # None values are dropped
 
-        partial = set(EXPECTED_GCD_TABLES) - {'gcd_story_credit', 'gcd_creator', 'gcd_issue_credit'}
-        conn = MagicMock()
-        cursor = MagicMock()
-        cursor.fetchone.side_effect = [
-            # Series query
-            {"id": 200, "name": "Batman", "year_began": 1940, "publisher_name": "DC Comics"},
-            # Issue query
-            {"id": 1, "number": "1", "volume": "1", "title": "Origin",
-             "summary": "Origin", "year": 1940, "month": 4},
-            # Legacy text-column fallback row
-            {"script": "Bill Finger", "pencils": "Bob Kane", "inks": None,
-             "colors": None, "letters": None, "editing": None},
-        ]
-        conn.cursor.return_value = cursor
-        mock_conn.return_value = conn
-
-        with patch("models.gcd.get_available_gcd_tables", return_value=partial):
-            result = get_issue_metadata(200, "1")
-
+    def test_falls_back_to_legacy_text_columns(self, tmp_path, monkeypatch):
+        """When gcd_story_credit is absent, legacy text columns on gcd_story win."""
+        from models.gcd import get_issue_metadata
+        path = build_gcd_sqlite(tmp_path / "legacy.db", core_only=True)
+        conn = sqlite3.connect(path)
+        conn.execute("UPDATE gcd_story SET script = 'Bill Finger', pencils = 'Bob Kane' WHERE id = 900")
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": path})
+        result = get_issue_metadata(200, "1")
         assert result is not None
         assert result["Writer"] == "Bill Finger"
         assert result["Penciller"] == "Bob Kane"
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_connection")
-    def test_no_credits_when_story_table_missing(self, mock_conn):
-        """When gcd_story is itself absent, no credits at all are returned and
-        no 500 is raised."""
-        from models.gcd import get_issue_metadata
-
-        partial = {'gcd_series', 'gcd_issue', 'gcd_publisher', 'stddata_language'}
-        conn = MagicMock()
-        cursor = MagicMock()
-        cursor.fetchone.side_effect = [
-            {"id": 200, "name": "Batman", "year_began": 1940, "publisher_name": "DC Comics"},
-            {"id": 1, "number": "1", "volume": "1", "title": "Origin",
-             "summary": "Origin", "year": 1940, "month": 4},
-        ]
-        conn.cursor.return_value = cursor
-        mock_conn.return_value = conn
-
-        with patch("models.gcd.get_available_gcd_tables", return_value=partial):
-            result = get_issue_metadata(200, "1")
-
-        assert result is not None
-        # Core fields still populated; credit fields are absent (None values dropped from result).
-        assert result["Series"] == "Batman"
-        assert "Writer" not in result
-
-    @patch("models.gcd.MYSQL_AVAILABLE", False)
-    def test_mysql_unavailable(self):
+    def test_not_configured(self, not_configured):
         from models.gcd import get_issue_metadata
         assert get_issue_metadata(200, "1") is None
 
@@ -175,40 +155,48 @@ class TestGetIssueMetadata:
 class TestGetAvailableGcdTables:
     """The cached helper that detects which expected GCD tables exist."""
 
-    def test_caches_after_first_call(self):
-        """Second call must not re-query information_schema."""
-        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
-        invalidate_gcd_table_cache()
+    def test_full_db_reports_all_tables(self, gcd_configured):
+        from models.gcd import get_available_gcd_tables
+        assert get_available_gcd_tables() == set(EXPECTED_GCD_TABLES)
 
+    def test_core_only_db_reports_core(self, gcd_core_only_db_path, monkeypatch):
+        from models.gcd import get_available_gcd_tables
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(gcd_core_only_db_path)})
+        present = get_available_gcd_tables()
+        assert GCD_CORE_TABLES.issubset(present)
+        assert 'gcd_story_credit' not in present
+
+    def _mock_conn(self, table_names):
         cursor = MagicMock()
-        cursor.fetchall.return_value = [('gcd_series',), ('gcd_issue',)]
+        cursor.fetchall.return_value = [{'name': t} for t in table_names]
         conn = MagicMock()
         conn.cursor.return_value = cursor
+        return conn, cursor
 
+    def test_caches_after_first_call(self):
+        from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
+        invalidate_gcd_table_cache()
+        conn, cursor = self._mock_conn(['gcd_series', 'gcd_issue'])
         with patch("models.gcd.get_connection", return_value=conn):
             first = get_available_gcd_tables()
             second = get_available_gcd_tables()
-
         assert first == second == {'gcd_series', 'gcd_issue'}
-        # Helper queries information_schema only once across two calls.
         assert cursor.execute.call_count == 1
 
     def test_force_refresh_requeries(self):
         from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
         invalidate_gcd_table_cache()
-
         cursor = MagicMock()
         cursor.fetchall.side_effect = [
-            [('gcd_series',)],
-            [('gcd_series',), ('gcd_issue',)],
+            [{'name': 'gcd_series'}],
+            [{'name': 'gcd_series'}, {'name': 'gcd_issue'}],
         ]
         conn = MagicMock()
         conn.cursor.return_value = cursor
-
         with patch("models.gcd.get_connection", return_value=conn):
             first = get_available_gcd_tables()
             second = get_available_gcd_tables(force_refresh=True)
-
         assert first == {'gcd_series'}
         assert second == {'gcd_series', 'gcd_issue'}
         assert cursor.execute.call_count == 2
@@ -216,71 +204,66 @@ class TestGetAvailableGcdTables:
     def test_returns_empty_set_on_error(self):
         from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
         invalidate_gcd_table_cache()
-
         conn = MagicMock()
         conn.cursor.side_effect = Exception("boom")
-
         with patch("models.gcd.get_connection", return_value=conn):
-            result = get_available_gcd_tables()
-
-        assert result == set()
+            assert get_available_gcd_tables() == set()
 
     def test_returns_empty_set_when_no_connection(self):
         from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
         invalidate_gcd_table_cache()
-
         with patch("models.gcd.get_connection", return_value=None):
-            result = get_available_gcd_tables()
-
-        assert result == set()
+            assert get_available_gcd_tables() == set()
 
     def test_warns_once_when_tables_missing(self, caplog):
-        """A single warning should be logged the first time we detect missing tables."""
         import logging
         from models.gcd import get_available_gcd_tables, invalidate_gcd_table_cache
         invalidate_gcd_table_cache()
-
-        cursor = MagicMock()
-        # Return a partial schema — gcd_creator and gcd_issue_credit missing.
         present = sorted(set(EXPECTED_GCD_TABLES) - {'gcd_creator', 'gcd_issue_credit'})
-        cursor.fetchall.return_value = [(t,) for t in present]
-        conn = MagicMock()
-        conn.cursor.return_value = cursor
-
+        conn, cursor = self._mock_conn(present)
         with caplog.at_level(logging.WARNING, logger="app_logger"):
             with patch("models.gcd.get_connection", return_value=conn):
                 get_available_gcd_tables()
                 get_available_gcd_tables()
                 get_available_gcd_tables()
-
         warnings = [r for r in caplog.records if "missing from dump" in r.getMessage()]
         assert len(warnings) == 1
 
 
+class TestGetDatabaseStats:
+
+    def test_counts(self, gcd_configured):
+        from models.gcd import get_database_stats
+        stats = get_database_stats()
+        assert stats is not None
+        assert stats["series"] == 1
+        assert stats["issues"] == 4
+        assert stats["stories"] == 1
+        assert stats["publishers"] == 1
+        assert stats["creators"] == 1
+        assert stats["core_ok"] is True
+        assert stats["missing_tables"] == []
+
+    def test_none_when_unconfigured(self, not_configured):
+        from models.gcd import get_database_stats
+        assert get_database_stats() is None
+
+
 class TestValidateIssue:
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_connection")
-    def test_valid_issue(self, mock_conn):
+    def test_valid_issue(self, gcd_configured):
         from models.gcd import validate_issue
-
-        conn, cursor = make_mock_mysql_connection(
-            fetchone_result={"id": 1, "number": "1", "title": "Origin"}
-        )
-        mock_conn.return_value = conn
-
         result = validate_issue(200, "1")
         assert result["success"] is True
         assert result["valid"] is True
 
-    @patch("models.gcd.MYSQL_AVAILABLE", True)
-    @patch("models.gcd.get_connection")
-    def test_invalid_issue(self, mock_conn):
+    def test_invalid_issue(self, gcd_configured):
         from models.gcd import validate_issue
-
-        conn, cursor = make_mock_mysql_connection(fetchone_result=None)
-        mock_conn.return_value = conn
-
         result = validate_issue(200, "999")
         assert result["success"] is True
         assert result["valid"] is False
+
+    def test_missing_args(self):
+        from models.gcd import validate_issue
+        result = validate_issue(None, None)
+        assert result["success"] is False

--- a/tests/mocked/test_gcd_provider.py
+++ b/tests/mocked/test_gcd_provider.py
@@ -1,9 +1,9 @@
-"""Tests for GCDProvider adapter -- mocked MySQL/gcd module."""
+"""Tests for GCDProvider adapter -- runs against a real temp SQLite GCD DB."""
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from models.providers.base import ProviderType, SearchResult, IssueResult
-from tests.mocked.conftest import make_mock_mysql_connection
+from tests.mocked.conftest import build_gcd_sqlite
 
 
 class TestGCDProviderInit:
@@ -15,158 +15,93 @@ class TestGCDProviderInit:
         assert p.provider_type == ProviderType.GCD
         assert p.display_name == "Grand Comics Database"
         assert p.requires_auth is True
-        assert "host" in p.auth_fields
-        assert "database" in p.auth_fields
+        assert p.auth_fields == ["database_path"]
 
 
 class TestGCDProviderTestConnection:
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection")
-    def test_successful_connection(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_successful_connection(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        mock_conn.return_value = MagicMock()
         p = GCDProvider(credentials=gcd_creds)
         assert p.test_connection() is True
 
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    def test_mysql_unavailable(self, mock_avail, gcd_creds):
+    def test_not_configured(self, monkeypatch, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
+        monkeypatch.setattr("models.gcd._get_saved_credentials", lambda: None)
+        monkeypatch.delenv("GCD_DATABASE_PATH", raising=False)
         p = GCDProvider(credentials=gcd_creds)
         assert p.test_connection() is False
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection", return_value=None)
-    def test_no_connection(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_missing_core_tables(self, tmp_path, monkeypatch, gcd_creds):
+        """A dump that lacks a core table must fail the connection test."""
         from models.providers.gcd_provider import GCDProvider
-
+        import sqlite3
+        path = str(tmp_path / "broken.db")
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE gcd_series (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": path})
         p = GCDProvider(credentials=gcd_creds)
         assert p.test_connection() is False
 
 
 class TestGCDProviderSearchSeries:
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.search_series")
-    def test_search_returns_results(self, mock_search, mock_status, mock_avail, gcd_creds):
+    def test_search_returns_results(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        mock_search.return_value = {
-            "id": 200, "name": "Batman", "year_began": 1940,
-            "publisher_name": "DC Comics", "issue_count": 713,
-        }
-
         p = GCDProvider(credentials=gcd_creds)
         results = p.search_series("Batman")
-
         assert len(results) == 1
         assert results[0].title == "Batman"
         assert results[0].provider == ProviderType.GCD
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.search_series", return_value=None)
-    def test_no_results(self, mock_search, mock_status, mock_avail, gcd_creds):
+    def test_no_results(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
         p = GCDProvider(credentials=gcd_creds)
         assert p.search_series("Nonexistent") == []
 
 
 class TestGCDProviderGetSeries:
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection")
-    def test_get_series_by_id(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_get_series_by_id(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        conn, cursor = make_mock_mysql_connection(
-            fetchone_result={
-                "id": 200, "name": "Batman", "year_began": 1940,
-                "year_ended": None, "publisher_name": "DC Comics", "issue_count": 713,
-            }
-        )
-        mock_conn.return_value = conn
-
         p = GCDProvider(credentials=gcd_creds)
         result = p.get_series("200")
-
         assert isinstance(result, SearchResult)
         assert result.title == "Batman"
         assert result.year == 1940
+        assert result.issue_count == 4
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection")
-    def test_series_not_found(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_series_not_found(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        conn, cursor = make_mock_mysql_connection(fetchone_result=None)
-        mock_conn.return_value = conn
-
         p = GCDProvider(credentials=gcd_creds)
         assert p.get_series("9999") is None
 
 
 class TestGCDProviderGetIssues:
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection")
-    def test_returns_issues(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_returns_issues_in_numeric_order(self, gcd_configured, gcd_creds):
+        """printf zero-padding must sort #2 before #10 (not lexicographically)."""
         from models.providers.gcd_provider import GCDProvider
-
-        conn, cursor = make_mock_mysql_connection(rows=[
-            {"id": 1, "number": "1", "title": "Origin", "key_date": "1940-04", "on_sale_date": None},
-            {"id": 2, "number": "2", "title": None, "key_date": "1940-06", "on_sale_date": None},
-        ])
-        mock_conn.return_value = conn
-
         p = GCDProvider(credentials=gcd_creds)
         results = p.get_issues("200")
+        assert len(results) == 4
+        assert [r.issue_number for r in results][:3] == ["1", "2", "10"]
 
-        assert len(results) == 2
-        assert results[0].issue_number == "1"
-        assert results[0].title == "Origin"
-
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection")
-    def test_empty_series(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_empty_series(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        conn, cursor = make_mock_mysql_connection(rows=[])
-        mock_conn.return_value = conn
-
         p = GCDProvider(credentials=gcd_creds)
-        assert p.get_issues("200") == []
+        assert p.get_issues("999") == []
 
 
 class TestGCDProviderGetIssue:
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_connection")
-    def test_get_single_issue(self, mock_conn, mock_status, mock_avail, gcd_creds):
+    def test_get_single_issue(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        conn, cursor = make_mock_mysql_connection(
-            fetchone_result={
-                "id": 1, "series_id": 200, "number": "1",
-                "title": "Origin", "key_date": "1940-04", "on_sale_date": None,
-            }
-        )
-        mock_conn.return_value = conn
-
         p = GCDProvider(credentials=gcd_creds)
-        result = p.get_issue("1")
-
+        result = p.get_issue("500")
         assert isinstance(result, IssueResult)
         assert result.issue_number == "1"
         assert result.series_id == "200"
@@ -174,29 +109,21 @@ class TestGCDProviderGetIssue:
 
 class TestGCDProviderToComicinfo:
 
-    @patch("models.gcd.is_mysql_available", return_value=True)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": True})
-    @patch("models.gcd.get_issue_metadata")
-    def test_uses_gcd_metadata(self, mock_meta, mock_status, mock_avail, gcd_creds):
+    def test_uses_gcd_metadata(self, gcd_configured, gcd_creds):
         from models.providers.gcd_provider import GCDProvider
-
-        mock_meta.return_value = {
-            "Series": "Batman", "Number": "1", "Publisher": "DC Comics",
-            "Year": 1940, "Writer": "Bill Finger",
-        }
-
         p = GCDProvider(credentials=gcd_creds)
         issue = IssueResult(
-            provider=ProviderType.GCD, id="1", series_id="200",
-            issue_number="1", title="Origin",
+            provider=ProviderType.GCD, id="500", series_id="200",
+            issue_number="1", title="The Beginning",
         )
-
         result = p.to_comicinfo(issue)
         assert result["Series"] == "Batman"
-        assert result["Writer"] == "Bill Finger"
+        assert result["Writer"] == "Bob Kane"
 
-    def test_fallback_without_metadata(self):
+    def test_fallback_without_metadata(self, monkeypatch):
         from models.providers.gcd_provider import GCDProvider
+        # Force get_issue_metadata to yield nothing so the fallback path runs.
+        monkeypatch.setattr("models.gcd.get_issue_metadata", lambda *a, **k: None)
 
         p = GCDProvider()
         issue = IssueResult(
@@ -207,7 +134,6 @@ class TestGCDProviderToComicinfo:
             provider=ProviderType.GCD, id="200", title="Batman",
             year=1940, publisher="DC Comics",
         )
-
         result = p.to_comicinfo(issue, series)
         assert result["Series"] == "Batman"
         assert result["Number"] == "1"

--- a/tests/mocked/test_gcd_stats.py
+++ b/tests/mocked/test_gcd_stats.py
@@ -1,4 +1,4 @@
-"""Unit tests for models.gcd.get_database_stats() with mocked MySQL."""
+"""Tests for models.gcd.get_database_stats() against a real temp SQLite DB."""
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -10,93 +10,51 @@ from models.gcd import (
 
 
 class TestGetDatabaseStats:
-    """Test get_database_stats with mocked connections."""
 
-    def _make_conn(self, fetchall_rows):
-        cursor = MagicMock()
-        cursor.fetchall.return_value = fetchall_rows
-        conn = MagicMock()
-        conn.cursor.return_value = cursor
-        return conn
-
-    def test_returns_stats_on_success(self):
-        """Returns a dict with mapped table counts when all tables present."""
-        rows = [
-            ('gcd_series', 250000),
-            ('gcd_issue', 2500000),
-            ('gcd_story', 3000000),
-            ('gcd_publisher', 50000),
-            ('gcd_creator', 400000),
-        ]
-        mock_conn = self._make_conn(rows)
-
-        with patch('models.gcd.get_connection', return_value=mock_conn), \
-             patch('models.gcd.get_available_gcd_tables', return_value=set(EXPECTED_GCD_TABLES)):
-            stats = get_database_stats()
-
+    def test_returns_stats_on_success(self, gcd_configured):
+        """Counts every mapped table via COUNT(*) against the test DB."""
+        stats = get_database_stats()
         assert stats is not None
-        assert stats['series'] == 250000
-        assert stats['issues'] == 2500000
-        assert stats['stories'] == 3000000
-        assert stats['publishers'] == 50000
-        assert stats['creators'] == 400000
+        assert stats['series'] == 1
+        assert stats['issues'] == 4
+        assert stats['stories'] == 1
+        assert stats['publishers'] == 1
+        assert stats['creators'] == 1
         assert stats['table_count'] == len(EXPECTED_GCD_TABLES)
         assert stats['missing_tables'] == []
         assert stats['core_ok'] is True
-        mock_conn.close.assert_called_once()
 
     def test_returns_none_when_no_connection(self):
-        """Returns None when get_connection() fails."""
         with patch('models.gcd.get_connection', return_value=None):
-            stats = get_database_stats()
-
-        assert stats is None
+            assert get_database_stats() is None
 
     def test_returns_none_on_query_error(self):
-        """Returns None when the SQL query raises an exception."""
+        """Returns None (and closes) when the COUNT query raises."""
         mock_conn = MagicMock()
         mock_conn.cursor.side_effect = Exception("query failed")
-
         with patch('models.gcd.get_connection', return_value=mock_conn), \
              patch('models.gcd.get_available_gcd_tables', return_value=set(EXPECTED_GCD_TABLES)):
-            stats = get_database_stats()
-
-        assert stats is None
+            assert get_database_stats() is None
         mock_conn.close.assert_called_once()
 
-    def test_reports_missing_tables_when_dump_partial(self):
-        """Surfaces missing_tables / core_ok when the dump excludes tables."""
-        # Simulate the May 2026 GCD dump: gcd_creator and gcd_issue_credit absent.
-        available = set(EXPECTED_GCD_TABLES) - {'gcd_creator', 'gcd_issue_credit'}
-        rows = [
-            ('gcd_series', 100),
-            ('gcd_issue', 200),
-            ('gcd_story', 300),
-            ('gcd_publisher', 50),
-        ]
-        mock_conn = self._make_conn(rows)
-
-        with patch('models.gcd.get_connection', return_value=mock_conn), \
-             patch('models.gcd.get_available_gcd_tables', return_value=available):
-            stats = get_database_stats()
-
+    def test_reports_missing_tables_when_dump_partial(self, gcd_core_only_db_path, monkeypatch):
+        """A core-only dump surfaces the missing auxiliary tables."""
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(gcd_core_only_db_path)})
+        stats = get_database_stats()
         assert stats is not None
-        assert stats['series'] == 100
-        # gcd_creator missing → creators defaults to 0 (key still present)
+        assert stats['series'] == 1
+        # gcd_creator absent → creators defaults to 0 (key still present)
         assert stats['creators'] == 0
         assert 'gcd_creator' in stats['missing_tables']
-        assert 'gcd_issue_credit' in stats['missing_tables']
-        assert stats['core_ok'] is True  # core tables (series/issue/publisher/story/stddata_language) still here
+        assert 'gcd_story_credit' in stats['missing_tables']
+        assert stats['core_ok'] is True  # core tables still present
 
-    def test_core_ok_false_when_core_tables_missing(self):
-        """core_ok is False when a core table (gcd_issue) is absent."""
+    def test_core_ok_false_when_core_tables_missing(self, gcd_configured):
+        """core_ok is False when a core table is reported missing."""
         available = set(EXPECTED_GCD_TABLES) - {'gcd_issue'}
-        mock_conn = self._make_conn([])
-
-        with patch('models.gcd.get_connection', return_value=mock_conn), \
-             patch('models.gcd.get_available_gcd_tables', return_value=available):
+        with patch('models.gcd.get_available_gcd_tables', return_value=available):
             stats = get_database_stats()
-
         assert stats is not None
         assert stats['core_ok'] is False
         assert 'gcd_issue' in stats['missing_tables']

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -297,8 +297,8 @@ class TestSearchMetadataParsedFilename:
 
     @patch("models.metron.is_metron_configured", return_value=False)
     @patch("models.metron.is_connection_error", return_value=False)
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": False})
+    @patch("models.gcd.is_database_available", return_value=False)
+    @patch("models.gcd.check_database_status", return_value={"gcd_available": False})
     @patch("models.comicvine.find_cvinfo_in_folder", return_value=None)
     @patch("models.comicvine.extract_issue_number", return_value=None)
     @patch("core.database.get_library_providers", return_value=[])
@@ -322,8 +322,8 @@ class TestSearchMetadataParsedFilename:
 
     @patch("models.metron.is_metron_configured", return_value=False)
     @patch("models.metron.is_connection_error", return_value=False)
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": False})
+    @patch("models.gcd.is_database_available", return_value=False)
+    @patch("models.gcd.check_database_status", return_value={"gcd_available": False})
     @patch("models.comicvine.find_cvinfo_in_folder", return_value=None)
     @patch("models.comicvine.extract_issue_number", return_value=None)
     @patch("core.database.get_library_providers", return_value=[])
@@ -345,8 +345,8 @@ class TestSearchMetadataParsedFilename:
 
     @patch("models.metron.is_metron_configured", return_value=False)
     @patch("models.metron.is_connection_error", return_value=False)
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": False})
+    @patch("models.gcd.is_database_available", return_value=False)
+    @patch("models.gcd.check_database_status", return_value={"gcd_available": False})
     @patch("models.comicvine.find_cvinfo_in_folder", return_value=None)
     @patch("models.comicvine.extract_issue_number", return_value=None)
     @patch("core.database.get_library_providers", return_value=[])
@@ -367,8 +367,8 @@ class TestSearchMetadataParsedFilename:
 
     @patch("models.metron.is_metron_configured", return_value=False)
     @patch("models.metron.is_connection_error", return_value=False)
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": False})
+    @patch("models.gcd.is_database_available", return_value=False)
+    @patch("models.gcd.check_database_status", return_value={"gcd_available": False})
     @patch("models.comicvine.find_cvinfo_in_folder", return_value="/data/foo/cvinfo")
     @patch("models.comicvine.extract_issue_number", return_value=None)
     @patch("core.database.get_library_providers", return_value=[])
@@ -402,8 +402,8 @@ class TestSearchMetadataParsedFilename:
 
     @patch("models.metron.is_metron_configured", return_value=False)
     @patch("models.metron.is_connection_error", return_value=False)
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": False})
+    @patch("models.gcd.is_database_available", return_value=False)
+    @patch("models.gcd.check_database_status", return_value={"gcd_available": False})
     @patch("models.comicvine.find_cvinfo_in_folder", return_value=None)
     @patch("models.comicvine.extract_issue_number", return_value=None)
     @patch("core.database.get_library_providers", return_value=[])
@@ -432,8 +432,8 @@ class TestSearchMetadataParsedFilename:
 
     @patch("models.metron.is_metron_configured", return_value=False)
     @patch("models.metron.is_connection_error", return_value=False)
-    @patch("models.gcd.is_mysql_available", return_value=False)
-    @patch("models.gcd.check_mysql_status", return_value={"gcd_mysql_available": False})
+    @patch("models.gcd.is_database_available", return_value=False)
+    @patch("models.gcd.check_database_status", return_value={"gcd_available": False})
     @patch("models.comicvine.find_cvinfo_in_folder", return_value=None)
     @patch("models.comicvine.extract_issue_number", return_value=None)
     @patch("core.database.get_library_providers", return_value=[])
@@ -468,9 +468,9 @@ class TestSearchMetadataComicVineFailover:
 
         stack.enter_context(patch("models.metron.is_metron_configured", return_value=False))
         stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
-        stack.enter_context(patch("models.gcd.is_mysql_available", return_value=False))
-        stack.enter_context(patch("models.gcd.check_mysql_status",
-                                  return_value={"gcd_mysql_available": False}))
+        stack.enter_context(patch("models.gcd.is_database_available", return_value=False))
+        stack.enter_context(patch("models.gcd.check_database_status",
+                                  return_value={"gcd_available": False}))
         stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
         stack.enter_context(patch("models.comicvine.is_simyan_available", return_value=True))
         stack.enter_context(patch("models.comicvine.search_volumes",
@@ -790,9 +790,9 @@ class TestSearchMetadataSkipProviders:
         app.config["COMICVINE_API_KEY"] = "test-key"
         stack.enter_context(patch("models.metron.is_metron_configured", return_value=True))
         stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
-        stack.enter_context(patch("models.gcd.is_mysql_available", return_value=False))
-        stack.enter_context(patch("models.gcd.check_mysql_status",
-                                  return_value={"gcd_mysql_available": False}))
+        stack.enter_context(patch("models.gcd.is_database_available", return_value=False))
+        stack.enter_context(patch("models.gcd.check_database_status",
+                                  return_value={"gcd_available": False}))
         stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
         stack.enter_context(patch("models.comicvine.extract_issue_number", return_value=None))
         stack.enter_context(patch("core.database.get_library_providers", return_value=[]))
@@ -877,9 +877,9 @@ class TestSearchMetadataMetronSelection:
         app.config["COMICVINE_API_KEY"] = ""
         stack.enter_context(patch("models.metron.is_metron_configured", return_value=True))
         stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
-        stack.enter_context(patch("models.gcd.is_mysql_available", return_value=False))
-        stack.enter_context(patch("models.gcd.check_mysql_status",
-                                  return_value={"gcd_mysql_available": False}))
+        stack.enter_context(patch("models.gcd.is_database_available", return_value=False))
+        stack.enter_context(patch("models.gcd.check_database_status",
+                                  return_value={"gcd_available": False}))
         stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
         stack.enter_context(patch("models.comicvine.extract_issue_number", return_value=None))
         stack.enter_context(patch("core.database.get_library_providers", return_value=[]))
@@ -1170,3 +1170,77 @@ class TestOneShotFolderHandling:
         gmv.assert_not_called()
         pcv.assert_not_called()
         assert '"type": "complete"' in body
+
+
+class TestGcdSqliteRoutes:
+    """End-to-end coverage of the GCD routes against a real temp SQLite dump.
+
+    These exercise the ported SQLite SQL (CONCAT->||, SUBSTRING->substr,
+    GROUP_CONCAT rewrites, REGEXP) rather than mocking cursors.
+    """
+
+    def _configure_gcd(self, tmp_path, monkeypatch):
+        from tests.mocked.conftest import build_gcd_sqlite
+        path = build_gcd_sqlite(tmp_path / "gcd.db")
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(path)})
+        return path
+
+    def test_validate_gcd_issue_valid(self, client, tmp_path, monkeypatch):
+        self._configure_gcd(tmp_path, monkeypatch)
+        resp = client.post('/validate-gcd-issue', json={
+            'series_id': 200, 'issue_number': '1',
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is True
+        assert data['issue_number'] == '1'
+
+    def test_validate_gcd_issue_invalid(self, client, tmp_path, monkeypatch):
+        self._configure_gcd(tmp_path, monkeypatch)
+        resp = client.post('/validate-gcd-issue', json={
+            'series_id': 200, 'issue_number': '999',
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is False
+
+    def test_search_with_selection_writes_metadata(self, client, tmp_path, monkeypatch):
+        """The full ComicInfo query (credits/genre/characters aggregates) resolves."""
+        self._configure_gcd(tmp_path, monkeypatch)
+        cbz = tmp_path / "Batman 001.cbz"
+        _make_cbz(str(cbz), with_comicinfo=False)
+
+        with patch("routes.metadata.add_comicinfo_to_cbz", return_value=True), \
+             patch("core.database.set_has_comicinfo"):
+            resp = client.post('/search-gcd-metadata-with-selection', json={
+                'file_path': str(cbz),
+                'file_name': 'Batman 001.cbz',
+                'series_id': 200,
+                'issue_number': '1',
+            })
+
+        assert resp.status_code == 200
+        meta = resp.get_json()['metadata']
+        assert meta['series'] == 'Batman'
+        assert meta['issue'] == '1'
+        assert meta['title'] == 'The Beginning'
+        assert meta['publisher'] == 'DC Comics'
+        assert meta['year'] == 1940
+        assert meta['writer'] == 'Bob Kane'
+        assert meta['genre'] == 'superhero'
+        assert 'Batman' in meta['characters']
+
+    def test_search_with_selection_not_configured(self, client, tmp_path, monkeypatch):
+        monkeypatch.setattr("models.gcd._get_saved_credentials", lambda: None)
+        monkeypatch.delenv("GCD_DATABASE_PATH", raising=False)
+        cbz = tmp_path / "Batman 001.cbz"
+        _make_cbz(str(cbz), with_comicinfo=False)
+        resp = client.post('/search-gcd-metadata-with-selection', json={
+            'file_path': str(cbz),
+            'file_name': 'Batman 001.cbz',
+            'series_id': 200,
+            'issue_number': '1',
+        })
+        assert resp.status_code == 500
+        assert resp.get_json()['success'] is False


### PR DESCRIPTION
## 📝 Description
Replace GCD MySQL connection with SQLite database support. Users now download the GCD dump from comics.org and point CLU to the local file instead of maintaining a separate MySQL server.

Key changes:
- Convert MySQL queries to SQLite dialect (CONCAT→||, SUBSTRING→substr, placeholders %s→?)
- Implement REGEXP function for SQLite pattern matching
- Store database_path in provider credentials instead of host/port/username/password
- Update Docker environment variables from GCD_MYSQL_* to GCD_DATABASE_PATH
- Rewrite all GCD tests to use temporary real SQLite databases instead of mocks
- Update routes, endpoints, and frontend to reference SQLite instead of MySQL

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass