### PR TITLE
Reset Release Card Loading State

### DIFF
--- a/templates/releases.html
+++ b/templates/releases.html
@@ -404,6 +404,14 @@
                 }
             });
         });
+
+        // Clear any stuck loading state when the page is restored from bfcache
+        // (e.g. user clicks a card, then hits the browser Back button).
+        window.addEventListener('pageshow', function () {
+            document.querySelectorAll('.release-card.loading').forEach(function (card) {
+                card.classList.remove('loading');
+            });
+        });
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
## 📝 Description
Add a `pageshow` handler in `templates/releases.html` that removes `.loading` from any `.release-card` elements when the page is restored from the browser back-forward cache. This prevents cards from staying visually stuck in a loading state after navigating back.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass