### PR TITLE
Reconcile Wanted Issues on File Changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -906,19 +906,15 @@ def process_incoming_wanted_issues():
             f"✅ Processed {moved_count} wanted issue(s) from TARGET folder"
         )
 
-        # Invalidate collection status cache for affected series
-        # This ensures the wanted list is updated to remove matched issues
-        from core.database import (
-            invalidate_collection_status_for_series,
-            clear_wanted_cache_for_series,
-        )
+        # Re-check each affected series against its folder and prune only the
+        # now-satisfied wanted issues (surgical, so the series isn't blanked out
+        # of the wanted list until the next full rebuild). This also refreshes
+        # the collection-status cache so the nightly auto-download won't
+        # re-download issues that just landed.
+        from helpers.collection import reconcile_wanted_for_series
 
         for series_id in affected_series:
-            invalidate_collection_status_for_series(series_id)
-            clear_wanted_cache_for_series(series_id)
-            app_logger.info(
-                f"Invalidated collection and wanted cache for series {series_id}"
-            )
+            reconcile_wanted_for_series(series_id)
     else:
         app_logger.info("No wanted issues matched files in TARGET folder")
 
@@ -3744,6 +3740,15 @@ def update_index_on_move(old_path, new_path):
         if not old_in_data and new_in_data:
             app_logger.info(f"📥 Adding to index (moved into /data): {new_path}")
             update_index_on_create(new_path)
+            # Reconcile the destination series: prune now-satisfied wanted issues
+            # and refresh the collection-status cache. This is the reliable hook
+            # for the manual Move File path (watchdog file events can be missed
+            # on networked/Docker volumes).
+            try:
+                from helpers.collection import reconcile_wanted_for_path
+                reconcile_wanted_for_path(new_path)
+            except Exception as e:
+                app_logger.error(f"Wanted reconcile failed for {new_path}: {e}")
             return
 
         # Scenario 2: Moving OUT OF /data -> DELETE from index
@@ -3833,6 +3838,15 @@ def update_index_on_move(old_path, new_path):
                         f"Updated {rows_affected} child entries for moved directory: {old_path} -> {new_path}"
                     )
 
+            # A file moved between series folders: reconcile both the source
+            # (an issue may now be missing) and the destination (an issue may
+            # now be satisfied).
+            try:
+                from helpers.collection import reconcile_wanted_for_path
+                reconcile_wanted_for_path(old_path)
+                reconcile_wanted_for_path(new_path)
+            except Exception as e:
+                app_logger.error(f"Wanted reconcile failed for move within /data: {e}")
             return
 
         # Scenario 4: Both outside /data -> do nothing

--- a/core/database.py
+++ b/core/database.py
@@ -8927,6 +8927,54 @@ def clear_wanted_cache_for_series(series_id):
             conn.close()
 
 
+def remove_wanted_issues(series_id, issue_numbers):
+    """
+    Delete specific issue rows from the wanted cache for a series.
+
+    Unlike clear_wanted_cache_for_series (which removes every wanted row for the
+    series and leaves the page under-reporting until the next full rebuild), this
+    surgically prunes only the issues that are now satisfied by a file on disk.
+
+    Args:
+        series_id: Metron series ID
+        issue_numbers: Iterable of issue number strings to remove
+
+    Returns:
+        Number of rows deleted.
+    """
+    numbers = [str(n) for n in issue_numbers if n is not None and str(n) != ""]
+    if not numbers:
+        return 0
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return 0
+
+        c = conn.cursor()
+        placeholders = ",".join("?" * len(numbers))
+        c.execute(
+            "DELETE FROM wanted_issues WHERE series_id = ? AND issue_number IN ("
+            + placeholders
+            + ")",
+            [series_id, *numbers],
+        )
+        deleted = c.rowcount
+        conn.commit()
+        if deleted > 0:
+            app_logger.debug(
+                f"Removed {deleted} wanted issue(s) for series {series_id}: {numbers}"
+            )
+        return deleted
+    except Exception as e:
+        app_logger.error(f"Failed to remove wanted issues for series {series_id}: {e}")
+        return 0
+    finally:
+        if conn:
+            conn.close()
+
+
 def clear_wanted_cache_all():
     """Clear all wanted issues cache."""
     conn = None

--- a/core/file_watcher.py
+++ b/core/file_watcher.py
@@ -6,6 +6,7 @@ from watchdog.events import FileSystemEventHandler
 from core.database import add_file_index_entry, delete_file_index_entry, invalidate_collection_status_for_path
 from core.app_logging import app_logger
 from core.metadata_scanner import queue_file_for_scan, PRIORITY_NEW_FILE
+from helpers.collection import _series_id_for_path, reconcile_wanted_for_series
 
 
 class DebouncedFileHandler(FileSystemEventHandler):
@@ -67,6 +68,10 @@ class DebouncedFileHandler(FileSystemEventHandler):
                     events_to_process.append(file_path)
                     del self.pending_events[file_path]
 
+            # Series touched in this batch — reconcile each once after the loop
+            # so a bulk import doesn't re-scan the same series folder per file.
+            affected_series = set()
+
             # Process the events
             for file_path in events_to_process:
                 if self._should_process_file(file_path):
@@ -83,12 +88,28 @@ class DebouncedFileHandler(FileSystemEventHandler):
                         if file_path.lower().endswith('.cbz'):
                             queue_file_for_scan(file_path, PRIORITY_NEW_FILE)
 
-                        # Invalidate collection status cache for this directory
-                        invalidate_collection_status_for_path(file_path)
+                        # Resolve the mapped series this file belongs to so we can
+                        # reconcile the wanted list (and collection-status cache)
+                        # below. Fall back to path-based invalidation when the file
+                        # is not under any mapped series folder.
+                        series_id = _series_id_for_path(file_path)
+                        if series_id:
+                            affected_series.add(series_id)
+                        else:
+                            invalidate_collection_status_for_path(file_path)
                     except Exception as e:
                         app_logger.error(f"Error processing file event for {file_path}: {e}")
                 else:
                     app_logger.debug(f"File watcher skipped (filtered): {file_path}")
+
+            # Reconcile each affected series once: prunes satisfied wanted issues
+            # and refreshes the collection-status cache so the nightly
+            # auto-download stops re-downloading files that already exist.
+            for series_id in affected_series:
+                try:
+                    reconcile_wanted_for_series(series_id)
+                except Exception as e:
+                    app_logger.error(f"Error reconciling wanted for series {series_id}: {e}")
 
             # Schedule next check if there are still pending events
             if self.pending_events:
@@ -158,8 +179,14 @@ class DebouncedFileHandler(FileSystemEventHandler):
             delete_file_index_entry(file_path)
             app_logger.info(f"❌ Removed deleted file from index: {os.path.basename(file_path)}")
 
-            # Invalidate collection status cache for this directory
-            invalidate_collection_status_for_path(file_path)
+            # Reconcile the owning series (robustly invalidates the
+            # collection-status cache by id so the deleted file is re-scanned);
+            # fall back to path-based invalidation if unresolved.
+            series_id = _series_id_for_path(file_path)
+            if series_id:
+                reconcile_wanted_for_series(series_id)
+            else:
+                invalidate_collection_status_for_path(file_path)
         except Exception as e:
             app_logger.error(f"Error removing deleted file {file_path}: {e}")
 

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -374,6 +374,30 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
                         valid_cache = False
                         break
 
+            # Detect newly-added files that could satisfy a still-missing issue.
+            # The existence/mtime loop above only re-validates issues that were
+            # cached as *found* (their file_path is set). Issues cached as
+            # not-found have file_path=None, so a file added after the last scan
+            # would never invalidate the cache — the issue would stay "missing"
+            # forever, keep showing on the wanted page, and get re-downloaded
+            # every night. If the folder now holds more comic files than the
+            # cache matched and something is still missing, force a re-scan.
+            if valid_cache and any(not entry['found'] for entry in cached):
+                found_paths = {e['file_path'] for e in cached if e['file_path']}
+                try:
+                    current_comic_count = sum(
+                        1 for f in os.listdir(mapped_path)
+                        if f.lower().endswith(comic_extensions)
+                    )
+                    if current_comic_count > len(found_paths):
+                        valid_cache = False
+                        app_logger.debug(
+                            f"Cache invalid for series {series_id}: {current_comic_count} "
+                            f"comic file(s) on disk > {len(found_paths)} matched, missing issues present"
+                        )
+                except OSError:
+                    pass
+
             if valid_cache:
                 # Return cached results
                 for entry in cached:
@@ -502,3 +526,116 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
         app_logger.debug(f"Cached collection status for series {series_id} ({len(cache_entries)} issues)")
 
     return results
+
+
+def reconcile_wanted_for_series(series_id):
+    """
+    Re-check a mapped series against the files on disk and prune any wanted-cache
+    rows that are now satisfied.
+
+    This is the single reconciliation path used whenever a file lands in a
+    subscribed series folder. It invalidates the collection-status cache by
+    series id (robust, unlike path-based invalidation), re-runs the canonical
+    matcher, removes the now-found issues from the wanted cache, and — as a side
+    effect of the fresh collection-status scan — stops the nightly GetComics
+    auto-download from re-downloading issues that already exist.
+
+    Args:
+        series_id: Metron series ID
+
+    Returns:
+        Number of wanted rows removed.
+    """
+    from core.database import (
+        get_series_by_id,
+        get_issues_for_series,
+        invalidate_collection_status_for_series,
+        remove_wanted_issues,
+    )
+    from models.issue import IssueObj, SeriesObj
+
+    if not series_id:
+        return 0
+
+    try:
+        series = get_series_by_id(series_id)
+        if not series:
+            return 0
+
+        mapped_path = series.get("mapped_path")
+        if not mapped_path or not os.path.exists(mapped_path):
+            return 0
+
+        issues = get_issues_for_series(series_id)
+        if not issues:
+            return 0
+
+        # Force a fresh scan of the folder so newly-added files are recognized.
+        invalidate_collection_status_for_series(series_id)
+
+        issue_objs = [IssueObj(i) for i in issues]
+        series_obj = SeriesObj(series)
+        status = match_issues_to_collection(mapped_path, issue_objs, series_obj)
+
+        found_numbers = [num for num, s in status.items() if s.get("found")]
+        removed = remove_wanted_issues(series_id, found_numbers)
+        if removed:
+            app_logger.info(
+                f"Reconciled series {series_id}: removed {removed} satisfied wanted issue(s)"
+            )
+        return removed
+    except Exception as e:
+        app_logger.error(f"Failed to reconcile wanted for series {series_id}: {e}")
+        return 0
+
+
+def _series_id_for_path(file_path):
+    """
+    Resolve the mapped series that owns a file (or directory) path.
+
+    Matches by normalized path prefix so subfolders, trailing slashes, and
+    case-insensitive filesystems (e.g. /data) all resolve — unlike the exact
+    `mapped_path = ?` equality used elsewhere. When a file sits under nested
+    mapped folders, the longest (most specific) mapped_path wins.
+
+    Returns:
+        The series id, or None if the path is not under any mapped series.
+    """
+    from core.database import get_all_mapped_series
+
+    try:
+        directory = file_path if os.path.isdir(file_path) else os.path.dirname(file_path)
+        norm_dir = os.path.normcase(os.path.normpath(directory))
+
+        best_id = None
+        best_len = -1
+        for series in get_all_mapped_series():
+            mapped_path = series.get("mapped_path")
+            if not mapped_path:
+                continue
+            norm_mapped = os.path.normcase(os.path.normpath(mapped_path))
+            if norm_dir == norm_mapped or norm_dir.startswith(norm_mapped + os.sep):
+                if len(norm_mapped) > best_len:
+                    best_len = len(norm_mapped)
+                    best_id = series.get("id")
+        return best_id
+    except Exception as e:
+        app_logger.error(f"Failed to resolve series for path {file_path}: {e}")
+        return None
+
+
+def reconcile_wanted_for_path(file_path):
+    """
+    Resolve the series that owns file_path and reconcile its wanted list.
+
+    Called when a comic file is added, moved, or removed under the collection so
+    the wanted cache and collection-status cache stay in sync without waiting for
+    a full manual refresh.
+
+    Returns:
+        Number of wanted rows removed (0 if the path is not under a mapped series).
+    """
+    series_id = _series_id_for_path(file_path)
+    if not series_id:
+        return 0
+    return reconcile_wanted_for_series(series_id)

--- a/tests/integration/test_database_series.py
+++ b/tests/integration/test_database_series.py
@@ -313,6 +313,38 @@ class TestWantedIssues:
         clear_wanted_cache_all()
         assert get_cached_wanted_issues() == []
 
+    def test_remove_wanted_issues_prunes_only_named(self, db_connection):
+        from core.database import (
+            save_wanted_issues_for_series,
+            remove_wanted_issues,
+            get_cached_wanted_issues,
+        )
+
+        pub_id = create_publisher()
+        series_id = create_series(publisher_id=pub_id)
+        save_wanted_issues_for_series(series_id, "X", 2020, [
+            {"id": 9001, "number": "5", "name": "A",
+             "store_date": None, "cover_date": None, "image": None},
+            {"id": 9002, "number": "6", "name": "B",
+             "store_date": None, "cover_date": None, "image": None},
+        ])
+
+        removed = remove_wanted_issues(series_id, ["5"])
+        assert removed == 1
+
+        remaining = [w["issue_number"] for w in get_cached_wanted_issues()
+                     if w["series_id"] == series_id]
+        assert "5" not in remaining
+        assert "6" in remaining
+
+    def test_remove_wanted_issues_empty_list_noop(self, db_connection):
+        from core.database import remove_wanted_issues
+
+        pub_id = create_publisher()
+        series_id = create_series(publisher_id=pub_id)
+        # No numbers -> nothing deleted, no error.
+        assert remove_wanted_issues(series_id, []) == 0
+
 
 class TestManualIssueStatus:
 

--- a/tests/integration/test_reconcile_wanted.py
+++ b/tests/integration/test_reconcile_wanted.py
@@ -1,0 +1,179 @@
+"""Tests for wanted-list reconciliation when a file lands in a series folder.
+
+Covers helpers/collection.py: reconcile_wanted_for_series, reconcile_wanted_for_path,
+and the robust path->series resolver _series_id_for_path.
+"""
+import pytest
+from tests.factories.db_factories import create_publisher, create_series, create_issue
+
+
+def _wanted(issue_id, number):
+    return {
+        "id": issue_id,
+        "number": number,
+        "name": f"Issue {number}",
+        "store_date": "2020-01-10",
+        "cover_date": "2020-01-15",
+        "image": None,
+    }
+
+
+class TestSeriesIdForPath:
+
+    def test_resolves_file_in_series_folder(self, db_connection, tmp_path):
+        from helpers.collection import _series_id_for_path
+
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        series_id = create_series(name="Batman", mapped_path=str(series_dir))
+
+        # File not yet on disk -> resolves via its parent directory.
+        assert _series_id_for_path(str(series_dir / "Batman #1.cbz")) == series_id
+
+    def test_resolves_file_in_nested_subfolder(self, db_connection, tmp_path):
+        from helpers.collection import _series_id_for_path
+
+        series_dir = tmp_path / "Flash"
+        (series_dir / "sub").mkdir(parents=True)
+        series_id = create_series(name="Flash", mapped_path=str(series_dir))
+
+        # Fragile exact-match invalidation misses subfolders; prefix match resolves.
+        assert _series_id_for_path(str(series_dir / "sub" / "Flash #2.cbz")) == series_id
+
+    def test_unrelated_path_returns_none(self, db_connection, tmp_path):
+        from helpers.collection import _series_id_for_path
+
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        create_series(name="Batman", mapped_path=str(series_dir))
+
+        assert _series_id_for_path(str(tmp_path / "Nowhere" / "x.cbz")) is None
+
+
+class TestReconcileWantedForSeries:
+
+    def test_prunes_only_satisfied_issue(self, db_connection, tmp_path):
+        from core.database import save_wanted_issues_for_series, get_cached_wanted_issues
+        from helpers.collection import reconcile_wanted_for_series
+
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        series_id = create_series(name="Batman", mapped_path=str(series_dir))
+        id5 = create_issue(series_id=series_id, number="5")
+        id6 = create_issue(series_id=series_id, number="6")
+
+        save_wanted_issues_for_series(
+            series_id, "Batman", 2020, [_wanted(id5, "5"), _wanted(id6, "6")]
+        )
+
+        # A file satisfying #5 lands in the folder (generic issue-number fallback).
+        (series_dir / "Batman #5.cbz").write_bytes(b"stub")
+
+        removed = reconcile_wanted_for_series(series_id)
+        assert removed == 1
+
+        remaining = [w["issue_number"] for w in get_cached_wanted_issues()
+                     if w["series_id"] == series_id]
+        assert "5" not in remaining
+        assert "6" in remaining
+
+    def test_no_matching_file_leaves_wanted_intact(self, db_connection, tmp_path):
+        from core.database import save_wanted_issues_for_series, get_cached_wanted_issues
+        from helpers.collection import reconcile_wanted_for_series
+
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        series_id = create_series(name="Batman", mapped_path=str(series_dir))
+        id5 = create_issue(series_id=series_id, number="5")
+        save_wanted_issues_for_series(series_id, "Batman", 2020, [_wanted(id5, "5")])
+
+        removed = reconcile_wanted_for_series(series_id)
+        assert removed == 0
+
+        remaining = [w["issue_number"] for w in get_cached_wanted_issues()
+                     if w["series_id"] == series_id]
+        assert "5" in remaining
+
+
+class TestReconcileWantedForPath:
+
+    def test_path_reconcile_removes_wanted(self, db_connection, tmp_path):
+        from core.database import save_wanted_issues_for_series, get_cached_wanted_issues
+        from helpers.collection import reconcile_wanted_for_path
+
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        series_id = create_series(name="Batman", mapped_path=str(series_dir))
+        id5 = create_issue(series_id=series_id, number="5")
+        save_wanted_issues_for_series(series_id, "Batman", 2020, [_wanted(id5, "5")])
+
+        landed = series_dir / "Batman #5.cbz"
+        landed.write_bytes(b"stub")
+
+        removed = reconcile_wanted_for_path(str(landed))
+        assert removed == 1
+        assert not any(w["series_id"] == series_id for w in get_cached_wanted_issues())
+
+    def test_path_outside_mapped_series_is_noop(self, db_connection, tmp_path):
+        from helpers.collection import reconcile_wanted_for_path
+
+        assert reconcile_wanted_for_path(str(tmp_path / "Unmapped" / "x.cbz")) == 0
+
+
+class TestCollectionStatusSelfHeal:
+    """A file added after the last scan must be detected even though nothing
+    explicitly invalidated the cache (watchdog events can be missed)."""
+
+    def _objs(self, series_id):
+        from core.database import get_series_by_id, get_issues_for_series
+        from models.issue import IssueObj, SeriesObj
+        series = get_series_by_id(series_id)
+        issues = get_issues_for_series(series_id)
+        return [IssueObj(i) for i in issues], SeriesObj(series)
+
+    def test_added_file_invalidates_stale_not_found(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_dir = tmp_path / "Sorcerer Supreme (2026)"
+        series_dir.mkdir()
+        series_id = create_series(
+            name="Sorcerer Supreme", volume=2026, mapped_path=str(series_dir)
+        )
+        create_issue(series_id=series_id, number="8")
+
+        issue_objs, series_obj = self._objs(series_id)
+
+        # First scan: empty folder -> #8 cached as not-found (file_path=None).
+        r1 = match_issues_to_collection(str(series_dir), issue_objs, series_obj)
+        assert r1["8"]["found"] is False
+
+        # A correctly-named file lands *after* the scan (no invalidation fires).
+        (series_dir / "Sorcerer Supreme 008 (2026).cbz").write_bytes(b"stub")
+
+        # Second scan must self-heal (dir now has more files than matched) and
+        # recognize #8 via the generic issue-number fallback.
+        r2 = match_issues_to_collection(str(series_dir), issue_objs, series_obj)
+        assert r2["8"]["found"] is True
+
+    def test_no_rescan_when_all_found(self, db_connection, tmp_path):
+        """An untracked extra file must not force endless re-scans once every
+        tracked issue is already satisfied."""
+        from helpers.collection import match_issues_to_collection
+
+        series_dir = tmp_path / "Batman (2020)"
+        series_dir.mkdir()
+        series_id = create_series(
+            name="Batman", volume=2020, mapped_path=str(series_dir)
+        )
+        create_issue(series_id=series_id, number="1")
+        (series_dir / "Batman 001 (2020).cbz").write_bytes(b"stub")
+
+        issue_objs, series_obj = self._objs(series_id)
+
+        r1 = match_issues_to_collection(str(series_dir), issue_objs, series_obj)
+        assert r1["1"]["found"] is True
+
+        # Add an untracked extra file; with no missing issues the cache stays valid.
+        (series_dir / "Some Extra Variant.cbz").write_bytes(b"stub")
+        r2 = match_issues_to_collection(str(series_dir), issue_objs, series_obj)
+        assert r2["1"]["found"] is True


### PR DESCRIPTION
## 📝 Description
Replace broad wanted-cache clearing with targeted reconciliation when files are added, moved, or deleted. The new flow resolves series ownership by path, refreshes collection status by series, and removes only now-satisfied wanted issues to prevent wanted-list underreporting and repeated auto-downloads. It also adds cache self-healing for stale not-found entries when new files appear, plus integration coverage for wanted pruning, path resolution, reconciliation by series/path, and cache invalidation behavior.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass