### PR TITLE
Always strip filesystem-hostile characters from filenames & subscribe paths

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -381,6 +381,14 @@ def _format_issue_month(month_raw):
     return "", ""
 
 
+# Filesystem-hostile characters always removed from generated filenames,
+# independent of the user's opt-in "Clean Special Characters" setting.
+# NOTE: mirrored in templates/config.html (JS preview) and the subscribe-path
+# sanitizer in helpers.sanitize_path_segment / templates/series.html —
+# keep all copies in lockstep.
+FILENAME_ILLEGAL_CHARS = '\\/:*?"<>|&$;'
+
+
 _FILENAME_CLEANUP_DEFAULTS = {
     "spaces_enabled": False,
     "spaces_mode": "replace",
@@ -444,12 +452,13 @@ def apply_filename_cleanup(stem, cfg=None):
     if cfg is None:
         cfg = load_filename_cleanup_config()
 
-    if not cfg.get("spaces_enabled") and not cfg.get("specials_enabled"):
-        return stem
-
     original = stem
     stem = re.sub(r"\s+", " ", stem)
 
+    # User-configured special-character cleanup runs FIRST so a user who chooses
+    # to *replace* a baseline character (e.g. "&" -> " and ") keeps that mapping;
+    # the always-on baseline below then guarantees any baseline char the user did
+    # not remap is stripped outright.
     if cfg.get("specials_enabled"):
         charset = cfg.get("specials_charset") or ""
         chars = {c for c in charset if c != " "}
@@ -460,6 +469,12 @@ def apply_filename_cleanup(stem, cfg=None):
             table = str.maketrans({c: replacement for c in chars})
             stem = stem.translate(table)
             stem = re.sub(r"\s+", " ", stem)
+
+    # Always-on baseline: strip filesystem-hostile characters regardless of the
+    # user's opt-in "Clean Special Characters" setting.
+    baseline_table = str.maketrans({c: "" for c in FILENAME_ILLEGAL_CHARS})
+    stem = stem.translate(baseline_table)
+    stem = re.sub(r"\s+", " ", stem)
 
     if cfg.get("spaces_enabled"):
         if cfg.get("spaces_mode") == "remove":

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -3,6 +3,7 @@
 # now that helpers/ is a package directory.
 
 import os
+import re
 import stat
 import zipfile
 from PIL import Image, ImageEnhance, ImageFilter, ImageOps
@@ -62,6 +63,35 @@ def is_hidden(filepath):
         except AttributeError:
             pass
     return False
+
+#########################
+#  Path Segment Safety  #
+#########################
+
+# Baseline set stripped from a single path segment (a folder/file name, never a
+# separator). Slash and colon get readable smart-replacements; the rest are
+# removed outright. Mirrors cbz_ops/rename.py:FILENAME_ILLEGAL_CHARS and the JS
+# sanitizePathSegment() in templates/series.html — keep all copies in lockstep.
+_PATH_SEGMENT_STRIP_RE = re.compile(r'[\\*?"<>|&$;]')
+
+
+def sanitize_path_segment(name):
+    """
+    Make a single path segment (one folder or file name, not a full path) safe
+    for the filesystem. Keeps readable smart-replacements for '/' and ':' and
+    strips the remaining filesystem-hostile characters.
+
+    - '/'  -> '-'      (a slash inside a segment is not a separator)
+    - ':'  -> ' -'     (e.g. "Batman: Year One" -> "Batman - Year One")
+    - \\ * ? " < > | & $ ;  -> removed
+    """
+    if not name:
+        return name
+    name = name.replace("/", "-").replace(":", " -")
+    name = _PATH_SEGMENT_STRIP_RE.sub("", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    return name
+
 
 #########################
 #   Sidecar Permissions #

--- a/routes/series.py
+++ b/routes/series.py
@@ -962,6 +962,20 @@ def subscribe_series(series_id):
     if not path:
         return jsonify({"success": False, "error": "Path required"}), 400
 
+    # Safety net: the path comes from a user-editable field (#subscribePath) and
+    # is handed straight to os.makedirs. Sanitize each segment (never the '/'
+    # separators) so filesystem-hostile characters can't reach disk. Mirrors the
+    # client-side sanitizePathSegment() in templates/series.html.
+    from helpers import sanitize_path_segment
+
+    leading_slash = path.startswith("/")
+    segments = [sanitize_path_segment(seg) for seg in path.split("/")]
+    segments = [seg for seg in segments if seg]
+    path = ("/" if leading_slash else "") + "/".join(segments)
+
+    if not path or path == "/":
+        return jsonify({"success": False, "error": "Path required"}), 400
+
     try:
         series = get_series_by_id(series_id)
         if not series:

--- a/templates/config.html
+++ b/templates/config.html
@@ -573,7 +573,9 @@
                                 class="form-control" value="{{ renameCleanSpecialsCharset }}"
                                 placeholder="&amp;!@#'">
                             <small class="form-text text-muted">Each character is treated literally, not as
-                                regex.</small>
+                                regex. These filesystem-hostile characters are <strong>always</strong> removed,
+                                even when this option is off: <code>\ / : * ? &quot; &lt; &gt; | &amp; $ ;</code>.
+                                Use this field to remove <em>additional</em> characters.</small>
                             <div class="mt-2 mb-2">
                                 <div class="form-check form-check-inline">
                                     <input class="form-check-input" type="radio" name="renameCleanSpecialsMode"
@@ -2693,30 +2695,39 @@
 
         // Filename character cleanup — mirrors cbz_ops/rename.py:apply_filename_cleanup.
         // Update both implementations in lockstep when the algorithm changes.
+        // Order: user specials (if enabled) -> always-on baseline -> user spaces.
+        const FILENAME_ILLEGAL_CHARS = new Set([...'\\/:*?"<>|&$;']);
         const specialsEnabled = document.getElementById('renameCleanSpecialsEnabled')?.checked;
         const spacesEnabled = document.getElementById('renameCleanSpacesEnabled')?.checked;
-        if (specialsEnabled || spacesEnabled) {
-            if (specialsEnabled) {
-                const charset = document.getElementById('renameCleanSpecialsCharset')?.value || '';
-                const chars = new Set([...charset].filter(c => c !== ' '));
-                if (chars.size > 0) {
-                    const mode = document.querySelector('input[name="renameCleanSpecialsMode"]:checked')?.value || 'remove';
-                    const repl = mode === 'remove' ? '' : (document.getElementById('renameCleanSpecialsReplacement')?.value || '');
-                    result = [...result].map(ch => chars.has(ch) ? repl : ch).join('');
-                    result = result.replace(/\s+/g, ' ');
-                }
+
+        // User-configured specials run first so a "replace" of a baseline char is honored.
+        if (specialsEnabled) {
+            const charset = document.getElementById('renameCleanSpecialsCharset')?.value || '';
+            const chars = new Set([...charset].filter(c => c !== ' '));
+            if (chars.size > 0) {
+                const mode = document.querySelector('input[name="renameCleanSpecialsMode"]:checked')?.value || 'remove';
+                const repl = mode === 'remove' ? '' : (document.getElementById('renameCleanSpecialsReplacement')?.value || '');
+                result = [...result].map(ch => chars.has(ch) ? repl : ch).join('');
+                result = result.replace(/\s+/g, ' ');
             }
-            if (spacesEnabled) {
-                const mode = document.querySelector('input[name="renameCleanSpacesMode"]:checked')?.value || 'replace';
-                if (mode === 'remove') {
-                    result = result.replace(/ /g, '');
-                } else {
-                    const repl = document.getElementById('renameCleanSpacesReplacement')?.value || '';
-                    result = result.split(' ').join(repl);
-                }
-            }
-            result = result.replace(/^[\s.]+|[\s.]+$/g, '');
         }
+
+        // Always-on baseline: strip filesystem-hostile characters regardless of
+        // the "Clean Special Characters" toggle.
+        result = [...result].map(ch => FILENAME_ILLEGAL_CHARS.has(ch) ? '' : ch).join('');
+        result = result.replace(/\s+/g, ' ');
+
+        if (spacesEnabled) {
+            const mode = document.querySelector('input[name="renameCleanSpacesMode"]:checked')?.value || 'replace';
+            if (mode === 'remove') {
+                result = result.replace(/ /g, '');
+            } else {
+                const repl = document.getElementById('renameCleanSpacesReplacement')?.value || '';
+                result = result.split(' ').join(repl);
+            }
+        }
+
+        result = result.replace(/^[\s.]+|[\s.]+$/g, '');
 
         return result;
     }

--- a/templates/series.html
+++ b/templates/series.html
@@ -922,8 +922,15 @@
     }
 
     function buildSubscribePath() {
+        // Mirrors helpers.sanitize_path_segment (Python) and
+        // cbz_ops/rename.py:FILENAME_ILLEGAL_CHARS — keep all copies in lockstep.
         function sanitizePathSegment(val) {
-            return val.replace(/\//g, '-').replace(/:/g, ' -');
+            return val
+                .replace(/\//g, '-')            // keep: slash -> dash
+                .replace(/:/g, ' -')            // keep: colon -> space-dash
+                .replace(/[\\*?"<>|&$;]/g, '')   // strip remaining baseline chars
+                .replace(/\s+/g, ' ')
+                .trim();
         }
 
         const publisher = sanitizePathSegment(seriesData.publisher?.name || 'Unknown');

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -196,6 +196,47 @@ class TestGetSeriesMapping:
         assert resp.get_json()["mapped_path"] is None
 
 
+class TestSubscribeSeries:
+    """The subscribe route must sanitize the user-supplied path before
+    os.makedirs so filesystem-hostile characters never reach disk."""
+
+    @patch("models.series_json.write_series_json")
+    @patch("models.getcomics.prepopulate_series_index")
+    @patch("core.database.save_series_mapping", return_value=True)
+    @patch("routes.series.metron")
+    @patch("routes.series.get_series_by_id",
+            return_value={"id": 100, "name": "Batman"})
+    @patch("routes.series.os.makedirs")
+    def test_subscribe_sanitizes_path(
+        self, mock_makedirs, mock_get, mock_metron, mock_save,
+        mock_prepop, mock_write, client,
+    ):
+        mock_metron.create_cvinfo_file.return_value = True
+        mock_metron.get_flask_api.return_value = None
+
+        resp = client.post("/api/series/100/subscribe", json={
+            "path": '/data/DC Comics/Bat:man & Robin? <v2>/v2016',
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+
+        # Baseline chars stripped, ':' -> ' -', separators preserved.
+        expected = "/data/DC Comics/Bat -man Robin v2/v2016"
+        assert data["path"] == expected
+        made = mock_makedirs.call_args[0][0]
+        assert made == expected
+        for ch in '\\*?"<>|&$;':
+            assert ch not in made
+
+    @patch("routes.series.os.makedirs")
+    def test_subscribe_rejects_empty_after_sanitize(self, mock_makedirs, client):
+        # A path made up entirely of illegal chars collapses to empty -> 400.
+        resp = client.post("/api/series/100/subscribe", json={"path": '/<>|?*/'})
+        assert resp.status_code == 400
+        mock_makedirs.assert_not_called()
+
+
 class TestDeleteSeriesMapping:
 
     @patch("core.database.remove_series_mapping", return_value=True)

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -118,7 +118,9 @@ class TestCleanFinalFilename:
 
     def test_removes_empty_parens(self):
         from cbz_ops.rename import clean_final_filename
-        assert clean_final_filename("Title () .cbz") == "Title .cbz"
+        # The always-on stem cleanup now also trims the trailing space left
+        # before the extension after the empty "()" is removed.
+        assert clean_final_filename("Title () .cbz") == "Title.cbz"
 
     def test_collapses_spaces(self):
         from cbz_ops.rename import clean_final_filename
@@ -531,7 +533,8 @@ class TestGetRenamedFilename:
             "Spider-Man 2099 044 (1992).cbz",
         ),
         # YEAR_MONTH_SERIES_VOLUME_ISSUE_PATTERN
-        ("199309 Hokum & Hex v1 001.cbz", "Hokum & Hex v1 001 (1993).cbz"),
+        # '&' is stripped by the always-on baseline (FILENAME_ILLEGAL_CHARS).
+        ("199309 Hokum & Hex v1 001.cbz", "Hokum Hex v1 001 (1993).cbz"),
         # SERIES_YEAR_MONTH_ISSUE_PATTERN
         (
             "Mister Miracle 1989-08 ( 08) (1989) (Digital) (Shadowcat-Empire).cbz",
@@ -1175,7 +1178,10 @@ class TestApplyFilenameCleanup:
     def test_empty_charset_noop(self):
         from cbz_ops.rename import apply_filename_cleanup
         cfg = _cleanup_cfg(specials_enabled=True, specials_charset="", specials_mode="remove")
-        assert apply_filename_cleanup("Hokum & Hex", cfg) == "Hokum & Hex"
+        # Empty user charset means no *user* cleanup, so a non-baseline char like
+        # '!' is left untouched. ('&' is now stripped by the always-on baseline —
+        # covered by TestBaselineIllegalChars below.)
+        assert apply_filename_cleanup("Hokum ! Hex", cfg) == "Hokum ! Hex"
 
     def test_charset_with_space_does_not_remove_spaces(self):
         from cbz_ops.rename import apply_filename_cleanup
@@ -1209,6 +1215,61 @@ class TestApplyFilenameCleanup:
             lambda: _cleanup_cfg(spaces_enabled=True, spaces_replacement="-"),
         )
         assert rename.apply_filename_cleanup("a b c") == "a-b-c"
+
+
+class TestBaselineIllegalChars:
+    """The FILENAME_ILLEGAL_CHARS baseline is always stripped, even when the
+    user's 'Clean Special Characters' option is disabled."""
+
+    def test_constant_is_the_expected_set(self):
+        from cbz_ops.rename import FILENAME_ILLEGAL_CHARS
+        assert set(FILENAME_ILLEGAL_CHARS) == set('\\/:*?"<>|&$;')
+
+    @pytest.mark.parametrize("ch", list('\\/:*?"<>|&$;'))
+    def test_each_baseline_char_removed_when_disabled(self, ch):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(specials_enabled=False, spaces_enabled=False)
+        out = apply_filename_cleanup(f"Bat{ch}man", cfg)
+        assert ch not in out
+        assert out in ("Batman", "Bat man")
+
+    def test_all_baseline_chars_stripped_together(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        cfg = _cleanup_cfg(specials_enabled=False, spaces_enabled=False)
+        out = apply_filename_cleanup('A\\/:*?"<>|&$;B', cfg)
+        assert out == "AB"
+
+    def test_clean_final_filename_strips_baseline_and_keeps_extension(self):
+        from cbz_ops.rename import clean_final_filename
+        # Default (DB-driven) config: cleanup toggles are off, baseline still runs.
+        out = clean_final_filename('Bat:man & Robin? <v2> $pecial.cbz')
+        for ch in '\\/:*?"<>|&$;':
+            assert ch not in out
+        assert out.endswith(".cbz")
+
+    def test_extension_dot_not_treated_as_illegal(self):
+        # The baseline set contains no '.', and clean_final_filename splits the
+        # extension off first, so ".cbz" is always preserved.
+        from cbz_ops.rename import clean_final_filename
+        assert clean_final_filename("Plain Title 001 (1999).cbz").endswith(".cbz")
+
+    def test_user_extras_union_on_top_of_baseline(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        # '!' is not in the baseline; the user adds it. Baseline '&' still goes.
+        cfg = _cleanup_cfg(
+            specials_enabled=True, specials_charset="!", specials_mode="remove",
+        )
+        assert apply_filename_cleanup("Hokum & Hex!", cfg) == "Hokum Hex"
+
+    def test_user_replace_of_baseline_char_is_honored(self):
+        from cbz_ops.rename import apply_filename_cleanup
+        # User chooses to *replace* '&' (a baseline char) with ' and '; because
+        # user specials run before the baseline strip, the mapping survives.
+        cfg = _cleanup_cfg(
+            specials_enabled=True, specials_charset="&", specials_mode="replace",
+            specials_replacement=" and ",
+        )
+        assert apply_filename_cleanup("Hokum & Hex", cfg) == "Hokum and Hex"
 
 
 class TestLoadFilenameCleanupConfig:


### PR DESCRIPTION
## Context

When CLU generated a filename (`cbz_ops/rename.py`) or a subscribe folder path (`templates/series.html` `#subscribePath`), it did **not** reliably strip characters that are illegal or hostile on disk:

- Filename special-char cleanup (`apply_filename_cleanup`) was **opt-in** — gated behind the `renameCleanSpecialsEnabled` toggle (default off) with an empty default charset, so a fresh install stripped nothing.
- The subscribe path was sanitized only client-side, replacing just `/`→`-` and `:`→` -`; `\ * ? " < > | & $ ;` passed straight through into `os.makedirs`, and the backend trusted the path verbatim.

## Change

Introduces an **always-on baseline** that removes `\ / : * ? " < > | & $ ;` from every generated filename and subscribe path, regardless of the user toggle. Users can still add **more** characters via the existing config field.

- **`cbz_ops/rename.py`** — new `FILENAME_ILLEGAL_CHARS` constant; `apply_filename_cleanup()` always applies the baseline (early-return removed). Order is **user specials → baseline → spaces** so a user who *replaces* a baseline char (e.g. `&`→` and `) keeps that mapping while unremapped baseline chars are still stripped. Covers all rename paths (default, custom, smart, metadata).
- **`helpers/__init__.py`** — new `sanitize_path_segment()` (keeps `:`→` -` and `/`→`-`, strips the rest).
- **`routes/series.py`** — `subscribe_series()` now sanitizes each path segment (preserving `/` separators) before `os.makedirs`, as a server-side safety net for the user-editable `#subscribePath`.
- **`templates/series.html`** — client `sanitizePathSegment()` updated to match.
- **`templates/config.html`** — charset help text now documents the always-removed set (field is for *additional* chars); JS live-preview mirror updated to the same order.

## Tests

- `tests/unit/test_rename.py` — new `TestBaselineIllegalChars` (per-char removal with cleanup disabled, extension preserved, user-extras union, replace-of-baseline honored); updated 3 pre-existing expectations that intentionally changed (e.g. `&` in "Hokum & Hex").
- `tests/routes/test_series_routes.py` — new `TestSubscribeSeries` verifying the route sanitizes the `os.makedirs` path and rejects an all-illegal path.

Full suite: **2021 passed, 4 skipped**. The only failures are the pre-existing env-only `test_pdf.py` cases (missing `pdf2image` locally), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)