### PR TITLE
Default UMASK to 000 for world-writable output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ EXPOSE 5577
 # Set default env vars
 ENV PUID=99 \
     PGID=100 \
-    UMASK=022 \
+    UMASK=000 \
     FLASK_ENV=production \
     MONITOR=no
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ services:
             ## For Windows/WSL, you need to set these to match your Windows user ID (see WINDOWS_WSL_SETUP.md)
             - PUID=99
             - PGID=100
-            ## Set the file creation mask (UMASK). 022 is a common value.
-            - UMASK=022
+            ## File creation mask. 000 -> world-writable folders (drwxrwsrwx) and files
+            ## (-rw-rw-rw-). Use 002 for group-writable (775/664) or 022 for owner-only writes.
+            - UMASK=000
             ### You can enable basic authentication by setting the two values below
             ## CLU_USERNAME=[username] - Set the username for the app.
             ## CLU_PASSWORD=[password] - Set the password for the app.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,10 +36,11 @@ services:
             ## For Windows/WSL, you need to set these to match your Windows user ID (see WINDOWS_WSL_SETUP.md)
             # - PUID=99
             # - PGID=100
-            ## File creation mask. Default is 002 -> group-writable folders (775) and files (664),
-            ## so a second account (e.g. your NAS file browser) can write into CLU-created folders
-            ## without needing 777. Set PGID to your NAS share group. Use 022 for owner-only writes.
-            # - UMASK=002
+            ## File creation mask. Default is 000 -> world-writable folders (drwxrwsrwx) and
+            ## files (-rw-rw-rw-), so any account (NAS file browser, other containers, a second
+            ## user not in the share group) can write into CLU-created files/folders. Use 002 for
+            ## group-writable (775/664, needs PGID = your NAS share group), or 022 for owner-only.
+            # - UMASK=000
             # GCD Database: download the SQLite dump from https://www.comics.org/download/,
             # mount it into the container, and point CLU at it (or set the path in
             # Config -> Metadata Providers instead of using this env var).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Defaults set in Dockerfile (PUID=99, PGID=100) — can be overridden.
 PUID="${PUID:-99}"
 PGID="${PGID:-100}"
-UMASK="${UMASK:-002}"
+UMASK="${UMASK:-000}"
 
 # Ensure the group exists (re-use if it already does)
 if ! getent group "${PGID}" >/dev/null 2>&1; then

--- a/readme/WINDOWS_WSL_SETUP.md
+++ b/readme/WINDOWS_WSL_SETUP.md
@@ -50,7 +50,7 @@ In Portainer, add these environment variables to your container:
 environment:
   - PUID=1000    # Replace with your actual user ID
   - PGID=1000    # Replace with your actual group ID
-  - UMASK=022
+  - UMASK=000
   - FLASK_ENV=development
   - MONITOR=no
 ```
@@ -67,7 +67,7 @@ services:
     environment:
       - PUID=1000    # Replace with your actual user ID
       - PGID=1000    # Replace with your actual group ID
-      - UMASK=022
+      - UMASK=000
       - FLASK_ENV=development
       - MONITOR=no
     volumes:
@@ -84,7 +84,7 @@ After updating PUID/PGID and redeploying, check the container logs. You should s
 Mounted volume ownership (for PUID/PGID configuration):
   /data owned by: 1000:1000
   /downloads owned by: 1000:1000
-Starting as UID:GID 1000:1000 (umask 022)
+Starting as UID:GID 1000:1000 (umask 000)
 ```
 
 **No warnings should appear** if the ownership matches.

--- a/unraid-templates/comic_utils.xml
+++ b/unraid-templates/comic_utils.xml
@@ -34,7 +34,7 @@ Features:&#xD;
    <Config Name="Flask Env" Target="FLASK_ENV" Default="development" Mode="" Description="Flask Environment" Type="Variable" Display="advanced" Required="false" Mask="false">development</Config>
   <Config Name="PUID" Target="PUID" Default="99" Mode="User ID" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">99</Config>
   <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Group ID" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>
-  <Config Name="UMASK" Target="UMASK" Default="022" Mode="" Description="File creation mask." Type="Variable" Display="advanced" Required="true" Mask="false">022</Config>
+  <Config Name="UMASK" Target="UMASK" Default="000" Mode="" Description="File creation mask. 000 -&gt; world-writable folders (drwxrwsrwx) and files (rw-rw-rw-). Use 002 for group-writable or 022 for owner-only." Type="Variable" Display="advanced" Required="true" Mask="false">000</Config>
   <Config Name="Config" Target="/config" Default="" Mode="rw" Description="Container Configuration files." Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/comic-library-utilities/config</Config>
   <Config Name="Cache" Target="/cache" Default="" Mode="rw" Description="Storage for DB and thumbnails." Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/comic-library-utilities/cache</Config>
 </Container>


### PR DESCRIPTION
## Problem

Unraid users reported that files and folders CLU creates come out owner-writable only — folders as `drwxr-xr-x` (or `drwxr-s---` owned by `nobody`) and sidecar files (`series.json`, `cvinfo`) as `-rw-r--r--`. A second account (Unraid's shared `users` group, a NAS file browser, or another container) then can't write to them without a manual `chmod` or file-manager fix.

## Root cause

CLU relies entirely on the process `umask` + setgid for permissions — it sets no explicit mode on any `os.makedirs`/`open` call. But the effective `UMASK` default was **`022`**, not the group-writable value the docs claimed. The default was inconsistent across the repo:

- `Dockerfile` shipped `ENV UMASK=022`
- `entrypoint.sh` defaulted to `002`
- `unraid-templates/comic_utils.xml` hardcoded `022` (Required)
- `README.md` / `docker-compose.yaml` documented `022` / claimed `002`

The Dockerfile ENV and the Unraid template win in practice → `umask 022` → dirs `755`, files `644`. The `chmod g+s` on `/data` and `/downloads` inherits the group and the `s` bit, but **setgid does not grant group/other write — only `umask` does.**

## Fix

Reconcile every `UMASK` default to **`000`** (single source of truth). Combined with the existing setgid, `umask 000` yields new folders `drwxrwsrwx` (2777) and new files `-rw-rw-rw-` (666) — exactly the requested behavior — with no new Python code. The `UMASK` env var stays exposed so it can be tightened per-deployment (`002` for group-writable, `022` for owner-only).

| File | Change |
|------|--------|
| `Dockerfile` | `ENV UMASK=022` → `000` |
| `entrypoint.sh` | `${UMASK:-002}` → `${UMASK:-000}` |
| `unraid-templates/comic_utils.xml` | `Default`/body `022` → `000` (existing installs pulled `022` from here) |
| `docker-compose.yaml`, `README.md`, `readme/WINDOWS_WSL_SETUP.md` | docs/examples updated to `000`, with `002`/`022` documented as tighter alternatives |

## Notes

- **Rebuild required** (Dockerfile ENV). Anyone with a manual `UMASK` override in their compose/template keeps their value until they change it.
- **Existing** files/folders aren't retroactively fixed — only newly created ones. A one-time `chmod -R` clears the backlog.
- Config/docs only — no Python touched. Sidecar permission tests (`tests/unit/test_sidecar_permissions.py`, `tests/unit/test_bulk_metadata_sidecars.py`) are independent of the umask default and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)