### PR TITLE
Harden GetComics link fetch and issue parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,6 +72,7 @@ from core.app_logging import app_logger, APP_LOG, MONITOR_LOG
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections import OrderedDict
 from core.version import __version__
+from core.download_utils import issue_number_to_int
 import requests
 from packaging import version as pkg_version
 from core.database import (
@@ -1011,15 +1012,20 @@ def scheduled_getcomics_download(dry_run=False):
                 if issue_num in manual_status:
                     continue
 
-                # Skip if this issue is covered by a downloaded range pack
-                issue_int = int(issue_num.lstrip('0')) or 0
+                # Skip if this issue is covered by a downloaded range pack.
+                # Guard the int() conversion: "0"/"00"/"" strip to '' (int('')
+                # raises) and non-numeric issue numbers (e.g. "1.MU") also fail —
+                # in those cases issue_number_to_int returns None and we skip the
+                # numeric range check rather than aborting the whole run.
+                issue_int = issue_number_to_int(issue_num)
                 series_ranges = downloaded_ranges.get(series_name, [])
                 skip_for_range = False
-                for r_start, r_end in series_ranges:
-                    if r_start <= issue_int <= r_end:
-                        skip_for_range = True
-                        app_logger.debug(f"Skipping {series_name} #{issue_num} — covered by downloaded range #{r_start}-{r_end}")
-                        break
+                if issue_int is not None:
+                    for r_start, r_end in series_ranges:
+                        if r_start <= issue_int <= r_end:
+                            skip_for_range = True
+                            app_logger.debug(f"Skipping {series_name} #{issue_num} — covered by downloaded range #{r_start}-{r_end}")
+                            break
                 if skip_for_range:
                     continue
 

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -6,6 +6,28 @@ connection, cloudscraper).
 """
 
 
+def issue_number_to_int(issue_num) -> int | None:
+    """Best-effort parse of an issue-number string to a whole number.
+
+    Used by the auto-download scheduler to test whether an issue falls inside a
+    already-downloaded range pack. Returns ``None`` for values that aren't a
+    whole number so callers skip the numeric comparison instead of raising:
+
+    - ``"0"`` / ``"00"`` -> ``0`` (leading zeros stripped, but a bare "0" that
+      strips to ``''`` must NOT blow up ``int('')``)
+    - ``""`` / ``None`` -> ``None``
+    - ``"1.MU"`` / ``"½"`` / ``"Annual"`` -> ``None`` (not a whole number)
+    - ``"007"`` -> ``7``
+    """
+    s = str(issue_num).strip()
+    if not s:
+        return None
+    try:
+        return int(s.lstrip('0') or '0')
+    except (ValueError, TypeError):
+        return None
+
+
 def is_cloudflare_challenge(response) -> bool:
     """Detect a Cloudflare managed / JS "Just a moment..." challenge response.
 

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -85,6 +85,7 @@ def get_crossover_keywords():
     ]
 import time
 from core.app_logging import app_logger
+from core.download_utils import is_cloudflare_challenge as _is_cloudflare_challenge
 
 logger = logging.getLogger(__name__)
 
@@ -558,15 +559,25 @@ def series_has_same_brand(search_series: str, result_title: str, publisher_name:
     return False
 
 
+def _make_scraper():
+    """Build a fresh cloudscraper session.
+
+    A stale/blocked Cloudflare clearance token can poison every request made
+    through a single session, so retries use a brand-new scraper rather than
+    reusing the shared one below.
+    """
+    return cloudscraper.create_scraper(
+        browser={
+            'browser': 'chrome',
+            'platform': 'windows',
+            'desktop': True
+        }
+    )
+
+
 # Create a cloudscraper instance for bypassing Cloudflare protection
 # This is reused across all requests for efficiency
-scraper = cloudscraper.create_scraper(
-    browser={
-        'browser': 'chrome',
-        'platform': 'windows',
-        'desktop': True
-    }
-)
+scraper = _make_scraper()
 
 
 def search_getcomics(query: str, max_pages: int = 3) -> list:
@@ -736,28 +747,101 @@ def _extract_download_links(root) -> dict:
     return links
 
 
-def get_download_links(page_url: str) -> dict:
+def _looks_like_rendered_post(soup) -> bool:
+    """True if the page looks like a fully-rendered getcomics post.
+
+    Used to tell a post that genuinely exposes no CLU-supported providers apart
+    from a thin / soft-blocked response where retrying is worthwhile. A real
+    post always renders the ``aio-*`` download buttons (or at least names an
+    unsupported provider like Terabox/Mediafire), even when every provider on it
+    is one CLU can't download.
+    """
+    if soup.select_one('a[class*="aio-"]'):
+        return True
+    text = soup.get_text(" ", strip=True).upper()
+    return any(label in text for label in (
+        "TERABOX", "MEDIAFIRE", "VIKINGFILE", "DATANODES",
+        "ZIPPYSHARE", "READ ONLINE",
+    ))
+
+
+def get_download_links(page_url: str, max_attempts: int = 3) -> dict:
     """
     Fetch a getcomics page and extract download links.
     Uses cloudscraper to bypass Cloudflare protection.
 
+    A single fetch can come back as a Cloudflare challenge, a transient error,
+    or a thin/incomplete page — any of which yields zero links even though the
+    post has downloadable mirrors. Those cases are retried (with a fresh scraper
+    session) before giving up, and the logging distinguishes "we were blocked"
+    from "the post genuinely has no CLU-supported providers" so the caller's
+    "No download link found" warning is actionable.
+
     Args:
         page_url: URL of the getcomics page
+        max_attempts: How many times to try before giving up (default 3)
 
     Returns:
         Dict with keys: pixeldrain, download_now, mega (values are URLs or None)
     """
-    try:
-        logger.info(f"Fetching download links from: {page_url}")
-        resp = scraper.get(page_url, timeout=30)
-        resp.raise_for_status()
+    empty = {"pixeldrain": None, "download_now": None, "mega": None}
+    last_reason = "unknown error"
 
-        soup = BeautifulSoup(resp.text, 'html.parser')
-        return _extract_download_links(soup)
+    # Start on the shared, already-cleared scraper. Only swap in a fresh session
+    # after a Cloudflare challenge, since that's the case where a poisoned
+    # clearance token would otherwise block every remaining attempt.
+    s = scraper
+    for attempt in range(1, max_attempts + 1):
+        try:
+            logger.info(
+                f"Fetching download links from: {page_url} "
+                f"(attempt {attempt}/{max_attempts})"
+            )
+            resp = s.get(page_url, timeout=30)
 
-    except Exception as e:
-        logger.error(f"Error fetching/parsing page: {e}")
-        return {"pixeldrain": None, "download_now": None, "mega": None}
+            if _is_cloudflare_challenge(resp):
+                last_reason = "Cloudflare challenge"
+                logger.warning(
+                    f"Cloudflare challenge fetching {page_url} "
+                    f"(attempt {attempt}/{max_attempts})"
+                )
+                s = _make_scraper()
+                continue
+
+            resp.raise_for_status()
+
+            soup = BeautifulSoup(resp.text, 'html.parser')
+            links = _extract_download_links(soup)
+
+            if any(links.values()):
+                return links
+
+            # No supported links found. If the page rendered fully, the post
+            # simply has no provider CLU can download — retrying won't help.
+            if _looks_like_rendered_post(soup):
+                logger.info(
+                    f"No CLU-supported download providers on page: {page_url}"
+                )
+                return links
+
+            last_reason = "no links on an incomplete page"
+            logger.warning(
+                f"No links and page looks incomplete for {page_url} "
+                f"(attempt {attempt}/{max_attempts})"
+            )
+
+        except Exception as e:
+            last_reason = str(e)
+            logger.error(
+                f"Error fetching/parsing page {page_url} "
+                f"(attempt {attempt}/{max_attempts}): {e}"
+            )
+
+    logger.error(
+        f"Giving up on download links for {page_url} after {max_attempts} "
+        f"attempts ({last_reason})"
+    )
+    return dict(empty)
 
 
 

--- a/tests/mocked/test_download_cloudflare.py
+++ b/tests/mocked/test_download_cloudflare.py
@@ -10,7 +10,9 @@ triggering api.py's import-time side effects (worker threads, DB, cloudscraper).
 """
 from types import SimpleNamespace
 
-from core.download_utils import is_cloudflare_challenge
+import pytest
+
+from core.download_utils import is_cloudflare_challenge, issue_number_to_int
 
 
 def _resp(status=403, headers=None, content=b""):
@@ -52,3 +54,33 @@ class TestIsCloudflareChallenge:
 
     def test_missing_headers_do_not_raise(self):
         assert is_cloudflare_challenge(_resp(headers={})) is False
+
+
+class TestIssueNumberToInt:
+    """Regression: a #0 issue (or empty/non-numeric number) used to raise
+    `invalid literal for int() with base 10: ''` in the auto-download range
+    check and abort the entire run."""
+
+    @pytest.mark.parametrize("value,expected", [
+        ("1", 1),
+        ("12", 12),
+        ("007", 7),
+        ("0", 0),        # bare zero must NOT blow up int('') after lstrip('0')
+        ("00", 0),
+        (0, 0),
+        (5, 5),
+    ])
+    def test_parses_whole_numbers(self, value, expected):
+        assert issue_number_to_int(value) == expected
+
+    @pytest.mark.parametrize("value", [
+        "",              # missing issue number
+        "   ",
+        None,
+        "1.MU",          # point-one / marketing issues
+        "½",
+        "Annual",
+        "1.5",
+    ])
+    def test_non_whole_numbers_return_none(self, value):
+        assert issue_number_to_int(value) is None

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -66,6 +66,14 @@ DOWNLOAD_NO_LINKS_HTML = """\
 </body></html>
 """
 
+# A fully-rendered post whose only mirrors are providers CLU can't download.
+DOWNLOAD_ONLY_UNSUPPORTED_HTML = """\
+<html><body>
+<a class="aio-blue" href="https://1024terabox.com/s/xyz" title="TERABOX">Terabox</a>
+<a class="aio-gray" href="https://datanodes.to/abc/comic.cbr" title="DATANODES">Datanodes</a>
+</body></html>
+"""
+
 # Older getcomics layout: provider names live in inner <span> text of
 # class-less, title-less <a> tags wrapped in <strong> (Supergirl Vol 4 style).
 DOWNLOAD_LINKS_SPAN_HTML = """\
@@ -338,6 +346,74 @@ class TestGetDownloadLinks:
 
         from models.getcomics import get_download_links
         links = get_download_links("https://getcomics.org/fail")
+
+        assert links == {"pixeldrain": None, "download_now": None, "mega": None}
+
+    @patch("models.getcomics.scraper")
+    def test_rendered_post_with_only_unsupported_providers_no_retry(self, mock_scraper):
+        # A real post that exposes only Terabox/Datanodes must NOT be retried —
+        # there is nothing CLU can download, and hammering it wastes requests.
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_ONLY_UNSUPPORTED_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/terabox-only")
+
+        assert links == {"pixeldrain": None, "download_now": None, "mega": None}
+        assert mock_scraper.get.call_count == 1
+
+    @patch("models.getcomics.scraper")
+    def test_incomplete_page_is_retried(self, mock_scraper):
+        # A thin page with no download UI looks soft-blocked, so we retry.
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_NO_LINKS_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/thin", max_attempts=3)
+
+        assert links == {"pixeldrain": None, "download_now": None, "mega": None}
+        assert mock_scraper.get.call_count == 3
+
+    @patch("models.getcomics._make_scraper")
+    @patch("models.getcomics.scraper")
+    def test_cloudflare_challenge_retries_with_fresh_scraper(self, mock_scraper, mock_make):
+        # First hit is a Cloudflare challenge; a fresh session then succeeds.
+        challenge = MagicMock()
+        challenge.status_code = 403
+        challenge.headers = {"Server": "cloudflare", "Content-Type": "text/html"}
+        challenge.content = b"<html><head><title>Just a moment...</title></head></html>"
+        challenge.text = challenge.content.decode()
+        challenge.raise_for_status = MagicMock()
+        mock_scraper.get.return_value = challenge
+
+        fresh = MagicMock()
+        fresh.get.return_value = _mock_response(DOWNLOAD_LINKS_BY_TITLE_HTML)
+        mock_make.return_value = fresh
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/blocked")
+
+        assert links["pixeldrain"] == "https://pixeldrain.com/u/abc123"
+        assert links["download_now"] == "https://getcomics.org/dlds/xyz"
+        mock_make.assert_called()  # a fresh scraper session was created for the retry
+
+    @patch("models.getcomics._make_scraper")
+    @patch("models.getcomics.scraper")
+    def test_persistent_cloudflare_challenge_gives_up_empty(self, mock_scraper, mock_make):
+        def _challenge():
+            resp = MagicMock()
+            resp.status_code = 403
+            resp.headers = {"Server": "cloudflare", "Content-Type": "text/html"}
+            resp.content = b"<html><title>Just a moment...</title></html>"
+            resp.text = resp.content.decode()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        mock_scraper.get.return_value = _challenge()
+        blocked = MagicMock()
+        blocked.get.return_value = _challenge()
+        mock_make.return_value = blocked
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/always-blocked", max_attempts=3)
 
         assert links == {"pixeldrain": None, "download_now": None, "mega": None}
 


### PR DESCRIPTION
## 📝 Description
Improve download reliability and scheduler robustness. `get_download_links` now retries transient/blocked fetches, detects Cloudflare challenges, and switches to a fresh scraper session when needed while avoiding pointless retries for fully rendered posts with only unsupported providers. Added `issue_number_to_int` and used it in scheduled range checks to prevent crashes on `#0`, empty, or non-numeric issue values. Expanded mocked tests to cover new retry behavior and issue-number parsing edge cases.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass