### PR TITLE
Make Wanted Matching Month-agnostic

### DIFF
--- a/app.py
+++ b/app.py
@@ -687,12 +687,15 @@ def process_incoming_wanted_issues():
     if not enabled or not pattern:
         pattern = "{series_name} {issue_number} ({volume_year})"
 
-    # Create a matching pattern WITHOUT year (year can differ between sources).
-    # Strips any year token variant (volume/cover/issue/store/legacy) so the
-    # year is not required for matching.
+    # Create a matching pattern WITHOUT year/month/title (they can differ between
+    # sources or be absent — downloads are often named with only a year). Strip
+    # every year token variant, the month tokens, and the title, then drop any
+    # parenthetical debris left behind (e.g. "(, )") so it isn't required.
     match_pattern = strip_year_token(pattern)
     match_pattern = strip_title_token(match_pattern)
-    app_logger.debug(f"Using match pattern (no year/title): '{match_pattern}'")
+    match_pattern = strip_month_token(match_pattern)
+    match_pattern = strip_empty_groups(match_pattern)
+    app_logger.debug(f"Using match pattern (no year/month/title): '{match_pattern}'")
 
     # Scan TARGET for comic files (including subdirectories)
     comic_extensions = (".cbz", ".cbr", ".zip", ".rar")
@@ -2360,6 +2363,8 @@ from helpers.collection import (
     generate_filename_pattern,
     strip_year_token,
     strip_title_token,
+    strip_month_token,
+    strip_empty_groups,
     build_series_match_names,
     get_series_name_from_files,
     extract_comicinfo,

--- a/config.ini
+++ b/config.ini
@@ -40,4 +40,5 @@ PUBLICATION_TYPES = annual,quarterly
 VARIANT_TYPES = annual,quarterly,tpB,oneshot,one-shot,o.s.,os,trade paperback,trade-paperback,omni,omnibus,omb,hardcover,deluxe,prestige,gallery
 SEQUEL_KEYWORDS = season,volume,book,part,chapter
 ONESHOT_FOLDERS = oneshots,one-shots,specials
+RECONCILE_INTERVAL_MINUTES = 5
 

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -46,6 +46,42 @@ def strip_title_token(pattern):
     return pattern.strip()
 
 
+# Matches both month token variants: {issue_month_m} (2-digit) / {issue_month_M} (name).
+_MONTH_TOKEN = r"\{issue_month_[mM]\}"
+
+
+def strip_month_token(pattern):
+    """Remove month tokens ({issue_month_m}/{issue_month_M}) for month-agnostic
+    matching. Mirrors strip_year_token.
+
+    A file's month can differ between sources or be absent (downloads are often
+    named with only a year, e.g. "Black Cat - 012 (2026).cbz"), so wanted-issue
+    matching must not require it.
+    """
+    if not pattern:
+        return pattern
+    # " ({issue_month_M})" / " [{issue_month_m}]" -> ""
+    pattern = re.sub(r"\s*[\(\[]\s*" + _MONTH_TOKEN + r"\s*[\)\]]", "", pattern)
+    # bare " {month}" with an optional leading -/:/, separator -> ""
+    pattern = re.sub(r"\s*[-:,]?\s*" + _MONTH_TOKEN, "", pattern)
+    return pattern.strip()
+
+
+def strip_empty_groups(pattern):
+    """Drop ()/[] groups left holding only separators after token removal.
+
+    Stripping year/month/title tokens from a *shared* parenthetical (e.g.
+    "({issue_month_M}, {issue_year})") leaves punctuation debris like "(, )" or
+    "( )" that would otherwise compile into a literal, unmatchable requirement.
+    A group still containing a real {token} is preserved (the char class
+    excludes "{").
+    """
+    if not pattern:
+        return pattern
+    pattern = re.sub(r"\s*[\(\[][^{}()\[\]]*[\)\]]", "", pattern)
+    return pattern.strip()
+
+
 def build_series_match_names(series_name, aliases):
     """Ordered, de-duplicated list of names to match a series against.
 
@@ -115,6 +151,12 @@ def get_series_name_from_files(mapped_path, db_series_name):
     # Renamed files can use a "NNN of M" count (see cbz_ops/rename.py); without
     # the "of M" branch only " M" is stripped, leaving "Series 001 of" as the name.
     name = re.sub(r"\s+#?\d+(?:\s+of\s+\d+)?\s*$", "", name, flags=re.IGNORECASE)
+    # Drop a trailing separator left by a "Series - NNN" naming style, so the
+    # derived name is "Black Cat" not "Black Cat -". Guarded below so a name
+    # that is *only* separators falls back to the DB name.
+    stripped = re.sub(r"[\s\-_:;,]+$", "", name)
+    if stripped:
+        name = stripped
 
     if name:
         extracted = name.strip()

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -12,6 +12,8 @@ from helpers.collection import (
     generate_filename_pattern,
     strip_year_token,
     strip_title_token,
+    strip_month_token,
+    strip_empty_groups,
     build_series_match_names,
 )
 
@@ -182,6 +184,90 @@ class TestStripTitleToken:
 
     def test_empty(self):
         assert strip_title_token("") == ""
+
+
+# ---- strip_month_token (month-agnostic matching path) -------------------
+
+class TestStripMonthToken:
+
+    @pytest.mark.parametrize("token", ["issue_month_m", "issue_month_M"])
+    def test_strips_parenthesized_month(self, token):
+        out = strip_month_token("{series_name} {issue_number} ({%s})" % token)
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_bracketed_month(self):
+        out = strip_month_token("{series_name} [{issue_month_M}] {issue_number}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_bare_month(self):
+        out = strip_month_token("{series_name} {issue_number} {issue_month_m}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_strips_comma_separated_month(self):
+        # Month leading a shared date group: only the token is removed here.
+        out = strip_month_token("{series_name} ({issue_month_M}, {issue_year})")
+        assert out == "{series_name} (, {issue_year})"
+
+    def test_no_month_token_unchanged(self):
+        out = strip_month_token("{series_name} {issue_number}")
+        assert out == "{series_name} {issue_number}"
+
+    def test_empty(self):
+        assert strip_month_token("") == ""
+
+
+# ---- strip_empty_groups (drop debris left by token removal) -------------
+
+class TestStripEmptyGroups:
+
+    def test_removes_comma_debris(self):
+        assert strip_empty_groups("{series_name} {issue_number} (, )") == (
+            "{series_name} {issue_number}"
+        )
+
+    def test_removes_whitespace_only_group(self):
+        assert strip_empty_groups("{series_name} {issue_number} ( )") == (
+            "{series_name} {issue_number}"
+        )
+
+    def test_removes_bracketed_debris(self):
+        assert strip_empty_groups("{series_name} {issue_number} [ - ]") == (
+            "{series_name} {issue_number}"
+        )
+
+    def test_preserves_group_with_token(self):
+        out = strip_empty_groups("{series_name} {issue_number} ({volume_number})")
+        assert out == "{series_name} {issue_number} ({volume_number})"
+
+    def test_empty(self):
+        assert strip_empty_groups("") == ""
+
+
+class TestMonthAgnosticMatching:
+    """A month in the rename pattern must not be required for matching: a
+    year-only download must match a library named "Series - NNN (Month, Year)".
+    Regression for 'Black Cat - 012 (2026).cbz' -> no match."""
+
+    def _regex(self):
+        match_pattern = strip_empty_groups(
+            strip_month_token(
+                strip_title_token(
+                    strip_year_token(
+                        "{series_name} - {issue_number} ({issue_month_M}, {issue_year})"
+                    )
+                )
+            )
+        )
+        return generate_filename_pattern(match_pattern, "Black Cat", "12")
+
+    def test_year_only_download_matches(self):
+        assert self._regex().match("Black Cat - 012 (2026).cbz")
+
+    def test_month_form_still_matches(self):
+        assert self._regex().match("Black Cat - 012 (October, 2025).cbz")
+
+    def test_wrong_issue_rejected(self):
+        assert not self._regex().match("Black Cat - 013 (2026).cbz")
 
 
 class TestTitleAgnosticMatching:

--- a/tests/unit/test_series_name_from_files.py
+++ b/tests/unit/test_series_name_from_files.py
@@ -25,6 +25,12 @@ def test_plain_issue_with_year(tmp_path):
     assert get_series_name_from_files(str(tmp_path), "Hidden Springs") == "Hidden Springs"
 
 
+def test_strips_trailing_dash_separator(tmp_path):
+    # "Series - NNN (Month, Year)" naming must not leave a trailing " -".
+    _make_comic(tmp_path, "Black Cat - 001 (October, 2025).cbz")
+    assert get_series_name_from_files(str(tmp_path), "Black Cat") == "Black Cat"
+
+
 def test_preserves_of_within_series_name(tmp_path):
     _make_comic(tmp_path, "Crisis of Infinite Earths 001.cbz")
     assert (


### PR DESCRIPTION
## 📝 Description
Improve wanted-issue filename matching by stripping month tokens in addition to year/title tokens, and removing empty punctuation-only groups left behind after token removal. This fixes misses for year-only downloads when the rename pattern includes month/year groups.

Also tighten series-name extraction from files by trimming trailing separators (e.g., "Series -"), and add unit coverage for month stripping, empty-group cleanup, month-agnostic regex matching, and trailing-dash series names. Adds `RECONCILE_INTERVAL_MINUTES = 5` to config defaults.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass