### PR TITLE
Support ComicVine-only series in sync flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -510,8 +510,15 @@ def scheduled_series_sync():
         skip_count = 0
         fail_count = 0
 
+        from helpers.comicvine_ids import is_comicvine_series_id
+
         for series in series_list:
             series_id = series["id"]
+            # ComicVine-sourced series aren't in Metron; skip them here (they're
+            # refreshed via the ComicVine path, not this Metron sync).
+            if is_comicvine_series_id(series_id):
+                skip_count += 1
+                continue
             # These values should come from your local database
             local_status = series.get("status")
             local_issue_count = series.get("issue_count", 0)

--- a/core/database.py
+++ b/core/database.py
@@ -8711,6 +8711,8 @@ def get_series_needing_sync(hours=24):
     Returns:
         List of series dicts needing sync
     """
+    from helpers.comicvine_ids import COMICVINE_SERIES_ID_OFFSET
+
     try:
         conn = get_db_connection()
         if not conn:
@@ -8722,11 +8724,12 @@ def get_series_needing_sync(hours=24):
             SELECT *, volume_year as year_began
             FROM series
             WHERE mapped_path IS NOT NULL
+              AND id < ?
               AND (last_synced_at IS NULL
                    OR last_synced_at < datetime('now', ? || ' hours'))
             ORDER BY last_synced_at ASC NULLS FIRST
         """,
-            (f"-{hours}",),
+            (COMICVINE_SERIES_ID_OFFSET, f"-{hours}"),
         )
 
         rows = c.fetchall()

--- a/helpers/comicvine_ids.py
+++ b/helpers/comicvine_ids.py
@@ -1,0 +1,33 @@
+"""Stable synthetic ids for ComicVine-only series.
+
+The ``series`` table is keyed by the Metron series id. A series that exists only
+in ComicVine (a sidecar with a ``cv_id`` but no Metron match) has no Metron id,
+so we mint a stable, positive, collision-free key by offsetting its ComicVine
+volume id into a reserved high range. Metron series ids are small (< ~10^6), so
+the offset guarantees no overlap while keeping the id positive (the series-slug
+/URL scheme extracts a trailing positive integer, which a negative id would
+break).
+
+An id at or above the offset flags the series as ComicVine-sourced, so Metron
+sync paths can skip it and ComicVine paths can recover the real ``cv_id``.
+"""
+
+COMICVINE_SERIES_ID_OFFSET = 2_000_000_000
+
+
+def make_comicvine_series_id(cv_id):
+    """Map a ComicVine volume id to its reserved series-table id."""
+    return COMICVINE_SERIES_ID_OFFSET + int(cv_id)
+
+
+def is_comicvine_series_id(series_id):
+    """True when ``series_id`` is a ComicVine-sourced (offset) id."""
+    try:
+        return series_id is not None and int(series_id) >= COMICVINE_SERIES_ID_OFFSET
+    except (TypeError, ValueError):
+        return False
+
+
+def cv_id_from_series_id(series_id):
+    """Recover the ComicVine volume id from a ComicVine-sourced series id."""
+    return int(series_id) - COMICVINE_SERIES_ID_OFFSET

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -1140,14 +1140,16 @@ def write_cvinfo_manga_fields(cvinfo_path: str, fields: Dict[str, str]) -> bool:
 
 def get_volume_details(api_key: str, volume_id: int) -> Dict[str, Any]:
     """
-    Fetch volume details from ComicVine including publisher and start_year.
+    Fetch volume details from ComicVine.
 
     Args:
         api_key: ComicVine API key
         volume_id: ComicVine volume ID
 
     Returns:
-        Dict with 'publisher_name' and 'start_year' keys
+        Dict with 'publisher_name' and 'start_year' (always present, for
+        backward compatibility) plus 'id', 'name', 'count_of_issues',
+        'description', 'image_url' when the volume is found.
     """
     result = {'publisher_name': None, 'start_year': None}
 
@@ -1164,17 +1166,112 @@ def get_volume_details(api_key: str, volume_id: int) -> Dict[str, Any]:
         )
 
         if volume:
+            result['id'] = getattr(volume, 'id', volume_id)
+            result['name'] = getattr(volume, 'name', None)
             result['start_year'] = getattr(volume, 'start_year', None)
+            result['count_of_issues'] = getattr(volume, 'issue_count', None) \
+                or getattr(volume, 'count_of_issues', None)
+            result['description'] = getattr(volume, 'description', None)
             if hasattr(volume, 'publisher') and volume.publisher:
                 result['publisher_name'] = getattr(volume.publisher, 'name', None)
+            image = getattr(volume, 'image', None)
+            if image:
+                url = getattr(image, 'original_url', None) or getattr(image, 'thumbnail', None)
+                result['image_url'] = str(url) if url else None
 
-            app_logger.info(f"Volume details: publisher={result['publisher_name']}, start_year={result['start_year']}")
+            app_logger.info(
+                f"Volume details: name={result.get('name')}, "
+                f"publisher={result['publisher_name']}, start_year={result['start_year']}"
+            )
 
         return result
 
     except Exception as e:
         app_logger.error(f"Error fetching volume details for {volume_id}: {e}")
         return result
+
+
+def get_all_issues_for_volume(api_key: str, volume_id: int) -> List[Dict[str, Any]]:
+    """
+    Fetch every issue belonging to a ComicVine volume (basic records).
+
+    Returns lightweight issue dicts suitable for save_issues_bulk / collection
+    matching — issue number and dates, not full per-issue credits. Paginated so
+    large volumes are fully covered.
+
+    Args:
+        api_key: ComicVine API key
+        volume_id: ComicVine volume ID
+
+    Returns:
+        List of dicts: {id, cv_id, number, name, cover_date, store_date,
+        image, resource_url}. The ``id`` is offset into the ComicVine range so
+        it can't collide with a Metron issue id.
+    """
+    from helpers.comicvine_ids import COMICVINE_SERIES_ID_OFFSET
+
+    if not SIMYAN_AVAILABLE:
+        app_logger.warning("Simyan library not available for volume issue listing")
+        return []
+
+    cv = _make_cv_client(api_key)
+    issues: List[Dict[str, Any]] = []
+    seen_ids = set()
+    offset = 0
+    page_size = 100
+    max_issues = 10000  # safety backstop against runaway pagination
+
+    try:
+        while len(issues) < max_issues:
+            page = _cv_call_with_retry(
+                lambda o=offset: cv.list_issues(
+                    params={"filter": f"volume:{volume_id}", "offset": o}
+                ),
+                f"issue list volume:{volume_id} offset:{offset}",
+            )
+            if not page:
+                break
+
+            new = 0
+            for issue in page:
+                iid = getattr(issue, "id", None)
+                if iid is None or iid in seen_ids:
+                    continue
+                seen_ids.add(iid)
+                new += 1
+
+                image = getattr(issue, "image", None)
+                image_url = None
+                if image:
+                    url = getattr(image, "original_url", None) or getattr(image, "thumbnail", None)
+                    image_url = str(url) if url else None
+
+                def _date(value):
+                    return str(value) if value else None
+
+                issues.append({
+                    "id": COMICVINE_SERIES_ID_OFFSET + int(iid),
+                    "cv_id": iid,
+                    "number": getattr(issue, "number", None)
+                    or getattr(issue, "issue_number", None),
+                    "name": getattr(issue, "name", None),
+                    "cover_date": _date(getattr(issue, "cover_date", None)),
+                    "store_date": _date(getattr(issue, "store_date", None)),
+                    "image": image_url,
+                    "resource_url": str(getattr(issue, "site_detail_url", None))
+                    if getattr(issue, "site_detail_url", None) else None,
+                })
+
+            if new < page_size:
+                break
+            offset += page_size
+
+        app_logger.info(f"Fetched {len(issues)} issues for ComicVine volume {volume_id}")
+        return issues
+
+    except Exception as e:
+        app_logger.error(f"Error fetching issues for ComicVine volume {volume_id}: {e}")
+        return issues
 
 
 # Re-export from shared provider base for backward compatibility

--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -100,6 +100,7 @@ def _resolve_identity(folder, api):
     name = meta.get("name")
     publisher = meta.get("publisher")
     year = meta.get("year")
+    status = meta.get("status")
     cv_id = _to_int(meta.get("comicid"))
 
     if cvinfo_path:
@@ -114,6 +115,7 @@ def _resolve_identity(folder, api):
             "series_name": name or os.path.basename(folder.rstrip("/\\")),
             "publisher_name": publisher,
             "year": year,
+            "status": status,
             "cv_id": cv_id,
             "source": source,
             "reason": reason,
@@ -273,6 +275,7 @@ def _fetch_series_dict(api, metron_id, fallback):
         "id": metron_id,
         "name": fallback.get("series_name") or f"Series {metron_id}",
         "publisher_name": fallback.get("publisher_name"),
+        "status": fallback.get("status"),
         "year_began": fallback.get("year"),
         "cv_id": fallback.get("cv_id"),
     }
@@ -319,7 +322,11 @@ def apply_automap(items, api=None):
         dict with ``applied`` (int), ``failed`` (list of {folder,error}), and
         ``applied_ids`` (list of Metron series ids).
     """
-    from core.database import save_publisher, save_series_mapping
+    from core.database import (
+        save_publisher,
+        save_series_mapping,
+        upsert_publisher_by_name,
+    )
 
     if api is None:
         api = metron.get_flask_api()
@@ -340,9 +347,23 @@ def apply_automap(items, api=None):
 
         try:
             series_dict = _fetch_series_dict(api, metron_id, item)
+
+            # Publisher: prefer the Metron nested publisher (has an id); when
+            # Metron is unavailable (fallback dict), resolve the sidecar
+            # publisher name to an id so the Pull List publisher column fills in.
             publisher = series_dict.get("publisher")
             if isinstance(publisher, dict) and publisher.get("id"):
                 save_publisher(publisher.get("id"), publisher.get("name"))
+            elif not series_dict.get("publisher_id"):
+                pub_name = series_dict.get("publisher_name") or item.get("publisher_name")
+                if pub_name:
+                    pub_id = upsert_publisher_by_name(pub_name)
+                    if pub_id:
+                        series_dict["publisher_id"] = pub_id
+
+            # Status: fall back to the sidecar status when Metron didn't supply one.
+            if not series_dict.get("status") and item.get("status"):
+                series_dict["status"] = item.get("status")
 
             if not save_series_mapping(series_dict, folder):
                 failed.append({"folder": folder, "error": "Failed to save mapping"})

--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -33,6 +33,11 @@ import time
 import uuid
 
 from core.app_logging import app_logger
+from helpers.comicvine_ids import (
+    cv_id_from_series_id,
+    is_comicvine_series_id,
+    make_comicvine_series_id,
+)
 from models import metron, comicvine
 from models.series_json import read_series_json, write_series_json
 
@@ -83,7 +88,7 @@ def _count_comics(folder):
         return 0
 
 
-def _resolve_identity(folder, api):
+def _resolve_identity(folder, api, cv_api_key=None):
     """Resolve a candidate folder to a Metron series id via the sidecar cascade.
 
     Returns a candidate dict, or None if the folder has no sidecar at all.
@@ -138,15 +143,24 @@ def _resolve_identity(folder, api):
         cv_id = metron.parse_cvinfo_for_comicvine_id(cvinfo_path)
 
     if cv_id:
+        # Prefer Metron: if the ComicVine id maps to a Metron series, use it.
         if api:
             mid = metron.get_series_id_by_comicvine_id(api, cv_id)
             if mid:
                 return _candidate(mid, "comicvine_id")
+        # Not in Metron (or no Metron API). Fall back to a ComicVine-sourced
+        # identity when the ComicVine API is enabled — cvinfo/series.json are
+        # natively ComicVine, so this is the original, not an edge case.
+        if cv_api_key:
+            return _candidate(make_comicvine_series_id(cv_id), "comicvine_api")
+        if api:
             return _candidate(
-                None, "comicvine_id", f"ComicVine ID {cv_id} not found on Metron"
+                None, "comicvine_id",
+                f"ComicVine ID {cv_id} not in Metron; enable the ComicVine API to map it",
             )
         return _candidate(
-            None, "comicvine_id", "Metron API unavailable to resolve ComicVine ID"
+            None, "comicvine_id",
+            "Not resolvable: no Metron match and ComicVine API not enabled",
         )
 
     return _candidate(None, "sidecar", "Sidecar has no Metron or ComicVine ID")
@@ -166,12 +180,15 @@ def _find_candidate_folders(roots):
     return folders
 
 
-def scan_library_for_automap(api=None, progress_cb=None):
+def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
     """Scan library roots and classify sidecar folders into auto/review/skipped.
 
     Args:
         api: Optional Metron API client. Without it, only steps 1-2 (direct
-            Metron id) can resolve; ComicVine-only sidecars become skipped.
+            Metron id) can resolve.
+        cv_api_key: Optional ComicVine API key. When set, sidecars carrying a
+            ComicVine id that isn't in Metron resolve to a ComicVine-sourced
+            series instead of being skipped.
         progress_cb: Optional callable(current, total, folder_or_None).
 
     Returns:
@@ -205,7 +222,7 @@ def scan_library_for_automap(api=None, progress_cb=None):
         if nfolder in mapped_paths:
             continue  # already tracked -- leave it alone
 
-        ident = _resolve_identity(folder, api)
+        ident = _resolve_identity(folder, api, cv_api_key=cv_api_key)
         if ident is None:
             continue
         ident["comic_count"] = _count_comics(folder)
@@ -249,13 +266,59 @@ def get_library_roots():
     return _roots()
 
 
+def _safe_cv_key():
+    """Return the ComicVine API key, or None (tolerates missing app context)."""
+    try:
+        return comicvine.get_cv_api_key()
+    except Exception:
+        return None
+
+
+def _strip_html(text):
+    """Reduce a ComicVine HTML description to plain text."""
+    if not text:
+        return None
+    import html
+    import re
+
+    return html.unescape(re.sub(r"<[^>]+>", "", str(text))).strip() or None
+
+
+def _fetch_comicvine_series_dict(series_id, fallback):
+    """Build a series payload from the ComicVine API for an offset (cv) id."""
+    cv_id = cv_id_from_series_id(series_id)
+    details = {}
+    key = _safe_cv_key()
+    if key:
+        try:
+            details = comicvine.get_volume_details(key, cv_id) or {}
+        except Exception as e:
+            app_logger.warning(f"automap: ComicVine volume {cv_id} fetch failed: {e}")
+
+    name = details.get("name") or fallback.get("series_name") or f"ComicVine {cv_id}"
+    return {
+        "id": series_id,
+        "name": name,
+        "publisher_name": details.get("publisher_name") or fallback.get("publisher_name"),
+        "status": fallback.get("status"),
+        "year_began": details.get("start_year") or fallback.get("year"),
+        "cv_id": cv_id,
+        "desc": _strip_html(details.get("description")),
+        "resource_url": f"https://comicvine.gamespot.com/volume/4050-{cv_id}/",
+        "cover_image": details.get("image_url"),
+    }
+
+
 def _fetch_series_dict(api, metron_id, fallback):
     """Build a series payload for save_series_mapping.
 
     Prefer the authoritative Metron object (gives name/publisher/status/year);
-    fall back to sidecar-derived fields if the API is unavailable, so we can
-    still write a valid (name-bearing) row.
+    for a ComicVine-sourced id fetch from ComicVine; otherwise fall back to
+    sidecar-derived fields so we can still write a valid (name-bearing) row.
     """
+    if is_comicvine_series_id(metron_id):
+        return _fetch_comicvine_series_dict(metron_id, fallback)
+
     if api:
         try:
             info = api.series(metron_id)
@@ -283,6 +346,12 @@ def _fetch_series_dict(api, metron_id, fallback):
 
 def _backfill_sidecars(folder, series_dict, metron_id, api):
     """Write the Metron id into the folder's sidecars so future scans skip the API."""
+    # A ComicVine-sourced series has no Metron id; its offset id must never be
+    # written into a sidecar as a Metron series_id (a later scan would misread
+    # it). The sidecar already carries the cv_id, so leave it untouched.
+    if is_comicvine_series_id(metron_id):
+        return
+
     try:
         existing = read_series_json(folder)
         if not _sidecar_metadata(existing).get("metron_id"):
@@ -365,7 +434,9 @@ def apply_automap(items, api=None):
             if not series_dict.get("status") and item.get("status"):
                 series_dict["status"] = item.get("status")
 
-            if not save_series_mapping(series_dict, folder):
+            if not save_series_mapping(
+                series_dict, folder, cover_image=series_dict.get("cover_image")
+            ):
                 failed.append({"folder": folder, "error": "Failed to save mapping"})
                 continue
 
@@ -401,10 +472,13 @@ def _sync_and_match(api, series_id):
             return
 
         issues = get_issues_for_series(series_id)
-        if not issues and api:
-            from sync import sync_series_from_api
+        if not issues:
+            if is_comicvine_series_id(series_id):
+                _sync_comicvine_issues(series_id)
+            elif api:
+                from sync import sync_series_from_api
 
-            sync_series_from_api(api, series_id)
+                sync_series_from_api(api, series_id)
             issues = get_issues_for_series(series_id)
 
         series_info = get_series_by_id(series_id)
@@ -414,6 +488,28 @@ def _sync_and_match(api, series_id):
             )
     except Exception as e:
         app_logger.warning(f"automap: sync+match failed for {series_id}: {e}")
+
+
+def _sync_comicvine_issues(series_id):
+    """Fetch a ComicVine volume's issue list into the issues cache."""
+    from core.database import (
+        delete_issues_for_series,
+        save_issues_bulk,
+        update_series_sync_time,
+    )
+
+    key = _safe_cv_key()
+    if not key:
+        app_logger.info(
+            f"automap: ComicVine API not available; cannot sync issues for {series_id}"
+        )
+        return
+    cv_issues = comicvine.get_all_issues_for_volume(key, cv_id_from_series_id(series_id))
+    if not cv_issues:
+        return
+    delete_issues_for_series(series_id)
+    save_issues_bulk(cv_issues, series_id)
+    update_series_sync_time(series_id, len(cv_issues))
 
 
 def _sync_and_match_ids(api, series_ids):
@@ -493,6 +589,7 @@ def _run_scan_job(op_id, app):
 def _run_scan_job_inner(op_id, app):
     try:
         api = metron.get_flask_api(app)
+        cv_api_key = comicvine.get_cv_api_key(app)
 
         def progress(current, total, folder):
             _update_job(
@@ -502,7 +599,9 @@ def _run_scan_job_inner(op_id, app):
                 detail=os.path.basename(folder) if folder else "Finishing...",
             )
 
-        scan = scan_library_for_automap(api=api, progress_cb=progress)
+        scan = scan_library_for_automap(
+            api=api, cv_api_key=cv_api_key, progress_cb=progress
+        )
         _update_job(op_id, detail="Applying matches...")
         applied = apply_automap(scan["auto"], api=api)
 

--- a/routes/series.py
+++ b/routes/series.py
@@ -539,8 +539,15 @@ def series_view(slug):
 
     series_id = int(match.group(1))
 
-    # Check for force refresh parameter
-    force_refresh = request.args.get("refresh", "").lower() in ("1", "true", "yes")
+    # Check for force refresh parameter. A ComicVine-sourced series has no
+    # Metron id, so a Metron force-refresh would 404 — always serve it from the
+    # local cache (use "API Sync" to refresh its issues from ComicVine).
+    from helpers.comicvine_ids import is_comicvine_series_id
+
+    force_refresh = (
+        request.args.get("refresh", "").lower() in ("1", "true", "yes")
+        and not is_comicvine_series_id(series_id)
+    )
 
     cached_series = None
     if not force_refresh:
@@ -1292,10 +1299,60 @@ def delete_bulk_manual_status(series_id):
 # =============================================================================
 
 
+def _sync_comicvine_series(series_id):
+    """Refresh a ComicVine-sourced series' issue list, then re-match the collection."""
+    from core.database import clear_wanted_cache_for_series
+    from helpers.comicvine_ids import cv_id_from_series_id
+    from models import comicvine as cv_mod
+
+    key = cv_mod.get_cv_api_key()
+    if not key:
+        return jsonify({"error": "ComicVine API not configured"}), 500
+
+    try:
+        series_mapping = get_series_by_id(series_id)
+        mapped_path = series_mapping.get("mapped_path") if series_mapping else None
+
+        cv_issues = cv_mod.get_all_issues_for_volume(
+            key, cv_id_from_series_id(series_id)
+        )
+        delete_issues_for_series(series_id)
+        save_issues_bulk(cv_issues, series_id)
+        update_series_sync_time(series_id, len(cv_issues))
+        clear_wanted_cache_for_series(series_id)
+
+        issue_status = {}
+        found_count = 0
+        missing_count = len(cv_issues)
+        if mapped_path and series_mapping and os.path.exists(mapped_path):
+            issue_status = match_issues_to_collection(
+                mapped_path, cv_issues, series_mapping
+            )
+            found_count = sum(1 for s in issue_status.values() if s.get("found"))
+            missing_count = len(cv_issues) - found_count
+
+        return jsonify({
+            "success": True,
+            "series_id": series_id,
+            "issue_count": len(cv_issues),
+            "issue_status": issue_status,
+            "found_count": found_count,
+            "missing_count": missing_count,
+            "synced_at": datetime.now().isoformat(),
+        })
+    except Exception as e:
+        app_logger.error(f"Error syncing ComicVine series {series_id}: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @series_bp.route("/api/sync/series/<int:series_id>", methods=["POST"])
 def sync_series(series_id):
-    """Force sync a specific series from Metron API"""
+    """Force sync a specific series (Metron, or ComicVine for cv-sourced ids)."""
     from core.database import clear_wanted_cache_for_series, update_series_desc
+    from helpers.comicvine_ids import is_comicvine_series_id
+
+    if is_comicvine_series_id(series_id):
+        return _sync_comicvine_series(series_id)
 
     api = metron.get_flask_api()
     if not api:

--- a/routes/series.py
+++ b/routes/series.py
@@ -422,6 +422,7 @@ def apply_library_automap():
             "series_name": it.get("series_name"),
             "publisher_name": it.get("publisher_name"),
             "year": it.get("year"),
+            "status": it.get("status"),
             "cv_id": it.get("cv_id"),
         }
         for it in items

--- a/sync.py
+++ b/sync.py
@@ -47,6 +47,17 @@ def sync_series_from_api(api, series_id: int) -> dict:
     Returns:
         dict with sync result info
     """
+    from helpers.comicvine_ids import is_comicvine_series_id
+
+    # ComicVine-sourced series have no Metron id; the Metron API can't sync them.
+    if is_comicvine_series_id(series_id):
+        return {
+            'series_id': series_id,
+            'success': False,
+            'skipped': True,
+            'error': 'ComicVine-sourced series; not syncable via Metron',
+        }
+
     try:
         # Get current mapping info
         series_mapping = get_series_by_id(series_id)

--- a/templates/series.html
+++ b/templates/series.html
@@ -75,9 +75,14 @@
                                 </div>
                                 <div class="col-6 col-md-5">
                                     <small class="text-uppercase fw-bold d-block mb-1"
-                                        style="font-size: 0.75rem;">Metron ID</small>
+                                        style="font-size: 0.75rem;">
+                                        {% if series.id >= 2000000000 %}Source{% else %}Metron ID{% endif %}</small>
+                                    {% if series.id >= 2000000000 %}
+                                    <span class="badge bg-info">ComicVine</span>
+                                    {% else %}
                                     <a href="https://metron.cloud/series/{{ series.id }}/" target="_blank"
                                         class="font-monospace text-decoration-none">{{ series.id }}</a>
+                                    {% endif %}
                                 </div>
                                 <div class="col-6 col-md-4">
                                     <small class="text-uppercase fw-bold d-block mb-1"
@@ -110,10 +115,12 @@
                             <button onclick="forceRefresh()" class="btn btn-outline-info w-100" title="Force refresh from Metron API">
                                 <i class="bi bi-arrow-clockwise me-1"></i>Refresh
                             </button>
+                            {% if series.id < 2000000000 %}
                             <a href="https://metron.cloud/series/{{ series.id }}/" target="_blank"
                                 class="btn btn-outline-primary w-100">
                                 <i class="bi bi-box-arrow-up-right me-1"></i>View on Metron
                             </a>
+                            {% endif %}
                             {% if series.cv_id %}
                             <a href="https://comicvine.gamespot.com/volume/4050-{{ series.cv_id }}/" target="_blank"
                                 class="btn btn-outline-info w-100">

--- a/tests/mocked/test_cv_sync_guards.py
+++ b/tests/mocked/test_cv_sync_guards.py
@@ -1,0 +1,49 @@
+"""ComicVine-only series: Metron sync guards and issue-list fetch."""
+import types
+from unittest.mock import MagicMock
+
+from helpers.comicvine_ids import make_comicvine_series_id
+
+
+def test_sync_series_from_api_skips_comicvine():
+    from sync import sync_series_from_api
+
+    res = sync_series_from_api(None, make_comicvine_series_id(5))
+    assert res["success"] is False
+    assert res.get("skipped") is True
+
+
+def test_get_series_needing_sync_excludes_comicvine(db_connection):
+    from core.database import save_series_mapping, get_series_needing_sync
+
+    save_series_mapping({"id": 100, "name": "Metron One"}, "/data/M")
+    save_series_mapping(
+        {"id": make_comicvine_series_id(5), "name": "CV One"}, "/data/CV"
+    )
+    ids = {s["id"] for s in get_series_needing_sync(24)}
+    assert 100 in ids
+    assert make_comicvine_series_id(5) not in ids
+
+
+def test_get_all_issues_for_volume(monkeypatch):
+    from models import comicvine
+
+    monkeypatch.setattr(comicvine, "SIMYAN_AVAILABLE", True)
+
+    def issue(iid, num):
+        return types.SimpleNamespace(
+            id=iid, number=num, name=f"Issue {num}",
+            cover_date="2012-03-01", store_date=None,
+            image=None, site_detail_url=None,
+        )
+
+    cv = MagicMock()
+    cv.list_issues.return_value = [issue(500, "1"), issue(501, "2")]
+    monkeypatch.setattr(comicvine, "_make_cv_client", lambda key: cv)
+
+    issues = comicvine.get_all_issues_for_volume("key", 18705)
+    assert len(issues) == 2
+    assert issues[0]["number"] == "1"
+    assert issues[0]["cv_id"] == 500
+    # issue id is offset so it can't collide with a Metron issue id
+    assert issues[0]["id"] == make_comicvine_series_id(500)

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from helpers.comicvine_ids import make_comicvine_series_id
 from models import library_automap
 
 
@@ -67,9 +68,9 @@ class TestResolveIdentity:
         folder = _make_folder(
             tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
         )
-        ident = library_automap._resolve_identity(folder, api=None)
+        ident = library_automap._resolve_identity(folder, api=None, cv_api_key=None)
         assert ident["metron_id"] is None
-        assert "unavailable" in ident["reason"].lower()
+        assert "comicvine api not enabled" in ident["reason"].lower()
 
     def test_comicid_not_found_on_metron(self, tmp_path):
         folder = _make_folder(
@@ -77,9 +78,9 @@ class TestResolveIdentity:
         )
         api = MagicMock()
         api.series_list.return_value = []
-        ident = library_automap._resolve_identity(folder, api=api)
+        ident = library_automap._resolve_identity(folder, api=api, cv_api_key=None)
         assert ident["metron_id"] is None
-        assert "not found" in ident["reason"].lower()
+        assert "not in metron" in ident["reason"].lower()
 
     def test_flat_legacy_series_json_still_resolves(self, tmp_path):
         folder = _make_folder(
@@ -210,6 +211,100 @@ class TestApply:
             )
         assert result["applied"] == 0
         assert len(result["failed"]) == 1
+
+class TestComicVineResolution:
+    def test_cv_only_resolves_with_cv_key(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        ident = library_automap._resolve_identity(folder, api=None, cv_api_key="key")
+        assert ident["metron_id"] == make_comicvine_series_id(18705)
+        assert ident["source"] == "comicvine_api"
+        assert ident["cv_id"] == 18705
+
+    def test_cv_only_skipped_without_key(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        ident = library_automap._resolve_identity(folder, api=None, cv_api_key=None)
+        assert ident["metron_id"] is None
+        assert "ComicVine API not enabled" in ident["reason"]
+
+    def test_prefers_metron_over_comicvine(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        api = MagicMock()
+        result = MagicMock()
+        result.id = 999
+        api.series_list.return_value = [result]
+        ident = library_automap._resolve_identity(folder, api=api, cv_api_key="key")
+        assert ident["metron_id"] == 999
+        assert ident["source"] == "comicvine_id"
+
+
+class TestComicVineApply:
+    def test_fetches_details_from_comicvine(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        cv_series_id = make_comicvine_series_id(18705)
+        item = {
+            "folder": folder, "metron_id": cv_series_id, "series_name": "Saga",
+            "cv_id": 18705, "publisher_name": "Image",
+        }
+        cv_details = {
+            "id": 18705, "name": "Saga", "publisher_name": "Image",
+            "start_year": 2012, "count_of_issues": 60,
+            "description": "<p>An epic.</p>", "image_url": "http://x/cover.jpg",
+        }
+        with patch("models.comicvine.get_cv_api_key", return_value="key"), \
+             patch("models.comicvine.get_volume_details", return_value=cv_details), \
+             patch("models.metron.get_flask_api", return_value=None), \
+             patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("core.database.upsert_publisher_by_name", return_value=7):
+            result = library_automap.apply_automap([item], api=None)
+        assert result["applied"] == 1
+        saved = save.call_args[0][0]
+        assert saved["id"] == cv_series_id
+        assert saved["cv_id"] == 18705
+        assert saved["name"] == "Saga"
+        assert "comicvine.gamespot.com/volume/4050-18705" in saved["resource_url"]
+        assert saved["desc"] == "An epic."  # HTML stripped
+        assert saved["publisher_id"] == 7
+
+    def test_backfill_skips_comicvine_series(self, tmp_path):
+        # A ComicVine offset id must never be written into a sidecar as a Metron id.
+        with patch("models.comicvine.find_cvinfo_in_folder") as find, \
+             patch("models.library_automap.write_series_json") as write:
+            library_automap._backfill_sidecars(
+                str(tmp_path), {"id": make_comicvine_series_id(1)},
+                make_comicvine_series_id(1), api=None,
+            )
+        find.assert_not_called()
+        write.assert_not_called()
+
+
+class TestComicVineSyncMatch:
+    def test_syncs_issues_from_comicvine_then_matches(self, tmp_path):
+        folder = str(tmp_path)
+        cv_series_id = make_comicvine_series_id(18705)
+        cv_issues = [{"id": 1, "number": "1"}, {"id": 2, "number": "2"}]
+        with patch("core.database.get_series_mapping", return_value=folder), \
+             patch("core.database.get_issues_for_series", side_effect=[[], cv_issues]), \
+             patch("core.database.get_series_by_id", return_value={"id": cv_series_id, "name": "Saga"}), \
+             patch("core.database.delete_issues_for_series"), \
+             patch("core.database.save_issues_bulk") as save_issues, \
+             patch("core.database.update_series_sync_time"), \
+             patch("models.comicvine.get_cv_api_key", return_value="key"), \
+             patch("models.comicvine.get_all_issues_for_volume", return_value=cv_issues) as fetch, \
+             patch("helpers.collection.match_issues_to_collection") as match:
+            library_automap._sync_and_match(api=None, series_id=cv_series_id)
+        fetch.assert_called_once_with("key", 18705)
+        save_issues.assert_called_once()
+        match.assert_called_once()
+
 
 class TestSyncAndMatch:
     def test_matches_when_issues_cached(self, tmp_path):

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -283,3 +283,33 @@ class TestApplyExtra:
         assert result["applied"] == 1
         saved_dict = save.call_args[0][0]
         assert saved_dict["name"] == "Batman"
+
+    def test_populates_publisher_and_status_from_sidecar_without_api(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Batman",
+            series_json={"name": "Batman", "metron_id": 555,
+                         "publisher": "DC Comics", "status": "Continuing"},
+            cvinfo="series_id: 555\npublisher_name: DC Comics\n",
+        )
+        item = {
+            "folder": folder, "metron_id": 555, "series_name": "Batman",
+            "publisher_name": "DC Comics", "status": "Continuing",
+        }
+        with patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("core.database.upsert_publisher_by_name", return_value=42) as upsert, \
+             patch("models.metron.get_flask_api", return_value=None):
+            result = library_automap.apply_automap([item], api=None)
+        assert result["applied"] == 1
+        upsert.assert_called_once_with("DC Comics")
+        saved_dict = save.call_args[0][0]
+        assert saved_dict["publisher_id"] == 42
+        assert saved_dict["status"] == "Continuing"
+
+    def test_scan_candidate_carries_status(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Batman",
+            series_json={"name": "Batman", "metron_id": 555, "status": "Ended"},
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["status"] == "Ended"

--- a/tests/unit/test_comicvine_ids.py
+++ b/tests/unit/test_comicvine_ids.py
@@ -1,0 +1,27 @@
+"""Tests for helpers/comicvine_ids.py -- synthetic ids for ComicVine-only series."""
+from helpers.comicvine_ids import (
+    COMICVINE_SERIES_ID_OFFSET,
+    cv_id_from_series_id,
+    is_comicvine_series_id,
+    make_comicvine_series_id,
+)
+
+
+def test_round_trip():
+    sid = make_comicvine_series_id(18705)
+    assert sid == COMICVINE_SERIES_ID_OFFSET + 18705
+    assert cv_id_from_series_id(sid) == 18705
+
+
+def test_is_comicvine_series_id():
+    assert is_comicvine_series_id(make_comicvine_series_id(1)) is True
+    assert is_comicvine_series_id(COMICVINE_SERIES_ID_OFFSET) is True
+    assert is_comicvine_series_id(12345) is False
+    assert is_comicvine_series_id(None) is False
+    assert is_comicvine_series_id("not-an-int") is False
+
+
+def test_metron_ids_never_flagged():
+    # Realistic Metron series ids are far below the offset.
+    for mid in (1, 100, 50_000, 999_999):
+        assert is_comicvine_series_id(mid) is False


### PR DESCRIPTION
## 📝 Description
Adds a reserved synthetic ID scheme for ComicVine-only series and threads it through automap, sync, and series views. Metron sync paths now explicitly skip ComicVine-sourced IDs, while ComicVine-backed series can be resolved, mapped, and refreshed via ComicVine issue fetching. The series UI now labels ComicVine sources appropriately, and new/updated tests cover ID helpers, sync guards, automap resolution, and ComicVine issue sync behavior.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary
- [x] Verified build locally (`docker build -t dev .`)

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass