### PR TITLE
Fix dark-theme contrast for toasts and card backgrounds

### DIFF
--- a/app.py
+++ b/app.py
@@ -3978,12 +3978,20 @@ def update_index_on_create(path):
         app_logger.error(f"Failed to update index on create {path}: {e}")
 
 
+# Bootswatch themes that ship a dark palette. Setting data-bs-theme="dark" for
+# these activates Bootstrap 5.3's dark helper variables (emphasis/tertiary-bg/etc.),
+# which the themes otherwise leave at light-mode defaults at :root.
+DARK_BOOTSWATCH_THEMES = {"cyborg", "darkly", "slate", "solar", "superhero", "vapor"}
+
+
 @app.context_processor
 def inject_global_vars():
+    theme = app.config.get("BOOTSTRAP_THEME", "default")
     return {
         "monitor": os.getenv("MONITOR", "no"),
         "version": __version__,
-        "bootstrap_theme": app.config.get("BOOTSTRAP_THEME", "default"),
+        "bootstrap_theme": theme,
+        "theme_is_dark": theme in DARK_BOOTSWATCH_THEMES,
     }
 
 

--- a/static/css/files.css
+++ b/static/css/files.css
@@ -1,8 +1,8 @@
     .cbz-preview-container {
-        border: 1px solid #dee2e6;
+        border: 1px solid var(--bs-border-color);
         border-radius: 0.375rem;
         padding: 0.5rem;
-        background-color: #f8f9fa;
+        background-color: var(--bs-tertiary-bg);
         margin-top: 0.5rem;
     }
 
@@ -13,12 +13,12 @@
 
     .cbz-metadata {
         font-size: 0.75rem;
-        color: #6c757d;
+        color: var(--bs-secondary-color);
         margin-top: 0.25rem;
     }
 
     .list-group-item:hover .cbz-preview-container {
-        border-color: #adb5bd;
+        border-color: var(--bs-secondary-color);
     }
 
     /* Smooth removal animation for deleted items */
@@ -56,24 +56,24 @@
 
     /* Drag and drop hover effects */
     .folder-hover {
-        background-color: #e3f2fd !important;
-        border-color: #2196f3 !important;
+        background-color: rgba(var(--bs-primary-rgb), 0.15) !important;
+        border-color: var(--bs-primary) !important;
         transform: scale(1.02);
         transition: all 0.2s ease;
-        box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+        box-shadow: 0 4px 8px rgba(var(--bs-primary-rgb), 0.3);
     }
 
     .hover {
-        background-color: #f0f8ff !important;
-        border: 2px dashed #2196f3 !important;
+        background-color: rgba(var(--bs-primary-rgb), 0.1) !important;
+        border: 2px dashed var(--bs-primary) !important;
         transition: all 0.2s ease;
     }
 
     /* Selected file highlighting */
     .list-group-item.selected {
-        background-color: #e3f2fd;
-        border-color: #2196f3;
-        box-shadow: 0 2px 4px rgba(33, 150, 243, 0.2);
+        background-color: rgba(var(--bs-primary-rgb), 0.15);
+        border-color: var(--bs-primary);
+        box-shadow: 0 2px 4px rgba(var(--bs-primary-rgb), 0.2);
         position: relative;
     }
 
@@ -146,8 +146,8 @@
 
     /* Upload drop zone (external file drag from desktop) */
     .upload-hover {
-        background-color: #e8f5e9 !important;
-        border: 2px dashed #4caf50 !important;
+        background-color: rgba(var(--bs-success-rgb), 0.15) !important;
+        border: 2px dashed var(--bs-success) !important;
         transition: all 0.2s ease;
         position: relative;
     }
@@ -284,10 +284,10 @@
     .cbz-image-info {
         margin-top: 0.75rem;
         padding: 0.5rem 1rem;
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: rgba(var(--bs-body-color-rgb), 0.05);
         border-radius: 0.375rem;
         font-size: 0.8rem;
-        color: #6c757d;
+        color: var(--bs-secondary-color);
         text-align: center;
     }
 
@@ -299,12 +299,12 @@
     .cbz-image-info .info-item:not(:last-child)::after {
         content: "•";
         margin-left: 1rem;
-        color: #adb5bd;
+        color: var(--bs-secondary-color);
     }
 
     .cbz-image-info .info-label {
         font-weight: 500;
-        color: #495057;
+        color: var(--bs-body-color);
     }
 
 /* =============================================================================
@@ -312,8 +312,8 @@
    ============================================================================= */
 
 #editCBZModal .modal-body.drag-over {
-    background-color: rgba(33, 150, 243, 0.1);
-    border: 2px dashed #2196f3;
+    background-color: rgba(var(--bs-primary-rgb), 0.1);
+    border: 2px dashed var(--bs-primary);
     transition: all 0.2s ease;
 }
 

--- a/static/css/reading_lists.css
+++ b/static/css/reading_lists.css
@@ -498,10 +498,10 @@ body.reading-list-select-mode .reading-list-card {
 }
 
 #toggleSelectModeBtn.active {
-    background-color: #6c757d;
-    border-color: #6c757d;
+    background-color: var(--bs-secondary);
+    border-color: var(--bs-secondary);
     color: #fff;
-    box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.35);
+    box-shadow: 0 0 0 0.2rem rgba(var(--bs-secondary-rgb), 0.35);
 }
 
 #toggleSelectModeBtn.active:hover {

--- a/static/css/source_wall.css
+++ b/static/css/source_wall.css
@@ -44,8 +44,8 @@
     /* If your header is 60px, use: calc(100vh - 60px) */
     min-height: 90vh; 
     
-    /* Ensure the table background stays white/consistent */
-    background-color: #fff;
+    /* Keep the table panel on the theme surface color */
+    background-color: var(--bs-body-bg);
     
     /* Important: prevent clipping of dropdowns */
     padding-bottom: 100px; 

--- a/static/js/clu-utils.js
+++ b/static/js/clu-utils.js
@@ -107,17 +107,21 @@
                   : type === 'success' ? 'success'
                   : type === 'warning' ? 'warning'
                   : 'info';
-      var textClass = type === 'warning' ? '' : 'text-white';
+      // Use Bootstrap's self-contrasting text-bg-* helper so the text color is
+      // chosen for the background — correct on both light and dark themes.
+      // Warning/info resolve to dark text; success/danger to light text.
+      var lightText = bgClass === 'success' || bgClass === 'danger';
+      var closeClass = lightText ? ' btn-close-white' : '';
 
       var toastEl = document.createElement('div');
-      toastEl.className = 'toast bg-' + bgClass + ' ' + textClass;
+      toastEl.className = 'toast text-bg-' + bgClass;
       toastEl.setAttribute('role', 'alert');
       toastEl.setAttribute('aria-live', 'assertive');
       toastEl.setAttribute('aria-atomic', 'true');
       toastEl.innerHTML =
-        '<div class="toast-header bg-' + bgClass + ' ' + textClass + '">' +
+        '<div class="toast-header text-bg-' + bgClass + '">' +
           '<strong class="me-auto">' + title + '</strong>' +
-          '<button type="button" class="btn-close' + (textClass ? ' btn-close-white' : '') + '" data-bs-dismiss="toast" aria-label="Close"></button>' +
+          '<button type="button" class="btn-close' + closeClass + '" data-bs-dismiss="toast" aria-label="Close"></button>' +
         '</div>' +
         '<div class="toast-body">' + message + '</div>';
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 <!-- templates/base.html -->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"{% if theme_is_dark %} data-bs-theme="dark"{% endif %}>
 
 <head>
   <meta charset="UTF-8">
@@ -35,7 +35,7 @@
     .edit-input {
       width: 100%;
       border: none;
-      border-bottom: 1px solid #ccc;
+      border-bottom: 1px solid var(--bs-border-color);
     }
 
     /* Basic drag styles - detailed styles in files.css */
@@ -45,7 +45,7 @@
     }
 
     .selected {
-      background-color: #c5e1fe;
+      background-color: rgba(var(--bs-primary-rgb), 0.15);
     }
 
     #source-directory-filter .btn {
@@ -54,7 +54,7 @@
     }
 
     .folder-hover {
-      background-color: #86f0ee;
+      background-color: rgba(var(--bs-info-rgb), 0.2);
       /* Adjust color to your preference */
     }
 
@@ -64,7 +64,7 @@
     }
 
     .card:hover {
-      background-color: #feeccb;
+      background-color: var(--bs-tertiary-bg);
       box-shadow: 0 0 11px rgba(33, 33, 33, 0.2);
       transition: background-color 0.3s ease, box-shadow 0.3s ease;
     }
@@ -96,11 +96,11 @@
       to { transform: rotate(360deg); }
     }
     .ops-spin { display: inline-block; animation: ops-spin 1.5s linear infinite; }
-    .ops-dropdown .ops-item { padding: 0.5rem 1rem; border-bottom: 1px solid rgba(0,0,0,0.05); }
+    .ops-dropdown .ops-item { padding: 0.5rem 1rem; border-bottom: 1px solid var(--bs-border-color); }
     .ops-dropdown .ops-item:last-child { border-bottom: none; }
     .ops-dropdown .ops-item .progress { height: 6px; border-radius: 3px; }
     .ops-dropdown .ops-label { font-size: 0.85rem; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 280px; }
-    .ops-dropdown .ops-detail { font-size: 0.75rem; color: #6c757d; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 280px; }
+    .ops-dropdown .ops-detail { font-size: 0.75rem; color: var(--bs-secondary-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 280px; }
     .ops-item-completed { opacity: 0.6; }
     .ops-item-error { border-left: 3px solid #dc3545; }
   </style>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"{% if theme_is_dark %} data-bs-theme="dark"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary

Fixes white-on-white / dark-on-dark contrast bugs on the six dark Bootswatch themes (Superhero, Darkly, Cyborg, Slate, Solar, Vapor), most visible in Toast notifications and the cards on the Insights page.

**Root cause** (confirmed against Superhero's actual CSS): Bootswatch dark themes set a dark *body* at `:root` (`--bs-body-bg`, `--bs-body-color`) but leave Bootstrap 5.3's *helper* variables at their light defaults there:

- `--bs-emphasis-color:#000` (black) — insights card headers/values
- `--bs-tertiary-bg:#ebebeb` (near-white) — `.stat-card` background
- `--bs-secondary-bg:#dee2e6` (light gray)

The correct dark values live only in each theme's `[data-bs-theme=dark]` block, which the app never activated — `<html>` had no `data-bs-theme`. (Corroborating: `collection.css` already contained `[data-bs-theme="dark"]` rules that were dead code.)

## Changes

1. **Activate Bootstrap dark mode** — `app.py` adds a `DARK_BOOTSWATCH_THEMES` set and a `theme_is_dark` flag in `inject_global_vars()`; `base.html` + `login.html` emit `data-bs-theme="dark"` on `<html>` for dark themes. Flips all helper vars correctly app-wide and revives the dormant `collection.css` dark rules. Light/default themes are unchanged.
2. **Warning-toast contrast** — `CLU.showToast` built warning toasts with `bg-warning` and no text color (light text over light yellow on dark themes). Now uses Bootstrap's self-contrasting `text-bg-*` classes.
3. **Hardcoded colors → theme variables** — `base.html` inline styles (`.card:hover` light beige on every card, `.selected`, `.folder-hover`, borders, muted text), plus a sweep of `files.css`, `source_wall.css`, and `reading_lists.css`. Intentional elements left as-is: branded publisher chips, glass overlays over cover art, and the explicitly always-dark bulk-action bar.

## Testing

- `pytest tests/routes` — **580 passed** (full template rendering).
- `pytest tests/unit tests/mocked tests/integration` — **1441 passed**, 4 skipped (POSIX-only); the only failures are the pre-existing env-only `test_pdf.py` set (missing `pdf2image`).
- Verified `data-bs-theme="dark"` is emitted for all six dark themes and absent for light/default.

**Manual check:** set theme to Superhero in `/config` → Personalization, then confirm Insights cards and warning toasts are readable; light themes (Cosmo/Default) unchanged.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)