### PR TITLE
Fix ComicVine as non-root: the app user's $HOME never exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,10 @@ WORKDIR /app
 COPY --from=builder /opt/venv /opt/venv
 
 # Install Playwright browsers (chromium only for scraping)
-# We run this here to ensure browsers are installed in the final image
+# We run this here to ensure browsers are installed in the final image.
+# Install to a shared path rather than root's HOME: at runtime gosu switches to the
+# app user, whose HOME differs, and the browsers would otherwise not be found.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 RUN playwright install chromium
 
 # Copy application source
@@ -127,7 +130,8 @@ ENV PUID=99 \
     PGID=100 \
     UMASK=000 \
     FLASK_ENV=production \
-    MONITOR=no
+    MONITOR=no \
+    XDG_CACHE_HOME=/config/.cache
 
 # Setup entrypoint
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,8 +30,18 @@ fi
 # Apply umask for the session
 umask "${UMASK}"
 
+# `useradd -M` records a home path (e.g. /home/cluser) in the passwd entry but never
+# creates the directory, and gosu exports HOME from that entry. Libraries that cache
+# under $HOME (Simyan, Mokkari) then fail with EACCES. See issue #396.
+# Only manage real per-user homes — never touch /, /root or /nonexistent.
+USER_HOME="$(getent passwd "${PUID}" 2>/dev/null | cut -d: -f6 || true)"
+case "${USER_HOME:-}" in
+  /home/?*) HOME_DIR="${USER_HOME}" ;;
+  *)        HOME_DIR="" ;;
+esac
+
 # Directories the app writes to (safe to chown lazily)
-for d in /app/logs /app/static /config; do
+for d in /app/logs /app/static /config ${HOME_DIR}; do
   mkdir -p "$d"
   # Only fix ownership if needed to avoid slow recursive chown every start
   if [ -e "$d" ]; then

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -11,7 +11,9 @@ from typing import Optional, Dict, List, Any
 import os
 import shutil
 import re
+import tempfile
 import time
+from pathlib import Path
 from cbz_ops.rename import rename_comic_from_metadata
 
 try:
@@ -36,29 +38,61 @@ def _get_cv_request_timeout() -> int:
 CV_REQUEST_TIMEOUT = _get_cv_request_timeout()
 
 
+def _cv_cache_dir() -> str:
+    """Writable directory for Simyan's cache/ratelimit SQLite files.
+
+    Simyan 3.x always caches and defaults to ``$HOME/.cache``, which doesn't exist
+    for the container's non-root user and can't be created by it (issue #396).
+    Mirrors Simyan's own resolution order, falling back to a temp dir if the
+    preferred location isn't writable.
+    """
+    from core.config import CONFIG_DIR
+
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.join(CONFIG_DIR, ".cache")
+    target = os.path.join(base, "simyan")
+    try:
+        os.makedirs(target, exist_ok=True)
+        return target
+    except OSError:
+        fallback = os.path.join(tempfile.gettempdir(), "clu-simyan")
+        os.makedirs(fallback, exist_ok=True)
+        app_logger.warning(
+            f"ComicVine cache dir {target} not writable; using {fallback}"
+        )
+        return fallback
+
+
 def _make_cv_client(api_key: str):
     """Construct a Simyan ComicVine client with an explicit request timeout.
 
     Handles both the modern and legacy Simyan constructor signatures:
 
-    * Modern Simyan (2.x) accepts ``user_agent`` and no longer takes a ``cache``
+    * Modern Simyan (3.x) accepts ``user_agent`` and no longer takes a ``cache``
       argument (caching is configured via ``cache_path``). Passing ``cache=None``
       to it raises ``TypeError``.
     * Legacy Simyan accepts ``cache`` but not ``user_agent``; there the browser
-      User-Agent is patched onto the underlying session instead.
+      User-Agent is patched onto the underlying session instead, and ``cache=None``
+      disables caching so no cache directory is needed.
 
     A browser-like User-Agent is set either way so ComicVine (fronted by
     Cloudflare) doesn't reject the default ``Simyan/x`` User-Agent with a 403
     from some hosts.
+
+    Both ``cache_path`` and ``ratelimit_path`` must be passed: each defaults to
+    ``get_cache_root() / ...``, which creates a directory under ``$HOME``. Passing
+    both short-circuits that and keeps the client independent of ``$HOME``.
     """
     from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
 
     # Modern Simyan: no `cache` kwarg, native `user_agent` support.
     try:
+        cache_dir = Path(_cv_cache_dir())
         return Comicvine(
             api_key=api_key,
             timeout=CV_REQUEST_TIMEOUT,
             user_agent=DEFAULT_PROVIDER_USER_AGENT,
+            cache_path=cache_dir / "cache.sqlite",
+            ratelimit_path=cache_dir / "ratelimits.sqlite",
         )
     except TypeError:
         pass

--- a/tests/mocked/test_comicvine_provider.py
+++ b/tests/mocked/test_comicvine_provider.py
@@ -1,4 +1,5 @@
 """Tests for ComicVineProvider adapter -- mocked Simyan/ComicVine."""
+import os
 import sys
 import pytest
 from unittest.mock import patch, MagicMock
@@ -88,6 +89,47 @@ class TestMakeCvClientUserAgent:
         fallback_client._session.headers.update.assert_called_once_with(
             {"User-Agent": DEFAULT_PROVIDER_USER_AGENT}
         )
+
+
+class TestMakeCvClientCachePaths:
+    """Simyan 3.x always caches and defaults both cache_path and ratelimit_path to
+    get_cache_root(), which mkdirs under $HOME. The container's non-root user has no
+    $HOME, so that raises PermissionError and disables ComicVine (issue #396).
+    Passing BOTH paths is what stops get_cache_root() being called at all."""
+
+    def test_passes_both_cache_paths_under_xdg_cache_home(self, tmp_path, monkeypatch):
+        import models.comicvine as cv
+
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+        with patch.object(cv, "Comicvine", create=True) as mock_cv:
+            cv._make_cv_client("KEY")
+
+        _, kwargs = mock_cv.call_args
+        expected_dir = tmp_path / "simyan"
+        # Both are required — a default on either one reaches get_cache_root()/$HOME.
+        assert kwargs.get("cache_path") == expected_dir / "cache.sqlite"
+        assert kwargs.get("ratelimit_path") == expected_dir / "ratelimits.sqlite"
+        # Simyan does not create parent dirs itself.
+        assert expected_dir.is_dir()
+
+    def test_falls_back_to_tempdir_when_cache_dir_unwritable(self, monkeypatch):
+        """An unwritable config dir must not take ComicVine down with it."""
+        import models.comicvine as cv
+
+        real_makedirs = os.makedirs
+
+        def fake_makedirs(path, *args, **kwargs):
+            if "clu-simyan" not in str(path):
+                raise OSError(13, "Permission denied")
+            return real_makedirs(path, *args, **kwargs)
+
+        monkeypatch.setenv("XDG_CACHE_HOME", "/nonexistent-unwritable")
+        monkeypatch.setattr(cv.os, "makedirs", fake_makedirs)
+
+        result = cv._cv_cache_dir()
+        assert "clu-simyan" in result
+        assert os.path.isdir(result)
 
 
 class TestComicVineProviderTestConnection:


### PR DESCRIPTION
Follow-up to #398, addressing item 3 of [this comment](https://github.com/allaboutduncan/clu-comics/issues/396#issuecomment-4976851656) on #396. (Item 1 — the version prompt — is out of scope. Item 2 is deferred; see below.)

## Problem

```
ERROR - Failed to initialize ComicVine client: [Errno 13] Permission denied: '/home/cluser'
```

The key is saved, but the API test always fails.

## Root cause

1. `entrypoint.sh` creates the user with **`useradd -M`**, which records `/home/cluser` in the passwd entry (`cluser:x:568:568::/home/cluser:/usr/sbin/nologin`) but **never creates the directory**. Nothing else in the image creates it, and `HOME`/`XDG_CACHE_HOME` were never set.
2. **`gosu` exports `HOME=/home/cluser`** from that passwd entry into the app process — a directory that has never existed.
3. Simyan 3.x's `get_cache_root()` does `folder.mkdir(parents=True, exist_ok=True)` under `$HOME/.cache/simyan`. `/home` is `root:root 755`, so uid 568 gets `EACCES`.
4. `models/providers/comicvine_provider.py:46` **swallows** the exception and returns `None`, so ComicVine silently stops working.

**This is a regression from #398.** Dropping `cache=None` (which *disabled* caching on Simyan 2.x) let 3.x fall back to its home-based cache default. Simyan 3.x **always** builds a `CachedLimiterSession` — caching can't be disabled — so it must be given a writable path.

### Why this wasn't reproducible

The failure mode is **inverted**. If any mount isn't writable by PUID/PGID, the entrypoint's `can_write` probe sets `NEED_ROOT=1` and execs as **root**, where `HOME=/root` exists and everything works. Users who configure PUID/PGID **correctly** take the `gosu` path and hit the bug. `568` isn't special — the home dir is missing for every PUID.

## Changes — three complementary layers

- **`entrypoint.sh`** — create + chown the app user's home, reusing the existing chown loop. Derived from the passwd entry rather than hardcoded, and **guarded to real `/home/*` paths** so a passwd home of `/` or `/nonexistent` (e.g. `nobody`) can never trigger a recursive chown of `/`. Makes the reporter's workaround permanent and survives container recreation.
- **`Dockerfile`** — `XDG_CACHE_HOME=/config/.cache` (already chowned by the entrypoint and a mounted volume, so caches persist). Simyan's `get_cache_root()` honours it natively, which also covers **Mokkari/Metron** (`models/metron.py:103`), the same latent bug. Plus `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright` before `playwright install`, so browsers aren't stranded in root's HOME at build time.
- **`models/comicvine.py`** — pass explicit `cache_path` **and** `ratelimit_path`. Both are required: each defaults to `get_cache_root() / …`, so passing both short-circuits it and keeps the client independent of `$HOME`. Falls back to a temp dir if the preferred location isn't writable.

## Verification

Verified against the **real simyan 3.0.0** by spying on `get_cache_root` — the function that mkdirs under `$HOME`:

```
get_cache_root calls = 0        <- the exact bug condition, gone
cache dir            = <XDG_CACHE_HOME>/simyan  (created, cache.sqlite present)
User-Agent           = Mozilla/5.0 ... Chrome/120  (preserved from #397)
```

- New regression tests assert **both** cache kwargs are passed under `XDG_CACHE_HOME` and that the dir is created, plus the unwritable-dir fallback. Passing both is precisely what stops `get_cache_root()` being reached.
- `bash -n entrypoint.sh` passes; the `/home/*` guard is unit-simulated against `/`, `/nonexistent` and empty.
- Full suite: **2039 passing**, only the 13 known env-only `test_pdf.py` failures (`pdf2image` not installed locally).

⚠️ **Not verified in a container** — the Docker daemon isn't running on my machine, so I could not do the end-to-end `docker run -e PUID=568 -e PGID=568` check. Unlike previous rounds this bug **is** locally reproducible that way, so it's worth doing before merge:

```sh
docker exec <c> ls -la /home/cluser      # must exist, owned 568:568
docker exec <c> printenv XDG_CACHE_HOME  # /config/.cache
```
then save a ComicVine key and hit **Test** — no `[Errno 13]` in the logs. PUID/PGID must match the mount ownership, or the entrypoint falls back to root and masks the bug.

## Item 2 still open

`Error loading providers: Server returned a non-JSON response (HTTP 200)` is **not** addressed here and wasn't root-caused: `/api/providers` is defined once, always returns `jsonify`, there's no catch-all route, no service worker, and auth is off in their compose — a 200 with a non-JSON body should be unreachable. Per the plan, re-test after this lands.

Also note their screenshot shows a **direct** `192.168.1.185:5577` connection, so the current *"If CLU is behind a reverse proxy…"* hint is misleading and should be softened when we revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)