### PR TITLE
Share rate-limit/retry logic between Metron and ComicVine

### DIFF
--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -1,0 +1,108 @@
+"""Shared rate-limit / retry primitives for HTTP API wrappers.
+
+Both ``models/metron.py`` and ``models/comicvine.py`` wrap third-party comic
+metadata APIs that throttle burst traffic. They share the same needs -- a
+process-wide throttle so concurrent background threads can't collectively
+exceed the upstream burst limit, and a retry loop that backs off on rate-limit
+rejections -- but differ in the mechanics (typed ``RateLimitError`` with a
+``retry_after`` header vs. a message-string match with linear backoff). This
+module holds the common skeleton; each caller injects the parts that differ.
+"""
+
+import threading
+import time
+from collections import deque
+from typing import Callable, Optional
+
+from core.app_logging import app_logger
+
+
+class SlidingWindowRateLimiter:
+    """Caps outgoing requests to ``max_requests`` per ``window_seconds``, process-wide.
+
+    Blocking (not rejecting): ``acquire()`` sleeps the calling thread until a slot
+    frees up rather than raising, so a caller's own retry/error handling doesn't
+    need to change.
+    """
+
+    def __init__(self, max_requests: int, window_seconds: float):
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._timestamps: deque = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                while self._timestamps and now - self._timestamps[0] >= self._window_seconds:
+                    self._timestamps.popleft()
+                if len(self._timestamps) < self._max_requests:
+                    self._timestamps.append(now)
+                    return
+                wait = self._window_seconds - (now - self._timestamps[0])
+            if wait > 0:
+                time.sleep(wait)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._timestamps.clear()
+
+
+def call_with_retry(
+    fn: Callable,
+    *,
+    max_attempts: int,
+    is_rate_limit: Callable[[BaseException], bool],
+    next_wait: Callable[[BaseException, int], Optional[float]],
+    context: str,
+    pre_call: Optional[Callable[[], None]] = None,
+    sleep: Callable[[float], None] = time.sleep,
+    logger=app_logger,
+):
+    """Call ``fn()`` with rate-limit-aware retry.
+
+    Args:
+        fn: Zero-arg callable performing the API request.
+        max_attempts: Total number of attempts (including the first).
+        is_rate_limit: Predicate deciding whether an exception is a rate-limit
+            rejection. Non-rate-limit exceptions propagate immediately.
+        next_wait: ``(exc, attempt) -> seconds`` to wait before the next attempt,
+            or ``None`` to give up early (e.g. a daily limit was hit).
+        context: Human-readable description used in log messages.
+        pre_call: Optional throttle hook run before every attempt (e.g. a shared
+            limiter's ``acquire``).
+        sleep: Sleep function (injectable for tests).
+        logger: Logger for retry messages.
+
+    Returns:
+        The return value of ``fn()``.
+
+    Raises:
+        The last rate-limit exception once attempts are exhausted, or any
+        non-rate-limit exception immediately.
+    """
+    last_exc: Optional[BaseException] = None
+    for attempt in range(max_attempts):
+        if pre_call is not None:
+            pre_call()
+        try:
+            return fn()
+        except Exception as exc:
+            if not is_rate_limit(exc):
+                raise
+            last_exc = exc
+            if attempt >= max_attempts - 1:
+                break
+            wait = next_wait(exc, attempt)
+            if wait is None:
+                break
+            logger.info(
+                f"Rate limit hit {context}: waiting {wait:.0f}s before retry "
+                f"(attempt {attempt + 1}/{max_attempts})"
+            )
+            # Flush handlers so the warning is visible before the sleep.
+            for handler in getattr(logger, "handlers", []):
+                handler.flush()
+            sleep(wait)
+    raise last_exc

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -15,6 +15,7 @@ import tempfile
 import time
 from pathlib import Path
 from cbz_ops.rename import rename_comic_from_metadata
+from core.rate_limit import SlidingWindowRateLimiter, call_with_retry
 
 try:
     from simyan.comicvine import Comicvine, ComicvineResource
@@ -124,6 +125,35 @@ def _cv_retry_config():
     return max(0, retries), max(0.0, backoff)
 
 
+def _cv_burst_config():
+    """Process-wide throttle for ComicVine requests.
+
+    ComicVine's velocity detection ("Slow down cowboy") triggers on bursts, and
+    CLU runs multiple background threads (bulk metadata, arc import) that can all
+    reach ComicVine concurrently -- Simyan's own on-disk rate store doesn't
+    coordinate across threads. A shared sliding-window limiter caps the aggregate
+    rate. Defaults to 1 request/second (the community-safe rate), overridable via
+    ``COMICVINE_BURST_LIMIT`` / ``COMICVINE_BURST_WINDOW``.
+    """
+    try:
+        limit = int(os.environ.get("COMICVINE_BURST_LIMIT", "1"))
+    except (ValueError, TypeError):
+        limit = 1
+    try:
+        window = float(os.environ.get("COMICVINE_BURST_WINDOW", "1"))
+    except (ValueError, TypeError):
+        window = 1.0
+    return max(1, limit), max(0.0, window)
+
+
+_comicvine_rate_limiter = SlidingWindowRateLimiter(*_cv_burst_config())
+
+
+def invalidate_comicvine_rate_limiter() -> None:
+    """Clear the ComicVine rate-limiter window (used by tests for isolation)."""
+    _comicvine_rate_limiter.reset()
+
+
 def _is_rate_limit_error(exc) -> bool:
     """True when a Simyan/ComicVine error is a rate-limit rejection.
 
@@ -141,22 +171,19 @@ def _cv_call_with_retry(fn, description: str):
     single throttle shouldn't make the bulk-metadata flow fail over to a
     lower-quality provider (GCD), so we back off and re-attempt a few times
     before letting the error propagate. Non-rate-limit errors raise immediately.
+    Each attempt also passes through the shared process-wide limiter so
+    concurrent threads can't collectively burst past ComicVine's velocity limit.
     """
     retries, backoff = _cv_retry_config()
-    attempt = 0
-    while True:
-        try:
-            return fn()
-        except Exception as e:
-            if not _is_rate_limit_error(e) or attempt >= retries:
-                raise
-            attempt += 1
-            wait = backoff * attempt
-            app_logger.warning(
-                f"ComicVine rate-limited on {description}; "
-                f"retry {attempt}/{retries} in {wait:.0f}s"
-            )
-            time.sleep(wait)
+    return call_with_retry(
+        fn,
+        max_attempts=retries + 1,
+        is_rate_limit=_is_rate_limit_error,
+        next_wait=lambda e, attempt: backoff * (attempt + 1),
+        context=description,
+        pre_call=_comicvine_rate_limiter.acquire,
+        sleep=time.sleep,
+    )
 
 
 def is_simyan_available() -> bool:

--- a/models/metron.py
+++ b/models/metron.py
@@ -7,9 +7,12 @@ from typing import Optional, Dict, Any, List, Tuple
 import re
 import threading
 import time
-from collections import deque
 from datetime import datetime, timedelta
 from core.version import __version__
+from core.rate_limit import (
+    SlidingWindowRateLimiter as _SlidingWindowRateLimiter,
+    call_with_retry,
+)
 
 import requests as requests_lib
 import requests.exceptions as requests_exceptions
@@ -42,39 +45,7 @@ _SESSION_CACHE_LOCK = threading.Lock()
 _BURST_WINDOW_SECONDS = 60.0
 _SAFE_BURST_LIMIT = 15  # stay under Metron's 20/min burst limit for headroom
 
-
-class _SlidingWindowRateLimiter:
-    """Caps outgoing requests to `max_requests` per `window_seconds`, process-wide.
-
-    Blocking (not rejecting): acquire() sleeps the calling thread until a slot
-    frees up rather than raising, so existing retry/error-handling logic above
-    it doesn't need to change.
-    """
-
-    def __init__(self, max_requests: int, window_seconds: float):
-        self._max_requests = max_requests
-        self._window_seconds = window_seconds
-        self._timestamps: deque = deque()
-        self._lock = threading.Lock()
-
-    def acquire(self) -> None:
-        while True:
-            with self._lock:
-                now = time.monotonic()
-                while self._timestamps and now - self._timestamps[0] >= self._window_seconds:
-                    self._timestamps.popleft()
-                if len(self._timestamps) < self._max_requests:
-                    self._timestamps.append(now)
-                    return
-                wait = self._window_seconds - (now - self._timestamps[0])
-            if wait > 0:
-                time.sleep(wait)
-
-    def reset(self) -> None:
-        with self._lock:
-            self._timestamps.clear()
-
-
+# Process-wide throttle shared across all callers/threads (see module docstring).
 _metron_rate_limiter = _SlidingWindowRateLimiter(_SAFE_BURST_LIMIT, _BURST_WINDOW_SECONDS)
 
 
@@ -85,48 +56,36 @@ def invalidate_session_cache() -> None:
     _metron_rate_limiter.reset()
 
 
-def _handle_rate_limit(e: "RateLimitError", attempt: int, context: str) -> bool:
-    """Sleep and signal whether to retry after a RateLimitError.
+def _metron_next_wait(e: "RateLimitError", attempt: int, context: str) -> Optional[float]:
+    """Seconds to wait before retrying a RateLimitError, or None to give up.
 
-    Returns True if the caller should retry, False if retries are exhausted
-    or the daily API rate limit has been exceeded.
+    A ``retry_after`` above the daily-limit threshold means the daily API quota
+    is exhausted -- retrying won't help, so give up.
     """
-    wait = e.retry_after if e.retry_after else _RATE_LIMIT_DEFAULT_WAIT
     if e.retry_after and e.retry_after > _DAILY_RATE_LIMIT_THRESHOLD:
         app_logger.info(
             f"Metron daily rate limit exceeded {context}: retry_after={e.retry_after}s, giving up"
         )
-        return False
-    if attempt < _RATE_LIMIT_MAX_RETRIES - 1:
-        app_logger.info(
-            f"Metron rate limit hit {context}: waiting {wait}s before retry "
-            f"(attempt {attempt + 1}/{_RATE_LIMIT_MAX_RETRIES})"
-        )
-        # Flush log handlers so the warning is visible before the sleep
-        for handler in app_logger.handlers:
-            handler.flush()
-        time.sleep(wait)
-        app_logger.info(f"Metron rate limit wait complete, retrying {context}")
-        return True
-    app_logger.info(
-        f"Metron rate limit exceeded {context}: giving up after {_RATE_LIMIT_MAX_RETRIES} attempts"
-    )
-    return False
+        return None
+    return e.retry_after if e.retry_after else _RATE_LIMIT_DEFAULT_WAIT
 
 
 def _api_call(fn, context: str, default=None):
     """Call fn() with rate-limit retry and standard error handling."""
-    for attempt in range(_RATE_LIMIT_MAX_RETRIES):
-        _metron_rate_limiter.acquire()
-        try:
-            return fn()
-        except RateLimitError as e:
-            if not _handle_rate_limit(e, attempt, context):
-                return default
-        except ApiError as e:
-            app_logger.error(f"Metron API error {context}: {e}")
-            return default
-    return default
+    try:
+        return call_with_retry(
+            fn,
+            max_attempts=_RATE_LIMIT_MAX_RETRIES,
+            is_rate_limit=lambda e: isinstance(e, RateLimitError),
+            next_wait=lambda e, attempt: _metron_next_wait(e, attempt, context),
+            context=context,
+            pre_call=_metron_rate_limiter.acquire,
+        )
+    except RateLimitError:
+        return default
+    except ApiError as e:
+        app_logger.error(f"Metron API error {context}: {e}")
+        return default
 
 
 def is_connection_error(exc: Exception) -> bool:

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -22,15 +22,23 @@ def _reset_gcd_table_cache():
 
 # ---------------------------------------------------------------------------
 # Reset the module-level Metron session cache and rate limiter between tests
-# so one test's mocked Session/timing doesn't leak into the next.
+# so one test's mocked Session/timing doesn't leak into the next. Also neutralise
+# the ComicVine limiter: its default is 1 req/sec, and its internal sleep isn't
+# the patched ``models.comicvine.time.sleep``, so a real ``acquire()`` would
+# block mocked tests. Individual tests can still re-patch ``acquire`` to assert
+# on it (the monkeypatch is restored at teardown).
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(autouse=True)
-def _reset_metron_session_cache():
+def _reset_metron_session_cache(monkeypatch):
     from models.metron import invalidate_session_cache
+    from models import comicvine
     invalidate_session_cache()
+    comicvine.invalidate_comicvine_rate_limiter()
+    monkeypatch.setattr(comicvine._comicvine_rate_limiter, "acquire", lambda: None)
     yield
     invalidate_session_cache()
+    comicvine.invalidate_comicvine_rate_limiter()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mocked/test_comicvine_model.py
+++ b/tests/mocked/test_comicvine_model.py
@@ -67,6 +67,17 @@ class TestRateLimitRetry:
             _cv_call_with_retry(always, "test")
         assert calls["n"] == 3  # first attempt + 2 retries
 
+    def test_cv_call_acquires_rate_limiter_slot(self):
+        """_cv_call_with_retry must throttle through the shared limiter so
+        concurrent threads calling different ComicVine functions still share
+        one budget (parity with Metron's _api_call)."""
+        from models.comicvine import _cv_call_with_retry, _comicvine_rate_limiter
+
+        with patch.object(_comicvine_rate_limiter, "acquire") as mock_acquire:
+            result = _cv_call_with_retry(lambda: "ok", "test context")
+        assert result == "ok"
+        mock_acquire.assert_called_once()
+
     @patch("models.comicvine.time.sleep")
     @patch("models.comicvine.SIMYAN_AVAILABLE", True)
     @patch("models.comicvine.ComicvineResource", create=True)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,164 @@
+"""Unit tests for core/rate_limit.py -- the shared retry/throttle primitives."""
+import time
+
+import pytest
+
+from core.rate_limit import SlidingWindowRateLimiter, call_with_retry
+
+
+class _RateLimit(Exception):
+    """Marker exception treated as a rate-limit rejection in these tests."""
+
+
+def _is_rl(exc):
+    return isinstance(exc, _RateLimit)
+
+
+class TestCallWithRetry:
+
+    def test_returns_immediately_on_success(self):
+        sleeps = []
+        result = call_with_retry(
+            lambda: "ok",
+            max_attempts=3,
+            is_rate_limit=_is_rl,
+            next_wait=lambda e, a: 1.0,
+            context="ctx",
+            sleep=sleeps.append,
+        )
+        assert result == "ok"
+        assert sleeps == []  # no retry, no sleep
+
+    def test_retries_then_succeeds(self):
+        calls = {"n": 0}
+        sleeps = []
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _RateLimit("slow down")
+            return "ok"
+
+        result = call_with_retry(
+            flaky,
+            max_attempts=5,
+            is_rate_limit=_is_rl,
+            next_wait=lambda e, a: (a + 1) * 2.0,
+            context="ctx",
+            sleep=sleeps.append,
+        )
+        assert result == "ok"
+        assert calls["n"] == 3
+        assert sleeps == [2.0, 4.0]  # backed off before each retry, next_wait uses attempt
+
+    def test_gives_up_and_reraises_last_exc(self):
+        calls = {"n": 0}
+        sleeps = []
+
+        def always():
+            calls["n"] += 1
+            raise _RateLimit(f"attempt {calls['n']}")
+
+        with pytest.raises(_RateLimit, match="attempt 3"):
+            call_with_retry(
+                always,
+                max_attempts=3,
+                is_rate_limit=_is_rl,
+                next_wait=lambda e, a: 1.0,
+                context="ctx",
+                sleep=sleeps.append,
+            )
+        assert calls["n"] == 3  # first attempt + 2 retries
+        assert sleeps == [1.0, 1.0]  # slept before the 2 retries, not after the last
+
+    def test_non_rate_limit_error_propagates_immediately(self):
+        calls = {"n": 0}
+        sleeps = []
+
+        def boom():
+            calls["n"] += 1
+            raise ValueError("something else")
+
+        with pytest.raises(ValueError):
+            call_with_retry(
+                boom,
+                max_attempts=3,
+                is_rate_limit=_is_rl,
+                next_wait=lambda e, a: 1.0,
+                context="ctx",
+                sleep=sleeps.append,
+            )
+        assert calls["n"] == 1  # raised immediately, no retry
+        assert sleeps == []
+
+    def test_next_wait_none_gives_up_early(self):
+        calls = {"n": 0}
+        sleeps = []
+
+        def always():
+            calls["n"] += 1
+            raise _RateLimit("daily limit")
+
+        with pytest.raises(_RateLimit):
+            call_with_retry(
+                always,
+                max_attempts=5,
+                is_rate_limit=_is_rl,
+                next_wait=lambda e, a: None,  # e.g. daily limit exceeded
+                context="ctx",
+                sleep=sleeps.append,
+            )
+        assert calls["n"] == 1  # gave up after first rate-limit, no retry
+        assert sleeps == []
+
+    def test_pre_call_invoked_once_per_attempt(self):
+        calls = {"n": 0}
+        pre = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise _RateLimit("slow down")
+            return "ok"
+
+        def pre_call():
+            pre["n"] += 1
+
+        result = call_with_retry(
+            flaky,
+            max_attempts=3,
+            is_rate_limit=_is_rl,
+            next_wait=lambda e, a: 0.0,
+            context="ctx",
+            pre_call=pre_call,
+            sleep=lambda s: None,
+        )
+        assert result == "ok"
+        assert calls["n"] == 2
+        assert pre["n"] == 2  # throttle hook ran before both attempts
+
+
+class TestSlidingWindowRateLimiter:
+
+    def test_allows_up_to_limit_without_blocking(self):
+        limiter = SlidingWindowRateLimiter(max_requests=3, window_seconds=60.0)
+        start = time.monotonic()
+        for _ in range(3):
+            limiter.acquire()
+        assert time.monotonic() - start < 0.5
+
+    def test_blocks_until_window_frees_a_slot(self):
+        limiter = SlidingWindowRateLimiter(max_requests=2, window_seconds=0.2)
+        limiter.acquire()
+        limiter.acquire()
+        start = time.monotonic()
+        limiter.acquire()
+        assert time.monotonic() - start >= 0.15
+
+    def test_reset_clears_recorded_requests(self):
+        limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+        limiter.acquire()
+        limiter.reset()
+        start = time.monotonic()
+        limiter.acquire()
+        assert time.monotonic() - start < 0.5


### PR DESCRIPTION
## Context

Follow-up to #410. That PR fixed Metron's concurrency bug — CLU was creating a fresh Mokkari session per call (discarding rate-limit tracking) and had no process-wide throttle, so concurrent background threads could burst past Metron's 20/min limit. The fix added a shared session cache plus a `_SlidingWindowRateLimiter`.

It left two things flagged for follow-up:

1. **Real duplication** — `models/comicvine.py` has its own independent retry implementation (`_cv_call_with_retry` / `_is_rate_limit_error` / `_cv_retry_config`) doing the same job as Metron's, just with a different mechanism (env vars + message-string detection vs. constants + typed `RateLimitError`). That drifts over time.
2. **ComicVine had no process-wide throttle at all** — it relied only on Simyan's on-disk `ratelimits.sqlite`, which doesn't coordinate across threads. So the *exact class of bug #410 fixed for Metron* still existed for ComicVine: concurrent bulk-metadata threads could burst past ComicVine's velocity limit and trigger repeated "Slow down cowboy" rejections.

## What changed

**New `core/rate_limit.py`:**
- `SlidingWindowRateLimiter` — the process-wide throttle, moved verbatim out of `models/metron.py`.
- `call_with_retry(fn, *, max_attempts, is_rate_limit, next_wait, context, pre_call, sleep, logger)` — the shared retry skeleton. The three axes where Metron and ComicVine legitimately differ are injected: detection (`is_rate_limit`), backoff (`next_wait`), throttle (`pre_call`).

**`models/metron.py`** — `_api_call` and the deleted `_handle_rate_limit`/limiter class collapse into a thin adapter over `call_with_retry`, with `_metron_next_wait` supplying the `retry_after`/daily-limit logic.

**`models/comicvine.py`** — `_cv_call_with_retry` routes through `call_with_retry` **and** a new `_comicvine_rate_limiter` (default 1 req/sec, overridable via `COMICVINE_BURST_LIMIT` / `COMICVINE_BURST_WINDOW`). This is the real win beyond dedup — it closes the concurrency gap for ComicVine.

## Compatibility

All pinned private symbols and signatures are preserved (`_api_call`, `_cv_call_with_retry`, `_cv_retry_config`, `_is_rate_limit_error`, `_SlidingWindowRateLimiter`, `_metron_rate_limiter`, `invalidate_session_cache`), so `app.py:527` and the Metron/ComicVine provider adapters need **no changes**.

Intentionally **out of scope**: the cosmetic "wrap the Metron `api` first-arg in a class" refactor (would churn `app.py`, routes, and adapters for no correctness gain), and Metron's raw-HTTP 429 loop in `fetch_arcs_page` (works on status codes, not exceptions).

## Tests

- New `tests/unit/test_rate_limit.py` — 9 tests covering `call_with_retry` (success, retry-then-succeed, give-up-and-reraise, non-rate-limit propagation, `next_wait -> None` early-out, `pre_call` per-attempt) and the limiter.
- New CV limiter-slot test mirroring Metron's `test_api_call_acquires_rate_limiter_slot`.
- Mocked conftest now resets and neutralises the CV limiter (its 1 req/sec default would otherwise block mocked tests, since the limiter's internal sleep isn't the patched `models.comicvine.time.sleep`).
- The 9 pre-existing Metron/ComicVine rate-limit tests pass unchanged.

**Full suite: 2157 passed** (the 13 `test_pdf.py` failures are the documented env-only baseline — `cbz_ops.pdf` unimportable without `pdf2image` locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)