### PR TITLE
Support Configurable metadata priority in Bulk Move if cvinfo Present

### DIFF
--- a/app.py
+++ b/app.py
@@ -4273,6 +4273,157 @@ def auto_fetch_metron_metadata(destination_path):
         return destination_path
 
 
+def auto_fetch_comicvine_sqlite_metadata(destination_path):
+    """
+    Automatically fetch metadata from the local ComicVine SQLite database for
+    moved files if conditions are met. Only triggers for non-root /data
+    directories that have a cvinfo file. Uses the same ComicVine volume ID stored
+    in cvinfo as the online ComicVine provider.
+
+    Returns:
+        The final file path (renamed path if file was renamed, original path otherwise)
+    """
+    try:
+        from models import comicvine_sqlite
+        from models.comicvine import (
+            find_cvinfo_in_folder,
+            parse_cvinfo_volume_id,
+            read_cvinfo_fields,
+            generate_comicinfo_xml,
+            add_comicinfo_to_archive,
+        )
+        from models.providers.base import extract_issue_number
+        from core.comicinfo import read_comicinfo_from_zip
+        from cbz_ops.rename import rename_comic_from_metadata
+
+        # Check 1: Is the local ComicVine SQLite database configured and present?
+        if not comicvine_sqlite.is_database_available():
+            app_logger.debug(
+                "Local ComicVine SQLite database not available, skipping"
+            )
+            return destination_path
+
+        # Determine the folder to check for cvinfo
+        if os.path.isfile(destination_path):
+            folder_path = os.path.dirname(destination_path)
+            target_file = destination_path
+        else:
+            folder_path = destination_path
+            target_file = None
+
+        # Check: Is this a non-root /data directory?
+        data_dir = DATA_DIR
+        rel_path = os.path.relpath(folder_path, data_dir)
+        rel_path_normalized = rel_path.replace("\\", "/")
+        if rel_path == "." or "/" not in rel_path_normalized:
+            app_logger.debug(
+                f"Skipping local ComicVine metadata for root-level directory: {folder_path}"
+            )
+            return destination_path
+
+        # Check: Does cvinfo exist and carry a volume ID?
+        cvinfo_path = find_cvinfo_in_folder(folder_path)
+        if not cvinfo_path:
+            app_logger.debug(
+                f"No cvinfo file found in {folder_path}, skipping local ComicVine metadata"
+            )
+            return destination_path
+
+        volume_id = parse_cvinfo_volume_id(cvinfo_path)
+        if not volume_id:
+            app_logger.warning(f"Could not extract volume ID from {cvinfo_path}")
+            return destination_path
+
+        cvinfo_fields = read_cvinfo_fields(cvinfo_path)
+        start_year = cvinfo_fields.get("start_year")
+
+        # If target_file specified, only process that file
+        if target_file:
+            files_to_process = [target_file]
+        else:
+            files_to_process = [
+                os.path.join(folder_path, f)
+                for f in os.listdir(folder_path)
+                if f.lower().endswith((".cbz", ".cbr"))
+            ]
+
+        processed = 0
+        renamed_path = None
+
+        for file_path in files_to_process:
+            # Skip if already has metadata (unless it's just Amazon scraped data)
+            existing = read_comicinfo_from_zip(file_path)
+            existing_notes = existing.get("Notes", "").strip() if existing else ""
+            if existing_notes and "Scraped metadata from Amazon" not in existing_notes:
+                app_logger.debug(f"Skipping {file_path} - already has metadata")
+                continue
+
+            # Extract issue number from filename
+            issue_number = extract_issue_number(os.path.basename(file_path))
+            if not issue_number:
+                # One-shot operations (a single target file) fall back to issue
+                # #1; multi-file folders skip un-numbered files.
+                if len(files_to_process) == 1:
+                    issue_number = "1"
+                    app_logger.info(f"No issue number in {os.path.basename(file_path)}; defaulting to #1 (one-shot)")
+                else:
+                    app_logger.warning(f"Could not extract issue number from {file_path}")
+                    continue
+
+            # Fetch metadata from the local ComicVine SQLite database
+            metadata = comicvine_sqlite.get_issue_metadata(
+                volume_id, issue_number, start_year=start_year
+            )
+            if not metadata:
+                app_logger.warning(
+                    f"No local ComicVine metadata for {file_path}, issue #{issue_number}"
+                )
+                continue
+
+            # Generate and add ComicInfo.xml (generate_comicinfo_xml ignores the
+            # underscore-prefixed _image_url key, matching the online path)
+            xml_content = generate_comicinfo_xml(metadata)
+            if add_comicinfo_to_archive(file_path, xml_content):
+                processed += 1
+                app_logger.info(f"Added local ComicVine metadata to {file_path}")
+
+                # Auto-rename FIRST (before index update)
+                old_path = file_path
+                new_path, was_renamed = rename_comic_from_metadata(file_path, metadata)
+                if was_renamed and file_path == target_file:
+                    renamed_path = new_path
+                if was_renamed:
+                    file_path = new_path
+                    from core.database import update_file_index_entry
+                    new_name = os.path.basename(new_path)
+                    update_file_index_entry(old_path, name=new_name, new_path=new_path,
+                                            parent=os.path.dirname(new_path))
+
+                # Update ci_ fields using the FINAL path (after rename)
+                from core.database import update_file_index_from_comicinfo
+                update_file_index_from_comicinfo(file_path, metadata)
+
+        if processed > 0:
+            app_logger.info(
+                f"Auto-fetched local ComicVine metadata: {processed} files processed"
+            )
+
+            final_path = renamed_path if renamed_path else destination_path
+            if final_path.lower().endswith(".cbz"):
+                from core.metadata_scanner import queue_file_for_scan, PRIORITY_NEW_FILE
+
+                queue_file_for_scan(final_path, PRIORITY_NEW_FILE)
+                app_logger.debug(
+                    f"Queued for metadata scan: {os.path.basename(final_path)}"
+                )
+
+        return renamed_path if renamed_path else destination_path
+
+    except Exception as e:
+        app_logger.error(f"Error in auto-fetch local ComicVine metadata: {e}")
+        return destination_path
+
+
 def resize_upload(file_path, target_dir):
     """
     Resize an uploaded image to match dimensions of existing images in the directory.

--- a/routes/files.py
+++ b/routes/files.py
@@ -37,24 +37,54 @@ files_bp = Blueprint('files', __name__)
 # Move
 # =============================================================================
 
+def _move_metadata_order(destination):
+    """Provider-type order for post-move auto-metadata, honoring the destination
+    library's configured priority; falls back to the legacy order when unconfigured.
+
+    Only providers whose metadata can be fetched from a cvinfo ID are considered
+    (cvinfo carries a ComicVine volume ID and, optionally, a Metron series ID).
+    """
+    from helpers.library import get_library_for_path
+    from core.database import get_library_providers
+    supported = ('metron', 'comicvine', 'comicvine_sqlite')
+    lib = get_library_for_path(destination)
+    if lib and lib.get('id'):
+        provs = get_library_providers(lib['id'])
+        order = [p['provider_type'] for p in provs
+                 if p.get('enabled', True) and p['provider_type'] in supported]
+        if order:
+            return order
+    return ['metron', 'comicvine']  # preserve legacy default when no library config
+
+
 def _do_move(op_id, source, destination, is_file):
     """Background thread: perform move + post-move tasks, updating app_state."""
     from app import auto_fetch_metron_metadata, auto_fetch_comicvine_metadata, \
+                     auto_fetch_comicvine_sqlite_metadata, \
                      log_file_if_in_data, update_index_on_move
+    dispatch = {
+        'metron': auto_fetch_metron_metadata,
+        'comicvine': auto_fetch_comicvine_metadata,
+        'comicvine_sqlite': auto_fetch_comicvine_sqlite_metadata,
+    }
     with memory_context("file_move"):
         try:
             app_state.update_operation(op_id, current=10, detail="Moving...")
             shutil.move(source, destination)
             app_state.update_operation(op_id, current=60, detail="Fetching metadata...")
 
+            provider_order = _move_metadata_order(destination)
             final_path = destination
             if is_file:
-                final_path = auto_fetch_metron_metadata(destination)
-                final_path = auto_fetch_comicvine_metadata(final_path)
+                # Chain the (possibly renamed) path through each provider in
+                # priority order. Each provider skips files that already have
+                # metadata, so the first that matches wins and later ones no-op.
+                for ptype in provider_order:
+                    final_path = dispatch[ptype](final_path)
                 log_file_if_in_data(final_path)
             else:
-                auto_fetch_metron_metadata(destination)
-                auto_fetch_comicvine_metadata(destination)
+                for ptype in provider_order:
+                    dispatch[ptype](destination)
                 for root, _, files in os.walk(destination):
                     for f in files:
                         log_file_if_in_data(os.path.join(root, f))

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -93,6 +93,7 @@ def _make_mock_app_module(data_dir, target_dir):
     # Functions that routes call
     mock.auto_fetch_metron_metadata = MagicMock(side_effect=lambda p: p)
     mock.auto_fetch_comicvine_metadata = MagicMock(side_effect=lambda p: p)
+    mock.auto_fetch_comicvine_sqlite_metadata = MagicMock(side_effect=lambda p: p)
     mock.log_file_if_in_data = MagicMock()
     mock.update_index_on_move = MagicMock()
     mock.update_index_on_delete = MagicMock()

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -1,5 +1,7 @@
 """Tests for routes/files.py -- file operations endpoints."""
 import os
+import sys
+import types
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -53,6 +55,94 @@ class TestMove:
         mock_thread.assert_called_once()
         # Verify the background thread was started as daemon
         mock_thread.return_value.start.assert_called_once()
+
+
+class TestMoveMetadataOrder:
+    """post-move auto-metadata must honor the destination library's provider priority."""
+
+    @patch("core.database.get_library_providers")
+    @patch("helpers.library.get_library_for_path")
+    def test_uses_library_priority(self, mock_lib, mock_provs):
+        from routes.files import _move_metadata_order
+        mock_lib.return_value = {"id": 5, "path": "/data/lib"}
+        mock_provs.return_value = [
+            {"provider_type": "comicvine_sqlite", "priority": 1, "enabled": 1},
+            {"provider_type": "metron", "priority": 2, "enabled": 1},
+        ]
+        assert _move_metadata_order("/data/lib/Batman/b.cbz") == \
+            ["comicvine_sqlite", "metron"]
+
+    @patch("core.database.get_library_providers")
+    @patch("helpers.library.get_library_for_path")
+    def test_filters_unsupported_and_disabled(self, mock_lib, mock_provs):
+        from routes.files import _move_metadata_order
+        mock_lib.return_value = {"id": 5}
+        mock_provs.return_value = [
+            {"provider_type": "gcd", "priority": 1, "enabled": 1},       # unsupported
+            {"provider_type": "metron", "priority": 2, "enabled": 0},    # disabled
+            {"provider_type": "comicvine", "priority": 3, "enabled": 1},
+        ]
+        assert _move_metadata_order("/data/lib/x.cbz") == ["comicvine"]
+
+    @patch("helpers.library.get_library_for_path", return_value=None)
+    def test_no_library_falls_back_to_legacy(self, mock_lib):
+        from routes.files import _move_metadata_order
+        assert _move_metadata_order("/somewhere/x.cbz") == ["metron", "comicvine"]
+
+    @patch("core.database.get_library_providers", return_value=[])
+    @patch("helpers.library.get_library_for_path", return_value={"id": 5})
+    def test_library_without_providers_falls_back(self, mock_lib, mock_provs):
+        from routes.files import _move_metadata_order
+        assert _move_metadata_order("/data/lib/x.cbz") == ["metron", "comicvine"]
+
+
+class TestDoMoveDispatch:
+    """_do_move dispatches auto-fetch functions in the resolved provider order.
+
+    The suite never imports the real ``app`` module (heavy side effects); route
+    functions do ``from app import X`` at call time, so we inject a fake ``app``
+    module recording call order -- matching the pattern in conftest.py.
+    """
+
+    def _run_file_move(self, order):
+        calls = []
+
+        def make(name):
+            def fn(path):
+                calls.append(name)
+                return path
+            return fn
+
+        fake_app = types.ModuleType("app")
+        fake_app.auto_fetch_metron_metadata = make("metron")
+        fake_app.auto_fetch_comicvine_metadata = make("comicvine")
+        fake_app.auto_fetch_comicvine_sqlite_metadata = make("comicvine_sqlite")
+        fake_app.log_file_if_in_data = lambda p: None
+        fake_app.update_index_on_move = lambda *a, **k: None
+
+        from routes.files import _do_move
+        old_app = sys.modules.get("app")
+        sys.modules["app"] = fake_app
+        try:
+            with patch("routes.files._move_metadata_order", return_value=order), \
+                 patch("routes.files.shutil.move"), \
+                 patch("routes.files.app_state"), \
+                 patch("routes.files.memory_context"):
+                _do_move("op1", "/data/lib/a.cbz", "/data/lib2/a.cbz", is_file=True)
+        finally:
+            if old_app is not None:
+                sys.modules["app"] = old_app
+            else:
+                sys.modules.pop("app", None)
+        return calls
+
+    def test_file_dispatch_follows_priority_order(self):
+        assert self._run_file_move(["comicvine_sqlite", "metron"]) == \
+            ["comicvine_sqlite", "metron"]
+
+    def test_file_dispatch_legacy_order(self):
+        assert self._run_file_move(["metron", "comicvine"]) == \
+            ["metron", "comicvine"]
 
 
 class TestFolderSize:


### PR DESCRIPTION
## 📝 Description
Add local ComicVine SQLite metadata fetching for moved files via new `auto_fetch_comicvine_sqlite_metadata` function. Refactor post-move metadata fetching to be provider-order-agnostic using a dispatch pattern in `_do_move`. The order is now determined by `_move_metadata_order`, which honors the destination library's configured provider priority, falling back to legacy order (metron, comicvine) when unconfigured. Includes tests for provider ordering and dispatch logic.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass