### PR TITLE
Keep Missing XML view and pagination after single-file metadata fetch

### DIFF
--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -125,6 +125,16 @@ function getFilteredItems() {
 }
 
 /**
+ * Pull currentPage back into range after items are removed from allItems,
+ * so emptying the last page falls back to the new last page instead of
+ * rendering a blank grid with no pagination controls.
+ */
+function clampCurrentPage() {
+    const totalPages = Math.max(1, Math.ceil(getFilteredItems().length / itemsPerPage));
+    if (currentPage > totalPages) currentPage = totalPages;
+}
+
+/**
  * Get the paths of folder items currently visible on the active page.
  * @returns {Array<string>} Paths for the current page's folder items
  */
@@ -2900,15 +2910,21 @@ function fetchMetadataCollection(filePath, fileName) {
     window._cluMetadata = {
         getLibraryId: function () { return null; },
         onMetadataFound: function (fp, data) {
+            // The rename below resolves after this handler returns, so latch the
+            // mode now rather than reading the global from inside the callback.
+            const inMissingXmlMode = isMissingXmlMode;
             // Apply the user's custom-rename pattern, mirroring the Files page.
             // The metadata fetch only writes ComicInfo.xml; renaming is client-driven.
             CLU.maybeRenameAfterMetadata(filePath, fileName, data, function () {
-                loadDirectory(currentPath, true);
+                // Missing XML mode already dropped the item locally; reloading the
+                // directory here would drop out of the view and reset pagination.
+                if (!inMissingXmlMode) loadDirectory(currentPath, true);
             });
             refreshThumbnail(filePath);
-            if (isMissingXmlMode) {
+            if (inMissingXmlMode) {
                 const index = allItems.findIndex(i => i.path === filePath);
                 if (index !== -1) allItems.splice(index, 1);
+                clampCurrentPage();
                 renderPage();
             } else {
                 loadDirectory(currentPath, true);


### PR DESCRIPTION
## Problem

From the Missing XML view, using a grid item's **Fetch Metadata** action would kick you back to the folder listing and lose your place in the paginated list once the metadata was applied.

## Cause

`fetchMetadataCollection` already handled this view correctly (#313): it removes the file from `allItems` and re-renders in place, keeping the current page. But the auto-rename callback added in #347 passed an unconditional `loadDirectory(currentPath, true)` as its on-renamed handler. That callback fires from a separate `POST /rename` promise after the handler returns, and `loadDirectory` resets `isMissingXmlMode` — so the view snapped back to the folder listing. It only triggers when rename is configured with `auto_rename` on, which is why it looks intermittent.

## Fix

`static/js/collection.js`:

- Skip the reload in the rename callback when the fetch started in Missing XML mode. The item is already removed from `allItems` locally, so there is nothing stale left to reload for; the folder view still reloads as before.
- Latch the mode into `inMissingXmlMode` at the top of the handler instead of reading the global from inside the callback, since the callback runs after an async gap.
- Add `clampCurrentPage()`, called after the splice. Removing the only item on the last page left `currentPage` past the end: the grid rendered an empty slice and `renderPagination` hid the controls entirely because the remaining count now fit on one page. This was a second, independent way to lose pagination.

The other reload paths in this view (`bulkFetchMetadata`, the refresh button) go through `refreshCurrentView(true, true)`, which already routes to `loadMissingXml(true)` and preserves the page — left alone.

## Verification

- `node --check static/js/collection.js` passes.
- `pytest`: 2039 passed, with the 13 known `tests/mocked/test_pdf.py` failures that are pre-existing locally (missing `pdf2image`) and unrelated to this change.
- No JS test harness exists in the repo (no `package.json`/jest/vitest), so there is no test to add for this JS-only change; no `routes/` or `cbz_ops/` code is touched.

Traced by reading the code rather than driving the UI — worth a quick manual pass with auto-rename enabled to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
