### PR TITLE
Add sidecar-based pull list Automap

### DIFF
--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -1,0 +1,546 @@
+"""
+Sidecar-based automatic library mapping.
+
+Walks the configured library roots looking for folders that carry a Mylar3-style
+``series.json`` or ``cvinfo`` sidecar, resolves each to a Metron series id, and
+maps the folder to that series (writes ``series.mapped_path``). This lets a user
+who imported an existing, already-tagged library get every series onto their
+Pull List without picking folders by hand.
+
+Match source is sidecars ONLY -- no folder-name/year guessing -- so false
+matches are near-zero. Resolution cascade per folder (first hit wins):
+
+  1. series.json ``metron_id``            -> direct, no API call
+  2. cvinfo ``series_id:``                 -> direct, no API call
+  3. series.json ``comicid`` (ComicVine)   -> Metron lookup (1 API call)
+  4. cvinfo ComicVine URL (``/4050-<id>``) -> Metron lookup (1 API call)
+
+Candidates are classified into:
+  * auto    -- resolved and unambiguous; applied automatically.
+  * review  -- resolved but the series is already mapped elsewhere, or two
+               scanned folders resolve to the same series (conflict).
+  * skipped -- a sidecar with no usable id, or a ComicVine id Metron can't
+               resolve. Reported with a reason, never applied.
+
+Reuses existing parsers/writers rather than re-implementing them:
+``models.series_json``, ``models.comicvine``, ``models.metron`` and
+``core.database.save_series_mapping``.
+"""
+
+import os
+import threading
+import time
+import uuid
+
+from core.app_logging import app_logger
+from models import metron, comicvine
+from models.series_json import read_series_json, write_series_json
+
+COMIC_EXTENSIONS = (".cbz", ".cbr", ".zip", ".rar")
+SIDECAR_NAMES = {"series.json", "cvinfo"}
+
+
+def _norm(path):
+    """Normalise a path for comparison against DB-stored mapped paths.
+
+    The file index stores forward-slash paths; mirror that so a Windows os.walk
+    result compares equal to a mapped_path saved on Linux.
+    """
+    if not path:
+        return ""
+    return os.path.normpath(path).replace("\\", "/").rstrip("/")
+
+
+def _to_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _sidecar_metadata(series_json):
+    """Return the field dict from a parsed series.json.
+
+    CLU/Mylar3 nest the fields under a ``metadata`` key
+    (``{"metadata": {"name": ..., "metron_id": ..., "comicid": ...}}``). Fall
+    back to the top-level dict to tolerate flat/hand-authored files.
+    """
+    if not isinstance(series_json, dict):
+        return {}
+    meta = series_json.get("metadata")
+    if isinstance(meta, dict):
+        return meta
+    return series_json
+
+
+def _count_comics(folder):
+    """Count comic archives directly inside a folder (display only)."""
+    try:
+        return sum(
+            1 for f in os.listdir(folder) if f.lower().endswith(COMIC_EXTENSIONS)
+        )
+    except OSError:
+        return 0
+
+
+def _resolve_identity(folder, api):
+    """Resolve a candidate folder to a Metron series id via the sidecar cascade.
+
+    Returns a candidate dict, or None if the folder has no sidecar at all.
+    On success ``metron_id`` is set and ``reason`` is None; when a sidecar is
+    present but cannot be resolved, ``metron_id`` is None and ``reason`` explains
+    why (so the caller can report it as skipped).
+    """
+    series_json = read_series_json(folder)
+    cvinfo_path = comicvine.find_cvinfo_in_folder(folder)
+    if not series_json and not cvinfo_path:
+        return None
+
+    meta = _sidecar_metadata(series_json)
+    name = meta.get("name")
+    publisher = meta.get("publisher")
+    year = meta.get("year")
+    cv_id = _to_int(meta.get("comicid"))
+
+    if cvinfo_path:
+        fields = comicvine.read_cvinfo_fields(cvinfo_path)
+        publisher = publisher or fields.get("publisher_name")
+        year = year or fields.get("start_year")
+
+    def _candidate(metron_id, source, reason=None):
+        return {
+            "folder": folder,
+            "metron_id": metron_id,
+            "series_name": name or os.path.basename(folder.rstrip("/\\")),
+            "publisher_name": publisher,
+            "year": year,
+            "cv_id": cv_id,
+            "source": source,
+            "reason": reason,
+            "conflict_with": None,
+        }
+
+    # 1. series.json -> metron_id (direct)
+    mid = _to_int(meta.get("metron_id"))
+    if mid:
+        return _candidate(mid, "series.json:metron_id")
+
+    # 2. cvinfo -> series_id: (direct)
+    if cvinfo_path:
+        mid = metron.parse_cvinfo_for_metron_id(cvinfo_path)
+        if mid:
+            return _candidate(mid, "cvinfo:series_id")
+
+    # 3/4. ComicVine id (series.json comicid, else cvinfo URL) -> Metron lookup
+    if not cv_id and cvinfo_path:
+        cv_id = metron.parse_cvinfo_for_comicvine_id(cvinfo_path)
+
+    if cv_id:
+        if api:
+            mid = metron.get_series_id_by_comicvine_id(api, cv_id)
+            if mid:
+                return _candidate(mid, "comicvine_id")
+            return _candidate(
+                None, "comicvine_id", f"ComicVine ID {cv_id} not found on Metron"
+            )
+        return _candidate(
+            None, "comicvine_id", "Metron API unavailable to resolve ComicVine ID"
+        )
+
+    return _candidate(None, "sidecar", "Sidecar has no Metron or ComicVine ID")
+
+
+def _find_candidate_folders(roots):
+    """Return every folder under the library roots that holds a sidecar file."""
+    folders = []
+    for root in roots:
+        if not root or not os.path.isdir(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            # Don't descend into hidden dirs (.git, .@__thumb, etc.)
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            if SIDECAR_NAMES.intersection(f.lower() for f in filenames):
+                folders.append(dirpath)
+    return folders
+
+
+def scan_library_for_automap(api=None, progress_cb=None):
+    """Scan library roots and classify sidecar folders into auto/review/skipped.
+
+    Args:
+        api: Optional Metron API client. Without it, only steps 1-2 (direct
+            Metron id) can resolve; ComicVine-only sidecars become skipped.
+        progress_cb: Optional callable(current, total, folder_or_None).
+
+    Returns:
+        dict with keys ``auto``, ``review``, ``skipped``, ``total_candidates``.
+    """
+    from core.database import get_all_mapped_series
+
+    roots = get_library_roots()
+    mapped_rows = get_all_mapped_series()
+    mapped_paths = {}
+    mapped_ids = {}
+    for row in mapped_rows:
+        path = row.get("mapped_path")
+        if path:
+            mapped_paths[_norm(path)] = row.get("id")
+            mapped_ids[row.get("id")] = _norm(path)
+
+    candidates = _find_candidate_folders(roots)
+    total = len(candidates)
+
+    auto = []
+    review = []
+    skipped = []
+    seen_ids = {}  # metron_id -> normalised folder that first claimed it
+
+    for index, folder in enumerate(candidates):
+        if progress_cb:
+            progress_cb(index, total, folder)
+
+        nfolder = _norm(folder)
+        if nfolder in mapped_paths:
+            continue  # already tracked -- leave it alone
+
+        ident = _resolve_identity(folder, api)
+        if ident is None:
+            continue
+        ident["comic_count"] = _count_comics(folder)
+
+        mid = ident["metron_id"]
+        if not mid:
+            skipped.append(ident)
+            continue
+
+        existing = mapped_ids.get(mid)
+        if existing and existing != nfolder:
+            ident["reason"] = f"Series already mapped to {existing}"
+            ident["conflict_with"] = existing
+            review.append(ident)
+            continue
+
+        if mid in seen_ids and seen_ids[mid] != nfolder:
+            ident["reason"] = f"Same series also found in {seen_ids[mid]}"
+            ident["conflict_with"] = seen_ids[mid]
+            review.append(ident)
+            continue
+
+        seen_ids[mid] = nfolder
+        auto.append(ident)
+
+    if progress_cb:
+        progress_cb(total, total, None)
+
+    return {
+        "auto": auto,
+        "review": review,
+        "skipped": skipped,
+        "total_candidates": total,
+    }
+
+
+def get_library_roots():
+    """Thin wrapper so tests can monkeypatch roots without touching helpers."""
+    from helpers.library import get_library_roots as _roots
+
+    return _roots()
+
+
+def _fetch_series_dict(api, metron_id, fallback):
+    """Build a series payload for save_series_mapping.
+
+    Prefer the authoritative Metron object (gives name/publisher/status/year);
+    fall back to sidecar-derived fields if the API is unavailable, so we can
+    still write a valid (name-bearing) row.
+    """
+    if api:
+        try:
+            info = api.series(metron_id)
+            if info:
+                if hasattr(info, "model_dump"):
+                    data = info.model_dump(mode="json")
+                elif hasattr(info, "dict"):
+                    data = info.dict()
+                else:
+                    data = {"id": metron_id, "name": getattr(info, "name", "")}
+                data["id"] = metron_id
+                return data
+        except Exception as e:
+            app_logger.warning(f"automap: api.series({metron_id}) failed: {e}")
+
+    return {
+        "id": metron_id,
+        "name": fallback.get("series_name") or f"Series {metron_id}",
+        "publisher_name": fallback.get("publisher_name"),
+        "year_began": fallback.get("year"),
+        "cv_id": fallback.get("cv_id"),
+    }
+
+
+def _backfill_sidecars(folder, series_dict, metron_id, api):
+    """Write the Metron id into the folder's sidecars so future scans skip the API."""
+    try:
+        existing = read_series_json(folder)
+        if not _sidecar_metadata(existing).get("metron_id"):
+            write_series_json(folder, series_dict, api=api)
+    except Exception as e:
+        app_logger.warning(f"automap: series.json backfill failed for {folder}: {e}")
+
+    try:
+        cvinfo_path = comicvine.find_cvinfo_in_folder(folder)
+        if cvinfo_path:
+            if metron.parse_cvinfo_for_metron_id(cvinfo_path) != metron_id:
+                metron.update_cvinfo_with_metron_id(cvinfo_path, metron_id)
+        else:
+            publisher = series_dict.get("publisher")
+            publisher_name = series_dict.get("publisher_name") or (
+                publisher.get("name") if isinstance(publisher, dict) else None
+            )
+            metron.create_cvinfo_file(
+                os.path.join(folder, "cvinfo"),
+                cv_id=series_dict.get("cv_id"),
+                series_id=metron_id,
+                publisher_name=publisher_name,
+                start_year=series_dict.get("year_began"),
+            )
+    except Exception as e:
+        app_logger.warning(f"automap: cvinfo backfill failed for {folder}: {e}")
+
+
+def apply_automap(items, api=None):
+    """Map each item's folder to its Metron series and backfill sidecars.
+
+    Args:
+        items: iterable of dicts with at least ``folder`` and ``metron_id``.
+        api: Optional Metron API client (fetched if None).
+
+    Returns:
+        dict with ``applied`` (int), ``failed`` (list of {folder,error}), and
+        ``applied_ids`` (list of Metron series ids).
+    """
+    from core.database import save_publisher, save_series_mapping
+
+    if api is None:
+        api = metron.get_flask_api()
+
+    applied = 0
+    failed = []
+    applied_ids = []
+
+    for item in items:
+        folder = item.get("folder")
+        metron_id = _to_int(item.get("metron_id"))
+        if not folder or not metron_id:
+            failed.append({"folder": folder, "error": "Missing folder or metron_id"})
+            continue
+        if not os.path.isdir(folder):
+            failed.append({"folder": folder, "error": "Folder no longer exists"})
+            continue
+
+        try:
+            series_dict = _fetch_series_dict(api, metron_id, item)
+            publisher = series_dict.get("publisher")
+            if isinstance(publisher, dict) and publisher.get("id"):
+                save_publisher(publisher.get("id"), publisher.get("name"))
+
+            if not save_series_mapping(series_dict, folder):
+                failed.append({"folder": folder, "error": "Failed to save mapping"})
+                continue
+
+            _backfill_sidecars(folder, series_dict, metron_id, api)
+            applied += 1
+            applied_ids.append(metron_id)
+        except Exception as e:
+            app_logger.error(f"automap: apply failed for {folder}: {e}")
+            failed.append({"folder": folder, "error": str(e)})
+
+    return {"applied": applied, "failed": failed, "applied_ids": applied_ids}
+
+
+def _sync_and_match(api, series_id):
+    """Bring a mapped series up to date and compute its collection match.
+
+    Mirrors what the per-series "Refresh"/sync button does on the backend:
+    pull issues from Metron (only if none are cached yet), then run
+    ``match_issues_to_collection`` so the found/missing status is populated and
+    cached — otherwise a freshly mapped series shows no owned/wanted state until
+    the user opens its page.
+    """
+    from core.database import (
+        get_series_by_id,
+        get_series_mapping,
+        get_issues_for_series,
+    )
+    from helpers.collection import match_issues_to_collection
+
+    try:
+        mapped_path = get_series_mapping(series_id)
+        if not mapped_path or not os.path.isdir(mapped_path):
+            return
+
+        issues = get_issues_for_series(series_id)
+        if not issues and api:
+            from sync import sync_series_from_api
+
+            sync_series_from_api(api, series_id)
+            issues = get_issues_for_series(series_id)
+
+        series_info = get_series_by_id(series_id)
+        if series_info and issues:
+            match_issues_to_collection(
+                mapped_path, issues, series_info, use_cache=False
+            )
+    except Exception as e:
+        app_logger.warning(f"automap: sync+match failed for {series_id}: {e}")
+
+
+def _sync_and_match_ids(api, series_ids):
+    for series_id in series_ids:
+        _sync_and_match(api, series_id)
+
+
+def match_unmatched_mapped_series(api):
+    """Sync + match every mapped series that has no cached collection status.
+
+    Covers the series just auto-mapped (which have none) plus any previously
+    mapped series that were never matched.
+    """
+    from core.database import (
+        get_all_mapped_series,
+        get_collection_status_for_series,
+    )
+
+    for row in get_all_mapped_series():
+        series_id = row.get("id")
+        if not series_id:
+            continue
+        if get_collection_status_for_series(series_id):
+            continue  # already matched — leave it (and its Metron budget) alone
+        _sync_and_match(api, series_id)
+
+
+def apply_and_sync(items, api=None):
+    """Apply mappings, then background-sync + match the newly mapped series."""
+    if api is None:
+        api = metron.get_flask_api()
+    result = apply_automap(items, api=api)
+    if result["applied_ids"]:
+        threading.Thread(
+            target=_sync_and_match_ids,
+            args=(api, list(result["applied_ids"])),
+            daemon=True,
+        ).start()
+    return result
+
+
+# ── Background scan jobs ───────────────────────────────────────────────────
+# A small self-contained job store so the Pull List can poll a long scan and
+# retrieve the review/skipped lists once it finishes. (app_state's operation
+# registry prunes completed ops after 15s, too short to hand back results.)
+
+_jobs = {}
+_jobs_lock = threading.Lock()
+_JOB_TTL = 900  # keep finished jobs 15 min for the UI to fetch
+
+
+def _prune_jobs_locked():
+    now = time.time()
+    for op_id in [
+        oid
+        for oid, job in _jobs.items()
+        if job["status"] in ("done", "error")
+        and (now - job.get("finished_at", now)) > _JOB_TTL
+    ]:
+        del _jobs[op_id]
+
+
+def _update_job(op_id, **fields):
+    with _jobs_lock:
+        job = _jobs.get(op_id)
+        if job:
+            job.update(fields)
+
+
+def _run_scan_job(op_id, app):
+    # Runs in a background thread with no request/app context of its own; push
+    # one so metron.get_flask_api() (and any downstream current_app use) works.
+    with app.app_context():
+        _run_scan_job_inner(op_id, app)
+
+
+def _run_scan_job_inner(op_id, app):
+    try:
+        api = metron.get_flask_api(app)
+
+        def progress(current, total, folder):
+            _update_job(
+                op_id,
+                current=current,
+                total=total,
+                detail=os.path.basename(folder) if folder else "Finishing...",
+            )
+
+        scan = scan_library_for_automap(api=api, progress_cb=progress)
+        _update_job(op_id, detail="Applying matches...")
+        applied = apply_automap(scan["auto"], api=api)
+
+        result = {
+            "applied": applied["applied"],
+            "applied_failed": applied["failed"],
+            "review": scan["review"],
+            "skipped": scan["skipped"],
+            "total_candidates": scan["total_candidates"],
+        }
+        with _jobs_lock:
+            job = _jobs.get(op_id)
+            if job:
+                job.update(
+                    status="done",
+                    result=result,
+                    current=job.get("total", 0),
+                    finished_at=time.time(),
+                )
+
+        # Result is already stored (UI can render), so this runs as a
+        # background tail: sync + match every mapped series that isn't matched
+        # yet, so the Pull List / Wanted lists reflect owned vs missing without
+        # the user opening each series.
+        match_unmatched_mapped_series(api)
+    except Exception as e:
+        app_logger.error(f"automap: scan job {op_id} failed: {e}")
+        with _jobs_lock:
+            job = _jobs.get(op_id)
+            if job:
+                job.update(status="error", error=str(e), finished_at=time.time())
+
+
+def start_scan_job(app):
+    """Start a background scan + auto-apply. Returns the job/op id to poll.
+
+    ``app`` is the Flask application object; the worker pushes its context so
+    credential/config lookups work off the request thread.
+    """
+    op_id = uuid.uuid4().hex
+    with _jobs_lock:
+        _prune_jobs_locked()
+        _jobs[op_id] = {
+            "id": op_id,
+            "status": "running",
+            "current": 0,
+            "total": 0,
+            "detail": "Starting...",
+            "result": None,
+            "error": None,
+            "started_at": time.time(),
+        }
+    threading.Thread(target=_run_scan_job, args=(op_id, app), daemon=True).start()
+    return op_id
+
+
+def get_scan_job(op_id):
+    """Return a copy of a scan job's state, or None if unknown/expired."""
+    with _jobs_lock:
+        _prune_jobs_locked()
+        job = _jobs.get(op_id)
+        return dict(job) if job else None

--- a/routes/series.py
+++ b/routes/series.py
@@ -368,6 +368,76 @@ def import_pull_list():
     })
 
 
+@series_bp.route("/api/pull-list/scan", methods=["POST"])
+def scan_library_automap():
+    """Start a background sidecar scan that auto-maps matching library folders.
+
+    Returns an ``op_id`` the client polls via /api/pull-list/scan/status.
+    """
+    from flask import current_app
+    from models import library_automap
+
+    op_id = library_automap.start_scan_job(current_app._get_current_object())
+    return jsonify({"success": True, "op_id": op_id})
+
+
+@series_bp.route("/api/pull-list/scan/status", methods=["GET"])
+def scan_library_automap_status():
+    """Poll a running/finished auto-map scan job."""
+    from models import library_automap
+
+    op_id = request.args.get("op_id", "")
+    job = library_automap.get_scan_job(op_id)
+    if not job:
+        return jsonify({"success": False, "error": "Unknown or expired scan job"}), 404
+
+    payload = {
+        "success": True,
+        "status": job["status"],
+        "current": job.get("current", 0),
+        "total": job.get("total", 0),
+        "detail": job.get("detail", ""),
+    }
+    if job["status"] == "done":
+        payload["result"] = job.get("result")
+    elif job["status"] == "error":
+        payload["error"] = job.get("error")
+    return jsonify(payload)
+
+
+@series_bp.route("/api/pull-list/apply", methods=["POST"])
+def apply_library_automap():
+    """Apply user-selected review matches from the auto-map scan."""
+    from models import library_automap
+
+    data = request.get_json(silent=True) or {}
+    items = data.get("items")
+    if not isinstance(items, list) or not items:
+        return jsonify({"success": False, "error": "No items provided"}), 400
+
+    clean = [
+        {
+            "folder": it.get("folder"),
+            "metron_id": it.get("metron_id"),
+            "series_name": it.get("series_name"),
+            "publisher_name": it.get("publisher_name"),
+            "year": it.get("year"),
+            "cv_id": it.get("cv_id"),
+        }
+        for it in items
+        if isinstance(it, dict) and it.get("folder") and it.get("metron_id")
+    ]
+    if not clean:
+        return jsonify({"success": False, "error": "No valid items provided"}), 400
+
+    result = library_automap.apply_and_sync(clean)
+    return jsonify({
+        "success": True,
+        "applied": result["applied"],
+        "failed": result["failed"],
+    })
+
+
 @series_bp.route("/series-search")
 def series_search():
     """

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -11,6 +11,10 @@
             <p class="text-muted lead mb-0">All tracked series in your collection</p>
         </div>
         <div class="d-flex gap-2">
+            <button type="button" class="btn btn-outline-info" id="scanLibraryBtn"
+                title="Scan library folders and auto-map series from series.json / cvinfo sidecars">
+                <i class="bi bi-magic me-1"></i>Scan Library
+            </button>
             <a href="{{ url_for('series.wanted') }}" class="btn btn-outline-warning">
                 <i class="bi bi-star me-1"></i>Wanted Issues
             </a>
@@ -47,10 +51,16 @@
             <i class="bi bi-collection display-1 text-muted opacity-25"></i>
         </div>
         <h3 class="h2 text-muted mb-3">No Tracked Series</h3>
-        <p class="text-muted mb-4 lead">Start tracking series by mapping them to your collection.</p>
-        <a href="{{ url_for('series.releases') }}" class="btn btn-outline-primary btn-lg">
-            <i class="bi bi-calendar-week me-1"></i>Browse Releases
-        </a>
+        <p class="text-muted mb-4 lead">Start tracking series by mapping them to your collection,
+            or scan your library to auto-map folders that already have <code>series.json</code> / <code>cvinfo</code> files.</p>
+        <div class="d-flex gap-2 justify-content-center">
+            <button type="button" class="btn btn-info btn-lg" id="scanLibraryBtnEmpty">
+                <i class="bi bi-magic me-1"></i>Scan Library
+            </button>
+            <a href="{{ url_for('series.releases') }}" class="btn btn-outline-primary btn-lg">
+                <i class="bi bi-calendar-week me-1"></i>Browse Releases
+            </a>
+        </div>
     </div>
     {% else %}
 
@@ -207,8 +217,247 @@
     </div>
 </div>
 
+<!-- Auto-Map Library Modal -->
+<div class="modal fade" id="automapModal" tabindex="-1" data-bs-backdrop="static">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title fw-bold">
+                    <i class="bi bi-magic me-2"></i>Scan Library
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" id="automapClose"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Progress -->
+                <div id="automapProgress">
+                    <p class="text-muted small mb-3">
+                        Scanning your library for folders with a <code>series.json</code> or <code>cvinfo</code>
+                        file and mapping them to the matching series. High-confidence matches are applied
+                        automatically; anything ambiguous is listed below for you to confirm.
+                    </p>
+                    <div class="d-flex align-items-center gap-3 mb-2">
+                        <div class="spinner-border spinner-border-sm text-info" role="status"></div>
+                        <span id="automapDetail" class="text-muted small">Starting…</span>
+                    </div>
+                    <div class="progress" style="height: 6px;">
+                        <div id="automapBar" class="progress-bar bg-info" role="progressbar" style="width: 0%;"></div>
+                    </div>
+                </div>
+
+                <!-- Results -->
+                <div id="automapResults" class="d-none">
+                    <div id="automapSummary" class="alert alert-success"></div>
+
+                    <div id="automapReviewWrap" class="d-none">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <h6 class="fw-bold mb-0">Needs review</h6>
+                            <button type="button" class="btn btn-sm btn-primary" id="automapApplySelected">
+                                <i class="bi bi-check2 me-1"></i>Apply selected
+                            </button>
+                        </div>
+                        <p class="text-muted small mb-2">These folders resolved to a series that is already
+                            mapped elsewhere, or two folders point at the same series. Pick the ones to map.</p>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm align-middle">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width:2rem;"></th>
+                                        <th>Series</th>
+                                        <th>Folder</th>
+                                        <th>Reason</th>
+                                        <th class="text-center">Files</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="automapReviewBody"></tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div id="automapSkippedWrap" class="d-none">
+                        <button class="btn btn-sm btn-outline-secondary mb-2" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#automapSkippedList">
+                            <i class="bi bi-chevron-down me-1"></i><span id="automapSkippedCount"></span>
+                        </button>
+                        <div class="collapse" id="automapSkippedList"></div>
+                    </div>
+                </div>
+
+                <div id="automapError" class="alert alert-danger d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary d-none" id="automapReload" onclick="location.reload()">
+                    <i class="bi bi-arrow-clockwise me-1"></i>Reload page
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
     document.addEventListener('DOMContentLoaded', function () {
+        // ── Auto-Map Library ──
+        const automapModalEl = document.getElementById('automapModal');
+        const automapModal = automapModalEl ? new bootstrap.Modal(automapModalEl) : null;
+        let automapPoll = null;
+        let reviewItems = [];
+
+        function esc(s) {
+            const d = document.createElement('div');
+            d.textContent = (s == null ? '' : String(s));
+            return d.innerHTML;
+        }
+
+        function resetAutomapUI() {
+            document.getElementById('automapProgress').classList.remove('d-none');
+            document.getElementById('automapResults').classList.add('d-none');
+            document.getElementById('automapError').classList.add('d-none');
+            document.getElementById('automapReviewWrap').classList.add('d-none');
+            document.getElementById('automapSkippedWrap').classList.add('d-none');
+            document.getElementById('automapReload').classList.add('d-none');
+            document.getElementById('automapBar').style.width = '0%';
+            document.getElementById('automapDetail').textContent = 'Starting…';
+        }
+
+        function startScan() {
+            if (!automapModal) return;
+            resetAutomapUI();
+            automapModal.show();
+            fetch('/api/pull-list/scan', { method: 'POST' })
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.success) throw new Error(data.error || 'Failed to start scan');
+                    pollScan(data.op_id);
+                })
+                .catch(err => showAutomapError(err.message));
+        }
+
+        function pollScan(opId) {
+            automapPoll = setInterval(() => {
+                fetch('/api/pull-list/scan/status?op_id=' + encodeURIComponent(opId))
+                    .then(r => r.json())
+                    .then(data => {
+                        if (!data.success) throw new Error(data.error || 'Scan status unavailable');
+                        const detail = document.getElementById('automapDetail');
+                        const bar = document.getElementById('automapBar');
+                        const pct = data.total ? Math.round((data.current / data.total) * 100) : 0;
+                        bar.style.width = pct + '%';
+                        detail.textContent = data.total
+                            ? `${data.current} / ${data.total} — ${data.detail || ''}`
+                            : (data.detail || 'Scanning…');
+                        if (data.status === 'done') {
+                            clearInterval(automapPoll);
+                            renderResults(data.result);
+                        } else if (data.status === 'error') {
+                            clearInterval(automapPoll);
+                            showAutomapError(data.error || 'Scan failed');
+                        }
+                    })
+                    .catch(err => { clearInterval(automapPoll); showAutomapError(err.message); });
+            }, 1000);
+        }
+
+        function showAutomapError(msg) {
+            document.getElementById('automapProgress').classList.add('d-none');
+            const el = document.getElementById('automapError');
+            el.textContent = msg;
+            el.classList.remove('d-none');
+        }
+
+        function renderResults(result) {
+            document.getElementById('automapProgress').classList.add('d-none');
+            document.getElementById('automapResults').classList.remove('d-none');
+
+            const applied = result.applied || 0;
+            const reviewN = (result.review || []).length;
+            const skippedN = (result.skipped || []).length;
+            document.getElementById('automapSummary').innerHTML =
+                `<strong>Mapped ${applied}</strong> series automatically from `
+                + `${result.total_candidates || 0} folder(s) with sidecar files. `
+                + (reviewN ? `${reviewN} need review. ` : '')
+                + (skippedN ? `${skippedN} skipped. ` : '')
+                + `<div class="small text-muted mt-2"><i class="bi bi-hourglass-split me-1"></i>`
+                + `Matching your files to issues in the background — reload in a moment to see owned/missing counts.</div>`;
+
+            // Review table
+            reviewItems = result.review || [];
+            const reviewWrap = document.getElementById('automapReviewWrap');
+            const body = document.getElementById('automapReviewBody');
+            if (reviewItems.length) {
+                body.innerHTML = reviewItems.map((it, i) => `
+                    <tr>
+                        <td><input class="form-check-input automap-review-cb" type="checkbox" data-idx="${i}"></td>
+                        <td>${esc(it.series_name)}${it.year ? ' <span class="text-muted">(' + esc(it.year) + ')</span>' : ''}</td>
+                        <td><small class="text-muted">${esc(it.folder)}</small></td>
+                        <td><small>${esc(it.reason)}</small></td>
+                        <td class="text-center"><span class="badge bg-info">${it.comic_count || 0}</span></td>
+                    </tr>`).join('');
+                reviewWrap.classList.remove('d-none');
+            } else {
+                reviewWrap.classList.add('d-none');
+            }
+
+            // Skipped list
+            const skipped = result.skipped || [];
+            const skWrap = document.getElementById('automapSkippedWrap');
+            if (skipped.length) {
+                document.getElementById('automapSkippedCount').textContent = `${skipped.length} skipped (reason)`;
+                document.getElementById('automapSkippedList').innerHTML =
+                    '<ul class="list-group list-group-flush small">' + skipped.map(it => `
+                        <li class="list-group-item px-0">
+                            <span class="text-muted">${esc(it.folder)}</span>
+                            — ${esc(it.reason)}
+                        </li>`).join('') + '</ul>';
+                skWrap.classList.remove('d-none');
+            } else {
+                skWrap.classList.add('d-none');
+            }
+
+            if (applied > 0) {
+                document.getElementById('automapReload').classList.remove('d-none');
+            }
+        }
+
+        const applySelectedBtn = document.getElementById('automapApplySelected');
+        if (applySelectedBtn) {
+            applySelectedBtn.addEventListener('click', () => {
+                const checked = Array.from(document.querySelectorAll('.automap-review-cb:checked'))
+                    .map(cb => reviewItems[parseInt(cb.dataset.idx, 10)]);
+                if (!checked.length) return;
+                applySelectedBtn.disabled = true;
+                applySelectedBtn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+                fetch('/api/pull-list/apply', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ items: checked }),
+                })
+                    .then(r => r.json())
+                    .then(data => {
+                        if (!data.success) throw new Error(data.error || 'Apply failed');
+                        document.getElementById('automapSummary').innerHTML =
+                            `<strong>Mapped ${data.applied}</strong> more series. Reload to see them.`;
+                        document.getElementById('automapReviewWrap').classList.add('d-none');
+                        document.getElementById('automapReload').classList.remove('d-none');
+                    })
+                    .catch(err => {
+                        applySelectedBtn.disabled = false;
+                        applySelectedBtn.innerHTML = '<i class="bi bi-check2 me-1"></i>Apply selected';
+                        showAutomapError(err.message);
+                    });
+            });
+        }
+
+        const scanBtn = document.getElementById('scanLibraryBtn');
+        if (scanBtn) scanBtn.addEventListener('click', startScan);
+        const scanBtnEmpty = document.getElementById('scanLibraryBtnEmpty');
+        if (scanBtnEmpty) scanBtnEmpty.addEventListener('click', startScan);
+
+        if (automapModalEl) {
+            automapModalEl.addEventListener('hidden.bs.modal', () => {
+                if (automapPoll) clearInterval(automapPoll);
+            });
+        }
+
         const importSubmit = document.getElementById('importSubmit');
         if (importSubmit) {
             importSubmit.addEventListener('click', async () => {

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -1,0 +1,285 @@
+"""Tests for models/library_automap.py -- sidecar-based auto-mapping."""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import library_automap
+
+
+def _make_folder(root, name, *, series_json=None, wrap=True, cvinfo=None, comics=0):
+    """Create a series folder with optional sidecars and dummy comic files.
+
+    ``series_json`` is written in the real Mylar/CLU ``{"metadata": {...}}``
+    shape by default; pass ``wrap=False`` to write a flat/legacy file.
+    """
+    folder = os.path.join(str(root), name)
+    os.makedirs(folder, exist_ok=True)
+    if series_json is not None:
+        payload = {"metadata": series_json} if wrap else series_json
+        with open(os.path.join(folder, "series.json"), "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    if cvinfo is not None:
+        with open(os.path.join(folder, "cvinfo"), "w", encoding="utf-8") as f:
+            f.write(cvinfo)
+    for i in range(comics):
+        with open(os.path.join(folder, f"issue {i}.cbz"), "w") as f:
+            f.write("x")
+    return folder
+
+
+class TestResolveIdentity:
+    def test_series_json_metron_id_is_direct(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Batman",
+            series_json={"name": "Batman", "metron_id": 555, "comicid": 4050,
+                         "publisher": "DC", "year": 2016},
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["metron_id"] == 555
+        assert ident["source"] == "series.json:metron_id"
+        assert ident["reason"] is None
+        assert ident["series_name"] == "Batman"
+
+    def test_cvinfo_series_id_is_direct(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Flash",
+            cvinfo="https://comicvine.gamespot.com/flash/4050-1234/\nseries_id: 777\n",
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["metron_id"] == 777
+        assert ident["source"] == "cvinfo:series_id"
+
+    def test_comicid_resolves_via_metron_lookup(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        api = MagicMock()
+        result = MagicMock()
+        result.id = 4242
+        api.series_list.return_value = [result]
+        ident = library_automap._resolve_identity(folder, api=api)
+        assert ident["metron_id"] == 4242
+        assert ident["source"] == "comicvine_id"
+
+    def test_comicid_unresolved_when_no_api(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["metron_id"] is None
+        assert "unavailable" in ident["reason"].lower()
+
+    def test_comicid_not_found_on_metron(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Obscure", series_json={"name": "Obscure", "comicid": 99999},
+        )
+        api = MagicMock()
+        api.series_list.return_value = []
+        ident = library_automap._resolve_identity(folder, api=api)
+        assert ident["metron_id"] is None
+        assert "not found" in ident["reason"].lower()
+
+    def test_flat_legacy_series_json_still_resolves(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Legacy",
+            series_json={"name": "Legacy", "metron_id": 321}, wrap=False,
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["metron_id"] == 321
+        assert ident["series_name"] == "Legacy"
+
+    def test_idless_sidecar_is_skipped(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Mystery", series_json={"name": "Mystery"},
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["metron_id"] is None
+        assert ident["reason"]
+
+    def test_no_sidecar_returns_none(self, tmp_path):
+        folder = _make_folder(tmp_path, "Empty", comics=2)
+        assert library_automap._resolve_identity(folder, api=None) is None
+
+
+class TestScan:
+    def _patch_roots_and_mapping(self, roots, mapped_rows):
+        return (
+            patch.object(library_automap, "get_library_roots", return_value=roots),
+            patch("core.database.get_all_mapped_series", return_value=mapped_rows),
+        )
+
+    def test_direct_id_goes_to_auto(self, tmp_path):
+        _make_folder(tmp_path, "Batman",
+                     series_json={"name": "Batman", "metron_id": 555}, comics=3)
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], [])
+        with p_roots, p_map:
+            result = library_automap.scan_library_for_automap(api=None)
+        assert len(result["auto"]) == 1
+        assert result["auto"][0]["metron_id"] == 555
+        assert result["auto"][0]["comic_count"] == 3
+        assert not result["review"]
+        assert not result["skipped"]
+
+    def test_already_mapped_series_goes_to_review(self, tmp_path):
+        folder = _make_folder(tmp_path, "Batman",
+                              series_json={"name": "Batman", "metron_id": 555})
+        mapped = [{"id": 555, "mapped_path": "/data/OtherBatman"}]
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], mapped)
+        with p_roots, p_map:
+            result = library_automap.scan_library_for_automap(api=None)
+        assert not result["auto"]
+        assert len(result["review"]) == 1
+        assert result["review"][0]["conflict_with"] == "/data/OtherBatman"
+
+    def test_folder_already_mapped_is_skipped_silently(self, tmp_path):
+        folder = _make_folder(tmp_path, "Batman",
+                              series_json={"name": "Batman", "metron_id": 555})
+        mapped = [{"id": 555, "mapped_path": library_automap._norm(folder)}]
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], mapped)
+        with p_roots, p_map:
+            result = library_automap.scan_library_for_automap(api=None)
+        assert not result["auto"]
+        assert not result["review"]
+        assert not result["skipped"]
+
+    def test_duplicate_series_in_scan_goes_to_review(self, tmp_path):
+        _make_folder(tmp_path, "Batman-A",
+                     series_json={"name": "Batman", "metron_id": 555})
+        _make_folder(tmp_path, "Batman-B",
+                     series_json={"name": "Batman", "metron_id": 555})
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], [])
+        with p_roots, p_map:
+            result = library_automap.scan_library_for_automap(api=None)
+        assert len(result["auto"]) == 1
+        assert len(result["review"]) == 1
+
+    def test_idless_folder_goes_to_skipped(self, tmp_path):
+        _make_folder(tmp_path, "Mystery", series_json={"name": "Mystery"})
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], [])
+        with p_roots, p_map:
+            result = library_automap.scan_library_for_automap(api=None)
+        assert not result["auto"]
+        assert len(result["skipped"]) == 1
+
+
+class TestApply:
+    def test_applies_and_saves_mapping(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Batman",
+            series_json={"name": "Batman", "metron_id": 555},
+            cvinfo="series_id: 555\n",
+        )
+        api = MagicMock()
+        series_obj = MagicMock()
+        series_obj.model_dump.return_value = {
+            "id": 555, "name": "Batman", "publisher": {"id": 10, "name": "DC"},
+            "year_began": 2016, "cv_id": 4050,
+        }
+        api.series.return_value = series_obj
+
+        with patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher") as save_pub:
+            result = library_automap.apply_automap(
+                [{"folder": folder, "metron_id": 555, "series_name": "Batman"}], api=api
+            )
+        assert result["applied"] == 1
+        assert result["applied_ids"] == [555]
+        saved_dict, saved_path = save.call_args[0][:2]
+        assert saved_path == folder
+        assert saved_dict["id"] == 555
+        save_pub.assert_called_once_with(10, "DC")
+
+    def test_missing_folder_is_failure(self, tmp_path):
+        api = MagicMock()
+        with patch("core.database.save_series_mapping", return_value=True), \
+             patch("core.database.save_publisher"):
+            result = library_automap.apply_automap(
+                [{"folder": str(tmp_path / "gone"), "metron_id": 1}], api=api
+            )
+        assert result["applied"] == 0
+        assert len(result["failed"]) == 1
+
+    def test_missing_metron_id_is_failure(self, tmp_path):
+        folder = _make_folder(tmp_path, "X", series_json={"name": "X"})
+        with patch("core.database.save_series_mapping", return_value=True), \
+             patch("core.database.save_publisher"):
+            result = library_automap.apply_automap(
+                [{"folder": folder, "metron_id": None}], api=MagicMock()
+            )
+        assert result["applied"] == 0
+        assert len(result["failed"]) == 1
+
+class TestSyncAndMatch:
+    def test_matches_when_issues_cached(self, tmp_path):
+        folder = str(tmp_path)
+        issues = [{"number": "1"}]
+        series = {"id": 555, "name": "Batman"}
+        with patch("core.database.get_series_mapping", return_value=folder), \
+             patch("core.database.get_issues_for_series", return_value=issues), \
+             patch("core.database.get_series_by_id", return_value=series), \
+             patch("helpers.collection.match_issues_to_collection") as match:
+            library_automap._sync_and_match(api=None, series_id=555)
+        match.assert_called_once()
+        args, kwargs = match.call_args
+        assert args[0] == folder
+        assert args[1] == issues
+        assert kwargs.get("use_cache") is False
+
+    def test_syncs_when_no_issues_then_matches(self, tmp_path):
+        folder = str(tmp_path)
+        api = MagicMock()
+        call_state = {"synced": False}
+
+        def get_issues(_sid):
+            return [{"number": "1"}] if call_state["synced"] else []
+
+        def do_sync(_api, _sid):
+            call_state["synced"] = True
+
+        with patch("core.database.get_series_mapping", return_value=folder), \
+             patch("core.database.get_issues_for_series", side_effect=get_issues), \
+             patch("core.database.get_series_by_id", return_value={"id": 9, "name": "X"}), \
+             patch("sync.sync_series_from_api", side_effect=do_sync) as sync_fn, \
+             patch("helpers.collection.match_issues_to_collection") as match:
+            library_automap._sync_and_match(api=api, series_id=9)
+        sync_fn.assert_called_once()
+        match.assert_called_once()
+
+    def test_skips_when_folder_missing(self, tmp_path):
+        with patch("core.database.get_series_mapping", return_value=str(tmp_path / "gone")), \
+             patch("helpers.collection.match_issues_to_collection") as match:
+            library_automap._sync_and_match(api=MagicMock(), series_id=1)
+        match.assert_not_called()
+
+    def test_match_unmatched_skips_already_matched(self):
+        rows = [{"id": 1}, {"id": 2}]
+
+        def cached(sid):
+            return [{"issue_number": "1"}] if sid == 1 else None
+
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", side_effect=cached), \
+             patch.object(library_automap, "_sync_and_match") as sm:
+            library_automap.match_unmatched_mapped_series(api=None)
+        called_ids = [c.args[1] for c in sm.call_args_list]
+        assert called_ids == [2]
+
+
+class TestApplyExtra:
+    def test_falls_back_to_sidecar_when_no_api(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Batman",
+            series_json={"name": "Batman", "metron_id": 555},
+            cvinfo="series_id: 555\n",
+        )
+        with patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("models.metron.get_flask_api", return_value=None):
+            result = library_automap.apply_automap(
+                [{"folder": folder, "metron_id": 555, "series_name": "Batman"}], api=None
+            )
+        assert result["applied"] == 1
+        saved_dict = save.call_args[0][0]
+        assert saved_dict["name"] == "Batman"

--- a/tests/routes/test_pull_list_automap.py
+++ b/tests/routes/test_pull_list_automap.py
@@ -1,0 +1,76 @@
+"""Tests for the Pull List auto-map routes in routes/series.py."""
+from unittest.mock import patch
+
+
+class TestScanRoute:
+    def test_scan_starts_job(self, client):
+        with patch("models.library_automap.start_scan_job", return_value="abc123") as start:
+            resp = client.post("/api/pull-list/scan")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["op_id"] == "abc123"
+        start.assert_called_once()
+
+
+class TestScanStatusRoute:
+    def test_unknown_job_returns_404(self, client):
+        with patch("models.library_automap.get_scan_job", return_value=None):
+            resp = client.get("/api/pull-list/scan/status?op_id=nope")
+        assert resp.status_code == 404
+        assert resp.get_json()["success"] is False
+
+    def test_running_job(self, client):
+        job = {"status": "running", "current": 3, "total": 10, "detail": "Batman"}
+        with patch("models.library_automap.get_scan_job", return_value=job):
+            resp = client.get("/api/pull-list/scan/status?op_id=x")
+        data = resp.get_json()
+        assert data["status"] == "running"
+        assert data["current"] == 3
+        assert "result" not in data
+
+    def test_done_job_returns_result(self, client):
+        job = {
+            "status": "done", "current": 10, "total": 10, "detail": "",
+            "result": {"applied": 4, "review": [], "skipped": [], "total_candidates": 4},
+        }
+        with patch("models.library_automap.get_scan_job", return_value=job):
+            resp = client.get("/api/pull-list/scan/status?op_id=x")
+        data = resp.get_json()
+        assert data["status"] == "done"
+        assert data["result"]["applied"] == 4
+
+    def test_error_job_returns_error(self, client):
+        job = {"status": "error", "current": 0, "total": 0, "detail": "", "error": "boom"}
+        with patch("models.library_automap.get_scan_job", return_value=job):
+            resp = client.get("/api/pull-list/scan/status?op_id=x")
+        data = resp.get_json()
+        assert data["status"] == "error"
+        assert data["error"] == "boom"
+
+
+class TestApplyRoute:
+    def test_no_items_is_400(self, client):
+        resp = client.post("/api/pull-list/apply", json={"items": []})
+        assert resp.status_code == 400
+
+    def test_invalid_items_is_400(self, client):
+        # items present but none have both folder and metron_id
+        resp = client.post("/api/pull-list/apply", json={"items": [{"folder": "/x"}]})
+        assert resp.status_code == 400
+
+    def test_valid_items_applied(self, client):
+        fake = {"applied": 1, "failed": []}
+        with patch("models.library_automap.apply_and_sync", return_value=fake) as apply:
+            resp = client.post(
+                "/api/pull-list/apply",
+                json={"items": [{"folder": "/data/Batman", "metron_id": 555}]},
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["applied"] == 1
+        # Only cleaned fields are forwarded
+        forwarded = apply.call_args[0][0]
+        assert forwarded[0]["folder"] == "/data/Batman"
+        assert forwarded[0]["metron_id"] == 555


### PR DESCRIPTION
## 📝 Description
Introduces a new `models/library_automap.py` service that scans library roots for `series.json`/`cvinfo` sidecars, resolves Metron series IDs through a direct/lookup cascade, classifies matches into auto/review/skipped, applies mappings, backfills sidecars, and runs background sync+collection matching.

Adds Pull List API routes to start scan jobs, poll scan status, and apply user-selected review items, then wires a new Pull List modal UI with scan progress, review selection, skipped-reason display, and reload flow.

Includes mocked and route tests covering identity resolution, conflict handling, apply behavior, sync/match behavior, and the new scan/apply endpoints.

Closes #401 

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass