### PR TITLE
Add local ComicVine SQLite metadata provider

### DIFF
--- a/core/bulk_metadata.py
+++ b/core/bulk_metadata.py
@@ -322,7 +322,7 @@ def _series_to_dict(provider_name: str, series: SearchResult) -> Dict:
     series_id = getattr(series, 'id', None)
     if provider_name == 'metron':
         d['id'] = series_id          # -> metron_id
-    elif provider_name == 'comicvine':
+    elif provider_name in ('comicvine', 'comicvine_sqlite'):
         d['cv_id'] = series_id       # -> comicid
     return d
 
@@ -346,7 +346,7 @@ def ensure_folder_sidecars(folder_path: str, provider_name: str, series: Optiona
 
     try:
         cvinfo_path = os.path.join(folder_path, 'cvinfo')
-        if provider_name in ('metron', 'comicvine') and not os.path.exists(cvinfo_path):
+        if provider_name in ('metron', 'comicvine', 'comicvine_sqlite') and not os.path.exists(cvinfo_path):
             _write_cvinfo(cvinfo_path, provider_name, series)
     except Exception as e:
         app_logger.warning(f"sidecar cvinfo write failed for {folder_path}: {e}")

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -618,7 +618,7 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
     }
 
 
-def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str, Any]] = None, start_year: Optional[int] = None) -> Dict[str, Any]:
+def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str, Any]] = None, start_year: Optional[int] = None, source_label: str = 'ComicVine CVDB') -> Dict[str, Any]:
     """
     Map ComicVine issue data to ComicInfo.xml format.
 
@@ -626,6 +626,9 @@ def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str,
         issue_data: Issue data from ComicVine
         volume_data: Optional volume data for additional context
         start_year: Optional series start year to use for Volume field (preferred over publication year)
+        source_label: Label used in the Notes field to identify the metadata
+            source. Defaults to the ComicVine API's "ComicVine CVDB"; the local
+            SQLite provider passes "ComicVine (Local DB)" to differentiate.
 
     Returns:
         Dictionary in ComicInfo.xml format
@@ -645,9 +648,9 @@ def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str,
     volume_id = volume_data.get('id') if volume_data else issue_data.get('volume_id')
     current_date = datetime.now().strftime('%Y-%m-%d')
     if volume_id:
-        notes = f'Metadata from ComicVine CVDB. Volume ID: {volume_id} — retrieved {current_date}.'
+        notes = f'Metadata from {source_label}. Volume ID: {volume_id} — retrieved {current_date}.'
     else:
-        notes = f'Metadata from ComicVine CVDB — retrieved {current_date}.'
+        notes = f'Metadata from {source_label} — retrieved {current_date}.'
 
     # Append cover_date or store_date if available
     if issue_data.get('cover_date') or issue_data.get('store_date'):

--- a/models/comicvine_sqlite.py
+++ b/models/comicvine_sqlite.py
@@ -1,0 +1,359 @@
+"""
+Local ComicVine SQLite integration for comic metadata retrieval.
+
+Reads a user-provided SQLite export of ComicVine data (a file the user places on
+a mapped path and points to in Settings). It produces ComicInfo output identical
+to the ComicVine API provider by reusing ``models.comicvine.map_to_comicinfo`` —
+this module only builds the intermediate ``issue_data`` dict (same keys as
+``comicvine._issue_to_dict``) from the SQLite rows + JSON credit columns.
+
+Schema (user-provided dump):
+- cv_volume(id, name, aliases, start_year, publisher_id, count_of_issues,
+            description, image_url, site_detail_url)   -- id IS the ComicVine volume id
+- cv_issue(id, volume_id, name, issue_number, cover_date, store_date, description,
+           image_url, site_detail_url, character_credits, person_credits,
+           team_credits, location_credits, story_arc_credits, associated_images)
+- cv_publisher(id, name)
+
+The credit columns are ComicVine-API-style JSON:
+- person_credits    = [{"id":.., "name":"..", "role":"writer, penciler"}, ...]
+- character/team/location/story_arc_credits = [{"id":.., "name":".."}, ...]
+"""
+import os
+import json
+import sqlite3
+from datetime import datetime
+from typing import Optional, Dict, Any, List
+
+from core.app_logging import app_logger
+from models.comicvine import map_to_comicinfo, _extract_year_from_date
+
+# Notes-field label so ComicInfo.xml written from the local DB is distinguishable
+# from the ComicVine API (which uses the default "ComicVine CVDB").
+SOURCE_LABEL = "ComicVine (Local DB)"
+
+
+# =============================================================================
+# Database Connection
+# =============================================================================
+
+def _dict_factory(cursor, row):
+    """Row factory returning plain dicts (callers rely on ``row.get(...)``)."""
+    return {col[0]: row[idx] for idx, col in enumerate(cursor.description)}
+
+
+def _get_saved_credentials() -> Optional[Dict[str, Any]]:
+    """Get ComicVine-SQLite credentials saved via the UI."""
+    try:
+        from core.database import get_provider_credentials
+        return get_provider_credentials('comicvine_sqlite')
+    except Exception:
+        return None
+
+
+def get_connection_params() -> Optional[Dict[str, Any]]:
+    """
+    Get the local ComicVine SQLite connection parameters.
+    Checks saved credentials first, then falls back to the
+    COMICVINE_DATABASE_PATH environment variable.
+
+    Returns:
+        Dict with database_path, or None if not configured
+    """
+    saved_creds = _get_saved_credentials()
+    if saved_creds and saved_creds.get('database_path'):
+        return {'database_path': saved_creds.get('database_path')}
+
+    env_path = os.environ.get('COMICVINE_DATABASE_PATH')
+    if env_path:
+        return {'database_path': env_path}
+
+    return None
+
+
+def is_database_available() -> bool:
+    """Check whether a configured ComicVine SQLite file exists on disk."""
+    params = get_connection_params()
+    path = params.get('database_path') if params else None
+    return bool(path and os.path.exists(path))
+
+
+def check_database_status() -> Dict[str, Any]:
+    """Check if the local ComicVine SQLite database is configured and present."""
+    try:
+        params = get_connection_params()
+        path = params.get('database_path') if params else None
+        available = bool(path and os.path.exists(path))
+        return {
+            "cv_sqlite_available": available,
+            "cv_sqlite_path_configured": bool(path),
+        }
+    except Exception as e:
+        return {
+            "cv_sqlite_available": False,
+            "cv_sqlite_path_configured": False,
+            "error": str(e),
+        }
+
+
+def get_connection():
+    """
+    Open and return a read-only SQLite connection to the ComicVine database.
+    Uses saved credentials from the UI first, falls back to COMICVINE_DATABASE_PATH.
+
+    Returns:
+        sqlite3.Connection (dict rows) or None on failure
+    """
+    try:
+        params = get_connection_params()
+        if not params or not params.get('database_path'):
+            app_logger.error("ComicVine database not configured (no saved path or COMICVINE_DATABASE_PATH)")
+            return None
+
+        path = params['database_path']
+        if not os.path.exists(path):
+            app_logger.error(f"ComicVine database file not found: {path}")
+            return None
+
+        # Read-only URI: never creates an empty DB on a bad path and never writes
+        # -wal/-shm/journal files next to the dump.
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.row_factory = _dict_factory
+        return conn
+    except sqlite3.Error as e:
+        app_logger.error(f"Failed to open ComicVine SQLite database: {e}")
+        return None
+    except Exception as e:
+        app_logger.error(f"Failed to open ComicVine SQLite database: {e}")
+        return None
+
+
+# =============================================================================
+# JSON credit parsing
+# =============================================================================
+
+def _load_json_list(value) -> List[Dict[str, Any]]:
+    """Parse a JSON-array credit column, returning [] on anything unexpected."""
+    if not value:
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, list) else []
+    except (ValueError, TypeError):
+        return []
+
+
+def _names_from(value) -> List[str]:
+    """Extract the 'name' of each object in a JSON credit array."""
+    names = []
+    for entry in _load_json_list(value):
+        if isinstance(entry, dict):
+            name = entry.get('name')
+            if name:
+                names.append(name)
+    return names
+
+
+def _parse_person_credits(value):
+    """Map person_credits JSON into ComicInfo role buckets.
+
+    Replicates comicvine._issue_to_dict exactly: the role string is lowercased
+    and matched with a first-match-wins if/elif chain (NOT split on commas), so
+    each creator lands in exactly one bucket. Roles matching none are dropped.
+    """
+    writers, pencillers, inkers, colorists, letterers, cover_artists = [], [], [], [], [], []
+    for credit in _load_json_list(value):
+        if not isinstance(credit, dict):
+            continue
+        name = credit.get('name')
+        if not name:
+            continue
+        role = (credit.get('role') or '').lower()
+        if "writer" in role or "script" in role:
+            writers.append(name)
+        elif "pencil" in role or "illustrat" in role:
+            pencillers.append(name)
+        elif "ink" in role:
+            inkers.append(name)
+        elif "color" in role:
+            colorists.append(name)
+        elif "letter" in role:
+            letterers.append(name)
+        elif "cover" in role:
+            cover_artists.append(name)
+    return writers, pencillers, inkers, colorists, letterers, cover_artists
+
+
+# =============================================================================
+# Volume / Issue queries
+# =============================================================================
+
+_VOLUME_SELECT = (
+    "SELECT v.id, v.name, v.start_year, v.count_of_issues, v.description,"
+    "       v.image_url, p.name AS publisher_name"
+    " FROM cv_volume v"
+    " LEFT JOIN cv_publisher p ON p.id = v.publisher_id"
+)
+
+
+def search_volumes(series_name: str, year: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Search cv_volume by name (optionally constrained by start_year).
+
+    Returns dicts shaped identically to comicvine.search_volumes so the same
+    selection modal and map_to_comicinfo path can consume them.
+    """
+    if not series_name:
+        return []
+    conn = get_connection()
+    if not conn:
+        return []
+    try:
+        cursor = conn.cursor()
+        # Match on name OR aliases (ComicVine searches aliases too). Alias-only
+        # matches deliberately won't satisfy the name-based "confident match"
+        # check in the cascade, so they surface a selection prompt.
+        like = f"%{series_name}%"
+        query = _VOLUME_SELECT + " WHERE (v.name LIKE ? OR v.aliases LIKE ?)"
+        params: List[Any] = [like, like]
+        if year:
+            query += " AND v.start_year = ?"
+            params.append(year)
+        query += " ORDER BY v.count_of_issues DESC LIMIT 50"
+        cursor.execute(query, params)
+        return cursor.fetchall()
+    except sqlite3.Error as e:
+        app_logger.error(f"ComicVine SQLite search_volumes failed: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def get_volume_details(volume_id: int) -> Optional[Dict[str, Any]]:
+    """Fetch a single volume by ComicVine volume id."""
+    conn = get_connection()
+    if not conn:
+        return None
+    try:
+        cursor = conn.cursor()
+        cursor.execute(_VOLUME_SELECT + " WHERE v.id = ?", (int(volume_id),))
+        return cursor.fetchone()
+    except (sqlite3.Error, ValueError) as e:
+        app_logger.error(f"ComicVine SQLite get_volume_details failed: {e}")
+        return None
+    finally:
+        conn.close()
+
+
+def get_issue_by_number(volume_id: int, issue_number: str, year: Optional[int] = None) -> Optional[Dict[str, Any]]:
+    """Look up an issue within a volume and build the intermediate issue_data dict.
+
+    The returned dict mirrors comicvine._issue_to_dict's keys so it can be passed
+    straight to comicvine.map_to_comicinfo. ``year`` is accepted for signature
+    parity with the API path but is unused (volume_id + issue_number is unique).
+    """
+    conn = get_connection()
+    if not conn:
+        return None
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT i.id, i.volume_id, i.name, i.issue_number, i.cover_date,"
+            "       i.store_date, i.description, i.image_url,"
+            "       i.character_credits, i.person_credits, i.team_credits,"
+            "       i.location_credits, i.story_arc_credits,"
+            "       v.name AS volume_name, v.start_year AS volume_start_year,"
+            "       p.name AS publisher_name"
+            " FROM cv_issue i"
+            " JOIN cv_volume v ON v.id = i.volume_id"
+            " LEFT JOIN cv_publisher p ON p.id = v.publisher_id"
+            " WHERE i.volume_id = ? AND i.issue_number = ?"
+            " LIMIT 1",
+            (int(volume_id), str(issue_number)),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return _row_to_issue_data(row)
+    except (sqlite3.Error, ValueError) as e:
+        app_logger.error(f"ComicVine SQLite get_issue_by_number failed: {e}")
+        return None
+    finally:
+        conn.close()
+
+
+def _row_to_issue_data(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn a joined cv_issue row into the comicvine._issue_to_dict-shaped dict."""
+    # Dates: prefer cover_date, fall back to store_date (mirrors _issue_to_dict).
+    cover_date = row.get('cover_date') or None
+    store_date = row.get('store_date') or None
+    date_value = cover_date or store_date
+    year = month = day = None
+    if date_value:
+        year = _extract_year_from_date(date_value)
+        try:
+            date_obj = datetime.strptime(date_value, "%Y-%m-%d")
+            month = date_obj.month
+            day = date_obj.day
+        except (ValueError, TypeError):
+            pass
+
+    writers, pencillers, inkers, colorists, letterers, cover_artists = \
+        _parse_person_credits(row.get('person_credits'))
+
+    story_arcs = _names_from(row.get('story_arc_credits'))
+    story_arc = story_arcs[0] if story_arcs else None
+
+    return {
+        "id": row.get('id'),
+        "name": row.get('name'),
+        "issue_number": row.get('issue_number'),
+        "volume_name": row.get('volume_name'),
+        "volume_id": row.get('volume_id'),
+        "volume_start_year": row.get('volume_start_year'),
+        "publisher": row.get('publisher_name'),
+        "cover_date": cover_date,
+        "store_date": store_date,
+        "year": year,
+        "month": month,
+        "day": day,
+        "description": row.get('description'),
+        "image_url": row.get('image_url'),
+        "page_count": None,
+        "writers": writers,
+        "pencillers": pencillers,
+        "inkers": inkers,
+        "colorists": colorists,
+        "letterers": letterers,
+        "cover_artists": cover_artists,
+        "characters": _names_from(row.get('character_credits')),
+        "teams": _names_from(row.get('team_credits')),
+        "locations": _names_from(row.get('location_credits')),
+        "story_arc": story_arc,
+    }
+
+
+def _volume_data_from_issue(issue_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the volume_data dict map_to_comicinfo expects from issue_data."""
+    return {
+        'id': issue_data.get('volume_id'),
+        'name': issue_data.get('volume_name'),
+        'publisher_name': issue_data.get('publisher'),
+        'start_year': issue_data.get('volume_start_year'),
+    }
+
+
+def get_issue_metadata(volume_id: int, issue_number: str, start_year: Optional[int] = None) -> Optional[Dict[str, Any]]:
+    """Return a fully-mapped ComicInfo dict for an issue, or None if not found.
+
+    Reuses comicvine.map_to_comicinfo for byte-for-byte parity with the API path,
+    and attaches ``_image_url`` (stripped by callers) like get_metadata_by_volume_id.
+    """
+    issue_data = get_issue_by_number(volume_id, issue_number)
+    if not issue_data:
+        return None
+    volume_data = _volume_data_from_issue(issue_data)
+    metadata = map_to_comicinfo(issue_data, volume_data, start_year=start_year, source_label=SOURCE_LABEL)
+    metadata['_image_url'] = issue_data.get('image_url')
+    return metadata

--- a/models/providers/__init__.py
+++ b/models/providers/__init__.py
@@ -153,6 +153,7 @@ def get_provider_class(provider_type: ProviderType) -> Optional[Type[BaseProvide
 # These imports trigger the @register_provider decorator
 from .metron_provider import MetronProvider
 from .comicvine_provider import ComicVineProvider
+from .comicvine_sqlite_provider import ComicVineSqliteProvider
 from .gcd_provider import GCDProvider
 from .gcd_api_provider import GCDApiProvider
 from .anilist_provider import AniListProvider
@@ -181,6 +182,7 @@ __all__ = [
     # Provider implementations
     'MetronProvider',
     'ComicVineProvider',
+    'ComicVineSqliteProvider',
     'GCDProvider',
     'GCDApiProvider',
     'AniListProvider',

--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -16,6 +16,7 @@ class ProviderType(Enum):
     """Enumeration of supported metadata providers."""
     METRON = "metron"
     COMICVINE = "comicvine"
+    COMICVINE_SQLITE = "comicvine_sqlite"
     GCD = "gcd"
     GCD_API = "gcd_api"
     ANILIST = "anilist"

--- a/models/providers/comicvine_sqlite_provider.py
+++ b/models/providers/comicvine_sqlite_provider.py
@@ -1,0 +1,237 @@
+"""
+ComicVine (Local SQLite) Provider Adapter.
+
+Wraps the local ComicVine SQLite database (a user-provided file on a mapped path)
+to conform to the BaseProvider interface. Output is identical to the ComicVine API
+provider because both funnel through models.comicvine.map_to_comicinfo.
+"""
+from typing import Optional, List, Dict, Any
+
+from core.app_logging import app_logger
+from .base import BaseProvider, ProviderType, ProviderCredentials, SearchResult, IssueResult
+from . import register_provider
+
+
+@register_provider
+class ComicVineSqliteProvider(BaseProvider):
+    """ComicVine metadata provider backed by a local SQLite database file."""
+
+    provider_type = ProviderType.COMICVINE_SQLITE
+    display_name = "ComicVine (Local DB)"
+    requires_auth = True
+    auth_fields = ["database_path"]
+    rate_limit = 1000  # Local database, no API rate limits
+
+    def __init__(self, credentials: Optional[ProviderCredentials] = None):
+        super().__init__(credentials)
+
+    def _is_configured(self) -> bool:
+        """Check if the ComicVine SQLite database is configured and present."""
+        from models import comicvine_sqlite as cv_sqlite
+        return cv_sqlite.check_database_status().get('cv_sqlite_available', False)
+
+    def test_connection(self) -> bool:
+        """Test the DB — open it and verify the cv_volume/cv_issue tables exist."""
+        try:
+            if not self._is_configured():
+                return False
+
+            from models import comicvine_sqlite as cv_sqlite
+            conn = cv_sqlite.get_connection()
+            if not conn:
+                return False
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type = 'table' AND name IN ('cv_volume', 'cv_issue')"
+                )
+                present = {row['name'] for row in cursor.fetchall()}
+                return {'cv_volume', 'cv_issue'}.issubset(present)
+            finally:
+                conn.close()
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite connection test failed: {e}")
+            return False
+
+    def search_series(self, query: str, year: Optional[int] = None) -> List[SearchResult]:
+        """Search for volumes (series) in the local ComicVine database."""
+        try:
+            if not self._is_configured():
+                return []
+
+            from models import comicvine_sqlite as cv_sqlite
+            volumes = cv_sqlite.search_volumes(query, year)
+
+            results = []
+            for vol in volumes:
+                results.append(SearchResult(
+                    provider=self.provider_type,
+                    id=str(vol.get('id', '')),
+                    title=vol.get('name', ''),
+                    year=vol.get('start_year'),
+                    publisher=vol.get('publisher_name'),
+                    issue_count=vol.get('count_of_issues'),
+                    cover_url=vol.get('image_url'),
+                    description=vol.get('description'),
+                ))
+            return results
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite search_series failed: {e}")
+            return []
+
+    def get_series(self, series_id: str) -> Optional[SearchResult]:
+        """Get volume details by ComicVine volume ID."""
+        try:
+            if not self._is_configured():
+                return None
+
+            from models import comicvine_sqlite as cv_sqlite
+            details = cv_sqlite.get_volume_details(int(series_id))
+            if not details:
+                return None
+
+            return SearchResult(
+                provider=self.provider_type,
+                id=str(details.get('id', series_id)),
+                title=details.get('name', ''),
+                year=details.get('start_year'),
+                publisher=details.get('publisher_name'),
+                issue_count=details.get('count_of_issues'),
+                cover_url=details.get('image_url'),
+                description=details.get('description'),
+            )
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite get_series failed: {e}")
+            return None
+
+    def get_issues(self, series_id: str) -> List[IssueResult]:
+        """Get all issues for a volume from the local database."""
+        try:
+            if not self._is_configured():
+                return []
+
+            from models import comicvine_sqlite as cv_sqlite
+            conn = cv_sqlite.get_connection()
+            if not conn:
+                return []
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT id, volume_id, name, issue_number, cover_date, "
+                    "       store_date, image_url"
+                    " FROM cv_issue WHERE volume_id = ?"
+                    " ORDER BY CAST(issue_number AS REAL), issue_number",
+                    (int(series_id),),
+                )
+                rows = cursor.fetchall()
+            finally:
+                conn.close()
+
+            results = []
+            for row in rows:
+                results.append(IssueResult(
+                    provider=self.provider_type,
+                    id=str(row.get('id')),
+                    series_id=series_id,
+                    issue_number=str(row['issue_number']) if row.get('issue_number') is not None else '',
+                    title=row.get('name'),
+                    cover_date=str(row['cover_date']) if row.get('cover_date') else None,
+                    store_date=str(row['store_date']) if row.get('store_date') else None,
+                    cover_url=row.get('image_url'),
+                    summary=None,
+                ))
+            return results
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite get_issues failed: {e}")
+            return []
+
+    def get_issue(self, issue_id: str) -> Optional[IssueResult]:
+        """Get issue details by ComicVine issue ID."""
+        try:
+            if not self._is_configured():
+                return None
+
+            from models import comicvine_sqlite as cv_sqlite
+            conn = cv_sqlite.get_connection()
+            if not conn:
+                return None
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT id, volume_id, name, issue_number, cover_date, "
+                    "       store_date, description, image_url"
+                    " FROM cv_issue WHERE id = ? LIMIT 1",
+                    (int(issue_id),),
+                )
+                row = cursor.fetchone()
+            finally:
+                conn.close()
+
+            if not row:
+                return None
+
+            return IssueResult(
+                provider=self.provider_type,
+                id=str(row.get('id')),
+                series_id=str(row.get('volume_id')) if row.get('volume_id') is not None else '',
+                issue_number=str(row['issue_number']) if row.get('issue_number') is not None else '',
+                title=row.get('name'),
+                cover_date=str(row['cover_date']) if row.get('cover_date') else None,
+                store_date=str(row['store_date']) if row.get('store_date') else None,
+                cover_url=row.get('image_url'),
+                summary=row.get('description'),
+            )
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite get_issue failed: {e}")
+            return None
+
+    def get_issue_metadata(self, volume_id: str, issue_number: str, start_year: Optional[int] = None) -> Optional[Dict[str, Any]]:
+        """Return the ComicInfo-ready metadata dict for an issue in a volume."""
+        try:
+            if not self._is_configured():
+                return None
+
+            from models import comicvine_sqlite as cv_sqlite
+            return cv_sqlite.get_issue_metadata(int(volume_id), issue_number, start_year=start_year)
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite get_issue_metadata failed: {e}")
+            return None
+
+    def to_comicinfo(self, issue: IssueResult, series: Optional[SearchResult] = None) -> Dict[str, Any]:
+        """Convert a local ComicVine issue into ComicInfo.xml fields."""
+        try:
+            if issue.series_id and issue.issue_number:
+                from models import comicvine_sqlite as cv_sqlite
+                metadata = cv_sqlite.get_issue_metadata(
+                    int(issue.series_id),
+                    issue.issue_number,
+                    start_year=series.year if series else None,
+                )
+                if metadata:
+                    metadata.pop('_image_url', None)
+                    return metadata
+
+            # Fallback: build from IssueResult
+            comicinfo = {
+                'Series': series.title if series else None,
+                'Number': issue.issue_number,
+                'Title': issue.title,
+                'Summary': issue.summary,
+                'CoverDate': issue.cover_date,
+                'StoreDate': issue.store_date,
+                'Notes': f'Metadata from ComicVine (Local DB). Issue ID: {issue.id}',
+            }
+            if series:
+                comicinfo['Publisher'] = series.publisher
+                comicinfo['Volume'] = series.year
+            if issue.cover_date and len(issue.cover_date) >= 4:
+                try:
+                    comicinfo['Year'] = int(issue.cover_date[:4])
+                except ValueError:
+                    pass
+
+            return {k: v for k, v in comicinfo.items() if v is not None}
+        except Exception as e:
+            app_logger.error(f"ComicVine SQLite to_comicinfo failed: {e}")
+            return {}

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -28,7 +28,7 @@ import core.app_state as app_state
 from core.app_logging import app_logger
 from core.config import config
 from helpers.library import is_valid_library_path
-from models import gcd, metron, comicvine
+from models import gcd, metron, comicvine, comicvine_sqlite
 from models.gcd import STOPWORDS
 
 metadata_bp = Blueprint('metadata', __name__)
@@ -1020,6 +1020,7 @@ def batch_metadata():
             library_providers = get_library_providers(library_id)
             enabled_providers = [p['provider_type'] for p in library_providers if p.get('enabled', True)]
             comicvine_available = 'comicvine' in enabled_providers
+            comicvine_sqlite_available = 'comicvine_sqlite' in enabled_providers
             metron_available = 'metron' in enabled_providers
             gcd_available = 'gcd' in enabled_providers
             anilist_available = 'anilist' in enabled_providers
@@ -1030,6 +1031,7 @@ def batch_metadata():
         else:
             # Fallback to global API credential availability checks
             comicvine_available = bool(comicvine_api_key and comicvine_api_key.strip())
+            comicvine_sqlite_available = comicvine_sqlite.check_database_status().get('cv_sqlite_available', False)
             metron_available = metron.is_metron_configured()
             gcd_available = gcd.check_database_status().get('gcd_available', False)
             anilist_available = False
@@ -1047,6 +1049,7 @@ def batch_metadata():
         else:
             provider_order = [p for p, avail in (
                 ('metron', metron_available),
+                ('comicvine_sqlite', comicvine_sqlite_available),
                 ('comicvine', comicvine_available),
                 ('gcd', gcd_available),
                 ('gcd_api', True),  # gcd_api has no availability flag; gated per-file
@@ -1060,6 +1063,8 @@ def batch_metadata():
                 metron_available = False
             if 'comicvine' in skip_providers:
                 comicvine_available = False
+            if 'comicvine_sqlite' in skip_providers:
+                comicvine_sqlite_available = False
             if 'gcd' in skip_providers:
                 gcd_available = False
             if 'anilist' in skip_providers:
@@ -1121,7 +1126,7 @@ def batch_metadata():
 
         # Determine if manga providers have higher priority than comic providers
         manga_providers_set = {'mangadex', 'mangaupdates', 'anilist'}
-        comic_providers_set = {'metron', 'comicvine'}
+        comic_providers_set = {'metron', 'comicvine', 'comicvine_sqlite'}
         skip_comic_cvinfo = False
         if library_id and library_providers:
             for p in library_providers:
@@ -1437,6 +1442,25 @@ def batch_metadata():
                             app_logger.warning(f"ComicVine lookup failed for {filename}: {e}")
                         return False
 
+                    # Helper function for local ComicVine SQLite lookup
+                    def try_comicvine_sqlite():
+                        nonlocal metadata, source
+                        if not (comicvine_sqlite_available and cv_volume_id):
+                            return False
+                        try:
+                            metadata = comicvine_sqlite.get_issue_metadata(
+                                cv_volume_id,
+                                issue_number,
+                                start_year=cvinfo_start_year,
+                            )
+                            if metadata:
+                                source = 'ComicVine (Local DB)'
+                                app_logger.info(f"Found metadata from ComicVine SQLite for {filename}")
+                                return True
+                        except Exception as e:
+                            app_logger.warning(f"ComicVine SQLite lookup failed for {filename}: {e}")
+                        return False
+
                     # Helper function for Metron lookup
                     def try_metron():
                         nonlocal metadata, source
@@ -1661,6 +1685,7 @@ def batch_metadata():
                     # Use providers in library-configured priority order
                     provider_try_fns = {
                         'metron': try_metron,
+                        'comicvine_sqlite': try_comicvine_sqlite,
                         'comicvine': try_comicvine,
                         'gcd': try_gcd,
                         'gcd_api': try_gcd_api,
@@ -3157,6 +3182,84 @@ def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year):
         return None, None, None, None
 
 
+def _try_comicvine_sqlite_single(cvinfo_path, series_name, issue_number, year):
+    """Try the local ComicVine SQLite provider for a single file.
+    Returns (metadata_dict, image_url, volume_data, None) on success,
+    or (None, None, None, selection_data) when user selection is needed,
+    or (None, None, None, None) when nothing found (cascade tries next provider,
+    e.g. the ComicVine API).
+
+    No thread/timeout wrapper is needed here — this reads a local SQLite file.
+    """
+    try:
+        if not comicvine_sqlite.check_database_status().get('cv_sqlite_available', False):
+            return None, None, None, None
+
+        # If a cvinfo sidecar pins a ComicVine volume id, use it directly.
+        if cvinfo_path:
+            cv_volume_id = comicvine.parse_cvinfo_volume_id(cvinfo_path)
+            if cv_volume_id:
+                issue_data = comicvine_sqlite.get_issue_by_number(cv_volume_id, issue_number, year)
+                if issue_data:
+                    volume_data = {
+                        'id': cv_volume_id,
+                        'name': issue_data.get('volume_name', ''),
+                        'start_year': issue_data.get('volume_start_year') or issue_data.get('year'),
+                        'publisher_name': issue_data.get('publisher', '')
+                    }
+                    cvinfo_fields = comicvine.read_cvinfo_fields(cvinfo_path)
+                    start_year = cvinfo_fields.get('start_year')
+                    metadata = comicvine.map_to_comicinfo(
+                        issue_data, volume_data, start_year=start_year,
+                        source_label=comicvine_sqlite.SOURCE_LABEL)
+                    return metadata, issue_data.get('image_url'), volume_data, None
+
+        # No cvinfo or no volume_id - search by series name
+        if not series_name:
+            return None, None, None, None
+
+        normalized_series = re.sub(r'[:\-–—\'\"\.\,\!\?]', ' ', series_name)
+        normalized_series = re.sub(r'\s+', ' ', normalized_series).strip()
+
+        volumes = comicvine_sqlite.search_volumes(normalized_series, year)
+        if not volumes:
+            return None, None, None, None
+
+        # Check for confident match (all search words present in the volume name)
+        search_words = set(normalized_series.lower().split())
+        confident_match = None
+        if len(volumes) > 1:
+            for volume in volumes:
+                volume_name_lower = (volume.get('name') or '').lower()
+                if all(word in volume_name_lower for word in search_words):
+                    confident_match = volume
+                    break
+
+        if confident_match:
+            selected_volume = confident_match
+        elif len(volumes) > 1:
+            # Multiple volumes, no confident match - need user selection
+            return None, None, None, {
+                "requires_selection": True,
+                "provider": "comicvine_sqlite",
+                "possible_matches": volumes
+            }
+        else:
+            selected_volume = volumes[0]
+
+        issue_data = comicvine_sqlite.get_issue_by_number(selected_volume['id'], issue_number, year)
+        if not issue_data:
+            return None, None, None, None
+
+        metadata = comicvine.map_to_comicinfo(
+            issue_data, selected_volume, source_label=comicvine_sqlite.SOURCE_LABEL)
+        return metadata, issue_data.get('image_url'), selected_volume, None
+
+    except Exception as e:
+        app_logger.warning(f"[search-metadata] ComicVine SQLite lookup failed: {e}")
+        return None, None, None, None
+
+
 def _try_gcd_single(series_name, issue_number, year):
     """Try GCD provider for a single file.
     Returns (metadata_dict, None, None) on success,
@@ -3535,6 +3638,21 @@ def search_metadata():
                         if img_url and not isinstance(img_url, str):
                             img_url = str(img_url)
 
+            elif provider == 'comicvine_sqlite':
+                volume_id = selected_match.get('volume_id')
+                if volume_id is not None:
+                    issue_data = comicvine_sqlite.get_issue_by_number(volume_id, issue_number, year)
+                    if issue_data:
+                        volume_data = {
+                            'id': volume_id,
+                            'name': issue_data.get('volume_name', ''),
+                            'start_year': issue_data.get('volume_start_year') or issue_data.get('year'),
+                            'publisher_name': selected_match.get('publisher_name') or issue_data.get('publisher', '')
+                        }
+                        metadata = comicvine.map_to_comicinfo(
+                            issue_data, volume_data, source_label=comicvine_sqlite.SOURCE_LABEL)
+                        img_url = issue_data.get('image_url')
+
             elif provider == 'gcd':
                 series_id = selected_match.get('series_id')
                 if series_id:
@@ -3616,6 +3734,8 @@ def search_metadata():
             provider_order = []
             if metron.is_metron_configured():
                 provider_order.append('metron')
+            if comicvine_sqlite.check_database_status().get('cv_sqlite_available', False):
+                provider_order.append('comicvine_sqlite')
             if current_app.config.get("COMICVINE_API_KEY", "").strip():
                 provider_order.append('comicvine')
             if gcd.check_database_status().get('gcd_available', False):
@@ -3653,6 +3773,21 @@ def search_metadata():
                     cvinfo_path, series_name, issue_number, year
                 )
                 if selection_data:
+                    selection_data["parsed_filename"] = {
+                        "series_name": series_name,
+                        "issue_number": issue_number,
+                        "year": year
+                    }
+                    selection_data["provider_order"] = provider_order
+                    app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
+                    return jsonify(selection_data)
+
+            elif provider_type == 'comicvine_sqlite':
+                metadata, img_url, volume_data, selection_data = _try_comicvine_sqlite_single(
+                    cvinfo_path, series_name, issue_number, year
+                )
+                if selection_data:
+                    # Pause cascade - need user selection
                     selection_data["parsed_filename"] = {
                         "series_name": series_name,
                         "issue_number": issue_number,

--- a/static/js/clu-metadata.js
+++ b/static/js/clu-metadata.js
@@ -486,6 +486,21 @@
     });
   }
 
+  function _showCVSqliteVolumeModal(data, filePath, fileName, skipProviders) {
+    _showCVStyleModal(data, filePath, fileName, skipProviders, {
+      provider: 'comicvine_sqlite',
+      titlePrefix: 'ComicVine (Local DB)',
+      unit: 'Volume',
+      onSelect: function (volume) {
+        CLU.searchMetadataWithSelection(filePath, fileName, {
+          provider: 'comicvine_sqlite',
+          volume_id: volume.id,
+          publisher_name: volume.publisher_name
+        });
+      }
+    });
+  }
+
   function _showMetronVolumeModal(data, filePath, fileName, skipProviders) {
     _showCVStyleModal(data, filePath, fileName, skipProviders, {
       provider: 'metron',
@@ -832,6 +847,8 @@
         _showMetronVolumeModal(data, filePath, fileName, skipProviders);
       } else if (data.provider === 'comicvine') {
         _showCVVolumeModal(data, filePath, fileName, skipProviders);
+      } else if (data.provider === 'comicvine_sqlite') {
+        _showCVSqliteVolumeModal(data, filePath, fileName, skipProviders);
       } else if (data.provider === 'gcd') {
         // Use page-level GCD modal if available, otherwise show info
         if (typeof showGCDSeriesSelectionModal === 'function') {

--- a/templates/config.html
+++ b/templates/config.html
@@ -3144,7 +3144,7 @@
             }
 
             // Define custom display order (MangaUpdates takes AniList's old slot)
-            const providerOrder = ['metron', 'comicvine', 'gcd', 'mangaupdates', 'bedetheque', 'mangadex'];
+            const providerOrder = ['metron', 'comicvine', 'comicvine_sqlite', 'gcd', 'mangaupdates', 'bedetheque', 'mangadex'];
             const sortedProviders = [...data.providers]
                 .filter(p => p.type !== 'anilist')
                 .sort((a, b) => {
@@ -3241,6 +3241,17 @@
                         </small>
                     </div>` : '';
 
+                const cvSqliteExtra = provider.type === 'comicvine_sqlite' ? `
+                    <div class="mt-2">
+                        <small class="form-text text-muted">
+                            Place your local ComicVine SQLite database on a mapped path and enter
+                            its full path above (e.g. <code>/config/comicvine.db</code>). The file is
+                            read directly from disk (not uploaded), and there are no API rate limits.
+                            Order this above "ComicVine" to serve locally and fall back to the
+                            ComicVine API for anything the local DB is missing.
+                        </small>
+                    </div>` : '';
+
                 if (isComingSoon) {
                     html += `
                     <div class="col-md-6 mb-3">
@@ -3267,13 +3278,14 @@
                             <div class="card-body">
                                 ${cardBody}
                                 ${gcdExtra}
+                                ${cvSqliteExtra}
                                 ${lastTested}
                             </div>
                             ${metronAttribution}
                             <div class="card-footer text-muted small" id="provider-footer-${provider.type}">
                                 ${provider.type === 'gcd' && provider.is_valid
                                     ? '<span class="spinner-border spinner-border-sm me-1"></span>Loading database stats...'
-                                    : provider.type === 'gcd'
+                                    : (provider.type === 'gcd' || provider.type === 'comicvine_sqlite')
                                         ? 'Local SQLite database'
                                         : `Rate limit: ${provider.rate_limit} requests/minute`}
                             </div>

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -283,3 +283,102 @@ def make_mock_cv_issue(*, id=1001, issue_number="1", name="Rebirth",
     return i
 
 
+# ---------------------------------------------------------------------------
+# ComicVine SQLite test database
+#
+# The comicvine_sqlite provider reads a user-supplied SQLite dump. These fixtures
+# build a tiny real SQLite file (cv_publisher/cv_volume/cv_issue with
+# ComicVine-API-style JSON credit columns) so the parsing + map_to_comicinfo
+# reuse are exercised end to end.
+# ---------------------------------------------------------------------------
+
+def build_comicvine_sqlite(path, *, extra_alias_volumes=False):
+    """Create a minimal ComicVine SQLite database at `path`.
+
+    Contains a Batman volume (id 4050) with one issue (#1). When
+    `extra_alias_volumes` is True, two additional volumes match the alias
+    "Batman" but NOT by name — used to exercise the ambiguous-selection path.
+    """
+    import json
+    import sqlite3
+    conn = sqlite3.connect(str(path))
+    cur = conn.cursor()
+    cur.executescript(
+        """
+        CREATE TABLE cv_publisher (id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE cv_volume (
+            id INTEGER PRIMARY KEY, name TEXT, aliases TEXT, start_year INTEGER,
+            publisher_id INTEGER, count_of_issues INTEGER, description TEXT,
+            image_url TEXT, site_detail_url TEXT
+        );
+        CREATE TABLE cv_issue (
+            id INTEGER PRIMARY KEY, volume_id INTEGER, name TEXT, issue_number TEXT,
+            cover_date TEXT, store_date TEXT, description TEXT, image_url TEXT,
+            site_detail_url TEXT, character_credits TEXT, person_credits TEXT,
+            team_credits TEXT, location_credits TEXT, story_arc_credits TEXT,
+            associated_images TEXT
+        );
+        """
+    )
+    cur.executemany("INSERT INTO cv_publisher (id, name) VALUES (?, ?)", [(1, "DC Comics")])
+    cur.executemany(
+        "INSERT INTO cv_volume (id, name, aliases, start_year, publisher_id, "
+        "count_of_issues, description, image_url, site_detail_url) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [(4050, "Batman", "", 2016, 1, 100, "The Dark Knight",
+          "https://example.com/batman.jpg", "https://comicvine.gamespot.com/volume/4050-4050/")],
+    )
+    person = json.dumps([
+        {"id": 1, "name": "Bob Kane", "role": "writer, penciler"},
+        {"id": 2, "name": "Jerry Robinson", "role": "penciler, cover"},
+    ])
+    characters = json.dumps([{"id": 9, "name": "Batman"}, {"id": 10, "name": "Robin"}])
+    teams = json.dumps([{"id": 5, "name": "Justice League"}])
+    locations = json.dumps([{"id": 7, "name": "Gotham City"}])
+    story_arcs = json.dumps([{"id": 3, "name": "Year One"}, {"id": 4, "name": "Second Arc"}])
+    cur.executemany(
+        "INSERT INTO cv_issue (id, volume_id, name, issue_number, cover_date, "
+        "store_date, description, image_url, character_credits, person_credits, "
+        "team_credits, location_credits, story_arc_credits) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [(500, 4050, "The Beginning", "1", "2016-06-01", "2016-05-15",
+          "An origin story.", "https://example.com/issue1.jpg",
+          characters, person, teams, locations, story_arcs)],
+    )
+
+    if extra_alias_volumes:
+        # Two volumes whose NAME lacks "Batman" but whose alias matches it, so a
+        # "Batman" search returns >1 rows with no name-confident match.
+        cur.executemany(
+            "INSERT INTO cv_volume (id, name, aliases, start_year, publisher_id, "
+            "count_of_issues, description, image_url, site_detail_url) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (4060, "The Dark Knight", "Batman", 2011, 1, 50, "", "", ""),
+                (4061, "Caped Crusader", "Batman", 1999, 1, 30, "", "", ""),
+            ],
+        )
+        # Rename 4050 so its name no longer contains "Batman" either.
+        cur.execute("UPDATE cv_volume SET name = 'World Finest', aliases = 'Batman' WHERE id = 4050")
+
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+@pytest.fixture
+def comicvine_sqlite_db_path(tmp_path):
+    """Path to a populated ComicVine SQLite test database."""
+    return build_comicvine_sqlite(tmp_path / "comicvine.db")
+
+
+@pytest.fixture
+def comicvine_sqlite_configured(comicvine_sqlite_db_path, monkeypatch):
+    """Point models.comicvine_sqlite at the test database via saved credentials."""
+    monkeypatch.setattr(
+        "models.comicvine_sqlite._get_saved_credentials",
+        lambda: {"database_path": str(comicvine_sqlite_db_path)},
+    )
+    return str(comicvine_sqlite_db_path)
+
+

--- a/tests/mocked/test_comicvine_sqlite_model.py
+++ b/tests/mocked/test_comicvine_sqlite_model.py
@@ -1,0 +1,174 @@
+"""Tests for models/comicvine_sqlite.py against a real temp SQLite DB."""
+import sqlite3
+import pytest
+
+from tests.mocked.conftest import build_comicvine_sqlite
+
+
+@pytest.fixture
+def not_configured(monkeypatch):
+    monkeypatch.setattr("models.comicvine_sqlite._get_saved_credentials", lambda: None)
+    monkeypatch.delenv("COMICVINE_DATABASE_PATH", raising=False)
+
+
+class TestDatabaseStatus:
+
+    def test_available_when_configured(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import check_database_status, is_database_available
+        status = check_database_status()
+        assert status["cv_sqlite_available"] is True
+        assert status["cv_sqlite_path_configured"] is True
+        assert is_database_available() is True
+
+    def test_not_available_when_unconfigured(self, not_configured):
+        from models.comicvine_sqlite import check_database_status, is_database_available
+        status = check_database_status()
+        assert status["cv_sqlite_available"] is False
+        assert status["cv_sqlite_path_configured"] is False
+        assert is_database_available() is False
+
+    def test_path_configured_but_missing(self, tmp_path, monkeypatch):
+        from models.comicvine_sqlite import check_database_status
+        missing = tmp_path / "nope.db"
+        monkeypatch.setattr("models.comicvine_sqlite._get_saved_credentials",
+                            lambda: {"database_path": str(missing)})
+        status = check_database_status()
+        assert status["cv_sqlite_available"] is False
+        assert status["cv_sqlite_path_configured"] is True
+
+    def test_env_var_fallback(self, comicvine_sqlite_db_path, monkeypatch):
+        from models.comicvine_sqlite import get_connection_params
+        monkeypatch.setattr("models.comicvine_sqlite._get_saved_credentials", lambda: None)
+        monkeypatch.setenv("COMICVINE_DATABASE_PATH", str(comicvine_sqlite_db_path))
+        assert get_connection_params() == {"database_path": str(comicvine_sqlite_db_path)}
+
+
+class TestGetConnection:
+
+    def test_opens_read_only(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import get_connection
+        conn = get_connection()
+        assert conn is not None
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("CREATE TABLE should_fail (x INTEGER)")
+        finally:
+            conn.close()
+
+    def test_none_when_unconfigured(self, not_configured):
+        from models.comicvine_sqlite import get_connection
+        assert get_connection() is None
+
+
+class TestSearchVolumes:
+
+    def test_finds_volume(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import search_volumes
+        results = search_volumes("Batman")
+        assert len(results) == 1
+        vol = results[0]
+        # Shape must match comicvine.search_volumes so the CV modal/map_to_comicinfo work.
+        for key in ('id', 'name', 'start_year', 'publisher_name', 'count_of_issues',
+                    'image_url', 'description'):
+            assert key in vol
+        assert vol['name'] == "Batman"
+        assert vol['publisher_name'] == "DC Comics"
+
+    def test_year_filter(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import search_volumes
+        assert len(search_volumes("Batman", year=2016)) == 1
+        assert search_volumes("Batman", year=1999) == []
+
+    def test_alias_match(self, tmp_path, monkeypatch):
+        from models.comicvine_sqlite import search_volumes
+        path = build_comicvine_sqlite(tmp_path / "cv.db", extra_alias_volumes=True)
+        monkeypatch.setattr("models.comicvine_sqlite._get_saved_credentials",
+                            lambda: {"database_path": path})
+        results = search_volumes("Batman")
+        # 3 volumes all match via alias; none is named "Batman".
+        assert len(results) == 3
+        assert all("batman" not in (v['name'] or '').lower() for v in results)
+
+    def test_not_configured(self, not_configured):
+        from models.comicvine_sqlite import search_volumes
+        assert search_volumes("Batman") == []
+
+
+class TestGetIssueByNumber:
+
+    def test_credit_parsing(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import get_issue_by_number
+        data = get_issue_by_number(4050, "1")
+        assert data is not None
+        # role "writer, penciler" -> Writer only (first-match-wins)
+        assert data['writers'] == ["Bob Kane"]
+        # role "penciler, cover" -> Penciller only
+        assert data['pencillers'] == ["Jerry Robinson"]
+        assert data['inkers'] == []
+        assert data['colorists'] == []
+        assert data['letterers'] == []
+        assert data['cover_artists'] == []
+        assert data['characters'] == ["Batman", "Robin"]
+        assert data['teams'] == ["Justice League"]
+        assert data['locations'] == ["Gotham City"]
+        # Only the FIRST story arc
+        assert data['story_arc'] == "Year One"
+        assert data['year'] == 2016
+        assert data['month'] == 6
+        assert data['day'] == 1
+        assert data['page_count'] is None
+        assert data['publisher'] == "DC Comics"
+        assert data['volume_name'] == "Batman"
+        assert data['volume_start_year'] == 2016
+
+    def test_missing_issue(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import get_issue_by_number
+        assert get_issue_by_number(4050, "999") is None
+
+    def test_not_configured(self, not_configured):
+        from models.comicvine_sqlite import get_issue_by_number
+        assert get_issue_by_number(4050, "1") is None
+
+
+class TestGetIssueMetadata:
+
+    def test_maps_to_comicinfo(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import get_issue_metadata
+        meta = get_issue_metadata(4050, "1")
+        assert meta is not None
+        assert meta['Series'] == "Batman"
+        assert meta['Number'] == "1"
+        assert meta['Title'] == "The Beginning"
+        assert meta['Publisher'] == "DC Comics"
+        assert meta['Writer'] == "Bob Kane"
+        assert meta['Penciller'] == "Jerry Robinson"
+        assert 'Inker' not in meta  # empty roles dropped
+        assert meta['Characters'] == "Batman, Robin"
+        assert meta['Teams'] == "Justice League"
+        assert meta['Locations'] == "Gotham City"
+        assert meta['StoryArc'] == "Year One"
+        assert meta['Year'] == 2016
+        assert meta['Month'] == 6
+        assert meta['Day'] == 1
+        assert meta['LanguageISO'] == "en"
+        # Notes must identify the local DB, distinct from the API's "ComicVine CVDB".
+        assert "ComicVine (Local DB)" in meta['Notes']
+        assert "ComicVine CVDB" not in meta['Notes']
+        assert "Volume ID: 4050" in meta['Notes']
+        assert meta['_image_url'] == "https://example.com/issue1.jpg"
+
+    def test_not_found(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import get_issue_metadata
+        assert get_issue_metadata(4050, "999") is None
+
+    def test_parity_with_map_to_comicinfo(self, comicvine_sqlite_configured):
+        """Output must equal calling comicvine.map_to_comicinfo directly."""
+        from models.comicvine_sqlite import (
+            get_issue_by_number, _volume_data_from_issue, get_issue_metadata, SOURCE_LABEL
+        )
+        from models.comicvine import map_to_comicinfo
+        issue_data = get_issue_by_number(4050, "1")
+        expected = map_to_comicinfo(issue_data, _volume_data_from_issue(issue_data),
+                                    source_label=SOURCE_LABEL)
+        actual = {k: v for k, v in get_issue_metadata(4050, "1").items() if k != '_image_url'}
+        assert actual == expected

--- a/tests/mocked/test_comicvine_sqlite_provider.py
+++ b/tests/mocked/test_comicvine_sqlite_provider.py
@@ -1,0 +1,103 @@
+"""Tests for ComicVineSqliteProvider adapter against a real temp SQLite DB."""
+import pytest
+
+from models.providers.base import ProviderType, SearchResult, IssueResult
+
+
+@pytest.fixture
+def cv_creds(comicvine_sqlite_db_path):
+    from models.providers.base import ProviderCredentials
+    return ProviderCredentials(database_path=str(comicvine_sqlite_db_path))
+
+
+class TestProviderInit:
+
+    def test_attributes(self):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        p = ComicVineSqliteProvider()
+        assert p.provider_type == ProviderType.COMICVINE_SQLITE
+        assert p.display_name == "ComicVine (Local DB)"
+        assert p.requires_auth is True
+        assert p.auth_fields == ["database_path"]
+
+    def test_registered(self):
+        from models.providers import get_provider_by_name
+        p = get_provider_by_name("comicvine_sqlite")
+        assert p is not None
+        assert p.provider_type == ProviderType.COMICVINE_SQLITE
+
+
+class TestTestConnection:
+
+    def test_success(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        assert ComicVineSqliteProvider(credentials=cv_creds).test_connection() is True
+
+    def test_not_configured(self, monkeypatch, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        monkeypatch.setattr("models.comicvine_sqlite._get_saved_credentials", lambda: None)
+        monkeypatch.delenv("COMICVINE_DATABASE_PATH", raising=False)
+        assert ComicVineSqliteProvider(credentials=cv_creds).test_connection() is False
+
+    def test_missing_tables(self, tmp_path, monkeypatch, cv_creds):
+        import sqlite3
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        path = str(tmp_path / "broken.db")
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE cv_volume (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.comicvine_sqlite._get_saved_credentials",
+                            lambda: {"database_path": path})
+        assert ComicVineSqliteProvider(credentials=cv_creds).test_connection() is False
+
+
+class TestSearchSeries:
+
+    def test_returns_results(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        results = ComicVineSqliteProvider(credentials=cv_creds).search_series("Batman")
+        assert len(results) == 1
+        assert results[0].title == "Batman"
+        assert results[0].provider == ProviderType.COMICVINE_SQLITE
+
+    def test_no_results(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        assert ComicVineSqliteProvider(credentials=cv_creds).search_series("Nonexistent") == []
+
+
+class TestGetSeriesAndIssues:
+
+    def test_get_series(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        result = ComicVineSqliteProvider(credentials=cv_creds).get_series("4050")
+        assert isinstance(result, SearchResult)
+        assert result.title == "Batman"
+        assert result.year == 2016
+
+    def test_get_issues(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        results = ComicVineSqliteProvider(credentials=cv_creds).get_issues("4050")
+        assert len(results) == 1
+        assert results[0].issue_number == "1"
+
+    def test_get_issue(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        result = ComicVineSqliteProvider(credentials=cv_creds).get_issue("500")
+        assert isinstance(result, IssueResult)
+        assert result.issue_number == "1"
+        assert result.series_id == "4050"
+
+
+class TestToComicInfo:
+
+    def test_uses_metadata(self, comicvine_sqlite_configured, cv_creds):
+        from models.providers.comicvine_sqlite_provider import ComicVineSqliteProvider
+        issue = IssueResult(
+            provider=ProviderType.COMICVINE_SQLITE, id="500", series_id="4050",
+            issue_number="1", title="The Beginning",
+        )
+        result = ComicVineSqliteProvider(credentials=cv_creds).to_comicinfo(issue)
+        assert result['Series'] == "Batman"
+        assert result['Writer'] == "Bob Kane"
+        assert '_image_url' not in result

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1244,3 +1244,93 @@ class TestGcdSqliteRoutes:
         })
         assert resp.status_code == 500
         assert resp.get_json()['success'] is False
+
+
+class TestComicVineSqliteRoutes:
+    """End-to-end coverage of comicvine_sqlite through the /api/search-metadata cascade.
+
+    Exercises the ported JSON credit parsing + map_to_comicinfo reuse, and the
+    ambiguous-volume selection round-trip via selected_match.
+    """
+
+    def _isolate_to_cv_sqlite(self, stack, client, db_path):
+        """Make comicvine_sqlite the only available cascade provider."""
+        from contextlib import ExitStack
+        # Point the local CV provider at our temp DB.
+        stack.enter_context(patch("models.comicvine_sqlite._get_saved_credentials",
+                                  return_value={"database_path": db_path}))
+        # Disable every other fallback provider.
+        stack.enter_context(patch("models.metron.is_metron_configured", return_value=False))
+        stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+        stack.enter_context(patch("models.gcd.check_database_status",
+                                  return_value={"gcd_available": False}))
+        stack.enter_context(patch("core.database.get_provider_credentials", return_value=None))
+        stack.enter_context(patch("models.comicvine.find_cvinfo_in_folder", return_value=None))
+        stack.enter_context(patch("models.comicvine.auto_move_file", return_value=None))
+        # Avoid real file/index writes.
+        stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+        stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+        stack.enter_context(patch("core.database.set_has_comicinfo"))
+        client.application.config["COMICVINE_API_KEY"] = ""
+
+    def test_cascade_success(self, client, tmp_path, monkeypatch):
+        from contextlib import ExitStack
+        from tests.mocked.conftest import build_comicvine_sqlite
+        db = build_comicvine_sqlite(tmp_path / "cv.db")
+        cbz = tmp_path / "Batman 001.cbz"
+        _make_cbz(str(cbz), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            self._isolate_to_cv_sqlite(stack, client, db)
+            resp = client.post('/api/search-metadata', json={
+                'file_path': str(cbz),
+                'file_name': 'Batman 001.cbz',
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is True
+        assert data['source'] == 'comicvine_sqlite'
+        meta = data['metadata']
+        assert meta['Series'] == 'Batman'
+        assert meta['Number'] == '1'
+        assert meta['Writer'] == 'Bob Kane'
+        assert meta['Characters'] == 'Batman, Robin'
+
+    def test_cascade_ambiguous_then_selection(self, client, tmp_path, monkeypatch):
+        from contextlib import ExitStack
+        from tests.mocked.conftest import build_comicvine_sqlite
+        # extra_alias_volumes => 3 volumes match "Batman" via alias, none by name.
+        db = build_comicvine_sqlite(tmp_path / "cv.db", extra_alias_volumes=True)
+        cbz = tmp_path / "Batman 001.cbz"
+        _make_cbz(str(cbz), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            self._isolate_to_cv_sqlite(stack, client, db)
+            # 1) Ambiguous search -> selection prompt.
+            resp = client.post('/api/search-metadata', json={
+                'file_path': str(cbz),
+                'file_name': 'Batman 001.cbz',
+            })
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data.get('requires_selection') is True
+            assert data['provider'] == 'comicvine_sqlite'
+            assert len(data['possible_matches']) == 3
+
+            # 2) User picks volume 4050 -> selected_match follow-up writes metadata.
+            resp2 = client.post('/api/search-metadata', json={
+                'file_path': str(cbz),
+                'file_name': 'Batman 001.cbz',
+                'selected_match': {
+                    'provider': 'comicvine_sqlite',
+                    'volume_id': 4050,
+                    'publisher_name': 'DC Comics',
+                },
+            })
+
+        assert resp2.status_code == 200
+        data2 = resp2.get_json()
+        assert data2['success'] is True
+        assert data2['source'] == 'comicvine_sqlite'
+        assert data2['metadata']['Writer'] == 'Bob Kane'

--- a/tests/unit/test_provider_base.py
+++ b/tests/unit/test_provider_base.py
@@ -16,6 +16,7 @@ class TestProviderType:
     def test_values(self):
         assert ProviderType.METRON.value == "metron"
         assert ProviderType.COMICVINE.value == "comicvine"
+        assert ProviderType.COMICVINE_SQLITE.value == "comicvine_sqlite"
         assert ProviderType.GCD.value == "gcd"
         assert ProviderType.ANILIST.value == "anilist"
         assert ProviderType.BEDETHEQUE.value == "bedetheque"


### PR DESCRIPTION
## 📝 Description
Introduces a new `comicvine_sqlite` provider that reads ComicVine data from a user-configured local SQLite file and maps results through existing ComicInfo conversion logic for parity with the API provider. The metadata search cascade, bulk metadata sidecar handling, provider registry/types, config UI ordering/help text, and metadata selection modal flow were updated to support this source, with comprehensive model/provider/route test coverage added.

Closes #372 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="427" height="106" alt="Screenshot 2026-07-01 200013" src="https://github.com/user-attachments/assets/73e8cdad-3fed-4f9c-886b-3c60f845af95" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass