### PR TITLE
Detect Cloudflare Challenges in getcomics Downloads

### DIFF
--- a/api.py
+++ b/api.py
@@ -159,6 +159,10 @@ def process_download(task):
     internal = task.get('internal', False)
     weekly_pack_info = task.get('weekly_pack_info')  # Optional: for weekly pack status updates
     fallback_urls = task.get('fallback_urls', [])  # List of (provider_name, url) tuples
+    # Original getcomics post page — surfaced as the manual-download link when a
+    # mirror is Cloudflare-protected. The page (unlike the resolved mirror or the
+    # tokenized /dls/ link) lets the browser establish the session/referrer.
+    source_page_url = task.get('page_url')
 
     # Use basic headers for internal downloads (Pull List, Weekly Packs, UI searches)
     # Use full headers (with custom_headers_str) for external downloads (browser extension)
@@ -221,7 +225,7 @@ def process_download(task):
             elif "comicfiles.ru" in final_url:              # GetComics' direct host
                 download_progress[download_id]['provider'] = 'getcomics'
                 monitor_logger.debug(f"Routing to: download_getcomics (comicfiles.ru)")
-                file_path = download_getcomics(final_url, download_id, hdrs=use_headers)
+                file_path = download_getcomics(final_url, download_id, hdrs=use_headers, source_url=(source_page_url or try_url))
             elif "mega.nz" in final_url or "mega.co.nz" in final_url:  # MEGA
                 download_progress[download_id]['provider'] = 'mega'
                 monitor_logger.debug(f"Routing to: download_mega")
@@ -229,7 +233,7 @@ def process_download(task):
             else:                                           # fall-back
                 download_progress[download_id]['provider'] = 'getcomics'
                 monitor_logger.debug(f"Routing to: download_getcomics (fallback)")
-                file_path = download_getcomics(final_url, download_id, hdrs=use_headers)
+                file_path = download_getcomics(final_url, download_id, hdrs=use_headers, source_url=(source_page_url or try_url))
 
             # Auto-convert CBR/RAR to CBZ and move to TARGET after download
             if file_path and file_path.lower().endswith(('.cbr', '.rar')):
@@ -379,13 +383,21 @@ for i in range(3):
 # -------------------------------
 # Other Download Functions
 # -------------------------------
-def download_getcomics(url, download_id, hdrs=None):
+from core.download_utils import is_cloudflare_challenge as _is_cloudflare_challenge
+
+
+def download_getcomics(url, download_id, hdrs=None, source_url=None):
     """Download a file from GetComics or similar direct download hosts.
 
     Args:
-        url: The download URL
+        url: The (resolved) download URL to fetch
         download_id: Unique identifier for progress tracking
         hdrs: Optional headers dict. If None, uses global headers (with custom_headers_str)
+        source_url: The original getcomics link to surface as the manual-download
+            link on a Cloudflare failure (preferably the post page). The resolved
+            mirror URL — and even the tokenized /dls/ link — 403 in a browser;
+            the post page lets the user establish the session/referrer the
+            mirrors require. Defaults to ``url``.
     """
     if hdrs is None:
         hdrs = headers
@@ -394,8 +406,19 @@ def download_getcomics(url, download_id, hdrs=None):
     delay = 2  # base delay in seconds
     last_exception = None
 
-    # Create a session with connection pooling and optimization for large files
-    session = requests.Session()
+    # Create a session with connection pooling and optimization for large files.
+    # Use cloudscraper so Cloudflare-fronted mirrors (e.g. comicfiles.ru) are
+    # fetched with a solved challenge instead of getting a 403. cloudscraper
+    # returns a requests.Session subclass, so the Retry adapter below still
+    # applies. A fresh instance (not the shared gc_scraper) avoids mutating the
+    # module-level scraper with our custom Retry adapter.
+    session = cloudscraper.create_scraper(
+        browser={
+            'browser': 'chrome',
+            'platform': 'windows',
+            'desktop': True
+        }
+    )
 
     # Configure retry strategy
     retry_strategy = Retry(
@@ -413,18 +436,47 @@ def download_getcomics(url, download_id, hdrs=None):
     session.mount("http://", adapter)
     session.mount("https://", adapter)
 
-    # Set TCP keepalive and socket options for better performance
+    # Apply caller headers, but preserve cloudscraper's fingerprint-consistent
+    # User-Agent (a stale hardcoded UA would undermine the challenge solve) and
+    # add a Referer, since getcomics mirrors gate on it.
+    scraper_ua = session.headers.get("User-Agent")
     session.headers.update(hdrs)
+    if scraper_ua:
+        session.headers["User-Agent"] = scraper_ua
+    session.headers["Referer"] = "https://getcomics.org/"
 
     for attempt in range(retries):
         try:
             monitor_logger.info(f"Attempt {attempt + 1} to download {url}")
             # Increase timeout for large files: 60s connection, 300s read (5 minutes)
             response = session.get(url, stream=True, timeout=(60, 300))
-            response.raise_for_status()
+            # Check for hard-forbidden/not-found before raise_for_status so we
+            # abort immediately instead of burning all retries on a 403/404.
             if response.status_code in (403, 404):
-                monitor_logger.warning(f"Fatal HTTP error {response.status_code}; aborting retries.")
+                if response.status_code == 403 and _is_cloudflare_challenge(response):
+                    host = urlparse(url).netloc
+                    # The resolved mirror URL 403s in a browser too; surface the
+                    # original getcomics link, which redirects through
+                    # getcomics.org and passes the challenge.
+                    manual_link = source_url or url
+                    last_exception = Exception(
+                        f"{host} is protected by a Cloudflare challenge that cannot be "
+                        f"bypassed by an automated download. Open this link in your browser "
+                        f"to download it manually: {manual_link}"
+                    )
+                    # Record the link so the UI can offer a manual download.
+                    # Persists across failover (later attempts don't clear it).
+                    if download_id in download_progress:
+                        download_progress[download_id]['manual_url'] = manual_link
+                    monitor_logger.warning(
+                        f"Cloudflare challenge on {host}; automated download not possible. "
+                        f"Manual link: {manual_link}"
+                    )
+                else:
+                    last_exception = Exception(f"HTTP {response.status_code} for {url}")
+                    monitor_logger.warning(f"Fatal HTTP error {response.status_code}; aborting retries.")
                 break
+            response.raise_for_status()
 
             # Guard: don't save HTML error/redirect pages as files
             ct = response.headers.get('content-type', '')
@@ -573,7 +625,7 @@ def download_getcomics(url, download_id, hdrs=None):
     # All retries failed - cleanup
     session.close()
 
-    monitor_logger.error(f"Download failed after {retries} attempts: {last_exception}")
+    monitor_logger.error(f"Download failed for {url}: {last_exception}")
     download_progress[download_id]['status'] = 'error'
     download_progress[download_id]['progress'] = -1
 
@@ -589,7 +641,7 @@ def download_getcomics(url, download_id, hdrs=None):
             else:
                 monitor_logger.debug(f"No leftover temp file to remove: {leftover}")
 
-    raise Exception(f"Download failed after {retries} attempts for {url}: {last_exception}")
+    raise Exception(f"Download failed for {url}: {last_exception}")
 
 # -------------------------------
 # Pixeldrain support

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -1,0 +1,35 @@
+"""Small, dependency-light helpers for the download pipeline.
+
+Kept separate from ``api.py`` so the pure logic can be imported and tested
+without triggering api.py's import-time side effects (worker threads, DB
+connection, cloudscraper).
+"""
+
+
+def is_cloudflare_challenge(response) -> bool:
+    """Detect a Cloudflare managed / JS "Just a moment..." challenge response.
+
+    These challenges cannot be solved by any automated HTTP client (requests,
+    cloudscraper, curl_cffi) or even headless/scripted browsers — only a real,
+    manually-driven browser passes them. When we see one there is no point
+    retrying; the caller surfaces a clear "download manually" error instead.
+
+    Accepts anything with ``.headers`` (mapping) and ``.content`` (bytes),
+    e.g. a ``requests.Response``.
+    """
+    try:
+        headers = response.headers
+        # Most reliable signal: Cloudflare stamps this on challenge responses.
+        if 'challenge' in headers.get('cf-mitigated', '').lower():
+            return True
+        if 'cloudflare' not in headers.get('Server', '').lower():
+            return False
+        if 'text/html' not in headers.get('Content-Type', '').lower():
+            return False
+        # Fall back to sniffing the (small) challenge page body for markers.
+        snippet = response.content[:4096].lower()
+        return (b'just a moment' in snippet
+                or b'__cf_chl' in snippet
+                or b'challenge-platform' in snippet)
+    except Exception:
+        return False

--- a/models/mega.py
+++ b/models/mega.py
@@ -101,6 +101,7 @@ class MegaDownloader:
                 -2: "Invalid arguments / File not found",
                 -3: "Request failed, retrying may help",
                 -4: "Rate limited",
+                -6: "Too many requests / temporarily unavailable",
                 -9: "Object not found",
                 -11: "Access denied",
                 -14: "Resource temporarily unavailable",

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -116,6 +116,7 @@ def api_getcomics_download():
             'filename': filename,
             'error': None,
             'provider': None,
+            'manual_url': None,
         }
         task = {
             'download_id': download_id,
@@ -123,6 +124,10 @@ def api_getcomics_download():
             'dest_filename': filename,
             'internal': True,
             'fallback_urls': fallback_urls,
+            # Surfaced as the manual-download link if every mirror is
+            # Cloudflare-protected — the post page lets the browser establish
+            # the session/referrer the mirrors require.
+            'page_url': page_url,
         }
         download_queue.put(task)
 
@@ -130,6 +135,31 @@ def api_getcomics_download():
     except Exception as e:
         app_logger.error(f"Error downloading from getcomics: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
+
+
+@downloads_bp.route('/api/getcomics/download-status/<download_id>', methods=['GET'])
+def api_getcomics_download_status(download_id):
+    """Report the status of a queued getcomics download so the UI can poll it.
+
+    When a download fails on a Cloudflare-protected mirror, `manual_url` holds
+    the direct link the user can open in their browser to download manually.
+    """
+    from api import download_progress
+
+    progress = download_progress.get(download_id)
+    if progress is None:
+        return jsonify({"success": False, "error": "Unknown download"}), 404
+
+    return jsonify({
+        "success": True,
+        "download_id": download_id,
+        "status": progress.get("status"),
+        "progress": progress.get("progress"),
+        "error": progress.get("error"),
+        "manual_url": progress.get("manual_url"),
+        "filename": progress.get("filename"),
+        "provider": progress.get("provider"),
+    })
 
 
 def _run_wanted_simulation(limit, target_series_id, target_series_name):

--- a/templates/series.html
+++ b/templates/series.html
@@ -1126,6 +1126,10 @@
                 // a wanted/not-found issue (table-danger) becomes table-warning
                 markIssueRowDownloading(currentSearchIssue);
 
+                // Poll the background download so we can surface a failure
+                // (e.g. a Cloudflare-protected mirror) with a manual link.
+                pollGetComicsDownload(data.download_id, currentSearchIssue);
+
                 setTimeout(() => {
                     getcomicsModal.hide();
                 }, 500);
@@ -1153,6 +1157,106 @@
             row.classList.remove('table-danger');
             row.classList.add('table-warning');
         }
+    }
+
+    // A queued download failed — revert its row from "downloading"
+    // (table-warning) back to "not found / wanted" (table-danger).
+    function markIssueRowFailed(issueNumber) {
+        if (issueNumber === '' || issueNumber === null || issueNumber === undefined) return;
+        const row = document.querySelector(
+            `tr[data-issue-number="${CSS.escape(String(issueNumber))}"]`
+        );
+        if (!row) return;
+        if (row.classList.contains('table-warning')) {
+            row.classList.remove('table-warning');
+            row.classList.add('table-danger');
+        }
+    }
+
+    // Poll a queued getcomics download until it completes, errors, or times out.
+    // On failure with a Cloudflare-protected mirror, show a persistent alert with
+    // the direct link so the user can download it manually in their browser.
+    function pollGetComicsDownload(downloadId, issueNumber) {
+        if (!downloadId) return;
+        const POLL_MS = 3000;
+        const MAX_MS = 30 * 60 * 1000; // stop polling after 30 minutes
+        const start = Date.now();
+
+        async function tick() {
+            try {
+                const resp = await fetch(
+                    `/api/getcomics/download-status/${encodeURIComponent(downloadId)}`
+                );
+                if (resp.status === 404) return; // progress entry gone — stop
+                const data = await resp.json();
+                if (!data.success) return;
+
+                if (data.status === 'complete') {
+                    showToastGC('Download completed' + (data.filename ? ': ' + data.filename : ''), 'success');
+                    return;
+                }
+                if (data.status === 'cancelled') {
+                    markIssueRowFailed(issueNumber);
+                    return;
+                }
+                if (data.status === 'error') {
+                    markIssueRowFailed(issueNumber);
+                    if (data.manual_url) {
+                        showManualDownloadAlert(data.manual_url, data.filename);
+                    } else {
+                        showToastGC('Download failed: ' + (data.error || 'unknown error'), 'danger');
+                    }
+                    return;
+                }
+            } catch (e) {
+                // transient network error — fall through and retry until MAX_MS
+            }
+            if (Date.now() - start < MAX_MS) {
+                setTimeout(tick, POLL_MS);
+            }
+        }
+
+        setTimeout(tick, POLL_MS);
+    }
+
+    // Persistent toast offering a manual (browser) download link for mirrors
+    // we can't fetch automatically (Cloudflare challenge).
+    function showManualDownloadAlert(manualUrl, filename) {
+        let container = document.querySelector('.toast-container');
+        if (!container) {
+            container = document.createElement('div');
+            container.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+            document.body.appendChild(container);
+        }
+
+        const toastId = 'manual-toast-' + Date.now();
+        const label = filename ? escapeHtmlGC(filename) : 'this file';
+        // manualUrl is placed in an href attribute; escapeHtmlGC() safely encodes
+        // quotes/angle brackets so it can't break out of the attribute.
+        const safeUrl = escapeHtmlGC(manualUrl);
+        const toastHtml = `
+        <div id="${toastId}" class="toast align-items-center text-bg-warning border-0" role="alert"
+             data-bs-autohide="false">
+            <div class="d-flex">
+                <div class="toast-body">
+                    <div class="fw-bold mb-1"><i class="bi bi-shield-lock me-1"></i>Automatic download blocked</div>
+                    <div class="small mb-2">This mirror is protected by Cloudflare and can't be fetched
+                        automatically. Open the GetComics page in your browser and download ${label}
+                        manually from there:</div>
+                    <a href="${safeUrl}" target="_blank" rel="noopener"
+                       class="btn btn-sm btn-dark">
+                        <i class="bi bi-box-arrow-up-right me-1"></i>Open GetComics page
+                    </a>
+                </div>
+                <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>`;
+        container.insertAdjacentHTML('beforeend', toastHtml);
+
+        const toastEl = document.getElementById(toastId);
+        const toast = new bootstrap.Toast(toastEl, { autohide: false });
+        toast.show();
+        toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
     }
 
     function escapeHtmlGC(text) {

--- a/tests/mocked/test_download_cloudflare.py
+++ b/tests/mocked/test_download_cloudflare.py
@@ -1,0 +1,54 @@
+"""Tests for Cloudflare-challenge detection in the getcomics downloader.
+
+`comicfiles.ru` and similar getcomics mirrors sit behind a Cloudflare managed
+challenge that no automated HTTP client can bypass. `is_cloudflare_challenge`
+lets `download_getcomics` recognize that case, stop retrying, and surface a
+clear "download manually" error instead of the old `... after 3 attempts: None`.
+
+Lives in `core.download_utils` (imported by api.py) so it can be tested without
+triggering api.py's import-time side effects (worker threads, DB, cloudscraper).
+"""
+from types import SimpleNamespace
+
+from core.download_utils import is_cloudflare_challenge
+
+
+def _resp(status=403, headers=None, content=b""):
+    """Minimal stand-in for a requests.Response (only the bits we read)."""
+    return SimpleNamespace(status_code=status, headers=headers or {}, content=content)
+
+
+class TestIsCloudflareChallenge:
+    def test_detects_cf_mitigated_header(self):
+        resp = _resp(headers={"cf-mitigated": "challenge", "Server": "cloudflare"})
+        assert is_cloudflare_challenge(resp) is True
+
+    def test_detects_just_a_moment_body(self):
+        resp = _resp(
+            headers={"Server": "cloudflare", "Content-Type": "text/html; charset=UTF-8"},
+            content=b"<!DOCTYPE html><html><head><title>Just a moment...</title>",
+        )
+        assert is_cloudflare_challenge(resp) is True
+
+    def test_detects_challenge_platform_marker(self):
+        resp = _resp(
+            headers={"Server": "cloudflare", "Content-Type": "text/html"},
+            content=b"<script>window.__cf_chl_opt = {}; challenge-platform</script>",
+        )
+        assert is_cloudflare_challenge(resp) is True
+
+    def test_non_cloudflare_403_is_not_challenge(self):
+        resp = _resp(headers={"Server": "nginx", "Content-Type": "text/html"},
+                     content=b"<html>Forbidden</html>")
+        assert is_cloudflare_challenge(resp) is False
+
+    def test_cloudflare_non_html_is_not_challenge(self):
+        # A genuine file served through Cloudflare (e.g. the real download) must
+        # not be mistaken for a challenge page.
+        resp = _resp(status=200,
+                     headers={"Server": "cloudflare", "Content-Type": "application/x-cbr"},
+                     content=b"Rar!\x1a\x07\x00")
+        assert is_cloudflare_challenge(resp) is False
+
+    def test_missing_headers_do_not_raise(self):
+        assert is_cloudflare_challenge(_resp(headers={})) is False

--- a/tests/routes/test_downloads_routes.py
+++ b/tests/routes/test_downloads_routes.py
@@ -55,6 +55,49 @@ class TestGetcomicsDownload:
         assert resp.status_code == 404
 
 
+class TestGetcomicsDownloadStatus:
+    """The UI polls this endpoint so it can surface a Cloudflare-blocked
+    download with a manual link instead of silently failing."""
+
+    def test_unknown_download_returns_404(self, client):
+        resp = client.get("/api/getcomics/download-status/does-not-exist")
+        assert resp.status_code == 404
+        assert resp.get_json()["success"] is False
+
+    @patch("api.download_progress", {
+        "abc-123": {"status": "in_progress", "progress": 42, "error": None,
+                    "manual_url": None, "filename": "b.cbz", "provider": "pixeldrain"},
+    })
+    def test_in_progress(self, client):
+        resp = client.get("/api/getcomics/download-status/abc-123")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["status"] == "in_progress"
+        assert data["progress"] == 42
+        assert data["manual_url"] is None
+
+    @patch("api.download_progress", {
+        "cf-1": {
+            "status": "error",
+            "progress": -1,
+            "error": "fs2.comicfiles.ru is protected by a Cloudflare challenge...",
+            # The getcomics post page (where the user clicks download themselves),
+            # NOT the resolved mirror URL or /dls/ link which 403 in a browser.
+            "manual_url": "https://getcomics.org/comic/geiger-ground-zero-2",
+            "filename": "Geiger.cbz",
+            "provider": "getcomics",
+        },
+    })
+    def test_error_surfaces_manual_url(self, client):
+        resp = client.get("/api/getcomics/download-status/cf-1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["status"] == "error"
+        assert data["manual_url"] == "https://getcomics.org/comic/geiger-ground-zero-2"
+
+
 class TestSyncSchedule:
 
     @patch("core.database.get_sync_schedule", return_value=None)


### PR DESCRIPTION
## 📝 Description
When a getcomics mirror (e.g. comicfiles.ru) returns a Cloudflare managed challenge, automated download is impossible. This change:

- Adds `core/download_utils.py` with `is_cloudflare_challenge()` to detect challenge responses via headers/body markers
- Switches `download_getcomics` to use `cloudscraper` session instead of plain `requests.Session`
- Surfaces the original GetComics post page URL as `manual_url` in download progress on Cloudflare 403s, instead of burning all retries
- Adds `/api/getcomics/download-status/<id>` endpoint so the UI can poll download state
- Polls downloads in `series.html` and shows a persistent toast with a manual download link when Cloudflare blocks
- Adds `manual_url` field to download progress tracking
- Adds MEGA error code -6 mapping
- Tests for challenge detection and the new status endpoint

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 📸 Screenshots / Logs
<img width="371" height="174" alt="Screenshot 2026-07-02 101703" src="https://github.com/user-attachments/assets/3d3186df-9abe-4b22-b944-e4c1ea72c08b" />

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass