### PR TITLE
Fix Komga sync matching every book against the wrong filename

### DIFF
--- a/app.py
+++ b/app.py
@@ -1832,79 +1832,9 @@ def configure_weekly_packs_schedule():
 #########################
 
 
-def map_komga_path(komga_path, komga_prefix, clu_prefix):
-    """
-    Convert a Komga file path to a CLU file path using prefix mapping.
-
-    Example:
-        komga_path:   /comics/Marvel/Spider-Man 001.cbz
-        komga_prefix: /comics
-        clu_prefix:   /data
-        result:       /data/Marvel/Spider-Man 001.cbz
-    """
-    if not komga_prefix or not clu_prefix:
-        return komga_path
-
-    # Normalize path separators
-    komga_path = komga_path.replace("\\", "/")
-    komga_prefix = komga_prefix.rstrip("/").replace("\\", "/")
-    clu_prefix = clu_prefix.rstrip("/").replace("\\", "/")
-
-    if komga_path.startswith(komga_prefix):
-        relative = komga_path[len(komga_prefix) :]
-        return clu_prefix + relative
-
-    return komga_path
-
-
-def map_komga_path_multi(komga_path, mappings):
-    """
-    Try each library mapping; return first match or original path.
-    Mappings should be sorted by prefix length descending so longer prefixes match first.
-
-    Args:
-        komga_path: The file path as Komga sees it
-        mappings: List of dicts with 'komga_prefix' and 'clu_prefix'
-
-    Returns:
-        Mapped CLU path, or original path if no mapping matches
-    """
-    for m in mappings:
-        result = map_komga_path(komga_path, m["komga_prefix"], m["clu_prefix"])
-        if result != komga_path:
-            return result
-    return komga_path
-
-
-def find_clu_file_by_name(filename):
-    """
-    Search CLU's file_index for a file by exact filename.
-    Used as a fallback when Komga path mapping doesn't find a file.
-
-    Args:
-        filename: The filename to search for (e.g., 'Spider-Man 001.cbz')
-
-    Returns:
-        Matched CLU file path, or None
-    """
-    try:
-        conn = get_db_connection()
-        if not conn:
-            return None
-        c = conn.cursor()
-        c.execute(
-            """
-            SELECT path FROM file_index
-            WHERE name = ? AND type = 'file'
-            LIMIT 1
-        """,
-            (filename,),
-        )
-        row = c.fetchone()
-        conn.close()
-        return row["path"] if row else None
-    except Exception:
-        return None
+# Cap on how many unmatched books are logged individually per sync, so a
+# fully-mismatched library can't flood the log with hundreds of identical lines.
+KOMGA_UNMATCHED_LOG_LIMIT = 5
 
 
 def run_komga_sync():
@@ -1920,7 +1850,7 @@ def run_komga_sync():
         mark_komga_book_synced,
         update_komga_last_sync,
     )
-    from models.komga import KomgaClient, extract_book_info
+    from models.komga import KomgaClient, extract_book_info, resolve_komga_book_path
 
     cfg = get_komga_config()
     if not cfg or not cfg.get("server_url"):
@@ -1947,10 +1877,49 @@ def run_komga_sync():
             active_mappings.append({"komga_prefix": komga_pfx, "clu_prefix": clu_pfx})
     active_mappings.sort(key=lambda x: len(x["komga_prefix"]), reverse=True)
 
+    prefix_summary = ", ".join(m["komga_prefix"] for m in active_mappings) or "none"
+    if not active_mappings:
+        app_logger.warning(
+            "Komga sync: no library path prefixes configured — matching by filename "
+            "against the file index only. If books do not match, set prefixes at "
+            "Config → Komga Reading Sync → Library Path Mapping."
+        )
+
     read_count = 0
     progress_count = 0
     skip_count = 0
+    progress_skip_count = 0
     no_match_count = 0
+    ambiguous_count = 0
+    logged_unmatched = 0
+
+    def resolve(info):
+        """Resolve a book to a CLU path, counting and logging any miss."""
+        nonlocal no_match_count, ambiguous_count, logged_unmatched
+
+        clu_path, reason = resolve_komga_book_path(info, active_mappings)
+        if clu_path:
+            return clu_path
+
+        if reason == "ambiguous":
+            ambiguous_count += 1
+            detail = "filename exists in more than one library, skipped"
+        else:
+            no_match_count += 1
+            detail = "no CLU match"
+
+        # repr() the values deliberately: trailing spaces, casing and empty
+        # strings are what make these fail, and plain formatting hides them.
+        msg = (
+            f"Komga sync: {detail} — komga url={info['url']!r} "
+            f"filename={info['file_name']!r} | configured prefixes: {prefix_summary}"
+        )
+        if logged_unmatched < KOMGA_UNMATCHED_LOG_LIMIT:
+            app_logger.info(msg)
+            logged_unmatched += 1
+        else:
+            app_logger.debug(msg)
+        return None
 
     app_logger.info("🔄 Starting Komga reading sync...")
     start_time = time.time()
@@ -1965,18 +1934,8 @@ def run_komga_sync():
                 skip_count += 1
                 continue
 
-            # Map Komga path to CLU path
-            clu_path = map_komga_path_multi(info["url"], active_mappings)
-
-            # If mapped path doesn't exist, try filename fallback
-            if not clu_path or not os.path.exists(clu_path):
-                clu_path = find_clu_file_by_name(info["name"])
-
-            if not clu_path or not os.path.exists(clu_path):
-                app_logger.debug(
-                    f"Komga sync: no CLU match for {info['url']} ({info['name']})"
-                )
-                no_match_count += 1
+            clu_path = resolve(info)
+            if not clu_path:
                 continue
 
             # Mark as read in CLU using existing function
@@ -1992,20 +1951,22 @@ def run_komga_sync():
 
     # Phase 2: Sync in-progress reading positions
     try:
-        from core.database import save_reading_position
+        from core.database import get_reading_position, save_reading_position
 
         for book in client.get_all_in_progress_books():
             info = extract_book_info(book)
             book_id = info["id"]
 
-            clu_path = map_komga_path_multi(info["url"], active_mappings)
-            if not clu_path or not os.path.exists(clu_path):
-                clu_path = find_clu_file_by_name(info["name"])
+            clu_path = resolve(info)
+            if not clu_path:
+                continue
 
-            if not clu_path or not os.path.exists(clu_path):
-                app_logger.debug(
-                    f"Komga sync: no CLU match for in-progress {info['name']}"
-                )
+            # No is_komga_book_synced guard here, unlike phase 1: "read" is
+            # terminal but progress moves, and komga_sync_log records only that
+            # a book synced, never at what page. Compare the position itself.
+            existing = get_reading_position(clu_path)
+            if existing and existing.get("page_number") == info["current_page"]:
+                progress_skip_count += 1
                 continue
 
             save_reading_position(
@@ -2023,19 +1984,36 @@ def run_komga_sync():
     # Clear stats caches so new data shows up
     clear_stats_cache_keys(["library_stats", "reading_history", "reading_heatmap"])
 
+    unlogged = (no_match_count + ambiguous_count) - logged_unmatched
+    if unlogged > 0:
+        app_logger.info(
+            f"Komga sync: {unlogged} further unmatched books not logged "
+            f"(first {KOMGA_UNMATCHED_LOG_LIMIT} shown above)"
+        )
+
     elapsed = time.time() - start_time
     app_logger.info(
         f"✅ Komga sync completed in {elapsed:.2f}s: "
         f"{read_count} read, {progress_count} in-progress, "
-        f"{skip_count} skipped, {no_match_count} unmatched"
+        f"{skip_count} already synced, {progress_skip_count} unchanged, "
+        f"{no_match_count} unmatched, {ambiguous_count} ambiguous"
     )
+
+    if (no_match_count or ambiguous_count) and not (read_count or progress_count):
+        app_logger.warning(
+            f"Komga sync: none of {no_match_count + ambiguous_count} books matched a "
+            f"CLU file. Compare the 'komga url' values logged above against your CLU "
+            f"library paths, and check the Library Path Mapping in Config."
+        )
 
     return {
         "success": True,
         "read_count": read_count,
         "progress_count": progress_count,
         "skip_count": skip_count,
+        "progress_skip_count": progress_skip_count,
         "no_match_count": no_match_count,
+        "ambiguous_count": ambiguous_count,
         "elapsed": round(elapsed, 2),
     }
 

--- a/core/database.py
+++ b/core/database.py
@@ -2861,6 +2861,66 @@ def search_file_index(query, limit=100):
         return []
 
 
+def find_file_index_paths_by_name(filename, limit=5):
+    """
+    Find indexed files whose name matches `filename` exactly.
+
+    Unlike search_file_index(), this does no substring matching: the caller
+    wants the file literally called `filename`, not one containing it.
+
+    Returns every match up to `limit` rather than just the first, so callers
+    can detect an ambiguous filename (the same name in two libraries) instead
+    of silently acting on an arbitrary row.
+
+    Args:
+        filename: Full filename including extension, e.g. 'Spider-Man 001.cbz'
+        limit: Maximum number of matches to return
+
+    Returns:
+        List of paths, ordered deterministically. Empty list on no match.
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+
+        c = conn.cursor()
+
+        # Exact first: idx_file_index_name has no COLLATE NOCASE, so only this
+        # query can use it as an index seek. The case-insensitive retry scans,
+        # and is reached only for genuinely re-cased filenames -- /data is
+        # case-insensitive, so those must still match.
+        c.execute(
+            """
+            SELECT path FROM file_index
+            WHERE name = ? AND type = 'file'
+            ORDER BY path
+            LIMIT ?
+        """,
+            (filename, limit),
+        )
+        rows = c.fetchall()
+
+        if not rows:
+            c.execute(
+                """
+                SELECT path FROM file_index
+                WHERE name = ? COLLATE NOCASE AND type = 'file'
+                ORDER BY path
+                LIMIT ?
+            """,
+                (filename, limit),
+            )
+            rows = c.fetchall()
+
+        conn.close()
+        return [row["path"] for row in rows]
+
+    except Exception as e:
+        app_logger.error(f"Failed to look up file index by name: {e}")
+        return []
+
+
 def search_by_comic_metadata(series, number, volume=None, year=None, publisher=None, limit=20):
     """
     Search file_index using ComicInfo.xml metadata columns.

--- a/models/komga.py
+++ b/models/komga.py
@@ -11,6 +11,8 @@ Key Komga API endpoints used:
 - GET /api/v1/libraries - Test connectivity
 - POST /api/v1/books/list - Search/filter books by read status (V2 condition format)
 """
+import os
+
 import requests
 from requests.auth import HTTPBasicAuth
 from core.app_logging import app_logger
@@ -154,6 +156,149 @@ class KomgaClient:
                 break
 
 
+def komga_file_name(url):
+    """
+    Extract the filename, with extension, from a Komga book's `url` field.
+
+    `url` is the only book field carrying the extension. Komga returns the full
+    server path to admins but strips the directory for everyone else
+    (BookDto.restrictUrl), so the filename is always the last path segment.
+    The `name` field is unusable here -- Komga sets it to the stem, without the
+    extension, while CLU's file_index stores names with it.
+
+    Both separators are normalized: os.path.basename() ignores '\\' on POSIX, so
+    a Komga host running Windows would otherwise yield the whole path.
+    """
+    return (url or "").replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+
+
+def _is_absolute_path(path):
+    """
+    True for a POSIX-absolute or natively-absolute path.
+
+    os.path.isabs() alone is not enough: on Windows it rejects '/data/x' (since
+    Python 3.13 a lone leading slash is no longer absolute), and the paths CLU
+    actually runs on in Docker are POSIX.
+    """
+    return path.startswith("/") or os.path.isabs(path)
+
+
+def _parent_dir_name(path):
+    """Name of the directory containing `path`, or None if it has no parent."""
+    parts = (path or "").replace("\\", "/").rstrip("/").split("/")
+    if len(parts) < 2 or not parts[-2]:
+        return None
+    return parts[-2]
+
+
+def map_komga_path(komga_path, komga_prefix, clu_prefix):
+    """
+    Convert a Komga file path to a CLU file path using prefix mapping.
+
+    Returns the path unchanged when the prefix doesn't apply.
+
+    Example:
+        komga_path:   /comics/Marvel/Spider-Man 001.cbz
+        komga_prefix: /comics
+        clu_prefix:   /data
+        result:       /data/Marvel/Spider-Man 001.cbz
+    """
+    if not komga_prefix or not clu_prefix:
+        return komga_path
+
+    # Normalize path separators
+    komga_path = komga_path.replace("\\", "/")
+    komga_prefix = komga_prefix.rstrip("/").replace("\\", "/")
+    clu_prefix = clu_prefix.rstrip("/").replace("\\", "/")
+
+    # Match on a path boundary: prefix '/comics' must not swallow
+    # '/comics-archive/X.cbz' and rewrite it to '/data-archive/X.cbz'.
+    if komga_path == komga_prefix or komga_path.startswith(komga_prefix + "/"):
+        relative = komga_path[len(komga_prefix):]
+        return clu_prefix + relative
+
+    return komga_path
+
+
+def map_komga_path_multi(komga_path, mappings):
+    """
+    Try each library mapping; return first match or original path.
+    Mappings should be sorted by prefix length descending so longer prefixes match first.
+
+    Args:
+        komga_path: The file path as Komga sees it
+        mappings: List of dicts with 'komga_prefix' and 'clu_prefix'
+
+    Returns:
+        Mapped CLU path, or original path if no mapping matches
+    """
+    for m in mappings:
+        result = map_komga_path(komga_path, m["komga_prefix"], m["clu_prefix"])
+        if result != komga_path:
+            return result
+    return komga_path
+
+
+def resolve_komga_book_path(info, mappings, lookup=None):
+    """
+    Resolve a Komga book to a file in CLU's library.
+
+    Tries the configured path prefixes first (exact and unambiguous), then falls
+    back to an exact filename match against the file index -- which is the only
+    thing that works for non-admin Komga accounts, or when no prefixes are set.
+
+    Args:
+        info: Dict from extract_book_info()
+        mappings: List of dicts with 'komga_prefix' and 'clu_prefix', sorted by
+            prefix length descending
+        lookup: Filename lookup, injectable for tests. Defaults to
+            core.database.find_file_index_paths_by_name.
+
+    Returns:
+        Tuple of (clu_path or None, reason) where reason is one of
+        'mapping', 'file_index', 'no_match', 'ambiguous'.
+    """
+    if lookup is None:
+        from core.database import find_file_index_paths_by_name as lookup
+
+    url = (info.get("url") or "").replace("\\", "/")
+    file_name = info.get("file_name") or komga_file_name(url)
+
+    # Prefix mapping only means anything when the url carries a directory.
+    # A non-admin's bare filename has nothing to map, and os.path.exists()
+    # would resolve it against CLU's working directory.
+    if "/" in url:
+        mapped = map_komga_path_multi(url, mappings)
+        # exists() is what separates "mapped correctly" from "no mapping
+        # applied" -- map_komga_path_multi returns its input on no match, and
+        # a Komga server path must never reach the database as a CLU path.
+        if mapped and _is_absolute_path(mapped) and os.path.exists(mapped):
+            return mapped, "mapping"
+
+    if not file_name:
+        return None, "no_match"
+
+    # No exists() check on this branch: the path came out of CLU's own index,
+    # so it is a CLU path by construction. A stale row costs one orphan history
+    # entry; a stat() per book would re-introduce the environment coupling that
+    # made every match fail in the first place.
+    candidates = lookup(file_name)
+    if len(candidates) == 1:
+        return candidates[0], "file_index"
+    if not candidates:
+        return None, "no_match"
+
+    # The same filename in two libraries. Try the directory Komga reports, then
+    # give up: marking the wrong comic read silently corrupts reading history
+    # and cannot be undone.
+    parent = _parent_dir_name(url)
+    if parent:
+        narrowed = [p for p in candidates if _parent_dir_name(p) == parent]
+        if len(narrowed) == 1:
+            return narrowed[0], "file_index"
+    return None, "ambiguous"
+
+
 def extract_book_info(book):
     """
     Extract relevant fields from a Komga book object.
@@ -162,16 +307,18 @@ def extract_book_info(book):
         book: Book dict from Komga API response
 
     Returns:
-        Dict with normalized fields: id, url, name, page_count,
+        Dict with normalized fields: id, url, name, file_name, page_count,
         current_page, completed, read_date, last_modified
     """
     media = book.get('media', {})
     read_progress = book.get('readProgress') or {}
+    url = book.get('url', '')
 
     return {
         'id': book.get('id', ''),
-        'url': book.get('url', ''),
+        'url': url,
         'name': book.get('name', ''),
+        'file_name': komga_file_name(url),
         'page_count': media.get('pagesCount', 0),
         'current_page': read_progress.get('page', 0),
         'completed': read_progress.get('completed', False),

--- a/tests/integration/test_database_file_index.py
+++ b/tests/integration/test_database_file_index.py
@@ -532,3 +532,88 @@ class TestGetFilesWithMissingComicinfoForRescan:
         paths = {r["path"] for r in rows}
         assert "/data/a.cbz" in paths
         assert "/data/b.txt" not in paths
+
+
+class TestFindFileIndexPathsByName:
+
+    def test_exact_match(self, db_connection):
+        from core.database import add_file_index_entry, find_file_index_paths_by_name
+
+        add_file_index_entry(
+            "Spider-Man 001.cbz", "/data/Marvel/Spider-Man 001.cbz",
+            "file", parent="/data/Marvel",
+        )
+
+        assert find_file_index_paths_by_name("Spider-Man 001.cbz") == [
+            "/data/Marvel/Spider-Man 001.cbz"
+        ]
+
+    def test_stem_without_extension_does_not_match(self, db_connection):
+        """Pins the original bug at the DB layer.
+
+        Komga's `name` field is the stem, and syncing used to look it up here
+        directly -- against a column that always stores the extension. The
+        lookup could never match, for any book.
+        """
+        from core.database import add_file_index_entry, find_file_index_paths_by_name
+
+        add_file_index_entry(
+            "Spider-Man 001.cbz", "/data/Marvel/Spider-Man 001.cbz",
+            "file", parent="/data/Marvel",
+        )
+
+        assert find_file_index_paths_by_name("Spider-Man 001") == []
+
+    def test_case_insensitive_fallback(self, db_connection):
+        """/data is case-insensitive, so a re-cased filename must still match."""
+        from core.database import add_file_index_entry, find_file_index_paths_by_name
+
+        add_file_index_entry(
+            "Spider-Man 001.cbz", "/data/Marvel/Spider-Man 001.cbz",
+            "file", parent="/data/Marvel",
+        )
+
+        assert find_file_index_paths_by_name("spider-man 001.CBZ") == [
+            "/data/Marvel/Spider-Man 001.cbz"
+        ]
+
+    def test_directories_excluded(self, db_connection):
+        from core.database import add_file_index_entry, find_file_index_paths_by_name
+
+        add_file_index_entry("Marvel", "/data/Marvel", "directory", parent="/data")
+
+        assert find_file_index_paths_by_name("Marvel") == []
+
+    def test_no_match_returns_empty(self, db_connection):
+        from core.database import find_file_index_paths_by_name
+
+        assert find_file_index_paths_by_name("Nonexistent 001.cbz") == []
+
+    def test_duplicate_names_return_all_ordered(self, db_connection):
+        """The caller needs every candidate to detect ambiguity, and a stable
+        order so a given sync never picks a different file than the last."""
+        from core.database import add_file_index_entry, find_file_index_paths_by_name
+
+        add_file_index_entry(
+            "Spider-Man 001.cbz", "/data/Marvel/Spider-Man 001.cbz",
+            "file", parent="/data/Marvel",
+        )
+        add_file_index_entry(
+            "Spider-Man 001.cbz", "/data/Backups/Spider-Man 001.cbz",
+            "file", parent="/data/Backups",
+        )
+
+        assert find_file_index_paths_by_name("Spider-Man 001.cbz") == [
+            "/data/Backups/Spider-Man 001.cbz",
+            "/data/Marvel/Spider-Man 001.cbz",
+        ]
+
+    def test_limit_is_respected(self, db_connection):
+        from core.database import add_file_index_entry, find_file_index_paths_by_name
+
+        for i in range(4):
+            add_file_index_entry(
+                "Dup.cbz", f"/data/lib{i}/Dup.cbz", "file", parent=f"/data/lib{i}",
+            )
+
+        assert len(find_file_index_paths_by_name("Dup.cbz", limit=2)) == 2

--- a/tests/mocked/test_komga_model.py
+++ b/tests/mocked/test_komga_model.py
@@ -34,12 +34,18 @@ def _make_page_response(content, total_pages=1, total_elements=None):
     return resp
 
 
-def _make_book(book_id="abc-123", name="Batman #1", pages_count=24,
+def _make_book(book_id="abc-123", name="Spider-Man 001",
+               url="/comics/Marvel/Spider-Man 001.cbz", pages_count=24,
                page=0, completed=False, read_date=None, last_modified=None):
-    """Return a dict mimicking a Komga book JSON object."""
+    """Return a dict mimicking a Komga book JSON object.
+
+    Mirrors the real API: `url` is the file's path on the Komga server (admin)
+    or the bare filename (non-admin), and `name` is the filename stem, without
+    the extension.
+    """
     book = {
         "id": book_id,
-        "url": f"/api/v1/books/{book_id}",
+        "url": url,
         "name": name,
         "media": {"pagesCount": pages_count},
     }
@@ -278,8 +284,8 @@ class TestExtractBookInfo:
 
         book = {
             "id": "abc-123",
-            "url": "/api/v1/books/abc-123",
-            "name": "Batman #1",
+            "url": "/comics/Marvel/Spider-Man 001.cbz",
+            "name": "Spider-Man 001",
             "media": {"pagesCount": 24},
             "readProgress": {
                 "page": 24,
@@ -291,8 +297,10 @@ class TestExtractBookInfo:
         info = extract_book_info(book)
 
         assert info["id"] == "abc-123"
-        assert info["url"] == "/api/v1/books/abc-123"
-        assert info["name"] == "Batman #1"
+        assert info["url"] == "/comics/Marvel/Spider-Man 001.cbz"
+        assert info["name"] == "Spider-Man 001"
+        # file_name carries the extension; name never does
+        assert info["file_name"] == "Spider-Man 001.cbz"
         assert info["page_count"] == 24
         assert info["current_page"] == 24
         assert info["completed"] is True
@@ -308,6 +316,7 @@ class TestExtractBookInfo:
         assert info["id"] == ""
         assert info["url"] == ""
         assert info["name"] == ""
+        assert info["file_name"] == ""
         assert info["page_count"] == 0
         assert info["current_page"] == 0
         assert info["completed"] is False
@@ -320,13 +329,14 @@ class TestExtractBookInfo:
 
         book = {
             "id": "xyz",
-            "url": "/api/v1/books/xyz",
-            "name": "Saga #1",
+            "url": "/comics/Image/Saga 001.cbz",
+            "name": "Saga 001",
             "media": {"pagesCount": 32},
             "readProgress": None,
         }
         info = extract_book_info(book)
 
+        assert info["file_name"] == "Saga 001.cbz"
         assert info["page_count"] == 32
         assert info["current_page"] == 0
         assert info["completed"] is False

--- a/tests/mocked/test_komga_resolve.py
+++ b/tests/mocked/test_komga_resolve.py
@@ -1,0 +1,175 @@
+"""Tests for resolve_komga_book_path -- file index lookup injected, no DB."""
+import pytest
+from unittest.mock import patch
+
+from models.komga import extract_book_info, resolve_komga_book_path
+
+
+def _info(url="/comics/Marvel/Spider-Man 001.cbz", name="Spider-Man 001", page=0):
+    """Build an info dict the way extract_book_info would, from a Komga book."""
+    return extract_book_info({
+        "id": "b1",
+        "url": url,
+        "name": name,
+        "media": {"pagesCount": 24},
+        "readProgress": {"page": page, "completed": False},
+    })
+
+
+def _lookup(*paths):
+    """A find_file_index_paths_by_name stub returning fixed paths."""
+    return lambda filename, **kw: list(paths)
+
+
+MAPPINGS = [{"komga_prefix": "/comics", "clu_prefix": "/data"}]
+
+
+# ---------------------------------------------------------------------------
+# Mapping branch
+# ---------------------------------------------------------------------------
+
+class TestMappingBranch:
+
+    def test_mapped_path_that_exists_wins(self):
+        with patch("models.komga.os.path.exists", return_value=True):
+            path, reason = resolve_komga_book_path(
+                _info(), MAPPINGS, lookup=_lookup()
+            )
+        assert path == "/data/Marvel/Spider-Man 001.cbz"
+        assert reason == "mapping"
+
+    def test_mapped_path_that_does_not_exist_falls_back_to_file_index(self):
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(
+                _info(), MAPPINGS,
+                lookup=_lookup("/data/Marvel/Spider-Man 001.cbz"),
+            )
+        assert path == "/data/Marvel/Spider-Man 001.cbz"
+        assert reason == "file_index"
+
+    def test_unmapped_path_that_exists_is_used(self):
+        """Identical bind mounts in both containers need no prefixes at all."""
+        with patch("models.komga.os.path.exists", return_value=True):
+            path, reason = resolve_komga_book_path(
+                _info(url="/data/Marvel/Spider-Man 001.cbz"), [], lookup=_lookup()
+            )
+        assert path == "/data/Marvel/Spider-Man 001.cbz"
+        assert reason == "mapping"
+
+
+# ---------------------------------------------------------------------------
+# File index fallback -- the regression this whole fix is about
+# ---------------------------------------------------------------------------
+
+class TestFileIndexFallback:
+
+    def test_looks_up_filename_with_extension_not_the_stem(self):
+        """The bug: Komga's `name` is the stem ('Spider-Man 001') but
+        file_index.name stores the extension too, so the lookup never matched.
+        The filename must come from `url`, which always carries the extension.
+        """
+        seen = []
+
+        def lookup(filename, **kw):
+            seen.append(filename)
+            return ["/data/Marvel/Spider-Man 001.cbz"]
+
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(_info(), [], lookup=lookup)
+
+        assert seen == ["Spider-Man 001.cbz"]
+        assert seen != ["Spider-Man 001"]
+        assert path == "/data/Marvel/Spider-Man 001.cbz"
+        assert reason == "file_index"
+
+    def test_non_admin_bare_url_skips_mapping_entirely(self):
+        """Non-admins get a bare filename. There is nothing to map, and
+        os.path.exists() would resolve it against the working directory.
+        """
+        with patch("models.komga.os.path.exists") as mock_exists:
+            path, reason = resolve_komga_book_path(
+                _info(url="Spider-Man 001.cbz"), MAPPINGS,
+                lookup=_lookup("/data/Marvel/Spider-Man 001.cbz"),
+            )
+        mock_exists.assert_not_called()
+        assert path == "/data/Marvel/Spider-Man 001.cbz"
+        assert reason == "file_index"
+
+    def test_no_exists_check_on_file_index_result(self):
+        """A path out of CLU's own index is a CLU path by construction."""
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(
+                _info(url="Spider-Man 001.cbz"), [],
+                lookup=_lookup("/data/Marvel/Spider-Man 001.cbz"),
+            )
+        assert path == "/data/Marvel/Spider-Man 001.cbz"
+        assert reason == "file_index"
+
+    def test_no_candidates_is_no_match(self):
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(_info(), [], lookup=_lookup())
+        assert path is None
+        assert reason == "no_match"
+
+    def test_empty_url_is_no_match(self):
+        path, reason = resolve_komga_book_path(
+            _info(url=""), MAPPINGS, lookup=_lookup("/data/X.cbz")
+        )
+        assert path is None
+        assert reason == "no_match"
+
+
+# ---------------------------------------------------------------------------
+# Ambiguity -- never guess which comic to mark read
+# ---------------------------------------------------------------------------
+
+class TestAmbiguity:
+
+    def test_two_candidates_without_parent_info_is_ambiguous(self):
+        """Non-admin url has no directory, so nothing can disambiguate."""
+        path, reason = resolve_komga_book_path(
+            _info(url="Spider-Man 001.cbz"), [],
+            lookup=_lookup(
+                "/data/Marvel/Spider-Man 001.cbz",
+                "/data/Backups/Spider-Man 001.cbz",
+            ),
+        )
+        assert path is None
+        assert reason == "ambiguous"
+
+    def test_parent_directory_disambiguates(self):
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(
+                _info(url="/comics/Backups/Spider-Man 001.cbz"), [],
+                lookup=_lookup(
+                    "/data/Marvel/Spider-Man 001.cbz",
+                    "/data/Backups/Spider-Man 001.cbz",
+                ),
+            )
+        assert path == "/data/Backups/Spider-Man 001.cbz"
+        assert reason == "file_index"
+
+    def test_parent_matching_two_candidates_stays_ambiguous(self):
+        """Same filename under same-named dirs in two libraries: give up."""
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(
+                _info(url="/comics/Marvel/Spider-Man 001.cbz"), [],
+                lookup=_lookup(
+                    "/data/libA/Marvel/Spider-Man 001.cbz",
+                    "/data/libB/Marvel/Spider-Man 001.cbz",
+                ),
+            )
+        assert path is None
+        assert reason == "ambiguous"
+
+    def test_parent_matching_no_candidates_stays_ambiguous(self):
+        with patch("models.komga.os.path.exists", return_value=False):
+            path, reason = resolve_komga_book_path(
+                _info(url="/comics/Elsewhere/Spider-Man 001.cbz"), [],
+                lookup=_lookup(
+                    "/data/Marvel/Spider-Man 001.cbz",
+                    "/data/Backups/Spider-Man 001.cbz",
+                ),
+            )
+        assert path is None
+        assert reason == "ambiguous"

--- a/tests/unit/test_komga_path_mapping.py
+++ b/tests/unit/test_komga_path_mapping.py
@@ -1,0 +1,104 @@
+"""Tests for Komga path mapping and filename extraction -- pure, no HTTP or DB."""
+import pytest
+
+from models.komga import (
+    komga_file_name,
+    map_komga_path,
+    map_komga_path_multi,
+)
+
+
+# ---------------------------------------------------------------------------
+# komga_file_name
+# ---------------------------------------------------------------------------
+
+class TestKomgaFileName:
+
+    def test_admin_posix_path(self):
+        """Admin users get the full server path; take the last segment."""
+        assert komga_file_name("/comics/Marvel/Spider-Man 001.cbz") == "Spider-Man 001.cbz"
+
+    def test_non_admin_bare_filename(self):
+        """Non-admins get a bare filename already (BookDto.restrictUrl)."""
+        assert komga_file_name("Spider-Man 001.cbz") == "Spider-Man 001.cbz"
+
+    def test_windows_path(self):
+        """A Komga host on Windows must not defeat a CLU running on POSIX."""
+        assert komga_file_name("C:\\comics\\Marvel\\Spider-Man 001.cbz") == "Spider-Man 001.cbz"
+
+    def test_empty_url(self):
+        assert komga_file_name("") == ""
+
+    def test_none_url(self):
+        assert komga_file_name(None) == ""
+
+    def test_spaces_preserved(self):
+        """Komga does not URL-encode the path; spaces stay as-is."""
+        assert komga_file_name("/comics/The Amazing Spider-Man 001.cbz") == \
+            "The Amazing Spider-Man 001.cbz"
+
+
+# ---------------------------------------------------------------------------
+# map_komga_path
+# ---------------------------------------------------------------------------
+
+class TestMapKomgaPath:
+
+    def test_simple_prefix_swap(self):
+        assert map_komga_path("/comics/Marvel/X.cbz", "/comics", "/data") == "/data/Marvel/X.cbz"
+
+    def test_trailing_slash_on_prefix(self):
+        assert map_komga_path("/comics/Marvel/X.cbz", "/comics/", "/data/") == "/data/Marvel/X.cbz"
+
+    def test_no_match_returns_input_unchanged(self):
+        assert map_komga_path("/media/X.cbz", "/comics", "/data") == "/media/X.cbz"
+
+    def test_empty_komga_prefix_returns_input(self):
+        assert map_komga_path("/comics/X.cbz", "", "/data") == "/comics/X.cbz"
+
+    def test_empty_clu_prefix_returns_input(self):
+        assert map_komga_path("/comics/X.cbz", "/comics", "") == "/comics/X.cbz"
+
+    def test_backslashes_normalized(self):
+        assert map_komga_path("\\comics\\Marvel\\X.cbz", "/comics", "/data") == "/data/Marvel/X.cbz"
+
+    def test_sibling_directory_must_not_match(self):
+        """Regression: prefix '/comics' must not swallow '/comics-archive'.
+
+        A bare startswith() rewrote this to '/data-archive/X.cbz' -- a path
+        belonging to no library at all.
+        """
+        assert map_komga_path("/comics-archive/X.cbz", "/comics", "/data") == "/comics-archive/X.cbz"
+
+    def test_exact_prefix_match(self):
+        assert map_komga_path("/comics", "/comics", "/data") == "/data"
+
+
+# ---------------------------------------------------------------------------
+# map_komga_path_multi
+# ---------------------------------------------------------------------------
+
+class TestMapKomgaPathMulti:
+
+    def test_first_matching_mapping_wins(self):
+        mappings = [
+            {"komga_prefix": "/manga", "clu_prefix": "/data/manga"},
+            {"komga_prefix": "/comics", "clu_prefix": "/data/comics"},
+        ]
+        assert map_komga_path_multi("/comics/X.cbz", mappings) == "/data/comics/X.cbz"
+
+    def test_longest_prefix_first_when_caller_sorts(self):
+        """map_komga_path_multi relies on the CALLER sorting by prefix length
+        descending (run_komga_sync does), so the nested mapping wins."""
+        mappings = [
+            {"komga_prefix": "/comics/marvel", "clu_prefix": "/data/marvel"},
+            {"komga_prefix": "/comics", "clu_prefix": "/data/other"},
+        ]
+        assert map_komga_path_multi("/comics/marvel/X.cbz", mappings) == "/data/marvel/X.cbz"
+
+    def test_no_mappings_returns_input(self):
+        assert map_komga_path_multi("/comics/X.cbz", []) == "/comics/X.cbz"
+
+    def test_no_matching_mapping_returns_input(self):
+        mappings = [{"komga_prefix": "/manga", "clu_prefix": "/data/manga"}]
+        assert map_komga_path_multi("/comics/X.cbz", mappings) == "/comics/X.cbz"


### PR DESCRIPTION
## The bug

Komga reading sync reported every book as unmatched, so no reading history was imported at all:

```
Komga: 192 completed books to process
Komga: 4 in-progress books to process
✅ Komga sync completed in 1.01s: 0 read, 0 in-progress, 0 skipped, 192 unmatched
```

`run_komga_sync()` resolved each book two ways, and **both dead-ended**:

| Komga account | `info["url"]` is | Prefix mapping + `os.path.exists` | `find_clu_file_by_name(info["name"])` |
|---|---|---|---|
| admin, no prefixes set | `/comics/Marvel/Spider-Man 001.cbz` | returns input unchanged → `exists()` False (that's Komga's disk, not CLU's) | `WHERE name = 'Spider-Man 001'` → **0 rows** |
| non-admin | `Spider-Man 001.cbz` | no prefix can match a bare filename | same → **0 rows** |

**Primary cause:** the fallback looked up Komga's `name` field — the filename stem, *without* the extension ([`FileSystemScanner.kt`](https://github.com/gotson/komga/blob/master/komga/src/main/kotlin/org/gotson/komga/domain/service/FileSystemScanner.kt): `name = path.nameWithoutExtension`) — against `file_index.name`, which always stores it *with* the extension. That comparison can never match, for any book, under any configuration.

**The fix hinges on `url`,** the only book field carrying the extension in both cases. Komga returns the full server path to admins but strips the directory for everyone else ([`BookDto.kt`](https://github.com/gotson/komga/blob/master/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/BookDto.kt): `restrictUrl(restrict) = copy(url = FilenameUtils.getName(url))`), so the filename is always its last path segment.

Matching is exact-filename only, case-insensitive (`/data` is case-insensitive, so re-cased files must still match). No fuzzy matching — `search_file_index` is deliberately not used.

## Also fixed — both unmasked by the above

- **Prefix matching had no path boundary.** `startswith("/comics")` also matched `/comics-archive/X.cbz`, rewriting it to `/data-archive/X.cbz` — a path in no library. Harmless only while nothing matched.
- **Wrong-comic hazard.** The lookup was `WHERE name = ? LIMIT 1` with no `ORDER BY`, so a filename in two libraries resolved to an arbitrary row. Marking the wrong comic read silently corrupts reading history, stats, heatmap and Wrapped, with no undo. The resolver now narrows by directory and reports `ambiguous` rather than guessing.
- **Phase 2 never counted its misses**, which is why the 4 in-progress books vanished without trace. It now counts them, and skips books whose position is unchanged. Guarding on `is_komga_book_synced` there would be wrong: `komga_sync_log` records only *that* a book synced, never at what page, and progress moves between syncs — an unconditional skip would freeze the position at whatever the first sync saw.

## Diagnostics

Unmatched books were logged at `debug`, so a fully-mismatched library gave nothing to act on. Now, capped at 5 per sync:

```
Komga sync: no CLU match — komga url='/comics/Marvel/X.cbz' filename='X.cbz' | configured prefixes: none
Komga sync: 3 further unmatched books not logged (first 5 shown above)
```

An empty path-prefix configuration now warns explicitly — it's a saveable, previously invisible state, since `save_komga_library_mappings` silently drops empty prefixes.

## Why files moved

`map_komga_path`, `map_komga_path_multi` and the filename lookup moved out of `app.py` into `models/komga.py` and `core/database.py`. No test in this repo can import `app.py` (`tests/routes/conftest.py` injects a `MagicMock` for it to dodge `api.py`'s import side effects), which is exactly why these functions had **zero** tests. They now have 94.

## Verification

Drove the real `run_komga_sync()` against a fake Komga server and a real SQLite index, reproducing the reported scenario (192 books, no prefixes configured):

```
{'read_count': 192, 'progress_count': 1, 'no_match_count': 0, 'ambiguous_count': 0}
rerun: {'read_count': 0, 'skip_count': 192, 'progress_skip_count': 1}
```

Passes for **both** admin (full paths) and non-admin (bare filenames) accounts; re-runs are idempotent. Diagnostics verified separately: 8 unmatched → 5 sampled at INFO, 3 suppressed, both warnings fired.

Full suite: **2098 passed**. The 13 `test_pdf.py` failures are the known local-env baseline (missing `pdf2image`) and are unrelated.

Two of the new tests caught a portability bug in this change during development: `os.path.isabs("/data/...")` returns `False` on Windows from Python 3.13 on, which the Linux deploy would never have surfaced.

Closes #405 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
