### PR TITLE
Set browser User-Agent on ComicVine & GCD API clients (fixes Cloudflare 403)

### DIFF
--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -41,8 +41,28 @@ CV_REQUEST_TIMEOUT = _get_cv_request_timeout()
 
 
 def _make_cv_client(api_key: str):
-    """Construct a Simyan ComicVine client with an explicit request timeout."""
-    return Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
+    """Construct a Simyan ComicVine client with an explicit request timeout.
+
+    A browser-like User-Agent is set so ComicVine (fronted by Cloudflare) doesn't
+    reject the default ``Simyan/x`` User-Agent with a 403 from some hosts. Newer
+    Simyan accepts ``user_agent`` directly; older versions get it patched onto the
+    underlying session.
+    """
+    from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
+    try:
+        return Comicvine(
+            api_key=api_key,
+            cache=None,
+            timeout=CV_REQUEST_TIMEOUT,
+            user_agent=DEFAULT_PROVIDER_USER_AGENT,
+        )
+    except TypeError:
+        client = Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
+        try:
+            client._session.headers.update({"User-Agent": DEFAULT_PROVIDER_USER_AGENT})
+        except Exception:
+            pass
+        return client
 
 
 def _cv_retry_config():

--- a/models/gcd_api.py
+++ b/models/gcd_api.py
@@ -9,6 +9,7 @@ from requests.auth import HTTPBasicAuth
 from urllib.parse import urlparse, parse_qs, quote
 from typing import Optional, Dict, Any, List
 from core.app_logging import app_logger
+from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
 
 
 BASE_URL = "https://www.comics.org/api"
@@ -20,7 +21,10 @@ class GCDApiClient:
     def __init__(self, username: str, password: str):
         self.session = requests.Session()
         self.session.auth = HTTPBasicAuth(username, password)
-        self.session.headers.update({"Accept": "application/json"})
+        self.session.headers.update({
+            "Accept": "application/json",
+            "User-Agent": DEFAULT_PROVIDER_USER_AGENT,
+        })
 
     def _get(self, path: str, params: dict = None) -> Optional[Dict]:
         """Make authenticated GET request to the GCD API."""
@@ -39,14 +43,14 @@ class GCDApiClient:
             app_logger.error(f"GCD API request error for {path}: {e}")
             raise
 
-    def search_series(self, name: str, year: int = None) -> List[Dict]:
+    def search_series(self, name: str, year: int = None, max_pages: int = 5) -> List[Dict]:
         """Search series by name, optionally filtered by year."""
         encoded_name = quote(name, safe="")
         if year:
             path = f"/series/name/{encoded_name}/year/{year}/"
         else:
             path = f"/series/name/{encoded_name}/"
-        return self._get_all_pages(path)
+        return self._get_all_pages(path, max_pages=max_pages)
 
     def get_series(self, series_id: int) -> Optional[Dict]:
         """Get series details by ID, including issue list."""

--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -12,6 +12,16 @@ from typing import Optional, List, Dict, Any
 from enum import Enum
 
 
+# Browser-like User-Agent for provider HTTP clients. Some upstreams (e.g. ComicVine
+# and comics.org, both fronted by Cloudflare) reject default library User-Agents like
+# ``python-requests/x`` or ``Simyan/x`` with a 403. Overridable via PROVIDER_USER_AGENT.
+DEFAULT_PROVIDER_USER_AGENT = os.environ.get(
+    "PROVIDER_USER_AGENT",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+)
+
+
 class ProviderType(Enum):
     """Enumeration of supported metadata providers."""
     METRON = "metron"

--- a/models/providers/gcd_api_provider.py
+++ b/models/providers/gcd_api_provider.py
@@ -102,7 +102,7 @@ class GCDApiProvider(BaseProvider):
             client = self._get_client()
             if not client:
                 return False
-            results = client.search_series("Batman")
+            results = client.search_series("Batman", max_pages=1)
             return len(results) > 0
         except Exception as e:
             app_logger.error(f"GCD API connection test failed: {e}")

--- a/templates/config.html
+++ b/templates/config.html
@@ -3138,11 +3138,26 @@
     // Metadata Provider Management Functions
     // =========================================
 
+    // Parse a JSON response, but surface a friendly message when the server returns
+    // a non-JSON body (e.g. an HTML gateway/timeout page) instead of throwing the
+    // cryptic "Unexpected token '<'" that JSON.parse produces on "<!DOCTYPE ...".
+    async function readJsonResponse(response) {
+        const ct = response.headers.get('content-type') || '';
+        if (!ct.includes('application/json')) {
+            throw new Error(
+                response.status >= 500
+                    ? 'Server error or timeout — the provider request may have been blocked or timed out.'
+                    : `Unexpected non-JSON response (HTTP ${response.status}).`
+            );
+        }
+        return response.json();
+    }
+
     async function loadProviders() {
         const container = document.getElementById('providersCredentialsList');
         try {
             const response = await fetch('/api/providers');
-            const data = await response.json();
+            const data = await readJsonResponse(response);
 
             if (!data.success) {
                 container.innerHTML = '<div class="alert alert-danger">Failed to load providers</div>';
@@ -3479,7 +3494,7 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(credentials)
             });
-            const data = await response.json();
+            const data = await readJsonResponse(response);
 
             if (data.success) {
                 showToast(`Credentials saved for ${providerType}`, 'success');
@@ -3509,7 +3524,7 @@
             const response = await fetch(`/api/providers/${providerType}/test`, {
                 method: 'POST'
             });
-            const data = await response.json();
+            const data = await readJsonResponse(response);
 
             if (data.success && data.valid) {
                 btn.innerHTML = '<i class="bi bi-check-circle me-1"></i>Success!';
@@ -3547,7 +3562,7 @@
             const response = await fetch(`/api/providers/${providerType}/credentials`, {
                 method: 'DELETE'
             });
-            const data = await response.json();
+            const data = await readJsonResponse(response);
 
             if (data.success) {
                 showToast(`Credentials deleted for ${providerType}`, 'success');

--- a/tests/mocked/test_comicvine_provider.py
+++ b/tests/mocked/test_comicvine_provider.py
@@ -54,6 +54,39 @@ class TestComicVineProviderInit:
         mock_make.assert_called_once_with(comicvine_creds.api_key)
 
 
+class TestMakeCvClientUserAgent:
+    """_make_cv_client must set a browser-like User-Agent so ComicVine (behind
+    Cloudflare) doesn't 403 the default Simyan UA from some hosts."""
+
+    def test_passes_user_agent_kwarg(self):
+        import models.comicvine as cv
+        from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
+
+        sentinel = MagicMock()
+        with patch.object(cv, "Comicvine", create=True) as mock_cv:
+            mock_cv.return_value = sentinel
+            client = cv._make_cv_client("KEY")
+
+        assert client is sentinel
+        _, kwargs = mock_cv.call_args
+        assert kwargs.get("user_agent") == DEFAULT_PROVIDER_USER_AGENT
+
+    def test_fallback_patches_session_on_typeerror(self):
+        """Older Simyan without a user_agent kwarg: patch the session instead."""
+        import models.comicvine as cv
+        from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
+
+        fallback_client = MagicMock()
+        with patch.object(cv, "Comicvine", create=True) as mock_cv:
+            mock_cv.side_effect = [TypeError("unexpected user_agent"), fallback_client]
+            client = cv._make_cv_client("KEY")
+
+        assert client is fallback_client
+        fallback_client._session.headers.update.assert_called_once_with(
+            {"User-Agent": DEFAULT_PROVIDER_USER_AGENT}
+        )
+
+
 class TestComicVineProviderTestConnection:
 
     @patch.dict(sys.modules, _SIMYAN_MODULES)

--- a/tests/mocked/test_gcd_api_provider.py
+++ b/tests/mocked/test_gcd_api_provider.py
@@ -343,6 +343,20 @@ class TestGCDApiProvider:
         assert provider.test_connection() is True
 
     @patch("models.gcd_api.GCDApiClient")
+    def test_test_connection_uses_single_page(self, mock_client_cls):
+        # The connection test must bound pagination so a slow search can't exceed
+        # the worker timeout and return an HTML error page to the UI.
+        mock_client = MagicMock()
+        mock_client.search_series.return_value = [SAMPLE_SERIES]
+        mock_client_cls.return_value = mock_client
+
+        provider = self._make_provider()
+        provider._client_instance = mock_client
+
+        assert provider.test_connection() is True
+        mock_client.search_series.assert_called_once_with("Batman", max_pages=1)
+
+    @patch("models.gcd_api.GCDApiClient")
     def test_test_connection_failure(self, mock_client_cls):
         mock_client = MagicMock()
         mock_client.search_series.side_effect = Exception("Connection refused")

--- a/tests/unit/test_gcd_api.py
+++ b/tests/unit/test_gcd_api.py
@@ -13,6 +13,35 @@ class TestGCDApiClient:
         client = self._make_client()
         assert client.session.auth is not None
 
+    def test_init_sets_browser_user_agent(self):
+        # comics.org is fronted by Cloudflare and 403s the default python-requests
+        # User-Agent from some hosts; a browser-like UA must be set instead.
+        from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
+        client = self._make_client()
+        assert client.session.headers.get("User-Agent") == DEFAULT_PROVIDER_USER_AGENT
+
+    @patch("models.gcd_api.requests.Session")
+    def test_search_series_respects_max_pages(self, mock_session_cls):
+        # A bounded page count keeps test_connection from paginating for minutes
+        # and tripping the worker timeout.
+        from models.gcd_api import GCDApiClient
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "count": 100,
+            "next": "https://www.comics.org/api/series/name/Batman/?page=2",
+            "results": [{"name": "Batman"}],
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_session_cls.return_value = mock_session
+
+        client = GCDApiClient("user", "pass")
+        results = client.search_series("Batman", max_pages=1)
+
+        assert mock_session.get.call_count == 1
+        assert len(results) == 1
+
     @patch("models.gcd_api.requests.Session")
     def test_search_series_url_no_year(self, mock_session_cls):
         from models.gcd_api import GCDApiClient


### PR DESCRIPTION
## Problem

Fixes #396. A TrueNAS SCALE user reported that a valid ComicVine API key saves fine but never validates (`is_valid: false`, `last_tested: null`), and the UI throws `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. Same for the **Grand Comics Database (API)** provider. The maintainer can't reproduce on Windows/Docker.

## Root cause

The reporter's own diagnostic is the smoking gun: the API key works in a **browser**, but the identical request **from inside the container** returns `403 Forbidden … Server: cloudflare` (tested with `wget`). Both provider clients sent a **non-browser User-Agent**:

- **ComicVine** (via Simyan) → default `Simyan/<ver> (Linux: …)`
- **GCD API** (`models/gcd_api.py`) → default `python-requests/<ver>`

Cloudflare bot-filters those UAs from some hosts. Providers that already set a browser UA (`bedetheque`) are unaffected. The maintainer's host simply isn't flagged by Cloudflare's IP/UA heuristics.

The `Unexpected token '<'` UI error is a **second, independent defect**: the frontend does an unguarded `await response.json()`, so a gateway/worker-timeout HTML page (the GCD test paginated up to 5×30s = 150s, past the 120s gunicorn timeout) throws a cryptic parse error.

## Changes

- **`models/providers/base.py`** — new `DEFAULT_PROVIDER_USER_AGENT` (browser UA, overridable via `PROVIDER_USER_AGENT` env var)
- **`models/gcd_api.py`** — set that UA on the session; thread `max_pages` through `search_series`
- **`models/providers/gcd_api_provider.py`** — `test_connection` uses `max_pages=1` (can't trip the worker timeout)
- **`models/comicvine.py`** — `_make_cv_client` passes `user_agent=…`, with a `TypeError` fallback that patches the session for older Simyan
- **`templates/config.html`** — new `readJsonResponse()` on all four provider fetches → friendly message instead of `Unexpected token '<'`

`api.py` is untouched.

## Tests

Added: GCD session UA header, `search_series(max_pages=1)` single-page bound, GCD `test_connection` single-page assertion, ComicVine `user_agent` kwarg + `TypeError`-fallback paths.

- Targeted suite: **58/58 passing**
- Full suite: **2026 passing** (only the 13 known env-only `test_pdf.py` failures remain — `pdf2image` not installed locally)

## Verification note

⚠️ The Cloudflare 403 can't be reproduced in the maintainer's environment (same reason it wasn't originally — the host isn't blocked), so this is verified by logic + unit tests, not by defeating the live block. **Final confirmation needs the reporter (`@truensado`)** to pull a rebuilt image and re-test. If Cloudflare turns out to run a full JS challenge rather than a simple UA filter, a UA alone won't suffice and the fallback is `cloudscraper` (already a dependency) — but the 403-on-UA pattern strongly indicates a simple filter. The `PROVIDER_USER_AGENT` env var also lets users try an alternate UA without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)