### PR TITLE
Fix auto-mapped series showing volume folder as the series name

### DIFF
--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -28,6 +28,7 @@ Reuses existing parsers/writers rather than re-implementing them:
 """
 
 import os
+import re
 import threading
 import time
 import uuid
@@ -43,6 +44,28 @@ from models.series_json import read_series_json, write_series_json
 
 COMIC_EXTENSIONS = (".cbz", ".cbr", ".zip", ".rar")
 SIDECAR_NAMES = {"series.json", "cvinfo"}
+
+# A leaf folder like ``v2017`` / ``v2`` is a *volume* marker, not a series name
+# (Mylar lays libraries out as ``<publisher>/<series>/v<year>/``). Mirrors the
+# existing convention in ``core.database.compute_display_name`` /
+# ``recommendations.py``.
+_VOLUME_LEAF_RE = re.compile(r"^v\d{1,4}$", re.IGNORECASE)
+
+
+def _series_name_from_folder(folder):
+    """Best-effort series name from a folder path when the sidecar has none.
+
+    If the leaf folder is a volume marker (``v2017``), the series name lives in
+    the parent folder (``.../Mister Miracle/v2017`` -> ``Mister Miracle``).
+    Otherwise the leaf itself is the best guess.
+    """
+    trimmed = folder.rstrip("/\\")
+    leaf = os.path.basename(trimmed)
+    if _VOLUME_LEAF_RE.match(leaf):
+        parent = os.path.basename(os.path.dirname(trimmed))
+        if parent and parent.lower() != "data":
+            return parent
+    return leaf
 
 
 def _norm(path):
@@ -117,7 +140,7 @@ def _resolve_identity(folder, api, cv_api_key=None):
         return {
             "folder": folder,
             "metron_id": metron_id,
-            "series_name": name or os.path.basename(folder.rstrip("/\\")),
+            "series_name": name or _series_name_from_folder(folder),
             "publisher_name": publisher,
             "year": year,
             "status": status,
@@ -285,7 +308,12 @@ def _strip_html(text):
 
 
 def _fetch_comicvine_series_dict(series_id, fallback):
-    """Build a series payload from the ComicVine API for an offset (cv) id."""
+    """Build a series payload from the ComicVine API for an offset (cv) id.
+
+    Returns ``(series_dict, authoritative)`` where ``authoritative`` is True only
+    when ComicVine actually returned a named volume (so the name/metadata is
+    trustworthy, not a folder-derived guess).
+    """
     cv_id = cv_id_from_series_id(series_id)
     details = {}
     key = _safe_cv_key()
@@ -295,6 +323,7 @@ def _fetch_comicvine_series_dict(series_id, fallback):
         except Exception as e:
             app_logger.warning(f"automap: ComicVine volume {cv_id} fetch failed: {e}")
 
+    authoritative = bool(details.get("name"))
     name = details.get("name") or fallback.get("series_name") or f"ComicVine {cv_id}"
     return {
         "id": series_id,
@@ -306,22 +335,32 @@ def _fetch_comicvine_series_dict(series_id, fallback):
         "desc": _strip_html(details.get("description")),
         "resource_url": f"https://comicvine.gamespot.com/volume/4050-{cv_id}/",
         "cover_image": details.get("image_url"),
-    }
+    }, authoritative
 
 
-def _fetch_series_dict(api, metron_id, fallback):
+def _fetch_series_dict(api, metron_id, fallback, blocking=False):
     """Build a series payload for save_series_mapping.
 
     Prefer the authoritative Metron object (gives name/publisher/status/year);
     for a ComicVine-sourced id fetch from ComicVine; otherwise fall back to
     sidecar-derived fields so we can still write a valid (name-bearing) row.
+
+    ``blocking`` selects the Metron fetch: True routes through
+    ``metron.get_series`` (waits on the rate limiter and retries -- use for the
+    background repair/sync where reliability matters); False keeps a single raw
+    ``api.series`` attempt so the interactive apply phase stays fast and simply
+    degrades to the fallback under load.
+
+    Returns ``(series_dict, authoritative)``. ``authoritative`` is False when the
+    dict is built only from sidecar/folder fallback data (API unreachable or
+    rate-limited) -- the caller must not let that overwrite a known-good name.
     """
     if is_comicvine_series_id(metron_id):
         return _fetch_comicvine_series_dict(metron_id, fallback)
 
     if api:
         try:
-            info = api.series(metron_id)
+            info = metron.get_series(api, metron_id) if blocking else api.series(metron_id)
             if info:
                 if hasattr(info, "model_dump"):
                     data = info.model_dump(mode="json")
@@ -330,9 +369,9 @@ def _fetch_series_dict(api, metron_id, fallback):
                 else:
                     data = {"id": metron_id, "name": getattr(info, "name", "")}
                 data["id"] = metron_id
-                return data
+                return data, True
         except Exception as e:
-            app_logger.warning(f"automap: api.series({metron_id}) failed: {e}")
+            app_logger.warning(f"automap: Metron fetch for series {metron_id} failed: {e}")
 
     return {
         "id": metron_id,
@@ -341,23 +380,31 @@ def _fetch_series_dict(api, metron_id, fallback):
         "status": fallback.get("status"),
         "year_began": fallback.get("year"),
         "cv_id": fallback.get("cv_id"),
-    }
+    }, False
 
 
-def _backfill_sidecars(folder, series_dict, metron_id, api):
-    """Write the Metron id into the folder's sidecars so future scans skip the API."""
+def _backfill_sidecars(folder, series_dict, metron_id, api, authoritative=True):
+    """Write the Metron id into the folder's sidecars so future scans skip the API.
+
+    ``authoritative`` gates writing the *name/metadata* into series.json: when the
+    series data is only a folder-derived fallback (API was unreachable), we must
+    not bake an unverified name (e.g. ``v2017``) into the sidecar, or the next
+    scan would read it straight back as the series name. The cvinfo ``series_id:``
+    line is still written -- the id itself is trustworthy.
+    """
     # A ComicVine-sourced series has no Metron id; its offset id must never be
     # written into a sidecar as a Metron series_id (a later scan would misread
     # it). The sidecar already carries the cv_id, so leave it untouched.
     if is_comicvine_series_id(metron_id):
         return
 
-    try:
-        existing = read_series_json(folder)
-        if not _sidecar_metadata(existing).get("metron_id"):
-            write_series_json(folder, series_dict, api=api)
-    except Exception as e:
-        app_logger.warning(f"automap: series.json backfill failed for {folder}: {e}")
+    if authoritative:
+        try:
+            existing = read_series_json(folder)
+            if not _sidecar_metadata(existing).get("metron_id"):
+                write_series_json(folder, series_dict, api=api)
+        except Exception as e:
+            app_logger.warning(f"automap: series.json backfill failed for {folder}: {e}")
 
     try:
         cvinfo_path = comicvine.find_cvinfo_in_folder(folder)
@@ -380,6 +427,33 @@ def _backfill_sidecars(folder, series_dict, metron_id, api):
         app_logger.warning(f"automap: cvinfo backfill failed for {folder}: {e}")
 
 
+def _prepare_series_dict_for_save(series_dict, fallback):
+    """Fill publisher_id / status on a series dict before save_series_mapping.
+
+    Prefers the Metron nested publisher (has an id); when the data is a fallback
+    dict (Metron unavailable) resolves the sidecar publisher *name* to an id so
+    the Pull List publisher column still fills in. ``fallback`` supplies
+    sidecar/DB-row publisher_name and status as a backstop.
+    """
+    from core.database import save_publisher, upsert_publisher_by_name
+
+    publisher = series_dict.get("publisher")
+    if isinstance(publisher, dict) and publisher.get("id"):
+        save_publisher(publisher.get("id"), publisher.get("name"))
+    elif not series_dict.get("publisher_id"):
+        pub_name = series_dict.get("publisher_name") or fallback.get("publisher_name")
+        if pub_name:
+            pub_id = upsert_publisher_by_name(pub_name)
+            if pub_id:
+                series_dict["publisher_id"] = pub_id
+
+    # Status: fall back to the sidecar/DB status when the API didn't supply one.
+    if not series_dict.get("status") and fallback.get("status"):
+        series_dict["status"] = fallback.get("status")
+
+    return series_dict
+
+
 def apply_automap(items, api=None):
     """Map each item's folder to its Metron series and backfill sidecars.
 
@@ -391,11 +465,7 @@ def apply_automap(items, api=None):
         dict with ``applied`` (int), ``failed`` (list of {folder,error}), and
         ``applied_ids`` (list of Metron series ids).
     """
-    from core.database import (
-        save_publisher,
-        save_series_mapping,
-        upsert_publisher_by_name,
-    )
+    from core.database import get_series_by_id, save_series_mapping
 
     if api is None:
         api = metron.get_flask_api()
@@ -415,24 +485,17 @@ def apply_automap(items, api=None):
             continue
 
         try:
-            series_dict = _fetch_series_dict(api, metron_id, item)
+            series_dict, authoritative = _fetch_series_dict(api, metron_id, item)
 
-            # Publisher: prefer the Metron nested publisher (has an id); when
-            # Metron is unavailable (fallback dict), resolve the sidecar
-            # publisher name to an id so the Pull List publisher column fills in.
-            publisher = series_dict.get("publisher")
-            if isinstance(publisher, dict) and publisher.get("id"):
-                save_publisher(publisher.get("id"), publisher.get("name"))
-            elif not series_dict.get("publisher_id"):
-                pub_name = series_dict.get("publisher_name") or item.get("publisher_name")
-                if pub_name:
-                    pub_id = upsert_publisher_by_name(pub_name)
-                    if pub_id:
-                        series_dict["publisher_id"] = pub_id
+            # When the fetch failed (fallback data), never overwrite a good name
+            # already on the row with the folder-derived guess (e.g. "v2017").
+            if not authoritative:
+                existing = get_series_by_id(metron_id)
+                existing_name = (existing or {}).get("name")
+                if existing_name and not _VOLUME_LEAF_RE.match(existing_name.strip()):
+                    series_dict["name"] = existing_name
 
-            # Status: fall back to the sidecar status when Metron didn't supply one.
-            if not series_dict.get("status") and item.get("status"):
-                series_dict["status"] = item.get("status")
+            _prepare_series_dict_for_save(series_dict, item)
 
             if not save_series_mapping(
                 series_dict, folder, cover_image=series_dict.get("cover_image")
@@ -440,7 +503,9 @@ def apply_automap(items, api=None):
                 failed.append({"folder": folder, "error": "Failed to save mapping"})
                 continue
 
-            _backfill_sidecars(folder, series_dict, metron_id, api)
+            _backfill_sidecars(
+                folder, series_dict, metron_id, api, authoritative=authoritative
+            )
             applied += 1
             applied_ids.append(metron_id)
         except Exception as e:
@@ -521,20 +586,127 @@ def match_unmatched_mapped_series(api):
     """Sync + match every mapped series that has no cached collection status.
 
     Covers the series just auto-mapped (which have none) plus any previously
-    mapped series that were never matched.
+    mapped series that were never matched. Progress is published to the nav
+    operations indicator so the user can watch this long tail (it pulls issues
+    from Metron/ComicVine, one series at a time under rate limits) instead of it
+    running invisibly.
     """
+    from core.app_state import (
+        complete_operation,
+        register_operation,
+        update_operation,
+    )
     from core.database import (
         get_all_mapped_series,
         get_collection_status_for_series,
     )
 
+    worklist = []
     for row in get_all_mapped_series():
         series_id = row.get("id")
         if not series_id:
             continue
         if get_collection_status_for_series(series_id):
             continue  # already matched — leave it (and its Metron budget) alone
-        _sync_and_match(api, series_id)
+        worklist.append(row)
+
+    if not worklist:
+        return
+
+    op_id = register_operation("match", "Matching library to issues", total=len(worklist))
+    try:
+        for index, row in enumerate(worklist):
+            update_operation(
+                op_id, current=index,
+                detail=row.get("name") or f"Series {row.get('id')}",
+            )
+            _sync_and_match(api, row["id"])
+        complete_operation(op_id)
+    except Exception:
+        complete_operation(op_id, error=True)
+        raise
+
+
+def repair_volume_named_series(api):
+    """Fix mapped series whose stored name is a volume token (e.g. ``v2017``).
+
+    Older/interrupted scans could persist a folder-derived fallback name when the
+    Metron/ComicVine fetch failed at apply time (a bulk scan hits rate limits).
+    This re-fetches each such series by its stored id and, when the API returns a
+    real name, corrects both the DB row and the folder's series.json so a future
+    scan reads the right name. Rows whose fetch is still unavailable are left as
+    they are -- the next Scan Library retries them.
+    """
+    from core.app_state import (
+        complete_operation,
+        register_operation,
+        update_operation,
+    )
+    from core.database import get_all_mapped_series, save_series_mapping
+
+    targets = [
+        row
+        for row in get_all_mapped_series()
+        if (row.get("name") or "").strip()
+        and _VOLUME_LEAF_RE.match((row.get("name") or "").strip())
+        and row.get("id")
+        and row.get("mapped_path")
+    ]
+    if not targets:
+        return 0
+
+    op_id = register_operation(
+        "repair", "Fixing volume-named series", total=len(targets)
+    )
+    repaired = 0
+    try:
+        for index, row in enumerate(targets):
+            name = row["name"].strip()
+            series_id = row["id"]
+            mapped_path = row["mapped_path"]
+            update_operation(op_id, current=index, detail=name)
+
+            try:
+                series_dict, authoritative = _fetch_series_dict(
+                    api, series_id, row, blocking=True
+                )
+            except Exception as e:
+                app_logger.warning(f"automap: repair fetch failed for {series_id}: {e}")
+                continue
+
+            new_name = (series_dict.get("name") or "").strip()
+            if not authoritative or not new_name or _VOLUME_LEAF_RE.match(new_name):
+                continue  # still can't get a real name; leave the row for next scan
+
+            _prepare_series_dict_for_save(series_dict, row)
+            if not save_series_mapping(
+                series_dict, mapped_path, cover_image=series_dict.get("cover_image")
+            ):
+                continue
+
+            # Correct the sidecar too, so a later scan doesn't reintroduce the bad
+            # name. Skip for ComicVine-sourced ids: write_series_json would stamp
+            # the offset id in as metron_id, which a later scan would misread (see
+            # _backfill_sidecars). Fixing the DB name is enough for the Pull List.
+            if os.path.isdir(mapped_path) and not is_comicvine_series_id(series_id):
+                try:
+                    write_series_json(mapped_path, series_dict, api=api)
+                except Exception as e:
+                    app_logger.warning(
+                        f"automap: repair series.json rewrite failed for {mapped_path}: {e}"
+                    )
+            repaired += 1
+            app_logger.info(
+                f"automap: repaired series {series_id} name '{name}' -> '{new_name}'"
+            )
+        complete_operation(op_id)
+    except Exception:
+        complete_operation(op_id, error=True)
+        raise
+
+    if repaired:
+        app_logger.info(f"automap: repaired {repaired} volume-named series")
+    return repaired
 
 
 def apply_and_sync(items, api=None):
@@ -622,10 +794,12 @@ def _run_scan_job_inner(op_id, app):
                     finished_at=time.time(),
                 )
 
-        # Result is already stored (UI can render), so this runs as a
-        # background tail: sync + match every mapped series that isn't matched
-        # yet, so the Pull List / Wanted lists reflect owned vs missing without
-        # the user opening each series.
+        # Result is already stored (UI can render), so this runs as a background
+        # tail. First heal any series left with a volume-folder fallback name
+        # (e.g. "v2017") from an earlier scan that hit the API rate limit, then
+        # sync + match every mapped series that isn't matched yet, so the Pull
+        # List / Wanted lists reflect owned vs missing without opening each one.
+        repair_volume_named_series(api)
         match_unmatched_mapped_series(api)
     except Exception as e:
         app_logger.error(f"automap: scan job {op_id} failed: {e}")

--- a/models/metron.py
+++ b/models/metron.py
@@ -975,6 +975,19 @@ def get_series_details(api, series_id: int) -> Optional[Dict[str, Any]]:
     return _api_call(_call, f"getting details for series {series_id}")
 
 
+def get_series(api, series_id: int):
+    """Fetch the full Metron series model, blocking and retrying on rate limits.
+
+    Unlike a raw ``api.series(id)`` call (which raises ``RateLimitError`` under
+    bulk load), this waits on the shared rate limiter and retries, so callers
+    that fetch many series in a row (sync, matching, name repair) get the real
+    object instead of erroring out. Returns the Mokkari series model, or None.
+    """
+    if not api or not series_id:
+        return None
+    return _api_call(lambda: api.series(series_id), f"getting series {series_id}")
+
+
 def get_series_cv_id(api, series_id: int) -> Optional[int]:
     """
     Get the ComicVine ID for a Metron series.

--- a/sync.py
+++ b/sync.py
@@ -68,14 +68,38 @@ def sync_series_from_api(api, series_id: int) -> dict:
                 'error': 'Series not found in database'
             }
 
-        # Fetch series info from API
-        series_info = api.series(series_id)
+        # Fetch series info from API. Use the rate-limit-aware helper so a bulk
+        # sync waits on the shared limiter instead of erroring out under load.
+        series_info = metron.get_series(api, series_id)
         if not series_info:
             return {
                 'series_id': series_id,
                 'success': False,
                 'error': 'Series not found in Metron API'
             }
+
+        # Persist the authoritative metadata (name/publisher/status/...). The
+        # series row may still carry a stale name (e.g. a "v2020" volume-folder
+        # fallback from an earlier scan); refreshing it here corrects the Pull
+        # List without a separate per-series action. Mirrors the series_view
+        # refresh path. Guard on mapped_path so we never null an existing mapping.
+        mapped_path = series_mapping.get('mapped_path')
+        if mapped_path:
+            from core.database import save_publisher, save_series_mapping
+
+            if hasattr(series_info, 'model_dump'):
+                series_dict = series_info.model_dump(mode='json')
+            elif hasattr(series_info, 'dict'):
+                series_dict = series_info.dict()
+            else:
+                series_dict = {'id': series_id, 'name': getattr(series_info, 'name', '')}
+            series_dict['id'] = series_id
+
+            publisher = getattr(series_info, 'publisher', None)
+            if publisher is not None and getattr(publisher, 'id', None):
+                save_publisher(publisher.id, getattr(publisher, 'name', None))
+
+            save_series_mapping(series_dict, mapped_path)
 
         # Fetch all issues
         all_issues_result = metron.get_all_issues_for_series(api, series_id)
@@ -89,7 +113,9 @@ def sync_series_from_api(api, series_id: int) -> dict:
         # Invalidate collection status cache to force re-scan with new issue data
         invalidate_collection_status_for_series(series_id)
 
-        series_name = series_mapping.get('name', f'Series {series_id}')
+        series_name = getattr(series_info, 'name', None) or series_mapping.get(
+            'name', f'Series {series_id}'
+        )
         app_logger.info(f"✓ Synced {series_name}: {len(all_issues)} issues")
 
         return {

--- a/templates/base.html
+++ b/templates/base.html
@@ -171,7 +171,7 @@
             return b.started_at - a.started_at;
           });
 
-          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up' };
+          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable' };
           let html = '';
           ops.forEach(op => {
             const icon = iconMap[op.op_type] || 'bi-gear';

--- a/tests/mocked/test_cv_sync_guards.py
+++ b/tests/mocked/test_cv_sync_guards.py
@@ -1,6 +1,6 @@
 """ComicVine-only series: Metron sync guards and issue-list fetch."""
 import types
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from helpers.comicvine_ids import make_comicvine_series_id
 
@@ -11,6 +11,44 @@ def test_sync_series_from_api_skips_comicvine():
     res = sync_series_from_api(None, make_comicvine_series_id(5))
     assert res["success"] is False
     assert res.get("skipped") is True
+
+
+def test_sync_series_from_api_persists_fresh_name(db_connection):
+    # A row left with a stale volume-folder name ("v2020") must be corrected
+    # from the authoritative Metron object during a normal sync -- not kept.
+    from core.database import save_series_mapping, get_series_by_id
+    from sync import sync_series_from_api
+
+    save_series_mapping({"id": 3596, "name": "v2020"}, "/data/Marvel/MZR/v2020")
+
+    fresh = types.SimpleNamespace(
+        id=3596, name="Marvel Zombies: Resurrection",
+        publisher=types.SimpleNamespace(id=10, name="Marvel"),
+        model_dump=lambda mode=None: {
+            "id": 3596, "name": "Marvel Zombies: Resurrection",
+            "publisher": {"id": 10, "name": "Marvel"},
+        },
+    )
+    with patch("models.metron.get_series", return_value=fresh), \
+         patch("models.metron.get_all_issues_for_series", return_value=[]):
+        res = sync_series_from_api(MagicMock(), 3596)
+
+    assert res["success"] is True
+    assert res["series_name"] == "Marvel Zombies: Resurrection"
+    assert get_series_by_id(3596)["name"] == "Marvel Zombies: Resurrection"
+
+
+def test_sync_series_from_api_no_write_when_api_exhausted(db_connection):
+    # If the (blocking) fetch ultimately returns None, leave the row untouched.
+    from core.database import save_series_mapping, get_series_by_id
+    from sync import sync_series_from_api
+
+    save_series_mapping({"id": 3596, "name": "v2020"}, "/data/Marvel/MZR/v2020")
+    with patch("models.metron.get_series", return_value=None):
+        res = sync_series_from_api(MagicMock(), 3596)
+
+    assert res["success"] is False
+    assert get_series_by_id(3596)["name"] == "v2020"
 
 
 def test_get_series_needing_sync_excludes_comicvine(db_connection):

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -5,6 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Import `sync` at collection time (unpatched) so its top-level
+# `from core.database import get_series_by_id` binds the real function. A test
+# below patches "sync.sync_series_from_api"; if that were sync's first import it
+# would happen while core.database is patched and permanently freeze the mock
+# into sync's namespace, breaking later tests that rely on the real fetch.
+import sync  # noqa: F401
 from helpers.comicvine_ids import make_comicvine_series_id
 from models import library_automap
 
@@ -361,6 +367,30 @@ class TestSyncAndMatch:
         called_ids = [c.args[1] for c in sm.call_args_list]
         assert called_ids == [2]
 
+    def test_match_unmatched_reports_progress(self):
+        rows = [{"id": 1, "name": "Batman"}, {"id": 2, "name": "Saga"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch.object(library_automap, "_sync_and_match"), \
+             patch("core.app_state.register_operation", return_value="op1") as reg, \
+             patch("core.app_state.update_operation") as upd, \
+             patch("core.app_state.complete_operation") as done:
+            library_automap.match_unmatched_mapped_series(api=None)
+        reg.assert_called_once()
+        assert reg.call_args.args[0] == "match"
+        assert reg.call_args.kwargs.get("total") == 2
+        assert upd.call_count == 2
+        done.assert_called_once_with("op1")
+
+    def test_match_unmatched_no_operation_when_all_matched(self):
+        rows = [{"id": 1, "name": "Batman"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series",
+                   return_value=[{"issue_number": "1"}]), \
+             patch("core.app_state.register_operation") as reg:
+            library_automap.match_unmatched_mapped_series(api=None)
+        reg.assert_not_called()
+
 
 class TestApplyExtra:
     def test_falls_back_to_sidecar_when_no_api(self, tmp_path):
@@ -371,6 +401,7 @@ class TestApplyExtra:
         )
         with patch("core.database.save_series_mapping", return_value=True) as save, \
              patch("core.database.save_publisher"), \
+             patch("core.database.get_series_by_id", return_value=None), \
              patch("models.metron.get_flask_api", return_value=None):
             result = library_automap.apply_automap(
                 [{"folder": folder, "metron_id": 555, "series_name": "Batman"}], api=None
@@ -392,6 +423,7 @@ class TestApplyExtra:
         }
         with patch("core.database.save_series_mapping", return_value=True) as save, \
              patch("core.database.save_publisher"), \
+             patch("core.database.get_series_by_id", return_value=None), \
              patch("core.database.upsert_publisher_by_name", return_value=42) as upsert, \
              patch("models.metron.get_flask_api", return_value=None):
             result = library_automap.apply_automap([item], api=None)
@@ -408,3 +440,197 @@ class TestApplyExtra:
         )
         ident = library_automap._resolve_identity(folder, api=None)
         assert ident["status"] == "Ended"
+
+
+class TestSeriesNameFromFolder:
+    def test_volume_leaf_uses_parent(self):
+        assert (
+            library_automap._series_name_from_folder("/data/DC Comics/Mister Miracle/v2017")
+            == "Mister Miracle"
+        )
+
+    def test_short_volume_leaf_uses_parent(self):
+        assert library_automap._series_name_from_folder("/data/Image/Saga/v2") == "Saga"
+
+    def test_normal_leaf_kept(self):
+        assert (
+            library_automap._series_name_from_folder("/data/DC/Batman (2016)")
+            == "Batman (2016)"
+        )
+
+    def test_volume_leaf_at_data_root_falls_back_to_leaf(self):
+        # No meaningful series name above the volume folder -- keep the leaf.
+        assert library_automap._series_name_from_folder("/data/v2017") == "v2017"
+
+    def test_trailing_slash_tolerated(self):
+        assert (
+            library_automap._series_name_from_folder("/data/DC/Mister Miracle/v2017/")
+            == "Mister Miracle"
+        )
+
+
+class TestVolumeNameResolution:
+    def test_cvinfo_only_volume_folder_uses_parent_name(self, tmp_path):
+        # cvinfo carries the id but no name; the leaf is the volume, so the
+        # series name must come from the parent folder, not "v2017".
+        folder = _make_folder(
+            tmp_path, os.path.join("Mister Miracle", "v2017"),
+            cvinfo="https://comicvine.gamespot.com/mm/4050-111/\nseries_id: 888\n",
+        )
+        ident = library_automap._resolve_identity(folder, api=None)
+        assert ident["metron_id"] == 888
+        assert ident["series_name"] == "Mister Miracle"
+
+
+class TestApplyDoesNotClobberName:
+    def _failing_api(self):
+        api = MagicMock()
+        api.series.side_effect = RuntimeError("rate limited")
+        return api
+
+    def test_failed_fetch_keeps_existing_good_name(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, os.path.join("Mister Miracle", "v2017"),
+            cvinfo="series_id: 888\n",
+        )
+        # The scan candidate carries the folder-derived guess; without the fix
+        # this would overwrite the good DB name.
+        item = {"folder": folder, "metron_id": 888, "series_name": "Mister Miracle"}
+        with patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("core.database.upsert_publisher_by_name", return_value=None), \
+             patch("core.database.get_series_by_id",
+                   return_value={"id": 888, "name": "Mister Miracle"}), \
+             patch("models.library_automap.write_series_json") as write:
+            result = library_automap.apply_automap([item], api=self._failing_api())
+        assert result["applied"] == 1
+        saved = save.call_args[0][0]
+        assert saved["name"] == "Mister Miracle"
+        # Unverified data must not be baked into series.json.
+        write.assert_not_called()
+
+    def test_failed_fetch_does_not_preserve_volume_token_name(self, tmp_path):
+        # If the DB name is itself a volume token, don't keep it -- fall through
+        # to the (best-effort) fallback name so it can be repaired later.
+        folder = _make_folder(tmp_path, os.path.join("Saga", "v2012"),
+                              cvinfo="series_id: 42\n")
+        item = {"folder": folder, "metron_id": 42, "series_name": "Saga"}
+        with patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("core.database.upsert_publisher_by_name", return_value=None), \
+             patch("core.database.get_series_by_id",
+                   return_value={"id": 42, "name": "v2012"}), \
+             patch("models.library_automap.write_series_json"):
+            library_automap.apply_automap([item], api=self._failing_api())
+        saved = save.call_args[0][0]
+        assert saved["name"] == "Saga"
+
+
+class TestRepairVolumeNamedSeries:
+    def test_renames_metron_series_and_rewrites_sidecar(self, tmp_path):
+        rows = [{"id": 555, "name": "v2017", "mapped_path": str(tmp_path)}]
+        series_obj = MagicMock()
+        series_obj.model_dump.return_value = {
+            "id": 555, "name": "Mister Miracle",
+            "publisher": {"id": 10, "name": "DC"}, "year_began": 2017,
+        }
+        api = MagicMock()
+        api.series.return_value = series_obj
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("models.library_automap.write_series_json") as write:
+            repaired = library_automap.repair_volume_named_series(api)
+        assert repaired == 1
+        saved, saved_path = save.call_args[0][:2]
+        assert saved["name"] == "Mister Miracle"
+        assert saved_path == str(tmp_path)
+        write.assert_called_once()
+
+    def test_uses_blocking_get_series(self, tmp_path):
+        # Repair must fetch through the rate-limit-aware metron.get_series so a
+        # bulk run doesn't error out and skip the rename.
+        rows = [{"id": 555, "name": "v2017", "mapped_path": str(tmp_path)}]
+        model = MagicMock()
+        model.model_dump.return_value = {"id": 555, "name": "Batman", "cv_id": 1}
+        api = MagicMock()
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.save_publisher"), \
+             patch("models.metron.get_series", return_value=model) as gs, \
+             patch("models.library_automap.write_series_json"):
+            repaired = library_automap.repair_volume_named_series(api)
+        assert repaired == 1
+        gs.assert_called_once_with(api, 555)
+        assert save.call_args[0][0]["name"] == "Batman"
+
+    def test_skips_when_api_unavailable(self, tmp_path):
+        # metron.get_series returns None when the API is exhausted/down -> the
+        # row is left as-is for the next scan (exact-name-only, no fallback).
+        rows = [{"id": 555, "name": "v2017", "mapped_path": str(tmp_path)}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("models.metron.get_series", return_value=None), \
+             patch("models.library_automap.write_series_json"):
+            repaired = library_automap.repair_volume_named_series(MagicMock())
+        assert repaired == 0
+        save.assert_not_called()
+
+    def test_skips_non_volume_names(self, tmp_path):
+        rows = [{"id": 555, "name": "Batman", "mapped_path": str(tmp_path)}]
+        api = MagicMock()
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.save_series_mapping", return_value=True) as save:
+            repaired = library_automap.repair_volume_named_series(api)
+        assert repaired == 0
+        api.series.assert_not_called()
+        save.assert_not_called()
+
+    def test_reports_progress_in_ops_indicator(self, tmp_path):
+        # A repairable row should register + complete an operation for the nav.
+        rows = [{"id": 555, "name": "v2017", "mapped_path": str(tmp_path)}]
+        series_obj = MagicMock()
+        series_obj.model_dump.return_value = {"id": 555, "name": "Batman", "cv_id": 1}
+        api = MagicMock()
+        api.series.return_value = series_obj
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.save_series_mapping", return_value=True), \
+             patch("core.database.save_publisher"), \
+             patch("models.library_automap.write_series_json"), \
+             patch("core.app_state.register_operation", return_value="op1") as reg, \
+             patch("core.app_state.update_operation") as upd, \
+             patch("core.app_state.complete_operation") as done:
+            library_automap.repair_volume_named_series(api)
+        reg.assert_called_once()
+        assert reg.call_args.args[0] == "repair"
+        assert reg.call_args.kwargs.get("total") == 1
+        upd.assert_called()
+        done.assert_called_once_with("op1")
+
+    def test_no_operation_when_nothing_to_repair(self, tmp_path):
+        rows = [{"id": 555, "name": "Batman", "mapped_path": str(tmp_path)}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.app_state.register_operation") as reg:
+            library_automap.repair_volume_named_series(api=MagicMock())
+        reg.assert_not_called()
+
+    def test_comicvine_offset_id_repaired_without_sidecar_write(self, tmp_path):
+        cv_id = 18705
+        cv_series_id = make_comicvine_series_id(cv_id)
+        rows = [{"id": cv_series_id, "name": "v2012", "mapped_path": str(tmp_path),
+                 "publisher_name": "Image"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.save_series_mapping", return_value=True) as save, \
+             patch("core.database.upsert_publisher_by_name", return_value=7), \
+             patch("models.comicvine.get_cv_api_key", return_value="key"), \
+             patch("models.comicvine.get_volume_details",
+                   return_value={"id": cv_id, "name": "Saga", "publisher_name": "Image",
+                                 "start_year": 2012}), \
+             patch("models.library_automap.write_series_json") as write:
+            repaired = library_automap.repair_volume_named_series(api=None)
+        assert repaired == 1
+        saved = save.call_args[0][0]
+        assert saved["name"] == "Saga"
+        assert saved["id"] == cv_series_id
+        # ComicVine offset id must not be stamped into series.json as a Metron id.
+        write.assert_not_called()

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -229,6 +229,40 @@ class TestGetSeriesDetails:
         assert get_series_details(mock_api, 9999) is None
 
 
+class TestGetSeries:
+
+    def test_returns_full_model(self):
+        from models.metron import get_series
+
+        mock_api = MagicMock()
+        model = make_mock_series(id=100, cv_id=12345)
+        mock_api.series.return_value = model
+
+        assert get_series(mock_api, 100) is model
+        mock_api.series.assert_called_once_with(100)
+
+    def test_missing_api_or_id(self):
+        from models.metron import get_series
+
+        assert get_series(None, 100) is None
+        assert get_series(MagicMock(), None) is None
+
+    def test_waits_and_retries_on_rate_limit(self):
+        # A transient RateLimitError must be retried (via _api_call), not raised,
+        # so bulk callers don't error out mid-scan.
+        from models.metron import get_series
+        from mokkari.exceptions import RateLimitError
+
+        mock_api = MagicMock()
+        model = make_mock_series(id=100)
+        mock_api.series.side_effect = [RateLimitError("rate limited", retry_after=0), model]
+
+        with patch("models.metron.time.sleep"):
+            result = get_series(mock_api, 100)
+        assert result is model
+        assert mock_api.series.call_count == 2
+
+
 class TestGetIssueMetadata:
 
     def test_double_fetch_pattern(self):


### PR DESCRIPTION
  - Volume-folder fallback — _series_name_from_folder derives the name from the parent folder when the leaf is a volume
  marker (v2017/v2020).
  - Rate-limit-aware fetch — new metron.get_series() fetches through the blocking _api_call; sync.sync_series_from_api
  and the repair use it and now persist the fresh name via save_series_mapping.
  - repair_volume_named_series — corrects already-mapped volume-token rows in the post-scan tail, exact-name-only.
  - Ops-indicator progress — the post-scan tail surfaces in the nav.