### PR TITLE
Respect download provider priority; stop mislabelling Pixeldrain

### DIFF
--- a/api.py
+++ b/api.py
@@ -26,6 +26,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 # Application logging and configuration (adjust these as needed)
+from models.getcomics import provider_label, is_unresolved_gc_redirect
 from core.app_logging import MONITOR_LOG
 from core.config import config, load_config, load_flask_config
 
@@ -91,14 +92,35 @@ basic_headers = {
     )
 }
 
+def _make_gc_scraper():
+    """Build a fresh cloudscraper session for getcomics.org.
+
+    A stale or blocked Cloudflare clearance token poisons every subsequent
+    request made through the same session, so challenged requests must retry on
+    a brand-new scraper rather than reuse the shared one below. requests.Session
+    is also not thread-safe, and the download queue resolves URLs from worker
+    threads.
+    """
+    return cloudscraper.create_scraper(
+        browser={
+            'browser': 'chrome',
+            'platform': 'windows',
+            'desktop': True
+        }
+    )
+
+
 # Cloudscraper instance for bypassing Cloudflare protection on getcomics.org
-gc_scraper = cloudscraper.create_scraper(
-    browser={
-        'browser': 'chrome',
-        'platform': 'windows',
-        'desktop': True
-    }
-)
+gc_scraper = _make_gc_scraper()
+
+
+def _is_cloudflare_challenge(resp) -> bool:
+    """True if *resp* is a Cloudflare interstitial rather than the real page."""
+    if resp.status_code not in (403, 429, 503):
+        return False
+    server = (resp.headers.get('Server') or '').lower()
+    return 'cloudflare' in server
+
 
 # Allow cross-origin requests.
 CORS(app, resources={r"/*": {"origins": "*"}})
@@ -114,36 +136,69 @@ def resolve_final_url(url: str, *, hdrs=headers, max_hops: int = 6) -> str:
     headers or a tiny bit of the HTML.
 
     Uses cloudscraper for getcomics.org URLs to bypass Cloudflare protection.
+    A challenged or failed getcomics hop is retried once on a fresh scraper --
+    resolution failing here is not cosmetic: it leaves a tokenized /dls/ URL
+    that no provider branch matches, so the caller would mislabel and misroute
+    the download.
     """
+    global gc_scraper
+
     current = url
     for _ in range(max_hops):
-        try:
-            # Use cloudscraper for getcomics.org URLs to bypass Cloudflare
-            if 'getcomics.org' in current.lower():
-                r = gc_scraper.get(current, allow_redirects=False, timeout=30)
-            else:
-                try:
-                    r = requests.head(current, headers=hdrs,
-                                      allow_redirects=False, timeout=15)
-                except requests.RequestException:
-                    # some hosts block HEAD → fall back to a very small GET
-                    r = requests.get(current, headers=hdrs, stream=True,
-                                     allow_redirects=False, timeout=15)
-        except Exception as e:
-            monitor_logger.warning(f"Error resolving URL {current}: {e}")
+        is_gc = 'getcomics.org' in current.lower()
+        r = None
+
+        for attempt in (1, 2):
+            try:
+                if is_gc:
+                    # Use cloudscraper for getcomics.org URLs to bypass Cloudflare
+                    r = gc_scraper.get(current, allow_redirects=False, timeout=30)
+                    if _is_cloudflare_challenge(r) and attempt == 1:
+                        monitor_logger.warning(
+                            f"Cloudflare challenge resolving {current} — retrying on a fresh scraper"
+                        )
+                        gc_scraper = _make_gc_scraper()
+                        continue
+                else:
+                    try:
+                        r = requests.head(current, headers=hdrs,
+                                          allow_redirects=False, timeout=15)
+                    except requests.RequestException:
+                        # some hosts block HEAD → fall back to a very small GET
+                        r = requests.get(current, headers=hdrs, stream=True,
+                                         allow_redirects=False, timeout=15)
+                break
+            except Exception as e:
+                if is_gc and attempt == 1:
+                    monitor_logger.warning(
+                        f"Error resolving URL {current}: {e} — retrying on a fresh scraper"
+                    )
+                    gc_scraper = _make_gc_scraper()
+                    continue
+                monitor_logger.warning(f"Error resolving URL {current}: {e}")
+                return current
+
+        if r is None:
+            monitor_logger.warning(f"Could not resolve URL {current}")
             return current
 
         # Ordinary HTTP 3xx
         if 300 <= r.status_code < 400 and 'location' in r.headers:
             current = urljoin(current, r.headers['location'])
             continue
-        # Meta-refresh (GetComics' /dlds pages)
-        if ('text/html' in r.headers.get('content-type', '') and
+        # Meta-refresh (GetComics' /dlds pages). Skip on a Cloudflare
+        # interstitial, whose markup can carry a bogus url= we'd chase.
+        if (not _is_cloudflare_challenge(r) and
+                'text/html' in r.headers.get('content-type', '') and
                 b'<meta' in r.content[:2048]):
             m = re.search(br'url=([^">]+)', r.content[:2048], flags=re.I)
             if m:
                 current = urljoin(current, m.group(1).decode().strip())
                 continue
+        if _is_cloudflare_challenge(r):
+            monitor_logger.warning(
+                f"Cloudflare still blocking {current} (HTTP {r.status_code}) — returning unresolved"
+            )
         return current
     return current        # give up after max_hops
 
@@ -191,8 +246,10 @@ def process_download(task):
         except Exception as e:
             monitor_logger.error(f"Error updating weekly pack status to downloading: {e}")
 
-    # Build list of URLs to try: primary first, then fallbacks
-    urls_to_try = [("primary", original_url)] + list(fallback_urls)
+    # Build list of URLs to try: primary first, then fallbacks. The primary
+    # carries the provider key the configured priority actually chose (absent
+    # for external/browser-extension downloads, which never ran selection).
+    urls_to_try = [(task.get('provider'), original_url)] + list(fallback_urls)
     last_error = None
 
     for attempt_idx, (provider_name, try_url) in enumerate(urls_to_try):
@@ -214,24 +271,34 @@ def process_download(task):
                 final_url = resolve_final_url(try_url, hdrs=use_headers)
             monitor_logger.info(f"Resolved → {final_url} (internal={internal})")
 
+            # getcomics wraps every provider's button in an indistinguishable
+            # /dls/<token> redirector, so an unresolved link tells us nothing
+            # about its provider. Downloading it here would fetch the provider's
+            # HTML page via the wrong handler and report the wrong provider —
+            # fail instead so the loop fails over to the next candidate.
+            if is_unresolved_gc_redirect(final_url):
+                raise RuntimeError(
+                    f"Could not resolve getcomics redirect for provider "
+                    f"'{provider_name or 'unknown'}': {final_url}"
+                )
+
+            # Prefer the provider the priority order chose; only fall back to
+            # sniffing the resolved URL when no key came with the task.
+            download_progress[download_id]['provider'] = provider_label(provider_name, final_url)
+
             if "pixeldrain.com" in final_url:
-                download_progress[download_id]['provider'] = 'pixeldrain'
                 monitor_logger.debug(f"Routing to: download_pixeldrain")
                 file_path = download_pixeldrain(final_url, download_id, dest_filename, hdrs=use_headers)
             elif "comicbookplus.com" in final_url:
-                download_progress[download_id]['provider'] = 'comicbookplus'
                 monitor_logger.debug(f"Routing to: download_comicbookplus")
                 file_path = download_comicbookplus(final_url, download_id, dest_filename, hdrs=use_headers)
             elif "comicfiles.ru" in final_url:              # GetComics' direct host
-                download_progress[download_id]['provider'] = 'getcomics'
                 monitor_logger.debug(f"Routing to: download_getcomics (comicfiles.ru)")
                 file_path = download_getcomics(final_url, download_id, hdrs=use_headers, source_url=(source_page_url or try_url))
             elif "mega.nz" in final_url or "mega.co.nz" in final_url:  # MEGA
-                download_progress[download_id]['provider'] = 'mega'
                 monitor_logger.debug(f"Routing to: download_mega")
                 file_path = download_mega(final_url, download_id, dest_filename, hdrs=use_headers)
             else:                                           # fall-back
-                download_progress[download_id]['provider'] = 'getcomics'
                 monitor_logger.debug(f"Routing to: download_getcomics (fallback)")
                 file_path = download_getcomics(final_url, download_id, hdrs=use_headers, source_url=(source_page_url or try_url))
 

--- a/app.py
+++ b/app.py
@@ -968,6 +968,8 @@ def scheduled_getcomics_download(dry_run=False):
             score_getcomics_result,
             accept_result,
             get_series_alias_list,
+            select_download_url,
+            PROVIDER_LABELS,
         )
         from api import download_queue, download_progress
         from datetime import date
@@ -1248,13 +1250,9 @@ def scheduled_getcomics_download(dry_run=False):
                         "DOWNLOAD_PROVIDER_PRIORITY",
                         fallback="pixeldrain,download_now,mega",
                     )
-                    priority_order = [
-                        p.strip() for p in priority_str.split(",") if p.strip()
-                    ]
-                    available = [(p, links[p]) for p in priority_order if links.get(p)]
-
-                    download_url = available[0][1] if available else None
-                    fallback_urls = available[1:] if len(available) > 1 else []
+                    (primary_provider, download_url), fallback_urls = select_download_url(
+                        links, priority_str
+                    )
 
                     if dry_run:
                         if best_accept:
@@ -1318,7 +1316,7 @@ def scheduled_getcomics_download(dry_run=False):
                             "status": "queued",
                             "filename": filename,
                             "error": None,
-                            "provider": None,
+                            "provider": PROVIDER_LABELS.get(primary_provider),
                         }
 
                         # Queue task (same structure as manual download)
@@ -1328,6 +1326,15 @@ def scheduled_getcomics_download(dry_run=False):
                             "dest_filename": filename,
                             "internal": True,
                             "fallback_urls": fallback_urls,
+                            # The provider priority already chose this link, so pass the
+                            # key through rather than letting api.py re-derive it from the
+                            # resolved URL — getcomics wraps every provider's button in an
+                            # indistinguishable /dls/ redirector.
+                            "provider": primary_provider,
+                            # Surfaced as the manual-download link if every mirror is
+                            # Cloudflare-protected — the post page lets the browser
+                            # establish the session/referrer the mirrors require.
+                            "page_url": best_result["link"],
                         }
                         download_queue.put(task)
 

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -747,6 +747,83 @@ def _extract_download_links(root) -> dict:
     return links
 
 
+# Maps a provider key (as used in DOWNLOAD_PROVIDER_PRIORITY and the dicts
+# returned by _extract_download_links) to the label the download status UI
+# shows. "download_now" is GetComics' own main server.
+PROVIDER_LABELS = {
+    "pixeldrain": "pixeldrain",
+    "download_now": "getcomics",
+    "mega": "mega",
+}
+
+
+def is_unresolved_gc_redirect(url: str) -> bool:
+    """True if *url* is still a getcomics ``/dls/`` or ``/dlds/`` redirector.
+
+    These tokenized links front every provider (Pixeldrain, the main server,
+    Mega) behind identical-looking URLs, so one that never resolved cannot be
+    routed to a downloader or attributed to a provider.
+    """
+    from urllib.parse import urlparse
+    try:
+        parts = urlparse(url)
+    except ValueError:
+        return False
+    if not _host_matches(url, "getcomics.org"):
+        return False
+    return parts.path.startswith(("/dls/", "/dlds/"))
+
+
+def provider_from_url(final_url: str) -> str:
+    """Infer the status-UI provider label from a *resolved* download URL.
+
+    Only a fallback for downloads that arrive without a provider key (external
+    / browser-extension requests, which never ran the priority selection).
+    Deliberately kept in lockstep with the routing branches in
+    ``api.process_download`` -- using stricter host matching here than the
+    routing uses would let the reported provider contradict the handler that
+    actually ran.
+    """
+    if "pixeldrain.com" in final_url:
+        return "pixeldrain"
+    if "comicbookplus.com" in final_url:
+        return "comicbookplus"
+    if "mega.nz" in final_url or "mega.co.nz" in final_url:
+        return "mega"
+    return "getcomics"
+
+
+def provider_label(provider_key, final_url: str) -> str:
+    """Label to show in the download status UI.
+
+    Prefers the provider the configured priority actually chose. Falls back to
+    sniffing the resolved URL only when no key is available -- getcomics wraps
+    every provider's button in an indistinguishable ``/dls/`` redirector, so the
+    URL alone is not a reliable signal.
+    """
+    return PROVIDER_LABELS.get(provider_key) or provider_from_url(final_url)
+
+
+def select_download_url(links: dict, priority_str: str):
+    """Pick the highest-priority link the post actually offers.
+
+    Providers absent from *priority_str* are never used, even when the post has
+    that link.
+
+    Args:
+        links: dict from :func:`_extract_download_links` (provider key -> URL or None).
+        priority_str: comma-separated provider keys, highest priority first.
+
+    Returns:
+        ``((provider_key, url), fallbacks)`` where *fallbacks* is the remaining
+        ``(provider_key, url)`` pairs in priority order. The winner is
+        ``(None, None)`` when no configured provider is available.
+    """
+    order = [p.strip() for p in (priority_str or "").split(",") if p.strip()]
+    available = [(p, links[p]) for p in order if links.get(p)]
+    return (available[0] if available else (None, None)), available[1:]
+
+
 def _looks_like_rendered_post(soup) -> bool:
     """True if the page looks like a fully-rendered getcomics post.
 

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -27,6 +27,8 @@ from models.getcomics import (
     score_getcomics_result,
     accept_result,
     get_series_alias_list,
+    select_download_url,
+    PROVIDER_LABELS,
 )
 from helpers.collection import match_issues_to_collection
 from models.issue import IssueObj, SeriesObj
@@ -78,6 +80,7 @@ def api_getcomics_search():
 @downloads_bp.route('/api/getcomics/download', methods=['POST'])
 def api_getcomics_download():
     """Get download link from getcomics page and queue download."""
+    # Imported lazily so tests can patch models.getcomics.get_download_links.
     from models.getcomics import get_download_links
     from api import download_queue, download_progress
     from core.config import config
@@ -95,16 +98,10 @@ def api_getcomics_download():
         # Get provider priority from config
         priority_str = config.get("SETTINGS", "DOWNLOAD_PROVIDER_PRIORITY",
                                    fallback="pixeldrain,download_now,mega")
-        priority_order = [p.strip() for p in priority_str.split(",") if p.strip()]
+        (primary_provider, download_url), fallback_urls = select_download_url(links, priority_str)
 
-        # Build ordered list of available (provider, url) pairs
-        available = [(p, links[p]) for p in priority_order if links.get(p)]
-
-        if not available:
+        if not download_url:
             return jsonify({"success": False, "error": "No download link found"}), 404
-
-        primary_provider, download_url = available[0]
-        fallback_urls = available[1:]
 
         # Queue download using existing system
         download_id = str(uuid.uuid4())
@@ -116,7 +113,7 @@ def api_getcomics_download():
             'status': 'queued',
             'filename': filename,
             'error': None,
-            'provider': None,
+            'provider': PROVIDER_LABELS.get(primary_provider),
             'manual_url': None,
         }
         task = {
@@ -125,6 +122,11 @@ def api_getcomics_download():
             'dest_filename': filename,
             'internal': True,
             'fallback_urls': fallback_urls,
+            # The provider priority already chose this link, so pass the key
+            # through rather than letting api.py re-derive it from the resolved
+            # URL — getcomics wraps every provider's button in an
+            # indistinguishable /dls/ redirector.
+            'provider': primary_provider,
             # Surfaced as the manual-download link if every mirror is
             # Cloudflare-protected — the post page lets the browser establish
             # the session/referrer the mirrors require.
@@ -287,9 +289,7 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
                 else:
                     links = get_download_links(best_result["link"])
                 priority_str = config.get("SETTINGS", "DOWNLOAD_PROVIDER_PRIORITY", fallback="pixeldrain,download_now,mega")
-                priority_order = [p.strip() for p in priority_str.split(",") if p.strip()]
-                available = [(p, links[p]) for p in priority_order if links.get(p)]
-                download_url = available[0][1] if available else None
+                (_primary_provider, download_url), _fallback_urls = select_download_url(links, priority_str)
 
                 if best_accept:
                     best_accept_data = {

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -66,6 +66,22 @@ DOWNLOAD_NO_LINKS_HTML = """\
 </body></html>
 """
 
+# Current getcomics layout (Nightwing #140 style): every provider's button is a
+# tokenized getcomics.org/dls/ redirector, so the hrefs are indistinguishable --
+# only the title/text names the provider. Pixeldrain sits on aio-orange, which
+# the aio-red/aio-blue tier does not match, and unsupported providers are mixed
+# in. Regression guard: the provider must still be identified from the label.
+DOWNLOAD_LINKS_DLS_WRAPPED_HTML = """\
+<html><body>
+<a rel="nofollow" href="https://getcomics.org/dls/MAINTOKEN==:abc==" class="aio-red" title="DOWNLOAD NOW"><i></i>DOWNLOAD NOW</a>
+<a href="https://1024terabox.com/s/1I-4GNpnIlcwrO5DGscBIwg" class="aio-blue" title="TERABOX"><i></i>TERABOX</a>
+<a href="https://vikingfile.com/f/pTPOtm5Aks" class="aio-purple" title="VIKINGFILE"><i></i>VIKINGFILE</a>
+<a rel="nofollow" href="https://getcomics.org/dls/PDTOKEN==:xyz==" class="aio-orange" title="PIXELDRAIN"><i></i>PIXELDRAIN</a>
+<a href="https://datanodes.to/mlz81n23h1b8/Nightwing_140.cbz" class="aio-gray" title="DATANODES"><i></i>DATANODES</a>
+<a href="https://readcomicsonline.ru/comic/nightwing-2016/140" class="aio-red" title="READ ONLINE"><i></i>READ ONLINE</a>
+</body></html>
+"""
+
 # A fully-rendered post whose only mirrors are providers CLU can't download.
 DOWNLOAD_ONLY_UNSUPPORTED_HTML = """\
 <html><body>
@@ -444,6 +460,155 @@ LI_PAGE_WITH_NAV_AD_HTML = """\
 <footer><ul><li><a href="https://ads.example.com/promo">Buy Premium Now Today</a></li></ul></footer>
 </body></html>
 """
+
+
+class TestDlsWrappedProviderDetection:
+    """getcomics fronts every provider with an identical /dls/ redirector.
+
+    The href is therefore useless for identifying a provider -- only the
+    label is. Regression guard for downloads being attributed to GetComics
+    when the post had a Pixeldrain link.
+    """
+
+    @patch("models.getcomics.scraper")
+    def test_extracts_dls_wrapped_links_by_label(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_LINKS_DLS_WRAPPED_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/dc/nightwing-140-2026")
+
+        # Both are getcomics.org/dls/ URLs -- only the title tells them apart.
+        assert links["pixeldrain"] == "https://getcomics.org/dls/PDTOKEN==:xyz=="
+        assert links["download_now"] == "https://getcomics.org/dls/MAINTOKEN==:abc=="
+        assert links["mega"] is None
+
+    @patch("models.getcomics.scraper")
+    def test_dls_wrapped_pixeldrain_wins_over_getcomics(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_LINKS_DLS_WRAPPED_HTML)
+
+        from models.getcomics import get_download_links, select_download_url
+        links = get_download_links("https://getcomics.org/dc/nightwing-140-2026")
+        (provider, url), fallbacks = select_download_url(links, "pixeldrain,download_now,mega")
+
+        assert provider == "pixeldrain"
+        assert url == "https://getcomics.org/dls/PDTOKEN==:xyz=="
+        assert fallbacks == [("download_now", "https://getcomics.org/dls/MAINTOKEN==:abc==")]
+
+    @patch("models.getcomics.scraper")
+    def test_unsupported_providers_ignored(self, mock_scraper):
+        """Terabox/Vikingfile/Datanodes/Read Online must not leak into a slot."""
+        mock_scraper.get.return_value = _mock_response(DOWNLOAD_LINKS_DLS_WRAPPED_HTML)
+
+        from models.getcomics import get_download_links
+        links = get_download_links("https://getcomics.org/dc/nightwing-140-2026")
+
+        assert set(links) == {"pixeldrain", "download_now", "mega"}
+        for url in links.values():
+            assert url is None or "terabox" not in url
+            assert url is None or "vikingfile" not in url
+            assert url is None or "datanodes" not in url
+
+
+class TestSelectDownloadUrl:
+
+    def test_respects_configured_priority(self):
+        from models.getcomics import select_download_url
+        links = {
+            "pixeldrain": "https://pixeldrain.com/u/pd",
+            "download_now": "https://getcomics.org/dls/dn",
+            "mega": "https://mega.nz/file/mg",
+        }
+
+        (provider, url), fallbacks = select_download_url(links, "pixeldrain,download_now,mega")
+        assert (provider, url) == ("pixeldrain", "https://pixeldrain.com/u/pd")
+        assert [p for p, _ in fallbacks] == ["download_now", "mega"]
+
+    def test_reordered_priority_changes_winner(self):
+        from models.getcomics import select_download_url
+        links = {
+            "pixeldrain": "https://pixeldrain.com/u/pd",
+            "download_now": "https://getcomics.org/dls/dn",
+            "mega": "https://mega.nz/file/mg",
+        }
+
+        (provider, _url), fallbacks = select_download_url(links, "mega,pixeldrain,download_now")
+        assert provider == "mega"
+        assert [p for p, _ in fallbacks] == ["pixeldrain", "download_now"]
+
+    def test_omitted_provider_never_used(self):
+        """A provider absent from the priority string is skipped even if present."""
+        from models.getcomics import select_download_url
+        links = {
+            "pixeldrain": "https://pixeldrain.com/u/pd",
+            "download_now": "https://getcomics.org/dls/dn",
+            "mega": None,
+        }
+
+        (provider, _url), fallbacks = select_download_url(links, "download_now")
+        assert provider == "download_now"
+        assert fallbacks == []
+
+    def test_skips_providers_the_post_lacks(self):
+        from models.getcomics import select_download_url
+        links = {"pixeldrain": None, "download_now": "https://getcomics.org/dls/dn", "mega": None}
+
+        (provider, url), fallbacks = select_download_url(links, "pixeldrain,download_now,mega")
+        assert (provider, url) == ("download_now", "https://getcomics.org/dls/dn")
+        assert fallbacks == []
+
+    def test_no_links_returns_none_pair(self):
+        from models.getcomics import select_download_url
+        (provider, url), fallbacks = select_download_url(
+            {"pixeldrain": None, "download_now": None, "mega": None},
+            "pixeldrain,download_now,mega",
+        )
+        assert (provider, url) == (None, None)
+        assert fallbacks == []
+
+    def test_tolerates_whitespace_and_empty_priority(self):
+        from models.getcomics import select_download_url
+        links = {"pixeldrain": "https://pixeldrain.com/u/pd", "download_now": None, "mega": None}
+
+        (provider, _url), _fb = select_download_url(links, " pixeldrain , download_now ")
+        assert provider == "pixeldrain"
+
+        assert select_download_url(links, "") == ((None, None), [])
+
+
+class TestProviderLabelling:
+
+    def test_label_prefers_the_chosen_provider_key(self):
+        """The key is what priority picked -- it must not be re-guessed."""
+        from models.getcomics import provider_label
+        assert provider_label("pixeldrain", "https://pixeldrain.com/u/abc") == "pixeldrain"
+        assert provider_label("download_now", "https://fs3.comicfiles.ru/x.cbz") == "getcomics"
+        assert provider_label("mega", "https://mega.nz/file/x") == "mega"
+
+    def test_label_falls_back_to_url_without_a_key(self):
+        """External/browser-extension downloads never ran priority selection."""
+        from models.getcomics import provider_label
+        assert provider_label(None, "https://pixeldrain.com/u/abc") == "pixeldrain"
+        assert provider_label(None, "https://mega.nz/file/x") == "mega"
+        assert provider_label(None, "https://comicbookplus.com/?dlid=1") == "comicbookplus"
+        assert provider_label(None, "https://fs3.comicfiles.ru/x.cbz") == "getcomics"
+
+    def test_unresolved_dls_redirect_detected(self):
+        from models.getcomics import is_unresolved_gc_redirect
+        assert is_unresolved_gc_redirect("https://getcomics.org/dls/TOKEN==:abc==")
+        assert is_unresolved_gc_redirect("https://getcomics.org/dlds/xyz")
+
+    def test_resolved_and_ordinary_urls_are_not_redirects(self):
+        from models.getcomics import is_unresolved_gc_redirect
+        # Successfully resolved to the real provider host.
+        assert not is_unresolved_gc_redirect("https://pixeldrain.com/u/8uSDFbt2")
+        assert not is_unresolved_gc_redirect("https://fs3.comicfiles.ru/x.cbz")
+        # The post page itself is not a download redirector.
+        assert not is_unresolved_gc_redirect("https://getcomics.org/dc/nightwing-140-2026/")
+
+    def test_redirect_check_is_not_spoofable_by_host(self):
+        from models.getcomics import is_unresolved_gc_redirect
+        assert not is_unresolved_gc_redirect("https://getcomics.org.evil.com/dls/token")
+        assert not is_unresolved_gc_redirect("https://evil.com/dls/?x=getcomics.org")
 
 
 class TestExtractContentLiEntries:

--- a/tests/routes/test_api_downloads.py
+++ b/tests/routes/test_api_downloads.py
@@ -1,38 +1,94 @@
-"""Tests for api.py -- download queue and status endpoints."""
+"""Tests for the download queue's provider selection, labelling and routing.
+
+api.py itself is deliberately not imported here: at import time it builds a
+Flask app, registers SIGINT/SIGTERM handlers, creates the download directory
+and starts three worker threads (see the note in tests/routes/conftest.py).
+The decision logic api.py depends on therefore lives in models/getcomics.py,
+which is side-effect free and covered directly below.
+
+Regression context: getcomics fronts every provider's button with an
+indistinguishable ``getcomics.org/dls/<token>`` redirector, so a download's
+provider cannot be inferred from its URL before resolution. Downloads with a
+Pixeldrain link were being reported (and downloaded) as GetComics.
+"""
 import pytest
-from unittest.mock import patch, MagicMock
+
+from models.getcomics import (
+    PROVIDER_LABELS,
+    is_unresolved_gc_redirect,
+    provider_label,
+    select_download_url,
+)
 
 
-class TestDownloadEndpoints:
+class TestProviderPrioritySelection:
 
-    def test_download_get_friendly(self, client):
-        """The GET endpoint for /download that api.py defines won't exist
-        on our test app, so we test the POST route via the blueprint approach.
-        These tests verify the download API routes defined in api.py.
-        Since api.py creates its own Flask app (with heavy side effects),
-        we test the core logic through direct function calls instead.
-        """
-        pass
+    def test_pixeldrain_beats_getcomics_when_configured_first(self):
+        links = {
+            "pixeldrain": "https://getcomics.org/dls/PDTOKEN",
+            "download_now": "https://getcomics.org/dls/MAINTOKEN",
+            "mega": None,
+        }
 
-    def test_resolve_final_url_returns_same_for_direct(self):
-        """Test the URL resolver with a simple direct URL."""
-        # We can test the pure function without Flask
-        pass
+        (provider, url), fallbacks = select_download_url(links, "pixeldrain,download_now,mega")
+
+        assert provider == "pixeldrain"
+        assert url == "https://getcomics.org/dls/PDTOKEN"
+        # The runner-up stays available for failover, in priority order.
+        assert fallbacks == [("download_now", "https://getcomics.org/dls/MAINTOKEN")]
+
+    def test_getcomics_used_only_when_pixeldrain_absent(self):
+        links = {"pixeldrain": None, "download_now": "https://getcomics.org/dls/MAINTOKEN", "mega": None}
+
+        (provider, _url), _fallbacks = select_download_url(links, "pixeldrain,download_now,mega")
+
+        assert provider == "download_now"
 
 
-class TestDownloadHelpers:
+class TestProviderLabelling:
+    """The label must reflect the provider priority chose, not a URL guess."""
 
-    def test_pd_id_extraction(self):
-        """Test PixelDrain ID extraction from URL."""
-        # Import directly since this is a pure function
-        import sys
-        # Only test if api module is safely importable
-        # (it has heavy side effects, so skip in most environments)
+    def test_dls_wrapped_pixeldrain_not_reported_as_getcomics(self):
+        # The exact regression: before resolution this URL is indistinguishable
+        # from the main-server link, and sniffing it yields "getcomics".
+        label = provider_label("pixeldrain", "https://getcomics.org/dls/PDTOKEN")
+        assert label == "pixeldrain"
 
-    def test_parse_total_from_headers_content_range(self):
-        """Test header parsing for resume support."""
-        pass
+    def test_resolved_pixeldrain_reported_as_pixeldrain(self):
+        assert provider_label("pixeldrain", "https://pixeldrain.com/u/8uSDFbt2") == "pixeldrain"
 
-    def test_parse_total_from_headers_content_length(self):
-        """Test header parsing with Content-Length."""
-        pass
+    def test_download_now_key_maps_to_getcomics_label(self):
+        # The config/priority key and the UI label differ by name.
+        assert PROVIDER_LABELS["download_now"] == "getcomics"
+        assert provider_label("download_now", "https://fs3.comicfiles.ru/x.cbz") == "getcomics"
+
+    def test_every_priority_key_has_a_status_ui_label(self):
+        # Guards against a new provider key that renders as a blank cell.
+        for key in ("pixeldrain", "download_now", "mega"):
+            assert PROVIDER_LABELS.get(key)
+
+    @pytest.mark.parametrize("url,expected", [
+        ("https://pixeldrain.com/u/abc", "pixeldrain"),
+        ("https://mega.nz/file/abc", "mega"),
+        ("https://comicbookplus.com/?dlid=1", "comicbookplus"),
+        ("https://fs3.comicfiles.ru/x.cbz", "getcomics"),
+    ])
+    def test_keyless_downloads_fall_back_to_url(self, url, expected):
+        # External/browser-extension downloads never ran priority selection.
+        assert provider_label(None, url) == expected
+
+
+class TestUnresolvedRedirectHandling:
+    """An unresolved /dls/ link must fail over, not download as GetComics."""
+
+    def test_unresolved_redirect_is_flagged(self):
+        assert is_unresolved_gc_redirect("https://getcomics.org/dls/PDTOKEN==:abc==")
+
+    def test_resolved_provider_url_is_not_flagged(self):
+        assert not is_unresolved_gc_redirect("https://pixeldrain.com/u/8uSDFbt2")
+        assert not is_unresolved_gc_redirect("https://fs3.comicfiles.ru/x.cbz")
+
+    def test_post_page_is_not_flagged(self):
+        # page_url is passed through as the Cloudflare escape hatch and must
+        # not be mistaken for an unresolved download redirect.
+        assert not is_unresolved_gc_redirect("https://getcomics.org/dc/nightwing-140-2026/")


### PR DESCRIPTION
## Problem

Running **Check for Missing Issues** from `templates/wanted.html` produced downloads that showed as **GetComics** on the status page even when the post had a Pixeldrain link and `DOWNLOAD_PROVIDER_PRIORITY` was `pixeldrain,download_now,mega`.

The label wasn't just cosmetic — the wrong downloader was running.

## Root cause

Verified against the live post `getcomics.org/dc/nightwing-140-2026/`.

GetComics now fronts **every** download button with a tokenized `getcomics.org/dls/<token>` redirector. The Pixeldrain and main-server hrefs are indistinguishable; only the button's `title`/text names the provider:

```html
<a href="https://getcomics.org/dls/IgWl7z5F..." class="aio-red"    title="DOWNLOAD NOW">DOWNLOAD NOW</a>
<a href="https://getcomics.org/dls/cq8+2/rc..." class="aio-orange" title="PIXELDRAIN">PIXELDRAIN</a>
```

1. **Priority selection was never broken.** Running the real `_extract_download_links()` against that page extracts both links correctly (Tier 1 matches `title="PIXELDRAIN"`) and the priority intersection returns `pixeldrain`.

2. **`process_download()` discarded that decision** and re-derived the provider by string-matching the *resolved* URL (`api.py:217-236`). When resolution succeeded the `/dls/` link resolved to `https://pixeldrain.com/u/8uSDFbt2` and it worked. When it failed, `final_url` stayed a `/dls/` URL, matched no branch, and fell to the catch-all — reporting `getcomics` **and** calling `download_getcomics()` instead of `download_pixeldrain()`, bypassing `PIXELDRAIN_API_KEY`.

3. **Why it failed persistently.** `models/getcomics.py` already documents that a stale Cloudflare clearance token "can poison every request made through a single session" and rebuilds a fresh scraper on challenge. `api.py` built `gc_scraper` **once at import, never refreshed it**, and swallowed every failure into a silent `return current`. In a long-running gunicorn container that session goes stale and resolution degrades permanently — hence *most* downloads.

## Changes

- **`models/getcomics.py`** — add `select_download_url()` + `PROVIDER_LABELS`, replacing the selection block copy-pasted across three call sites (`app.py`, and twice in `routes/downloads.py`).
- **Call sites** — thread the chosen provider key through the queued task so the reported provider is what priority picked, not a guess from the URL.
- **`api.py`** — raise on an unresolved `/dls/` link so the existing failover advances to the next provider instead of silently downloading through the wrong handler.
- **`api.py`** — harden `resolve_final_url`: detect Cloudflare interstitials, retry once on a fresh scraper, guard the meta-refresh regex against a bogus `url=`, and log unresolved failures instead of hiding them.
- **`app.py`** — add the missing `page_url` to the auto-download task. The manual path sets it as the Cloudflare escape hatch and `app.py` claimed to match that structure, but omitted it.

## Tests

`2061 passed` (was 2039), `13 failed` — all 13 are the pre-existing `test_pdf.py` failures from the missing `pdf2image` dep, byte-identical to the baseline captured before any edit.

- Replaced the six empty `pass` stubs in `tests/routes/test_api_downloads.py` with real coverage.
- Added a regression fixture mirroring the live Nightwing #140 page: both providers behind `/dls/` tokens, Pixeldrain on `aio-orange` (which the `aio-red`/`aio-blue` tier does *not* match), plus Terabox/Vikingfile/Datanodes noise.

`api.py` is deliberately still not imported by the suite — importing it registers SIGINT/SIGTERM handlers, starts three worker threads and creates the download dir, which `tests/routes/conftest.py` explicitly exists to avoid. The decision logic therefore lives in `models/getcomics.py`, which is side-effect free and covered directly.

## Notes for review

- **The Cloudflare-retry code inside `resolve_final_url` has no unit test**, for the import-side-effect reason above. It was verified by hand against the live URL.
- **`retry_download` rebuilds its task without the provider key or `fallback_urls`** — pre-existing and left alone. It still labels correctly via the URL fallback, and now errors honestly on an unresolvable link rather than fetching a provider's HTML page.

## Verification

With priority `pixeldrain,download_now,mega`, run **Check for Missing Issues** and confirm the status page shows the Pixeldrain icon. Logs should show `Resolved → https://pixeldrain.com/...` and `Routing to: download_pixeldrain` rather than `download_getcomics (fallback)`. A post with no Pixeldrain link must still download and correctly show GetComics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
