### PR TITLE
Fix new comic files landing root:0600 and breaking thumbnails/metadata

### DIFF
--- a/cbz_ops/rebuild.py
+++ b/cbz_ops/rebuild.py
@@ -235,7 +235,10 @@ def rebuild_single_cbz_file(cbz_path, directory):
         
         # Remove backup file
         os.remove(bak_file)
-        
+
+        from helpers import match_parent_permissions
+        match_parent_permissions(cbz_file)
+
         app_logger.info(f"Successfully rebuilt: {filename}")
         return True
         

--- a/cbz_ops/single_file.py
+++ b/cbz_ops/single_file.py
@@ -127,8 +127,11 @@ def convert_single_rar_file(rar_path, cbz_path, temp_extraction_dir):
                         progress_percent = (processed_files / total_files) * 100
                         app_logger.info(f"Compression progress: {progress_percent:.1f}% ({processed_files}/{total_files} files)")
         
+        from helpers import match_parent_permissions
+        match_parent_permissions(cbz_path)
+
         app_logger.info(f"Successfully converted: {os.path.basename(rar_path)}")
-        
+
         # Regenerate thumbnail for the converted file
         try:
             import hashlib
@@ -272,7 +275,10 @@ def rebuild_single_cbz_file(cbz_path):
         os.remove(bak_file_path)
         if os.path.exists(folder_name):
             shutil.rmtree(folder_name)
-        
+
+        from helpers import match_parent_permissions
+        match_parent_permissions(cbz_path)
+
         app_logger.info(f"Successfully rebuilt: {filename}")
         
         # Regenerate thumbnail for the rebuilt file

--- a/core/comicinfo.py
+++ b/core/comicinfo.py
@@ -368,6 +368,8 @@ def update_comicinfo_in_zip(zip_path: str, updates: dict):
 
     # Replace the original ZIP/CBZ with the updated one
     os.replace(temp_zip_path, zip_path)
+    from helpers import match_parent_permissions
+    match_parent_permissions(zip_path)
 
 
 def bulk_update_comicinfo_in_zips(items, progress_callback=None, max_workers=4):

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -210,6 +210,12 @@ for p in /downloads/temp /downloads/processed /data "${CFG_TARGET}" ; do
   fi
 done
 
+# When this fallback fires, the app runs as root and new library files are
+# stamped root-owned. CLU normalizes each written CBZ back to its folder's
+# owner/mode (see helpers.match_parent_permissions), so files stay readable
+# even here -- but the durable fix is to make the mount writable by PUID:PGID
+# (correct the volume ownership, or set PUID/PGID to match it) so the gosu
+# branch is taken and nothing is owned by root in the first place.
 if [ "$NEED_ROOT" = "1" ]; then
   echo "Falling back to root due to non-writable mounts."
   exec "$@"

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -98,17 +98,22 @@ def sanitize_path_segment(name):
 #########################
 
 def match_parent_permissions(path):
-    """Best-effort: make a freshly written sidecar inherit its parent folder's
-    accessibility (group + rwx bits minus execute) so shared/NAS accounts can
-    read and write files CLU creates (cvinfo, series.json, ...).
+    """Best-effort: make a freshly written file inherit its parent folder's
+    accessibility (owner, group, and rwx bits minus execute) so shared/NAS
+    accounts can read and write files CLU creates — both sidecars (cvinfo,
+    series.json, ...) and the comic archives themselves.
 
-    Files are otherwise created with the process umask and, for series.json,
-    a 0o600 temp file from mkstemp — leaving sidecars unwritable for NAS users
-    even when the containing folder is group-writable. We mirror the parent
-    folder's mode (dropping the execute bits, which only matter on directories)
-    and set the group to the parent's, so the file is as accessible as its
-    folder. Silently ignored where unsupported (Windows-backed mounts, files
-    CLU does not own).
+    Files are otherwise created with the process umask and, for series.json and
+    the CBZ-rewrite paths, a 0o600 temp file from mkstemp — leaving them
+    inaccessible even when the containing folder is world-readable. Worse, when
+    the container falls back to running as root (non-writable mount at startup),
+    new files land as root:0600 and become unreadable once the app runs as the
+    unprivileged app user. We mirror the parent folder's mode (dropping the
+    execute bits, which only matter on directories) and set the owner/group to
+    the parent's, so the file is as accessible as its folder. The owner change
+    silently no-ops when unprivileged (a same-uid rewrite) and only takes effect
+    when we have the privilege to do it (e.g. running as root). Silently ignored
+    where unsupported (Windows-backed mounts, files CLU does not own).
     """
     try:
         parent = os.path.dirname(os.path.abspath(path)) or "."
@@ -116,7 +121,7 @@ def match_parent_permissions(path):
         os.chmod(path, stat.S_IMODE(pst.st_mode) & ~0o111)  # drop x for files
         if hasattr(os, "chown"):                            # absent on Windows
             try:
-                os.chown(path, -1, pst.st_gid)              # group only; keep owner
+                os.chown(path, pst.st_uid, pst.st_gid)      # match folder owner+group
             except (PermissionError, OSError):
                 pass
     except OSError:

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -1197,8 +1197,10 @@ def add_comicinfo_to_archive(file_path: str, xml_content) -> bool:
 
     temp_path = None
     try:
-        # Create temp file
-        temp_fd, temp_path = tempfile.mkstemp(suffix='.cbz')
+        # Create temp file on the SAME filesystem as the target so shutil.move
+        # is an atomic rename rather than a cross-device copy that would stamp
+        # mkstemp's 0600 mode onto the library file.
+        temp_fd, temp_path = tempfile.mkstemp(suffix='.cbz', dir=os.path.dirname(file_path) or ".")
         os.close(temp_fd)
 
         with zipfile.ZipFile(file_path, 'r') as zin:
@@ -1217,6 +1219,8 @@ def add_comicinfo_to_archive(file_path: str, xml_content) -> bool:
 
         # Replace original with temp
         shutil.move(temp_path, file_path)
+        from helpers import match_parent_permissions
+        match_parent_permissions(file_path)
         return True
 
     except Exception as e:

--- a/models/update_xml.py
+++ b/models/update_xml.py
@@ -74,6 +74,8 @@ def update_field_in_cbz_files(folder_path: str, field: str, value: str) -> dict:
                             shutil.copyfileobj(source, target)
 
             os.replace(temp_path, cbz_path)
+            from helpers import match_parent_permissions
+            match_parent_permissions(cbz_path)
             result['updated'] += 1
             result['details'].append({'file': filename, 'status': 'updated'})
 

--- a/monitor.py
+++ b/monitor.py
@@ -518,6 +518,13 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             else:
                 monitor_logger.warning(f"File move verification failed: {target_path} not found.")
 
+            # Make the moved/converted file as accessible as its library folder,
+            # so it stays readable regardless of the download's original perms or
+            # whether the container fell back to running as root.
+            if os.path.exists(final_target_path):
+                from helpers import match_parent_permissions
+                match_parent_permissions(final_target_path)
+
         except Exception as e:
             monitor_logger.error(f"Error moving file: {e}")
             # Allow filesystem update

--- a/routes/bulk_metadata.py
+++ b/routes/bulk_metadata.py
@@ -1005,6 +1005,8 @@ def _strip_comicinfo_from_cbz(file_path):
                     continue
                 dst.writestr(info, src.read(info.filename))
     os.replace(temp_zip, file_path)
+    from helpers import match_parent_permissions
+    match_parent_permissions(file_path)
 
 
 # ----------------------------------------------------------------------------

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -289,6 +289,8 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
 
         # Step 4: Replace original file
         os.replace(temp_zip_path, file_path)
+        from helpers import match_parent_permissions
+        match_parent_permissions(file_path)
 
     except zipfile.BadZipFile as e:
         # Handle the case where a .cbz file is actually a RAR file
@@ -447,6 +449,8 @@ def _remove_comicinfo_from_cbz(file_path):
             return {"success": False, "error": "ComicInfo.xml not found in CBZ"}
 
         os.replace(temp_zip_path, file_path)
+        from helpers import match_parent_permissions
+        match_parent_permissions(file_path)
 
         from core.database import set_has_comicinfo
         set_has_comicinfo(file_path, 0)

--- a/tests/unit/test_cbz_permissions.py
+++ b/tests/unit/test_cbz_permissions.py
@@ -1,0 +1,52 @@
+"""Regression tests: CBZ files CLU rewrites must stay as accessible as their
+containing folder.
+
+Before this fix, ``add_comicinfo_to_archive`` created its rewrite temp with
+``tempfile.mkstemp`` and no ``dir=``, so the temp landed in the system temp dir
+at the hardcoded ``0600`` mode; ``shutil.move`` into the library then copied
+``0600`` onto the file. Combined with the container's root fallback this yielded
+``root:-rw-------`` archives the app could no longer read, breaking thumbnails
+and metadata for new issues. The rewrite paths now (a) keep the temp on the same
+filesystem and (b) call ``match_parent_permissions`` on the result.
+"""
+import io
+import os
+import stat
+import zipfile
+
+import pytest
+
+from PIL import Image
+
+pytestmark = pytest.mark.skipif(os.name == 'nt', reason='POSIX chmod/group semantics')
+
+
+def _make_cbz(path):
+    """Write a minimal but real CBZ (one JPEG page) to ``path``."""
+    buf = io.BytesIO()
+    Image.new('RGB', (4, 4), (200, 10, 10)).save(buf, format='JPEG')
+    with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr('001.jpg', buf.getvalue())
+
+
+def test_add_comicinfo_leaves_world_readable_file(tmp_path):
+    from models.comicvine import add_comicinfo_to_archive
+
+    folder = tmp_path
+    os.chmod(folder, 0o777)
+    cbz = folder / 'Book - 001.cbz'
+    _make_cbz(str(cbz))
+    os.chmod(cbz, 0o600)  # simulate a prior 0600-leaked archive
+
+    ok = add_comicinfo_to_archive(str(cbz), '<?xml version="1.0"?><ComicInfo/>')
+    assert ok is True
+
+    # ComicInfo.xml was embedded ...
+    with zipfile.ZipFile(str(cbz)) as zf:
+        names = {n.lower() for n in zf.namelist()}
+    assert 'comicinfo.xml' in names
+
+    # ... and the archive is now as accessible as its 0777 folder (0666),
+    # not the 0600 it started with.
+    mode = stat.S_IMODE(os.stat(cbz).st_mode)
+    assert mode == 0o666

--- a/tests/unit/test_sidecar_permissions.py
+++ b/tests/unit/test_sidecar_permissions.py
@@ -47,6 +47,18 @@ class TestMatchParentPermissions:
 
         assert os.stat(f).st_gid == os.stat(tmp_path).st_gid
 
+    def test_file_inherits_parent_owner(self, tmp_path):
+        # Unprivileged: parent owner == current uid, so the chown is a no-op that
+        # must not raise and must leave the file owned by the current user. When
+        # running as root (e.g. the container's root fallback) this same call
+        # re-owns a root-created file back to the folder's owner.
+        f = tmp_path / 'cvinfo'
+        f.write_text('x')
+
+        match_parent_permissions(str(f))
+
+        assert os.stat(f).st_uid == os.stat(tmp_path).st_uid
+
 
 class TestMatchParentPermissionsBestEffort:
     """Must never raise — it is a best-effort cosmetic step."""


### PR DESCRIPTION
## Problem

Thumbnails and metadata for newly downloaded/tagged issues stop generating. The app hits `PermissionError: [Errno 13]` when opening a brand-new CBZ for reading (both `read_comic_info` and `search_metadata`). The offending files are owned by `root` with mode `-rw-------` (`0600`), whereas they used to be `nobody` / `-rw-rw-rw-`. A `0600` file owned by root is unreadable by the app when it runs as the unprivileged app user (UID 99).

Two independent, **pre-existing** bugs combine (not a #404 regression — that commit only touched provider selection):

1. **Mode `0600`:** `models/comicvine.py` `add_comicinfo_to_archive` created its rewrite temp with `tempfile.mkstemp()` and **no `dir=`**, so the temp landed in the system temp dir at the hardcoded `0600` mode; the cross-filesystem `shutil.move` into `/data` then copied `0600` onto the library file. More broadly, **none** of the CBZ create/rewrite/move paths called the existing `match_parent_permissions()` helper that sidecar writers already use, so a leaked `0600` (or a non-`000` umask) was never corrected.
2. **Owner `root`:** `entrypoint.sh` silently falls back to running as root when a mount isn't writable by `PUID:PGID` at startup, stamping root ownership onto new files.

## Changes

- **`models/comicvine.py`** — `mkstemp` now uses `dir=os.path.dirname(file_path)` so `shutil.move` is a same-filesystem rename, not a `0600`-copying cross-device move.
- **`helpers/match_parent_permissions`** — also normalizes the file's **owner** uid (not just group) to the parent folder's, best-effort. Restores `nobody` ownership when the writer is root; no-ops on a same-uid rewrite.
- **Wired `match_parent_permissions` into every CBZ create/rewrite/move into the library** (best-effort, non-fatal): `models/comicvine.py`, `routes/metadata.py` (both rewrite branches), `cbz_ops/single_file.py` (RAR-convert + rebuild), `cbz_ops/rebuild.py`, `core/comicinfo.py`, `models/update_xml.py`, `routes/bulk_metadata.py`, `monitor.py`.
- **`entrypoint.sh`** — documents the root-fallback ownership trigger (no behavior change). The durable fix is making the mount writable by `PUID:PGID` (correct volume ownership, or set `PUID`/`PGID` to match) so the `gosu` branch is taken.

`api.py` is intentionally left untouched (its download write is already `0666`/world-readable via `open()`).

## Tests

- Extended `tests/unit/test_sidecar_permissions.py` with an owner-inheritance case.
- Added `tests/unit/test_cbz_permissions.py` asserting a rewritten CBZ ends up world-readable (`0666`) rather than the `0600` it started with.
- Both are POSIX-only (`skipif os.name == 'nt'`), consistent with the existing perms tests — they run in the Linux container/CI.
- Full suite: **2098 passed, 6 skipped** (POSIX perms tests skip on Windows), with the known `test_pdf.py` env-only baseline excluded. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)