### PR TITLE
Pull List: status color-coding, filtering, and Monitor flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -1005,6 +1005,10 @@ def scheduled_getcomics_download(dry_run=False):
             mapped_path = series.get("mapped_path")
             publisher_name = series.get("publisher_name")
 
+            # Skip series the user isn't monitoring (NULL on legacy rows => on).
+            if series.get("monitored") == 0:
+                continue
+
             if not mapped_path or not os.path.exists(mapped_path):
                 continue
 
@@ -2320,6 +2324,10 @@ def refresh_wanted_cache_background():
             series_name = series.get("name", "")
             series_volume = series.get("volume")
             mapped_path = series.get("mapped_path")
+
+            # Skip series the user isn't monitoring (NULL on legacy rows => on).
+            if series.get("monitored") == 0:
+                continue
 
             if not mapped_path or not os.path.exists(mapped_path):
                 continue

--- a/core/database.py
+++ b/core/database.py
@@ -753,6 +753,9 @@ def init_db():
         if "series_subscription" not in series_columns:
             c.execute("ALTER TABLE series ADD COLUMN series_subscription INTEGER DEFAULT NULL")
             app_logger.info("Added series_subscription column to series table")
+        if "monitored" not in series_columns:
+            c.execute("ALTER TABLE series ADD COLUMN monitored INTEGER DEFAULT 1")
+            app_logger.info("Added monitored column to series table")
 
         # Create issues table (Metron issues cached for tracked series)
         c.execute("""
@@ -7021,6 +7024,107 @@ def get_series_subscription(series_id):
         return False
 
 
+def set_series_monitored(series_id, enabled):
+    """Set whether a series is monitored (searched for new/missing issues)."""
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return False
+        c = conn.cursor()
+        c.execute(
+            "UPDATE series SET monitored = ? WHERE id = ?",
+            (1 if enabled else 0, series_id)
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to set series monitored: {e}")
+        return False
+
+
+def get_series_monitored(series_id):
+    """Get monitored status. Returns True/False, treating NULL as monitored."""
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return True
+        c = conn.cursor()
+        c.execute("SELECT monitored FROM series WHERE id = ?", (series_id,))
+        row = c.fetchone()
+        conn.close()
+        if not row:
+            return True
+        # NULL (legacy rows created before the column existed) => monitored.
+        return row["monitored"] is None or bool(row["monitored"])
+    except Exception as e:
+        app_logger.error(f"Failed to get series monitored: {e}")
+        return True
+
+
+def get_pull_list_collection_counts(today):
+    """
+    Aggregate owned/missing issue counts per mapped series for the Pull List.
+
+    "Missing" = an issue not found in the collection cache and without a manual
+    owned/skipped mark (owned and skipped both count as present, mirroring the
+    per-row logic in templates/series.html). Missing issues are split by whether
+    their store_date is in the past/unknown (missing_past) or the future
+    (missing_future). ISO date strings compare lexically.
+
+    Args:
+        today: "YYYY-MM-DD" string used as the past/future boundary.
+
+    Returns:
+        Dict mapping series_id -> {total, scanned, found, missing_past, missing_future}
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return {}
+        c = conn.cursor()
+        c.execute("""
+            SELECT s.id AS series_id,
+                   COUNT(i.id) AS total,
+                   SUM(CASE WHEN cs.id IS NOT NULL THEN 1 ELSE 0 END) AS scanned,
+                   SUM(CASE WHEN cs.found = 1 THEN 1 ELSE 0 END) AS found,
+                   SUM(CASE WHEN (cs.found IS NULL OR cs.found = 0)
+                             AND ims.status IS NULL
+                             AND (i.store_date IS NULL OR i.store_date = ''
+                                  OR i.store_date <= ?)
+                            THEN 1 ELSE 0 END) AS missing_past,
+                   SUM(CASE WHEN (cs.found IS NULL OR cs.found = 0)
+                             AND ims.status IS NULL
+                             AND i.store_date > ?
+                            THEN 1 ELSE 0 END) AS missing_future
+            FROM series s
+            JOIN issues i ON i.series_id = s.id
+            LEFT JOIN collection_status cs
+                   ON cs.series_id = s.id AND cs.issue_id = i.id
+            LEFT JOIN issue_manual_status ims
+                   ON ims.series_id = s.id AND ims.issue_number = i.number
+            WHERE s.mapped_path IS NOT NULL AND s.mapped_path != ''
+            GROUP BY s.id
+        """, (today, today))
+        rows = c.fetchall()
+        conn.close()
+
+        return {
+            row["series_id"]: {
+                "total": row["total"] or 0,
+                "scanned": row["scanned"] or 0,
+                "found": row["found"] or 0,
+                "missing_past": row["missing_past"] or 0,
+                "missing_future": row["missing_future"] or 0,
+            }
+            for row in rows
+        }
+
+    except Exception as e:
+        app_logger.error(f"Failed to get pull list collection counts: {e}")
+        return {}
+
+
 #########################
 #   Reading Lists       #
 #########################
@@ -8631,6 +8735,7 @@ def get_wanted_issues():
             FROM issues i
             JOIN series s ON i.series_id = s.id
             WHERE s.mapped_path IS NOT NULL
+              AND (s.monitored = 1 OR s.monitored IS NULL)
               AND (i.store_date <= date('now') OR i.store_date IS NULL)
             ORDER BY s.name, i.number
         """)

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -184,6 +184,10 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
         mapped_path = series.get("mapped_path")
         publisher_name = series.get("publisher_name")
 
+        # Skip series the user isn't monitoring (NULL on legacy rows => on).
+        if series.get("monitored") == 0:
+            continue
+
         if not mapped_path:
             continue
 

--- a/routes/series.py
+++ b/routes/series.py
@@ -255,10 +255,39 @@ def pull_list():
     """
     Pull List page - shows all tracked series in the database.
     """
-    from core.database import get_all_mapped_series, get_all_publishers
+    from core.database import (
+        get_all_mapped_series,
+        get_all_publishers,
+        get_pull_list_collection_counts,
+    )
 
     series_list = get_all_mapped_series()
     publishers = get_all_publishers()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    counts = get_pull_list_collection_counts(today)
+
+    for series in series_list:
+        c = counts.get(series["id"], {})
+        missing_past = c.get("missing_past", 0)
+        missing_future = c.get("missing_future", 0)
+        series["missing_count"] = missing_past + missing_future
+        series["missing_future"] = missing_future
+
+        # Grey overrides everything: a series the user isn't monitoring is not
+        # searched for new/missing issues (monitored NULL on legacy rows => on).
+        monitored = series.get("monitored")
+        if monitored is not None and not monitored:
+            series["row_status"] = "unmonitored"
+        elif not c.get("total") or (not c.get("scanned") and not c.get("found")):
+            # No issue data, or never matched against the collection yet.
+            series["row_status"] = "unknown"
+        elif missing_past + missing_future == 0:
+            series["row_status"] = "complete"
+        elif missing_past > 0:
+            series["row_status"] = "missing"
+        else:
+            series["row_status"] = "upcoming"
 
     return render_template(
         "pull_list.html",
@@ -761,9 +790,10 @@ def series_view(slug):
         if not default_library and libraries:
             default_library = libraries[0]
 
-        from core.database import get_series_subscription
+        from core.database import get_series_subscription, get_series_monitored
 
         series_subscription = get_series_subscription(series_id)
+        series_monitored = get_series_monitored(series_id)
 
         has_series_json = False
         if mapped_path:
@@ -786,6 +816,7 @@ def series_view(slug):
             libraries=libraries,
             default_library=default_library,
             series_subscription=series_subscription,
+            series_monitored=series_monitored,
             has_series_json=has_series_json,
         )
     except Exception as e:
@@ -1117,6 +1148,21 @@ def toggle_series_subscription(series_id):
         return jsonify({"success": True})
     except Exception as e:
         app_logger.error(f"Error toggling subscription for series {series_id}: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@series_bp.route("/api/series/<int:series_id>/monitored", methods=["POST"])
+def toggle_series_monitored(series_id):
+    """Toggle whether a series is monitored (searched for new/missing issues)."""
+    from core.database import set_series_monitored
+
+    try:
+        data = request.get_json()
+        enabled = data.get("enabled", True)
+        set_series_monitored(series_id, enabled)
+        return jsonify({"success": True})
+    except Exception as e:
+        app_logger.error(f"Error toggling monitored for series {series_id}: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
 
 

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -86,6 +86,24 @@
                     <span class="text-muted" id="resultCount">Showing {{ total_series }} series</span>
                 </div>
             </div>
+            <hr class="my-3">
+            <div class="d-flex flex-wrap align-items-center gap-2" id="statusFilter"
+                 role="group" aria-label="Collection status filter">
+                <small class="text-muted me-1">Status:</small>
+                <button type="button" class="btn btn-sm btn-outline-secondary active" data-status="all">All</button>
+                <button type="button" class="btn btn-sm btn-outline-success" data-status="complete">
+                    <i class="bi bi-square-fill me-1"></i>Complete
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" data-status="missing">
+                    <i class="bi bi-square-fill me-1"></i>Missing
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-info" data-status="upcoming">
+                    <i class="bi bi-square-fill me-1"></i>Upcoming
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-status="unmonitored">
+                    <i class="bi bi-square-fill me-1"></i>Not monitored
+                </button>
+            </div>
         </div>
     </div>
 
@@ -117,6 +135,9 @@
                             <th scope="col" class="text-center sortable" data-sort="issues" style="cursor: pointer;">
                                 Issues <i class="bi bi-chevron-expand text-muted ms-1"></i>
                             </th>
+                            <th scope="col" class="sortable" data-sort="collection" style="cursor: pointer;">
+                                Collection <i class="bi bi-chevron-expand text-muted ms-1"></i>
+                            </th>
                             <th scope="col" class="sortable" data-sort="synced" style="cursor: pointer;">
                                 Last Synced <i class="bi bi-chevron-expand text-muted ms-1"></i>
                             </th>
@@ -128,7 +149,10 @@
                         <tr data-name="{{ series.name|lower }}"
                             data-status="{{ (series.status or '')|lower }}"
                             data-publisher="{{ (series.publisher_name or '')|lower }}"
-                            data-issues="{{ series.issue_count or 0 }}" data-synced="{{ series.last_synced_at or '' }}">
+                            data-issues="{{ series.issue_count or 0 }}" data-synced="{{ series.last_synced_at or '' }}"
+                            data-status-color="{{ series.row_status }}"
+                            data-missing="{{ series.missing_count or 0 }}"
+                            class="{{ {'complete':'table-success','missing':'table-danger','upcoming':'table-info','unmonitored':'table-secondary'}.get(series.row_status, '') }}">
                             <td class="ps-4">
                                 <a href="{{ url_for('series.series_view', slug=generate_series_slug(series.name, series.id, series.volume)) }}"
                                     class="text-decoration-none fw-bold">
@@ -155,6 +179,19 @@
                             <td class="text-center">
                                 {% if series.issue_count %}
                                 <span class="badge bg-info">{{ series.issue_count }}</span>
+                                {% else %}
+                                <span class="text-muted">-</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if series.row_status == 'unmonitored' %}
+                                <span class="badge bg-secondary"><i class="bi bi-slash-circle me-1"></i>Not monitored</span>
+                                {% elif series.row_status == 'complete' %}
+                                <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Complete</span>
+                                {% elif series.row_status == 'missing' %}
+                                <span class="badge bg-danger"><i class="bi bi-exclamation-circle me-1"></i>{{ series.missing_count }} missing</span>
+                                {% elif series.row_status == 'upcoming' %}
+                                <span class="badge bg-info"><i class="bi bi-calendar-event me-1"></i>{{ series.missing_count }} upcoming</span>
                                 {% else %}
                                 <span class="text-muted">-</span>
                                 {% endif %}
@@ -513,6 +550,7 @@
         // Current filter state
         let currentLetterFilter = 'all';
         let currentPublisherFilter = '';
+        let currentStatusFilter = 'all';
 
         // Build alphabet filter buttons
         function buildAlphabetFilter() {
@@ -583,6 +621,10 @@
                 // Check publisher filter match
                 const matchesPublisher = !currentPublisherFilter || publisher === currentPublisherFilter;
 
+                // Check collection-status filter match
+                const statusColor = row.dataset.statusColor || '';
+                const matchesStatus = currentStatusFilter === 'all' || statusColor === currentStatusFilter;
+
                 // Check letter filter match
                 let matchesLetter = true;
                 if (currentLetterFilter !== 'all') {
@@ -594,7 +636,7 @@
                     }
                 }
 
-                const isVisible = matchesSearch && matchesPublisher && matchesLetter;
+                const isVisible = matchesSearch && matchesPublisher && matchesLetter && matchesStatus;
                 row.style.display = isVisible ? '' : 'none';
                 if (isVisible) visibleCount++;
             });
@@ -615,6 +657,19 @@
             publisherFilter.addEventListener('change', function () {
                 currentPublisherFilter = this.value;
                 applyFilters();
+            });
+        }
+
+        // Collection-status filter (chips double as the color key)
+        const statusFilter = document.getElementById('statusFilter');
+        if (statusFilter) {
+            statusFilter.querySelectorAll('button[data-status]').forEach(btn => {
+                btn.addEventListener('click', function () {
+                    currentStatusFilter = this.dataset.status;
+                    statusFilter.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+                    this.classList.add('active');
+                    applyFilters();
+                });
             });
         }
 
@@ -662,6 +717,10 @@
                         case 'issues':
                             aVal = parseInt(a.dataset.issues) || 0;
                             bVal = parseInt(b.dataset.issues) || 0;
+                            return currentSort.ascending ? aVal - bVal : bVal - aVal;
+                        case 'collection':
+                            aVal = parseInt(a.dataset.missing) || 0;
+                            bVal = parseInt(b.dataset.missing) || 0;
                             return currentSort.ascending ? aVal - bVal : bVal - aVal;
                         case 'synced':
                             aVal = a.dataset.synced || '';

--- a/templates/series.html
+++ b/templates/series.html
@@ -219,6 +219,16 @@
                                 <small>On the Stack</small>
                             </label>
                         </div>
+                        <div class="form-check form-switch mb-0">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="monitorSeries"
+                                   {% if series_monitored %}checked{% endif %}
+                                   onchange="toggleMonitored(this.checked)">
+                            <label class="form-check-label" for="monitorSeries"
+                                   title="When off, this series is not searched for new or missing issues">
+                                <small>Monitor</small>
+                            </label>
+                        </div>
                     </div>
                     {% endif %}
 
@@ -981,6 +991,25 @@
         } catch (e) {
             document.getElementById('stackSubscription').checked = !enabled;
             showToast('Failed to update subscription', 'danger');
+        }
+    }
+
+    async function toggleMonitored(enabled) {
+        const seriesId = {{ series.id }};
+        try {
+            const response = await fetch(`/api/series/${seriesId}/monitored`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({enabled: enabled})
+            });
+            const data = await response.json();
+            if (!data.success) {
+                document.getElementById('monitorSeries').checked = !enabled;
+                showToast('Failed to update monitoring', 'danger');
+            }
+        } catch (e) {
+            document.getElementById('monitorSeries').checked = !enabled;
+            showToast('Failed to update monitoring', 'danger');
         }
     }
 

--- a/tests/integration/test_pull_list_status.py
+++ b/tests/integration/test_pull_list_status.py
@@ -1,0 +1,129 @@
+"""Tests for Pull List collection-status aggregation and the monitored flag."""
+import pytest
+from tests.factories.db_factories import create_publisher, create_series, create_issue
+
+
+def _mark_found(series_id, issue_id, issue_number, found):
+    from core.database import save_collection_status_bulk
+    save_collection_status_bulk([{
+        "series_id": series_id,
+        "issue_id": issue_id,
+        "issue_number": str(issue_number),
+        "found": 1 if found else 0,
+        "file_path": "/data/x.cbz" if found else None,
+        "file_mtime": 0.0,
+        "matched_via": "filename",
+    }])
+
+
+class TestSeriesMonitoredFlag:
+
+    def test_defaults_to_monitored(self, db_connection):
+        from core.database import get_series_monitored
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        # New rows default to monitored (column DEFAULT 1).
+        assert get_series_monitored(sid) is True
+
+    def test_set_and_get(self, db_connection):
+        from core.database import set_series_monitored, get_series_monitored
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+
+        set_series_monitored(sid, False)
+        assert get_series_monitored(sid) is False
+        set_series_monitored(sid, True)
+        assert get_series_monitored(sid) is True
+
+    def test_flows_into_mapped_series(self, db_connection):
+        from core.database import set_series_monitored, get_all_mapped_series
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        set_series_monitored(sid, False)
+
+        row = next(s for s in get_all_mapped_series() if s["id"] == sid)
+        assert row["monitored"] == 0
+
+
+class TestPullListCollectionCounts:
+
+    def test_complete_when_all_found(self, db_connection):
+        from core.database import get_pull_list_collection_counts
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        i1 = create_issue(series_id=sid, number="1", store_date="2020-01-10")
+        i2 = create_issue(series_id=sid, number="2", store_date="2020-02-10")
+        _mark_found(sid, i1, "1", True)
+        _mark_found(sid, i2, "2", True)
+
+        counts = get_pull_list_collection_counts("2026-01-01")[sid]
+        assert counts["total"] == 2
+        assert counts["found"] == 2
+        assert counts["missing_past"] == 0
+        assert counts["missing_future"] == 0
+
+    def test_missing_past(self, db_connection):
+        from core.database import get_pull_list_collection_counts
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        i1 = create_issue(series_id=sid, number="1", store_date="2020-01-10")
+        _mark_found(sid, i1, "1", False)
+
+        counts = get_pull_list_collection_counts("2026-01-01")[sid]
+        assert counts["missing_past"] == 1
+        assert counts["missing_future"] == 0
+
+    def test_missing_future_only(self, db_connection):
+        from core.database import get_pull_list_collection_counts
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        i1 = create_issue(series_id=sid, number="1", store_date="2099-01-10")
+        _mark_found(sid, i1, "1", False)
+
+        counts = get_pull_list_collection_counts("2026-01-01")[sid]
+        assert counts["missing_past"] == 0
+        assert counts["missing_future"] == 1
+
+    def test_manual_status_counts_as_present(self, db_connection):
+        from core.database import get_pull_list_collection_counts, set_manual_status
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        i1 = create_issue(series_id=sid, number="1", store_date="2020-01-10")
+        _mark_found(sid, i1, "1", False)
+        # Owned/skipped issues are not "missing" (mirrors series.html row logic).
+        set_manual_status(sid, "1", "owned")
+
+        counts = get_pull_list_collection_counts("2026-01-01")[sid]
+        assert counts["missing_past"] == 0
+        assert counts["missing_future"] == 0
+
+    def test_unscanned_series_reports_zero_scanned(self, db_connection):
+        from core.database import get_pull_list_collection_counts
+        pub_id = create_publisher()
+        sid = create_series(series_id=100, publisher_id=pub_id)
+        create_issue(series_id=sid, number="1", store_date="2020-01-10")
+        # No collection_status rows written -> not yet matched.
+
+        counts = get_pull_list_collection_counts("2026-01-01")[sid]
+        assert counts["total"] == 1
+        assert counts["scanned"] == 0
+        assert counts["found"] == 0
+
+
+class TestWantedIssuesRespectsMonitored:
+
+    def test_unmonitored_series_excluded(self, db_connection):
+        from core.database import (
+            set_series_monitored, get_wanted_issues,
+        )
+        pub_id = create_publisher()
+        on_id = create_series(series_id=100, name="Monitored", publisher_id=pub_id)
+        off_id = create_series(series_id=200, name="Silenced", publisher_id=pub_id)
+        create_issue(series_id=on_id, number="1", store_date="2020-01-10")
+        create_issue(series_id=off_id, number="1", store_date="2020-01-10")
+
+        set_series_monitored(off_id, False)
+
+        wanted_ids = {w["series_id"] for w in get_wanted_issues()}
+        assert on_id in wanted_ids
+        assert off_id not in wanted_ids

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -494,6 +494,55 @@ class TestSeriesSubscription:
         mock_set.assert_called_once_with(100, False)
 
 
+class TestSeriesMonitored:
+
+    @patch("core.database.set_series_monitored", return_value=True)
+    def test_toggle_monitored_enable(self, mock_set, client):
+        resp = client.post("/api/series/100/monitored", json={"enabled": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_set.assert_called_once_with(100, True)
+
+    @patch("core.database.set_series_monitored", return_value=True)
+    def test_toggle_monitored_disable(self, mock_set, client):
+        resp = client.post("/api/series/100/monitored", json={"enabled": False})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_set.assert_called_once_with(100, False)
+
+
+class TestPullListPage:
+    """The /pull-list page must render with per-series collection status
+    coloring and the status filter/legend controls."""
+
+    @staticmethod
+    def _register_slug_global(app):
+        # app.py registers this Jinja global; the test harness doesn't.
+        app.jinja_env.globals["generate_series_slug"] = (
+            lambda name, sid, volume=None: f"{sid}-slug"
+        )
+
+    def test_renders_with_status_controls(self, app, client_with_data):
+        self._register_slug_global(app)
+        resp = client_with_data.get("/pull-list")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # Legend/filter chips and per-row color hooks are present.
+        assert 'id="statusFilter"' in html
+        assert "data-status-color=" in html
+
+    def test_unmonitored_series_marked(self, app, client_with_data):
+        self._register_slug_global(app)
+        from core.database import set_series_monitored
+        set_series_monitored(100, False)
+
+        resp = client_with_data.get("/pull-list")
+        html = resp.get_data(as_text=True)
+        # A non-monitored series is greyed and labelled.
+        assert 'data-status-color="unmonitored"' in html
+        assert "Not monitored" in html
+
+
 def _post_import(client, payload, *, raw=None, filename="pull-list.json"):
     """Helper: POST a JSON payload (or raw bytes) to the import endpoint."""
     if raw is None:


### PR DESCRIPTION
## Context

The Pull List now supports scan/import of an existing library, which auto-subscribes many series at once and makes the page long. This adds at-a-glance collection health and a way to silence series the app shouldn't search.

## What's new

**Row color-coding** by collection status:
- 🟢 Complete — all issues present (found or manually owned/skipped)
- 🔴 Missing — ≥1 missing issue with a past store date
- 🔵 Upcoming — missing issue(s), all future-dated
- ⚪ Not monitored — Monitor flag off (overrides the others)
- neutral — never matched yet

**Missing-count badge** per row in a new sortable **Collection** column.

**Status filter + legend** — a chip row whose colored swatches double as the key, composing with the existing search / publisher / alphabet filters.

**New per-series Monitor flag** (toggle on the series page). When off, the series is greyed on the Pull List **and** excluded from the wanted-issues refresh and GetComics auto-download (both the live path and the dry-run simulation).

## Changes

- `core/database.py`: `series.monitored` column + `get/set_series_monitored`; `get_pull_list_collection_counts()` aggregate; monitored gate on `get_wanted_issues()`
- `routes/series.py`: `row_status`/`missing_count` in `pull_list`; `POST /api/series/<id>/monitored`; `series_monitored` passed to `series_view`
- `app.py` + `routes/downloads.py`: skip non-monitored series in the wanted-refresh, auto-download, and dry-run loops
- `templates/pull_list.html`, `templates/series.html`: UI
- Tests: route + integration coverage

## Notes

- `monitored` defaults to `1`; legacy NULL rows are treated as monitored, so nothing stops being searched after the migration.
- Coloring reads cached data (`collection_status`), so a freshly imported series shows neutral "unknown" until the background match runs, then colors correctly on next load.

## Testing

Full suite passes (2182 passed); the only failures are the pre-existing `test_pdf.py` environment-only failures (missing `pdf2image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)