### PR TITLE
Add Series Alias Search Support to Auto-downloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -948,6 +948,7 @@ def scheduled_getcomics_download(dry_run=False):
             get_download_links,
             score_getcomics_result,
             accept_result,
+            get_series_alias_list,
         )
         from api import download_queue, download_progress
         from datetime import date
@@ -978,6 +979,11 @@ def scheduled_getcomics_download(dry_run=False):
 
             if not mapped_path or not os.path.exists(mapped_path):
                 continue
+
+            # Configured GetComics search aliases for this series (e.g. "2000AD"
+            # for "2000 AD"). Loaded once per series and reused for every issue's
+            # search and scoring so alias-named posts are found and accepted.
+            series_aliases = get_series_alias_list(series_name)
 
             # Get cached issues for this series
             issues = get_issues_for_series(series_id)
@@ -1085,6 +1091,7 @@ def scheduled_getcomics_download(dry_run=False):
                     series_volume=series_volume,
                     series_year=series_year,  # Pass volume_year to help find correct series edition
                     search_variants=search_variants,
+                    series_aliases=series_aliases,
                 )
 
                 if not results:
@@ -1125,6 +1132,7 @@ def scheduled_getcomics_download(dry_run=False):
                         series_volume=series_volume,
                         volume_year=series_year,
                         publisher_name=publisher_name,
+                        series_aliases=series_aliases,
                     )
                     decision = accept_result(
                         score, is_range, series_match,
@@ -1172,6 +1180,7 @@ def scheduled_getcomics_download(dry_run=False):
                             series_volume=series_volume,
                             volume_year=series_year,
                             publisher_name=publisher_name,
+                            series_aliases=series_aliases,
                         )
                         r_decision = accept_result(
                             r_score, r_is_range, r_series_match,

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -1388,6 +1388,7 @@ def score_getcomics_result(
     series_volume: int = None,
     volume_year: int = None,
     publisher_name: str = None,
+    series_aliases: list = None,
 ) -> tuple:
     """
     Score a GetComics search result against a wanted issue.
@@ -1403,6 +1404,10 @@ def score_getcomics_result(
         series_volume: Volume number of the series (e.g., 3 for "Vol. 3")
         volume_year: Volume year of the series (e.g., 2024 for "Flash Gordon 2024")
         publisher_name: Publisher name for brand keyword matching (e.g., "DC", "Marvel")
+        series_aliases: Optional list of GetComics search aliases for the series
+                        (e.g., ["2000AD"] for series "2000 AD"). The result is
+                        scored against the series name and each alias; the best
+                        score wins.
     Returns:
         (score, range_contains_target, series_match)
         - score:                 Integer score; higher = better match
@@ -1450,17 +1455,33 @@ def score_getcomics_result(
         FALLBACK requires series_match=True — arc sub-series range packs ARE allowed
         (arcs are often bundled in packs).
     """
-    search = search_criteria(
-        series_name=series_name,
-        issue_number=issue_number,
-        year=year,
-        series_volume=series_volume,
-        volume_year=volume_year,
-        publisher_name=publisher_name,
-        accept_variants=accept_variants,
-    )
-    comic_score = score_comic(result_title, search)
-    return comic_score.score, comic_score.range_contains_target, comic_score.series_match
+    # Try the canonical series name plus any configured GetComics search
+    # aliases, keeping the best-scoring match. A series listed as "2000 AD"
+    # won't startswith-match a "2000AD" result title, but scoring against its
+    # "2000AD" alias will — this mirrors the manual search, which swaps the
+    # alias in as the query name.
+    names = [series_name]
+    for alias in (series_aliases or []):
+        alias = (alias or "").strip()
+        if alias and alias.lower() != series_name.lower() and alias not in names:
+            names.append(alias)
+
+    best = None
+    for name in names:
+        search = search_criteria(
+            series_name=name,
+            issue_number=issue_number,
+            year=year,
+            series_volume=series_volume,
+            volume_year=volume_year,
+            publisher_name=publisher_name,
+            accept_variants=accept_variants,
+        )
+        comic_score = score_comic(result_title, search)
+        candidate = (comic_score.score, comic_score.range_contains_target, comic_score.series_match)
+        if best is None or candidate[0] > best[0]:
+            best = candidate
+    return best
 
 
 def score_comic(result_title: str, search: SearchCriteria) -> ComicScore:
@@ -3861,6 +3882,35 @@ def get_series_aliases(series_name: str) -> str:
         conn.close()
 
 
+def get_series_alias_list(series_name: str) -> list[str]:
+    """
+    Return the configured GetComics search aliases for a series as a clean list.
+
+    Wraps get_series_aliases() (which returns a comma-separated string), dropping
+    blanks and any alias equal to the series name (case-insensitive). Returns an
+    empty list on any error so callers can always safely iterate.
+
+    Args:
+        series_name: The canonical series name (e.g., "2000 AD")
+
+    Returns:
+        List of alias strings (e.g., ["2000AD"]), or [] if none configured
+    """
+    try:
+        raw = get_series_aliases(series_name) or ""
+    except Exception as e:
+        logger.debug(f"Failed to load search aliases for '{series_name}': {e}")
+        return []
+    out: list[str] = []
+    seen = {series_name.strip().lower()}
+    for alias in raw.split(","):
+        alias = alias.strip()
+        if alias and alias.lower() not in seen:
+            out.append(alias)
+            seen.add(alias.lower())
+    return out
+
+
 def get_sitemap_subseries_aliases(series_name: str) -> list[str]:
     """
     Get candidate aliases for a series from the GetComics sitemap.
@@ -4235,6 +4285,7 @@ def search_getcomics_for_issue(
     series_year=None,  # Volume year (e.g., 2024 for "Flash Gordon 2024")
     search_variants=None,
     rate_limit=2,
+    series_aliases=None,
 ):
     """
     Search GetComics for a specific issue, combining base and variant searches.
@@ -4252,6 +4303,10 @@ def search_getcomics_for_issue(
         series_year: Volume year of the series (e.g., 2024 for "Flash Gordon 2024") - optional
         search_variants: List of variant keywords to include in search - optional
         rate_limit: Seconds to wait between searches (default 2)
+        series_aliases: Optional list of GetComics search aliases for the series
+                        (e.g., ["2000AD"] for "2000 AD"). Used as alternate series
+                        names in the live-search queries so alias-named posts are
+                        found. If None, aliases are loaded from the DB.
 
     Returns:
         list: Combined search results from GetComics (deduplicated), or empty list if none found
@@ -4263,6 +4318,8 @@ def search_getcomics_for_issue(
         return []
 
     search_variants = search_variants or []
+    if series_aliases is None:
+        series_aliases = get_series_alias_list(series_name)
 
     # Build searchable context for logging
     ctx_parts = [f"{series_name} #{issue_num}"]
@@ -4392,22 +4449,36 @@ def search_getcomics_for_issue(
                            f"— falling through to live search {search_context}")
 
     # ── STEP 2: Build search queries ───────────────────────────────────────────
+    def _queries_for(name):
+        """Build the ordered set of live-search queries for a given series name."""
+        q = []
+        if series_year:
+            q.append(" ".join([name, str(series_year), issue_num]))
+        if series_volume and series_year:
+            q.append(" ".join([name, "vol.", str(series_volume), str(series_year), issue_num]))
+            q.append(" ".join([name, "vol", str(series_volume), str(series_year), issue_num]))
+            q.append(" ".join([name, "volume", str(series_volume), str(series_year), issue_num]))
+        if series_volume and not series_year:
+            q.append(" ".join([name, "vol.", str(series_volume), issue_num]))
+            q.append(" ".join([name, "vol", str(series_volume), issue_num]))
+            q.append(" ".join([name, "volume", str(series_volume), issue_num]))
+        if issue_year and issue_year != series_year:
+            q.append(" ".join([name, str(issue_year), issue_num]))
+        if series_volume:
+            q.append(" ".join([name, "vol.", str(series_volume), issue_num]))
+        q.append(" ".join([name, issue_num]))  # bare query always last
+        return q
+
+    # Search under the canonical name plus any configured aliases (e.g. "2000AD"
+    # for "2000 AD"), so alias-named posts are found in the live search too.
     queries_to_try = []
-    if series_year:
-        queries_to_try.append(" ".join([series_name, str(series_year), issue_num]))
-    if series_volume and series_year:
-        queries_to_try.append(" ".join([series_name, "vol.", str(series_volume), str(series_year), issue_num]))
-        queries_to_try.append(" ".join([series_name, "vol", str(series_volume), str(series_year), issue_num]))
-        queries_to_try.append(" ".join([series_name, "volume", str(series_volume), str(series_year), issue_num]))
-    if series_volume and not series_year:
-        queries_to_try.append(" ".join([series_name, "vol.", str(series_volume), issue_num]))
-        queries_to_try.append(" ".join([series_name, "vol", str(series_volume), issue_num]))
-        queries_to_try.append(" ".join([series_name, "volume", str(series_volume), issue_num]))
-    if issue_year and issue_year != series_year:
-        queries_to_try.append(" ".join([series_name, str(issue_year), issue_num]))
-    if series_volume:
-        queries_to_try.append(" ".join([series_name, "vol.", str(series_volume), issue_num]))
-    queries_to_try.append(" ".join([series_name, issue_num]))  # bare query always last
+    for name in [series_name, *series_aliases]:
+        for q in _queries_for(name):
+            if q not in queries_to_try:
+                queries_to_try.append(q)
+    if series_aliases:
+        app_logger.info(f"   Including {len(series_aliases)} search alias(es) "
+                       f"for '{series_name}': {', '.join(series_aliases)} {search_context}")
 
     # Execute all queries CONCURRENTLY (3 workers)
     all_results = []

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -26,6 +26,7 @@ from models.getcomics import (
     get_download_links,
     score_getcomics_result,
     accept_result,
+    get_series_alias_list,
 )
 from helpers.collection import match_issues_to_collection
 from models.issue import IssueObj, SeriesObj
@@ -184,6 +185,11 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
         if not mapped_path:
             continue
 
+        # GetComics search aliases for this series (e.g. "2000AD" for "2000 AD"),
+        # loaded once and reused for each issue's search and scoring. Mirrors the
+        # auto-download path in scheduled_getcomics_download.
+        series_aliases = get_series_alias_list(series_name)
+
         issues = get_issues_for_series(sid)
         if not issues:
             continue
@@ -224,6 +230,7 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
                 series_volume=series_volume,
                 series_year=series_year,
                 search_variants=search_variants,
+                series_aliases=series_aliases,
             )
 
             if not results:
@@ -252,6 +259,7 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
                     series_volume=series_volume,
                     volume_year=series_year,
                     publisher_name=publisher_name,
+                    series_aliases=series_aliases,
                 )
                 decision = accept_result(score, is_range, series_match, single_issue_found=single_found)
                 scored_results.append({

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -511,6 +511,43 @@ class TestScoreGetcomicsResult:
         score, _, _ = score_getcomics_result(title, series, issue, year)
         assert score == 95
 
+    def test_series_alias_enables_match(self):
+        # "2000 AD" (from online sources) is listed on GetComics as "2000AD".
+        # Without the alias the space mismatch fails the series match; passing
+        # the alias must recover a full-confidence match.
+        from models.getcomics import score_getcomics_result
+        title = "2000AD #2400 (2026)"
+
+        score_no_alias, _, match_no_alias = score_getcomics_result(
+            title, "2000 AD", "2400", 2026
+        )
+        assert match_no_alias is False
+        assert score_no_alias == 0
+
+        score_alias, _, match_alias = score_getcomics_result(
+            title, "2000 AD", "2400", 2026, series_aliases=["2000AD"]
+        )
+        assert match_alias is True
+        assert score_alias == 95
+
+    def test_series_alias_keeps_best_score(self):
+        # The canonical name already matches; an irrelevant alias must not lower
+        # the score (best of canonical + aliases wins).
+        from models.getcomics import score_getcomics_result
+        score_plain, _, _ = score_getcomics_result("Batman #1 (2020)", "Batman", "1", 2020)
+        score_with_alias, _, _ = score_getcomics_result(
+            "Batman #1 (2020)", "Batman", "1", 2020, series_aliases=["Caped Crusader"]
+        )
+        assert score_with_alias == score_plain == 95
+
+    def test_series_alias_empty_and_none_are_safe(self):
+        from models.getcomics import score_getcomics_result
+        for aliases in (None, [], ["", "   "]):
+            score, _, match = score_getcomics_result(
+                "Batman #1 (2020)", "Batman", "1", 2020, series_aliases=aliases
+            )
+            assert match is True and score == 95
+
     @pytest.mark.parametrize(
         "title, issue",
         [
@@ -1700,3 +1737,79 @@ class TestScoreGetcomicsResultEdgeCases:
         # Should have -40 penalty for confirmed issue mismatch
         # series(30) - mismatch(40) + tight(15) + year(20) = 25
         assert score == 25
+
+
+# ===================================================================
+# get_series_alias_list
+# ===================================================================
+
+class TestGetSeriesAliasList:
+
+    @patch("models.getcomics.get_series_aliases", return_value="2000AD")
+    def test_parses_single_alias(self, _mock):
+        from models.getcomics import get_series_alias_list
+        assert get_series_alias_list("2000 AD") == ["2000AD"]
+
+    @patch("models.getcomics.get_series_aliases", return_value="2000AD, Two Thousand AD ,")
+    def test_splits_trims_and_drops_blanks(self, _mock):
+        from models.getcomics import get_series_alias_list
+        assert get_series_alias_list("2000 AD") == ["2000AD", "Two Thousand AD"]
+
+    @patch("models.getcomics.get_series_aliases", return_value="Batman, batman, BATMAN, Bruce")
+    def test_drops_aliases_equal_to_series_name_case_insensitive(self, _mock):
+        from models.getcomics import get_series_alias_list
+        # "batman"/"BATMAN" duplicate the series name and each other → only "Bruce".
+        assert get_series_alias_list("Batman") == ["Bruce"]
+
+    @patch("models.getcomics.get_series_aliases", return_value="")
+    def test_no_aliases_returns_empty_list(self, _mock):
+        from models.getcomics import get_series_alias_list
+        assert get_series_alias_list("Batman") == []
+
+    @patch("models.getcomics.get_series_aliases", side_effect=Exception("db down"))
+    def test_errors_return_empty_list(self, _mock):
+        from models.getcomics import get_series_alias_list
+        assert get_series_alias_list("Batman") == []
+
+
+# ===================================================================
+# search_getcomics_for_issue — alias query expansion
+# ===================================================================
+
+class TestSearchGetcomicsForIssueAliases:
+
+    @patch("models.getcomics.search_scrape_index", return_value=[])
+    @patch("models.getcomics.try_scrape_index", return_value=(None, 0))
+    @patch("models.getcomics.lookup_series_urls", return_value=[])
+    @patch("models.getcomics.search_getcomics", return_value=[])
+    def test_live_search_includes_alias_queries(self, mock_search, *_):
+        from models.getcomics import search_getcomics_for_issue
+        search_getcomics_for_issue(
+            series_name="2000 AD",
+            issue_num="2400",
+            issue_year=2026,
+            series_aliases=["2000AD"],
+            rate_limit=0,
+        )
+        queries = [c.args[0] for c in mock_search.call_args_list]
+        # Canonical name is still searched...
+        assert any(q.startswith("2000 AD ") for q in queries)
+        # ...and the alias name is searched too.
+        assert "2000AD 2400" in queries
+
+    @patch("models.getcomics.search_scrape_index", return_value=[])
+    @patch("models.getcomics.try_scrape_index", return_value=(None, 0))
+    @patch("models.getcomics.lookup_series_urls", return_value=[])
+    @patch("models.getcomics.search_getcomics", return_value=[])
+    def test_no_aliases_only_searches_canonical(self, mock_search, *_):
+        from models.getcomics import search_getcomics_for_issue
+        search_getcomics_for_issue(
+            series_name="Batman",
+            issue_num="5",
+            issue_year=2026,
+            series_aliases=[],
+            rate_limit=0,
+        )
+        queries = [c.args[0] for c in mock_search.call_args_list]
+        assert queries  # some queries ran
+        assert all(q.startswith("Batman ") for q in queries)


### PR DESCRIPTION
## 📝 Description
Wire configured series aliases into wanted-issue download flows so searches and scoring evaluate both canonical names and aliases (for cases like "2000 AD" vs "2000AD"). Adds alias parsing helper logic, query expansion, best-score selection across names, and mocked tests covering alias matching, safety cases, and live-search query generation.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass