### PR TITLE
Add periodic reconciliation sweep for stranded files

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -65,6 +65,7 @@ def load_config():
         "CONSOLIDATE_DIRECTORIES": "False",
         "AUTO_UNPACK": "False",
         "AUTO_RENAME_MONITOR": "True",
+        "RECONCILE_INTERVAL_MINUTES": "5",
         "SKIPPED_FILES": ".xml",
         "DELETED_FILES": ".nfo,.sfv,.db,.DS_Store",
         "DOWNLOAD_PROVIDER_PRIORITY": "pixeldrain,download_now,mega",

--- a/monitor.py
+++ b/monitor.py
@@ -2,6 +2,7 @@ import time
 import logging
 import shutil
 import os
+import threading # Added for in-flight processing guard
 import zipfile
 import re # Added for _is_temporary_download_file
 import math # Added for format_size
@@ -35,6 +36,7 @@ auto_unpack = config.getboolean("SETTINGS", "AUTO_UNPACK", fallback=False)
 auto_rename_monitor = config.getboolean("SETTINGS", "AUTO_RENAME_MONITOR", fallback=True)
 auto_cleanup = config.getboolean("SETTINGS", "AUTO_CLEANUP_ORPHAN_FILES", fallback=True)
 cleanup_interval_hours = config.getint("SETTINGS", "CLEANUP_INTERVAL_HOURS", fallback=1)
+reconcile_interval_minutes = config.getint("SETTINGS", "RECONCILE_INTERVAL_MINUTES", fallback=5)
 
 # Logging setup - MONITOR_LOG imported from app_logging
 monitor_logger = logging.getLogger("monitor_logger")
@@ -56,6 +58,7 @@ monitor_logger.info(f"7. Consolidate Directories: {consolidate_directories}")
 monitor_logger.info(f"8. Auto Unpack Enabled: {auto_unpack}")
 monitor_logger.info(f"9. Auto Cleanup Orphan Files: {auto_cleanup}")
 monitor_logger.info(f"10. Cleanup Interval: {cleanup_interval_hours} hour(s)")
+monitor_logger.info(f"11. Reconciliation Sweep Interval: {reconcile_interval_minutes} minute(s)")
 
 class DownloadCompleteHandler(FileSystemEventHandler):
     def __init__(self, directory, target_directory, ignored_extensions):
@@ -72,7 +75,14 @@ class DownloadCompleteHandler(FileSystemEventHandler):
         self.consolidate_directories = consolidate_directories
         self.auto_unpack = auto_unpack
         self.auto_rename_monitor = auto_rename_monitor
+        self.reconcile_interval_minutes = reconcile_interval_minutes
         self._initial_dir_file_counts = {}
+
+        # Guard so the periodic reconciliation sweep (main thread) and live
+        # watchdog callbacks (observer thread) never process the same file at
+        # once, which would cause a double-move or spurious errors.
+        self._processing_lock = threading.Lock()
+        self._in_flight = set()
 
 
     def reload_settings(self):
@@ -94,6 +104,7 @@ class DownloadCompleteHandler(FileSystemEventHandler):
         self.auto_rename_monitor = config.getboolean("SETTINGS", "AUTO_RENAME_MONITOR", fallback=True)
         self.auto_cleanup = config.getboolean("SETTINGS", "AUTO_CLEANUP_ORPHAN_FILES", fallback=True)
         self.cleanup_interval_hours = config.getint("SETTINGS", "CLEANUP_INTERVAL_HOURS", fallback=1)
+        self.reconcile_interval_minutes = config.getint("SETTINGS", "RECONCILE_INTERVAL_MINUTES", fallback=5)
 
         monitor_logger.info(f"********************// Config Reloaded //********************")
         monitor_logger.info(
@@ -102,7 +113,8 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             f"subdirectories: {self.subdirectories}, move_directories: {self.move_directories}, "
             f"consolidate_directories: {self.consolidate_directories}, "
             f"auto_unpack: {self.auto_unpack}, auto_cleanup: {self.auto_cleanup}, "
-            f"cleanup_interval: {self.cleanup_interval_hours}h"
+            f"cleanup_interval: {self.cleanup_interval_hours}h, "
+            f"reconcile_interval: {self.reconcile_interval_minutes}m"
         )
 
 
@@ -199,11 +211,30 @@ class DownloadCompleteHandler(FileSystemEventHandler):
                 monitor_logger.info(f"Ignoring file with extension '{extension}': {filepath}")
                 return
 
-        if self._is_download_complete(filepath):
-            self._process_file(filepath)
-            monitor_logger.info(f"File Download Complete: {filepath}")
-        else:
-            monitor_logger.info(f"File not yet complete: {filepath}")
+        # Claim the file so the reconciliation sweep and a live watchdog event
+        # can't process it concurrently. Skip if another thread already holds it.
+        key = os.path.abspath(filepath)
+        with self._processing_lock:
+            if key in self._in_flight:
+                monitor_logger.debug(f"Already processing, skipping: {filepath}")
+                return
+            self._in_flight.add(key)
+
+        try:
+            if self._is_download_complete(filepath):
+                self._process_file(filepath)
+                monitor_logger.info(f"File Download Complete: {filepath}")
+            elif not os.path.exists(filepath):
+                # File vanished during the stability check — almost always because
+                # api.py renamed it in place (e.g. to its " (1)" form). Expected;
+                # the renamed file gets picked up by its own event or the next
+                # reconciliation sweep.
+                monitor_logger.debug(f"File changed/renamed during stability check; will retry: {filepath}")
+            else:
+                monitor_logger.info(f"File not yet complete: {filepath}")
+        finally:
+            with self._processing_lock:
+                self._in_flight.discard(key)
 
     def _is_temporary_download_file(self, filepath, extension):
         """
@@ -275,9 +306,44 @@ class DownloadCompleteHandler(FileSystemEventHandler):
                 monitor_logger.info(f"Cleanup completed: {cleaned_count} files removed, {format_size(total_size_cleaned)} freed")
             else:
                 monitor_logger.info("No orphan files found during cleanup")
-                
+
         except Exception as e:
             monitor_logger.error(f"Error during orphan file cleanup: {e}")
+
+
+    def reconcile_directory(self):
+        """Safety-net sweep: re-scan WATCH and process any comic file stranded
+        by a missed watchdog event.
+
+        The monitor otherwise relies solely on live watchdog events plus a
+        one-time startup scan, so a file that misses its event (observer poll
+        coalescing, api.py's in-place rename firing during the stability check,
+        a transient move error, or a restart gap) would sit in WATCH forever.
+        This periodic sweep drains those files.
+
+        Idempotent and safe to run alongside live events: each file is claimed
+        via the in-flight lock in ``_handle_file_if_complete``, so the sweep and
+        the observer thread never move the same file at once. Temporary/ignored/
+        hidden files are filtered there too, and only size-stable files are
+        moved, so re-driving the whole directory is harmless.
+        """
+        try:
+            self.reload_settings()
+            if not os.path.isdir(self.directory):
+                monitor_logger.debug(f"Reconciliation skipped, directory missing: {self.directory}")
+                return
+
+            monitor_logger.info(f"Running reconciliation sweep of: {self.directory}")
+            for root, dirs, files in os.walk(self.directory):
+                # Skip hidden directories from being traversed.
+                dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    if is_hidden(file_path):
+                        continue
+                    self._handle_file_if_complete(file_path)
+        except Exception as e:
+            monitor_logger.error(f"Error during reconciliation sweep: {e}")
 
 
     def _rename_file(self, filepath):
@@ -573,12 +639,9 @@ if __name__ == "__main__":
     else:
         monitor_logger.info("Auto cleanup disabled, skipping initial cleanup")
 
-    # Initial scan
-    for root, _, files in os.walk(directory):
-        for file in files:
-            filepath = os.path.join(root, file)
-            monitor_logger.info(f"Initial startup scan for: {filepath}")
-            event_handler._handle_file_if_complete(filepath)
+    # Initial scan — drain anything already sitting in WATCH at startup.
+    monitor_logger.info("Performing initial startup scan...")
+    event_handler.reconcile_directory()
 
     observer = PollingObserver(timeout=30)
     observer.schedule(event_handler, directory, recursive=subdirectories)
@@ -588,18 +651,30 @@ if __name__ == "__main__":
     last_cleanup_time = time.time()
     cleanup_interval = cleanup_interval_hours * 3600  # Convert hours to seconds
 
+    # Set up periodic reconciliation sweep (self-healing for missed events).
+    last_reconcile_time = time.time()
+    reconcile_interval = reconcile_interval_minutes * 60  # Convert minutes to seconds
+
     try:
         while True:
             time.sleep(1)
-            
+
+            current_time = time.time()
+
             # Check if it's time for periodic cleanup (only if auto_cleanup is enabled)
             if auto_cleanup:
-                current_time = time.time()
                 if current_time - last_cleanup_time >= cleanup_interval:
                     monitor_logger.info("Running periodic cleanup of orphan files...")
                     event_handler.cleanup_orphan_files()
                     last_cleanup_time = current_time
-                
+
+            # Periodic reconciliation sweep so files that missed their watchdog
+            # event get moved instead of being stranded (0 disables).
+            if reconcile_interval > 0:
+                if current_time - last_reconcile_time >= reconcile_interval:
+                    event_handler.reconcile_directory()
+                    last_reconcile_time = current_time
+
     except KeyboardInterrupt:
         observer.stop()
     observer.join()

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for monitor.py folder monitoring.
+
+Focus: the reconciliation sweep (self-healing for files that miss a watchdog
+event) and the in-flight concurrency guard that keeps the sweep from colliding
+with live watchdog callbacks. These cover the regression where a completed
+comic sat in the WATCH dir forever because nothing re-drove the move.
+
+The handler is exercised directly (no observer/threads) with temp WATCH/TARGET
+dirs. Real time.sleep and the size-stability helpers are stubbed so the tests
+run fast and deterministically.
+"""
+import os
+import pytest
+
+
+@pytest.fixture
+def handler(tmp_path, monkeypatch):
+    """A DownloadCompleteHandler wired to temp WATCH/TARGET dirs.
+
+    Returns (handler, watch_dir, target_dir). Sleeps and the size-stability
+    checks are neutralized so a file present on disk counts as "complete".
+    reload_settings() is stubbed so our temp dirs aren't clobbered by prod config.
+    """
+    import monitor
+
+    watch = tmp_path / "watch"
+    target = tmp_path / "target"
+    watch.mkdir()
+    target.mkdir()
+
+    h = monitor.DownloadCompleteHandler(
+        directory=str(watch),
+        target_directory=str(target),
+        ignored_extensions=[".crdownload", ".tmp"],
+    )
+    h.directory = str(watch)
+    h.target_directory = str(target)
+    h.auto_rename_monitor = False   # test the move path, not renaming
+    h.auto_unpack = False
+    h.autoconvert = False
+    h.consolidate_directories = False
+    h.move_directories = False
+
+    # No real waiting: a file that exists on disk is "complete".
+    monkeypatch.setattr(h, "_is_download_complete", lambda fp: os.path.exists(fp))
+    monkeypatch.setattr(monitor, "_wait_for_download_completion", lambda *a, **k: True)
+    monkeypatch.setattr(monitor.time, "sleep", lambda *a, **k: None)
+    # reconcile_directory() calls reload_settings(); keep our temp dirs.
+    monkeypatch.setattr(h, "reload_settings", lambda: None)
+
+    return h, str(watch), str(target)
+
+
+def _write(path, content=b"comic-bytes"):
+    with open(path, "wb") as f:
+        f.write(content)
+
+
+def _moved_path(target_dir, name):
+    """Where _move_file lands a file: it runs clean_directory_name over the
+    destination dir. (In pytest temp paths that rewrites underscores to spaces,
+    so we must mirror it rather than assume the raw path.)"""
+    from cbz_ops.rename import clean_directory_name
+    return os.path.join(clean_directory_name(target_dir), name)
+
+
+def test_reconcile_directory_moves_stranded_cbz(handler):
+    """A completed .cbz sitting in WATCH with no event gets drained to TARGET."""
+    h, watch, target = handler
+    name = "Series 001 (2024).cbz"
+    _write(os.path.join(watch, name))
+
+    h.reconcile_directory()
+
+    assert not os.path.exists(os.path.join(watch, name)), "file should leave WATCH"
+    assert os.path.exists(_moved_path(target, name)), "file should land in TARGET"
+
+
+def test_in_flight_guard_prevents_double_processing(handler, monkeypatch):
+    """A file already claimed by another thread is skipped, not re-processed."""
+    h, watch, target = handler
+    name = "Series 002 (2024).cbz"
+    path = os.path.join(watch, name)
+    _write(path)
+
+    called = []
+    monkeypatch.setattr(h, "_process_file", lambda fp: called.append(fp))
+
+    # Simulate the observer thread currently holding this file.
+    h._in_flight.add(os.path.abspath(path))
+
+    h._handle_file_if_complete(path)
+
+    assert called == [], "_process_file must not run while file is in-flight"
+    assert os.path.exists(path), "file must stay put when skipped"
+
+
+def test_in_flight_claim_released_after_processing(handler):
+    """After a normal move the in-flight set is empty (claim released)."""
+    h, watch, target = handler
+    name = "Series 003 (2024).cbz"
+    _write(os.path.join(watch, name))
+
+    h._handle_file_if_complete(os.path.join(watch, name))
+
+    assert h._in_flight == set(), "claim must be released via finally"
+    assert os.path.exists(_moved_path(target, name))
+
+
+def test_move_file_tolerates_file_renamed_midflight(handler, monkeypatch):
+    """If the file vanishes mid-move (api.py in-place rename), no exception
+    escapes and the sweep keeps going."""
+    import monitor
+    h, watch, target = handler
+    name = "Series 004 (2024).cbz"
+    path = os.path.join(watch, name)
+    _write(path)
+
+    # Wait "succeeds" but the file is renamed away right before shutil.move.
+    def _steal(fp, *a, **k):
+        os.remove(fp)
+        return True
+    monkeypatch.setattr(monitor, "_wait_for_download_completion", _steal)
+
+    # Must not raise even though shutil.move will hit FileNotFoundError.
+    h._move_file(path)
+
+    assert not os.path.exists(os.path.join(target, name))
+
+
+def test_reconcile_does_not_crash_on_disappearing_file(handler, monkeypatch):
+    """A file that disappears during the stability check is handled quietly."""
+    h, watch, target = handler
+    path = os.path.join(watch, "Series 005 (2024).cbz")
+    _write(path)
+
+    # Report "not complete" and delete it, mimicking an in-place rename race.
+    def _not_complete(fp):
+        if os.path.exists(fp):
+            os.remove(fp)
+        return False
+    monkeypatch.setattr(h, "_is_download_complete", _not_complete)
+
+    h.reconcile_directory()  # must not raise
+    assert h._in_flight == set()
+
+
+def test_reconcile_skips_temp_and_ignored_files(handler):
+    """Temporary downloads and ignored-extension files stay in WATCH; only the
+    real comic is moved."""
+    h, watch, target = handler
+    temp = "Series 006 (2024).cbz.crdownload"   # temp download in progress
+    ignored = "notes.tmp"                        # ignored extension
+    real = "Series 006 (2024).cbz"
+
+    _write(os.path.join(watch, temp))
+    _write(os.path.join(watch, ignored))
+    _write(os.path.join(watch, real))
+
+    h.reconcile_directory()
+
+    assert os.path.exists(os.path.join(watch, temp)), "temp file must remain"
+    assert os.path.exists(os.path.join(watch, ignored)), "ignored file must remain"
+    assert os.path.exists(_moved_path(target, real)), "real comic must move"
+    assert not os.path.exists(os.path.join(watch, real))
+
+
+def test_reconcile_missing_watch_dir_is_noop(handler):
+    """A missing WATCH dir doesn't raise."""
+    h, watch, target = handler
+    h.directory = os.path.join(watch, "does-not-exist")
+    h.reconcile_directory()  # must not raise


### PR DESCRIPTION
## 📝 Description
Add a self-healing safety-net sweep that periodically re-scans the WATCH directory to process comic files that missed their watchdog event (due to observer coalescing, api.py in-place renames, transient errors, or restart gaps). Includes thread-safe in-flight locking to prevent the sweep and live watchdog callbacks from double-processing files concurrently. Handles edge cases like files disappearing mid-move. New config option RECONCILE_INTERVAL_MINUTES (default 5) controls sweep frequency; 0 disables it. Comprehensive unit tests cover the reconciliation logic and concurrency guarantees.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass