### PR TITLE
Fix ComicVine provider on fresh deploys: Simyan 3.x compat + content-type-agnostic response parsing

### DIFF
--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -16,10 +16,6 @@ from cbz_ops.rename import rename_comic_from_metadata
 
 try:
     from simyan.comicvine import Comicvine, ComicvineResource
-    try:
-        from simyan.cache import SQLiteCache
-    except ImportError:
-        from simyan.sqlite_cache import SQLiteCache
     SIMYAN_AVAILABLE = True
 except ImportError:
     SIMYAN_AVAILABLE = False
@@ -43,26 +39,37 @@ CV_REQUEST_TIMEOUT = _get_cv_request_timeout()
 def _make_cv_client(api_key: str):
     """Construct a Simyan ComicVine client with an explicit request timeout.
 
-    A browser-like User-Agent is set so ComicVine (fronted by Cloudflare) doesn't
-    reject the default ``Simyan/x`` User-Agent with a 403 from some hosts. Newer
-    Simyan accepts ``user_agent`` directly; older versions get it patched onto the
-    underlying session.
+    Handles both the modern and legacy Simyan constructor signatures:
+
+    * Modern Simyan (2.x) accepts ``user_agent`` and no longer takes a ``cache``
+      argument (caching is configured via ``cache_path``). Passing ``cache=None``
+      to it raises ``TypeError``.
+    * Legacy Simyan accepts ``cache`` but not ``user_agent``; there the browser
+      User-Agent is patched onto the underlying session instead.
+
+    A browser-like User-Agent is set either way so ComicVine (fronted by
+    Cloudflare) doesn't reject the default ``Simyan/x`` User-Agent with a 403
+    from some hosts.
     """
     from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
+
+    # Modern Simyan: no `cache` kwarg, native `user_agent` support.
     try:
         return Comicvine(
             api_key=api_key,
-            cache=None,
             timeout=CV_REQUEST_TIMEOUT,
             user_agent=DEFAULT_PROVIDER_USER_AGENT,
         )
     except TypeError:
-        client = Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
-        try:
-            client._session.headers.update({"User-Agent": DEFAULT_PROVIDER_USER_AGENT})
-        except Exception:
-            pass
-        return client
+        pass
+
+    # Legacy Simyan: takes `cache`, no `user_agent` — patch the session afterwards.
+    client = Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
+    try:
+        client._session.headers.update({"User-Agent": DEFAULT_PROVIDER_USER_AGENT})
+    except Exception:
+        pass
+    return client
 
 
 def _cv_retry_config():

--- a/templates/config.html
+++ b/templates/config.html
@@ -3138,19 +3138,22 @@
     // Metadata Provider Management Functions
     // =========================================
 
-    // Parse a JSON response, but surface a friendly message when the server returns
-    // a non-JSON body (e.g. an HTML gateway/timeout page) instead of throwing the
-    // cryptic "Unexpected token '<'" that JSON.parse produces on "<!DOCTYPE ...".
+    // Parse a response body as JSON regardless of its Content-Type header — some
+    // reverse proxies rewrite or strip it, and the Fetch API's response.json()
+    // ignores Content-Type anyway. Only surface an error when the body genuinely
+    // isn't JSON (e.g. an HTML gateway/timeout or proxy page), with an actionable
+    // message instead of the cryptic "Unexpected token '<'" / "did not match the
+    // expected pattern" that JSON.parse throws on "<!DOCTYPE ...".
     async function readJsonResponse(response) {
-        const ct = response.headers.get('content-type') || '';
-        if (!ct.includes('application/json')) {
+        const text = await response.text();
+        try {
+            return JSON.parse(text);
+        } catch (e) {
             throw new Error(
-                response.status >= 500
-                    ? 'Server error or timeout — the provider request may have been blocked or timed out.'
-                    : `Unexpected non-JSON response (HTTP ${response.status}).`
+                `Server returned a non-JSON response (HTTP ${response.status}). ` +
+                `If CLU is behind a reverse proxy, make sure it forwards /api requests to CLU without rewriting the response.`
             );
         }
-        return response.json();
     }
 
     async function loadProviders() {
@@ -3581,7 +3584,7 @@
         try {
             // Get libraries first
             const libResponse = await fetch('/api/libraries?all=true');
-            const libData = await libResponse.json();
+            const libData = await readJsonResponse(libResponse);
 
             if (!libData.success || libData.libraries.length === 0) {
                 container.innerHTML = '<div class="alert alert-info">Add libraries first to configure their metadata providers.</div>';
@@ -3590,7 +3593,7 @@
 
             // Get available providers
             const provResponse = await fetch('/api/providers');
-            const provData = await provResponse.json();
+            const provData = await readJsonResponse(provResponse);
 
             if (!provData.success) {
                 container.innerHTML = '<div class="alert alert-danger">Failed to load providers</div>';
@@ -3608,7 +3611,7 @@
             for (const lib of libData.libraries) {
                 // Get library's current provider config
                 const libProvResponse = await fetch(`/api/libraries/${lib.id}/providers`);
-                const libProvData = await libProvResponse.json();
+                const libProvData = await readJsonResponse(libProvResponse);
                 const libraryProviders = libProvData.success ? libProvData.providers : [];
 
                 html += `
@@ -3746,7 +3749,7 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ providers })
             });
-            const data = await response.json();
+            const data = await readJsonResponse(response);
 
             if (data.success) {
                 showToast('Library provider settings saved', 'success');

--- a/tests/mocked/test_comicvine_provider.py
+++ b/tests/mocked/test_comicvine_provider.py
@@ -70,6 +70,9 @@ class TestMakeCvClientUserAgent:
         assert client is sentinel
         _, kwargs = mock_cv.call_args
         assert kwargs.get("user_agent") == DEFAULT_PROVIDER_USER_AGENT
+        # Modern Simyan (3.x) removed the `cache` kwarg; passing it raises TypeError
+        # and disables the provider. The primary construction path must not send it.
+        assert "cache" not in kwargs
 
     def test_fallback_patches_session_on_typeerror(self):
         """Older Simyan without a user_agent kwarg: patch the session instead."""


### PR DESCRIPTION
Follow-up to #397, on branch `bug/metadata-errors`. Two related fixes for problems that surfaced after deploying #397 (issue #396).

---

## Fix 1 — Simyan 3.x compatibility (`models/comicvine.py`)

**Symptom:** `Connection test failed` with log `WARNING - Simyan library not available`.

A fresh build pulls **Simyan 3.0.0** (allowed by the unpinned `simyan>=2.0.0`), whose API changed in two breaking ways:

1. `SQLiteCache` moved out of `simyan.cache` / `simyan.sqlite_cache` (now in `requests_cache`). The import block tried both submodules, both failed, and the **outer `except` flipped `SIMYAN_AVAILABLE` to `False`** — disabling ComicVine even though `Comicvine` imports fine.
2. The `cache` constructor kwarg was removed (now `cache_path`), so `Comicvine(..., cache=None)` raises `TypeError`.

This is likely the reporter's true root cause in #396 ("worked before, broke on a fresh install").

**Changes:**
- Drop the unused `SQLiteCache` import; `SIMYAN_AVAILABLE` now reflects only whether `Comicvine` is importable.
- `_make_cv_client` tries the modern signature first (`user_agent=…`, no `cache`), falling back to the legacy one (`cache=None` + session UA patch). Works across Simyan 2.x/3.x while keeping the browser User-Agent from #397.

**Verified** against real **simyan 3.0.0**: `SIMYAN_AVAILABLE = True`, client builds, browser User-Agent present.

## Fix 2 — Content-type-agnostic response parsing (`templates/config.html`)

**Symptoms (reporter screenshot):**
- `Provider Credentials — Error loading providers: unexpected non-JSON response (http 200)`
- `Library Provider Settings — Error loading library providers: the string did not match the expected pattern`

The `readJsonResponse` helper from #397 gated on the `Content-Type` header and rejected **valid 200 JSON bodies** when a reverse proxy (common on TrueNAS) rewrote/stripped `Content-Type`. The Fetch API's `response.json()` ignores `Content-Type` and just parses the body, so the gate was a regression.

**Changes:**
- Rewrite `readJsonResponse` to read the body as text and `JSON.parse` it regardless of `Content-Type`, only erroring — with an actionable reverse-proxy hint — when the body genuinely isn't JSON.
- Apply the helper to the Library Provider Settings fetches (load + save), which still used raw `.json()` and threw the cryptic "did not match the expected pattern" on a non-JSON body.

---

## Verification

- ComicVine-related tests (provider, model, metadata routes): **108 passing**
- Full suite: **2026 passing** (only the 13 known env-only `test_pdf.py` failures — `pdf2image` not installed locally)
- Added a regression assertion that the ComicVine construction path never passes `cache` (the kwarg that breaks Simyan 3.x)

## Notes

- The frontend JS is template-only and has no test harness (as noted in #397).
- `requirements.txt` left unpinned since the code is now version-tolerant — happy to pin Simyan if you'd prefer reproducible builds.
- If the reporter still sees a non-JSON error after this, it means their reverse proxy is genuinely returning HTML for `/api` routes — the new message now points them there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)