### PR TITLE
Preserve decimal/suffix issue numbers in rename and matching

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -18,7 +18,7 @@ from core.config import config
 #   Group(5) => ".cbz"
 # -------------------------------------------------------------------
 VOLUME_ISSUE_PATTERN = re.compile(
-    r"^(.*?)\s+(v\d{1,3})\s+(\d{1,4})(.*)(\.\w+)$", re.IGNORECASE
+    r"^(.*?)\s+(v\d{1,3})\s+(\d{1,4}(?:\.\w+)?)(.*)(\.\w+)$", re.IGNORECASE
 )
 
 # -------------------------------------------------------------------
@@ -50,7 +50,9 @@ TITLE_YEAR_PATTERN = re.compile(
 #   Group(3) ⇒ " (2018)"
 #   Group(4) ⇒ ".cbz"
 # -------------------------------------------------------------------
-ISSUE_HASH_PATTERN = re.compile(r"^(.*?)\s*#\s*(\d{1,4})\b(.*)(\.\w+)$", re.IGNORECASE)
+ISSUE_HASH_PATTERN = re.compile(
+    r"^(.*?)\s*#\s*(\d{1,4}(?:\.\w+)?)\b(.*)(\.\w+)$", re.IGNORECASE
+)
 
 # -------------------------------------------------------------------
 # Original ISSUE_PATTERN:
@@ -59,7 +61,7 @@ ISSUE_HASH_PATTERN = re.compile(r"^(.*?)\s*#\s*(\d{1,4})\b(.*)(\.\w+)$", re.IGNO
 #   e.g. "2000AD 1795.cbz" (4-digit issue numbers for 2000AD)
 # -------------------------------------------------------------------
 ISSUE_PATTERN = re.compile(
-    r"^(.*?)\s+((?:v\d{1,3})|(?:\d{1,4}))\b(.*)(\.\w+)$", re.IGNORECASE
+    r"^(.*?)\s+((?:v\d{1,3})|(?:\d{1,4}(?:\.\w+)?))\b(.*)(\.\w+)$", re.IGNORECASE
 )
 
 # -------------------------------------------------------------------
@@ -74,7 +76,7 @@ ISSUE_PATTERN = re.compile(
 #   Group(5) => Extension (e.g. ".cbz")
 # -------------------------------------------------------------------
 ISSUE_AFTER_YEAR_PATTERN = re.compile(
-    r"^(.*?)\s*\((\d{4})\)\s*(#\d{1,4})(.*)(\.\w+)$", re.IGNORECASE
+    r"^(.*?)\s*\((\d{4})\)\s*(#\d{1,4}(?:\.\w+)?)(.*)(\.\w+)$", re.IGNORECASE
 )
 
 # -------------------------------------------------------------------
@@ -87,7 +89,7 @@ ISSUE_AFTER_YEAR_PATTERN = re.compile(
 #   Group(5) ⇒ ".cbz"
 # -------------------------------------------------------------------
 SERIES_ISSUE_PATTERN = re.compile(
-    r"^(.*?)\s+(\d{1,3})\s+(\d{1,3})\b(.*)(\.\w+)$", re.IGNORECASE
+    r"^(.*?)\s+(\d{1,3})\s+(\d{1,3}(?:\.\w+)?)\b(.*)(\.\w+)$", re.IGNORECASE
 )
 
 # -------------------------------------------------------------------
@@ -145,7 +147,7 @@ TITLE_COMMA_YEAR_HASH_ISSUE_PATTERN = re.compile(
 #   Group(5) => ".cbz" (extension)
 # -------------------------------------------------------------------
 YEAR_MONTH_SERIES_VOLUME_ISSUE_PATTERN = re.compile(
-    r"^(\d{6})\s+(.*?)\s+(v\d{1,3})\s+(\d{1,4})(\.\w+)$", re.IGNORECASE
+    r"^(\d{6})\s+(.*?)\s+(v\d{1,3})\s+(\d{1,4}(?:\.\w+)?)(\.\w+)$", re.IGNORECASE
 )
 
 # -------------------------------------------------------------------
@@ -177,18 +179,18 @@ SERIES_YEAR_MONTH_DAY_ISSUE_PATTERN = re.compile(
 
 # Pattern: "Series (YYYY-MM) ### (...)" → extract series, year, issue
 SERIES_YEAR_MONTH_SIMPLE_PATTERN = re.compile(
-    r"^(.*?)\s*\((\d{4})-\d{2}\)\s+(\d{1,4})(.*)(\.\w+)$", re.IGNORECASE
+    r"^(.*?)\s*\((\d{4})-\d{2}\)\s+(\d{1,4}(?:\.\w+)?)(.*)(\.\w+)$", re.IGNORECASE
 )
 
 # Pattern: "Series International/Annual v# ### (YYYY)" → extract series, volume, year, issue
 SERIES_INTERNATIONAL_ANNUAL_PATTERN = re.compile(
-    r"^(.*?(?:International|Annual).*?)\s+(v\d+\s+)?(Annual\s+)?(\d{1,4})\s*\((\d{4})\)(.*)(\.\w+)$",
+    r"^(.*?(?:International|Annual).*?)\s+(v\d+\s+)?(Annual\s+)?(\d{1,4}(?:\.\w+)?)\s*\((\d{4})\)(.*)(\.\w+)$",
     re.IGNORECASE,
 )
 
 # Pattern: "Series # ### (YYYY)" → extract series with number, year, issue
 SERIES_NUMBER_ISSUE_YEAR_PATTERN = re.compile(
-    r"^(.*\s+\d+)(?!\s+v\d)\s+(\d{1,4})\s*\((\d{4})\)(.*)(\.\w+)$", re.IGNORECASE
+    r"^(.*\s+\d+)(?!\s+v\d)\s+(\d{1,4}(?:\.\w+)?)\s*\((\d{4})\)(.*)(\.\w+)$", re.IGNORECASE
 )
 
 
@@ -243,9 +245,10 @@ def _apply_filters(val: str, filters: list[str]) -> str:
             val = re.sub(r"\D+", "", val or "")
             val = val[:4] if len(val) >= 4 else val
         elif f == "pad3":
-            val = f"{int(val):03d}" if val else val
+            # Suffix-aware: "1.MU" -> "001.MU", "12.1" -> "012.1", "1" -> "001".
+            val = _pad_issue_number(val, 3) if val else val
         elif f == "pad4":
-            val = f"{int(val):04d}" if val else val
+            val = _pad_issue_number(val, 4) if val else val
         elif f == "upper":
             val = (val or "").upper()
         elif f == "lower":
@@ -343,8 +346,14 @@ def try_rule_engine(filename: str, cfg_path="/config/rename_rules.ini"):
 
 
 def norm_issue(s):
-    s = re.sub(r"\D+", "", s or "")
-    return f"{int(s):03d}" if s else ""
+    # Strip a leading marker (#, _, whitespace) then preserve any decimal/alpha
+    # suffix (e.g. "1.MU", "700.1") by delegating to the suffix-aware padder.
+    stripped = (s or "").strip().lstrip("#_").strip()
+    if re.fullmatch(r"\d{1,4}(?:\.\w+)?", stripped):
+        return _pad_issue_number(stripped)
+    # Fallback for anything else (weird archival tokens): old strip-digits behavior.
+    digits = re.sub(r"\D+", "", s or "")
+    return f"{int(digits):03d}" if digits else ""
 
 
 def _pad_issue_number(num_str, width=3):
@@ -702,15 +711,28 @@ def parse_comic_filename(filename, custom_pattern=None):
     additional_patterns = [
         (r'^(.+?)\s+v(\d+)\s*\((\d{4})\)', True),    # "Series v1 (2020)" - volume as issue
         (r'^(.+?)\s+v(\d+)$', True),                   # "Series v01" - volume as issue
-        (r'^(.+?)\s+#(\d{1,4})\s*\((\d{4})\)', False), # "Series #42 (2020)"
-        (r'^(.+?)\s+(\d{1,4})\s+\(of\s+\d+\)\s+\((\d{4})\)', False),  # "Series 05 (of 12) (2020)"
+        (r'^(.+?)\s+#(\d{1,4}(?:\.\w+)?)\s*\((\d{4})\)', False), # "Series #42 (2020)" / "#1.MU (2020)"
+        (r'^(.+?)\s+(\d{1,4}(?:\.\w+)?)\s+\(of\s+\d+\)\s+\((\d{4})\)', False),  # "Series 05 (of 12) (2020)"
     ]
+
+    def _strip_issue_zeros(num):
+        # "001" -> "1", "012.1" -> "12.1", "001.MU" -> "1.MU"; keep the suffix.
+        if "." in num:
+            head, tail = num.split(".", 1)
+            try:
+                return str(int(head)) + "." + tail
+            except ValueError:
+                return num
+        try:
+            return str(int(num))
+        except ValueError:
+            return num
 
     for pattern, is_volume_as_issue in additional_patterns:
         match = re.match(pattern, name_without_ext, re.IGNORECASE)
         if match:
             result["series_name"] = match.group(1).strip()
-            result["issue_number"] = str(int(match.group(2)))
+            result["issue_number"] = _strip_issue_zeros(match.group(2))
             if is_volume_as_issue:
                 result["volume_number"] = "v" + match.group(2)
             if len(match.groups()) >= 3:
@@ -816,7 +838,7 @@ def extract_comic_values(filename):
 
     # First, try to match "Series ### extra_info YYYY" format (e.g., "Batman 046 52p ctc 04-05 1948.cbz")
     series_issue_extra_year_match = re.match(
-        r"^(?P<series>.*?)\s+(?P<issue>\d{1,4})\s+.*?\s+(?P<year>\d{4})(?P<ext>\.\w+)?$",
+        r"^(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.\w+)?)\s+.*?\s+(?P<year>\d{4})(?P<ext>\.\w+)?$",
         filename,
         re.IGNORECASE,
     )
@@ -826,7 +848,7 @@ def extract_comic_values(filename):
         year = series_issue_extra_year_match.group("year")
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
         values["year"] = year
         return values
 
@@ -840,7 +862,7 @@ def extract_comic_values(filename):
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["volume_number"] = (volume or "").strip()
         values["year"] = year
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
         return values
 
     # Try to match Series # ### (YYYY) format (e.g., "Lady Killer 2 001 (2016)")
@@ -852,7 +874,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["year"] = year
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
         return values
 
     # Try to match "Series v# ### (YYYYMM)" format (e.g., "Astonishing v1 063 (195708).cbz")
@@ -914,7 +936,7 @@ def extract_comic_values(filename):
         values["year"] = year_month[:4]
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["volume_number"] = volume.strip()
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
         return values
 
     # Try to match the Series Name YYYY-MM ( NN) (YYYY) format
@@ -952,7 +974,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["year"] = year
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
         return values
 
     # Try to match the Title, YYYY-MM-DD (#NN) format
@@ -990,9 +1012,14 @@ def extract_comic_values(filename):
     # "Civil War - Unmasked 002.cbz" (output of an earlier rename pass before
     # metadata is available). Keeps re-renames idempotent instead of failing
     # extraction and falling back with warnings.
+    # Ext is optional: extract_comic_values is called both with full filenames
+    # ("... 002.cbz") and with bare stems ("... 12.1" from smart_rename). The
+    # negative lookahead stops a real file extension being read as an issue
+    # suffix, while still capturing a genuine ".1"/".MU" when no extension follows.
     series_issue_no_year_match = re.match(
-        r"^(?P<series>.+?)\s+(?P<issue>\d{1,4}(?:\.\d+)?)(?P<ext>\.\w+)$",
+        r"^(?P<series>.+?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$",
         filename,
+        re.IGNORECASE,
     )
     if series_issue_no_year_match:
         series_name = series_issue_no_year_match.group("series")
@@ -1001,13 +1028,29 @@ def extract_comic_values(filename):
         series_name = series_name.replace("_", " ").strip()
         series_name = re.sub(r"[#\-\s]+$", "", series_name).strip()
         values["series_name"] = smart_title_case(series_name)
-        if "." in issue_num:
-            parts = issue_num.split(".", 1)
-            values["issue_number"] = f"{int(parts[0]):03d}.{parts[1]}"
-        else:
-            values["issue_number"] = f"{int(issue_num):03d}"
+        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
         app_logger.info(
             f"Matched series/issue (no year) pattern: series={values['series_name']}, issue={values['issue_number']}"
+        )
+        return values
+
+    # Clean "Series ### (YYYY)" with the issue immediately before the year, e.g.
+    # "Avengers 1.MU (2017).cbz" or "Batman 012 (2020).cbz". Placed before the
+    # loose fallback so decimal/alpha suffixes are captured with the right series.
+    # Messy scene names (tokens between issue and year) intentionally do NOT match
+    # here and fall through to the loose fallback / default-logic renamer.
+    series_issue_year_match = re.match(
+        r"^(?P<series>.+?)\s+#?(?P<issue>\d{1,4}(?:\.\w+)?)\s*\((?P<year>\d{4})\)",
+        filename,
+    )
+    if series_issue_year_match:
+        series_name = series_issue_year_match.group("series").replace("_", " ").strip()
+        series_name = re.sub(r"[#\-\s]+$", "", series_name).strip()
+        values["series_name"] = smart_title_case(series_name)
+        values["issue_number"] = _pad_issue_number(series_issue_year_match.group("issue"))
+        values["year"] = series_issue_year_match.group("year")
+        app_logger.info(
+            f"Matched series/issue/year pattern: series={values['series_name']}, issue={values['issue_number']}, year={values['year']}"
         )
         return values
 
@@ -1705,10 +1748,11 @@ def get_renamed_filename(filename, file_path=None):
         final_volume = volume_part.strip()
 
         # If issue_part starts with 'v', keep as-is, else zero-pad numeric
+        # (preserving any decimal/alpha suffix like ".1" or ".MU").
         if issue_part.lower().startswith("v"):
             final_issue = issue_part
         else:
-            final_issue = f"{int(issue_part):03d}"  # zero-pad if numeric
+            final_issue = _pad_issue_number(issue_part)
 
         # Look for the first 4-digit year in `middle`
         found_year = None
@@ -1829,10 +1873,11 @@ def get_renamed_filename(filename, file_path=None):
         clean_title = smart_title_case(raw_title.replace("_", " ").strip())
 
         # If issue_part starts with 'v', keep "vXX" as-is, else zero-pad
+        # (preserving any decimal/alpha suffix like ".1" or ".MU").
         if issue_part.lower().startswith("v"):
             final_issue = issue_part  # e.g. 'v01'
         else:
-            final_issue = f"{int(issue_part):03d}"  # e.g. 1 -> 001
+            final_issue = _pad_issue_number(issue_part)  # e.g. 1 -> 001, 1.MU -> 001.MU
 
         # Attempt to find a 4-digit year in `middle`
         found_year = None

--- a/config/rename_rules.ini
+++ b/config/rename_rules.ini
@@ -3,72 +3,72 @@
 
 # 145) "Series (YYYY) Volume ## Issue ###" → Series 0### (YYYY) (explicit Volume/Issue keywords)
 # e.g. "Top 10 (1999) Volume 01 Issue 010.cbz" → "Top 10 010 (1999).cbz"
-rule145.pattern = ^(?P<series>.*?)\s*\((?P<year>\d{4})\)\s*Volume\s*\d+\s*Issue\s*(?P<issue>\d+)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule145.pattern = ^(?P<series>.*?)\s*\((?P<year>\d{4})\)\s*Volume\s*\d+\s*Issue\s*(?P<issue>\d+(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule145.output  = {series|title} {issue|pad3} ({year}){ext}
 rule145.priority= 145
 
 # 130) "Series #### ## (of ##) (YYYY)" → Series #### 0## (YYYY) (series name with non-year 4-digit numbers like Marvel 1602)
-rule130.pattern = ^(?P<series>.*?\s+(?:1[0-8]\d{2}|19[0-3]\d|20[5-9]\d|2[1-9]\d{2}))\s+(?P<issue>\d{1,4})\s+\(of\s+\d+\)\s+\((?P<year>19[4-9]\d|20[0-4]\d)\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule130.pattern = ^(?P<series>.*?\s+(?:1[0-8]\d{2}|19[0-3]\d|20[5-9]\d|2[1-9]\d{2}))\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(of\s+\d+\)\s+\((?P<year>19[4-9]\d|20[0-4]\d)\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule130.output  = {series|title} {issue|pad3} ({year}){ext}
 rule130.priority= 130
 
 # 135) "Series Season # ## (YYYY)" → Series Season # 0## (YYYY) (season patterns)
-rule135.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4})\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule135.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule135.output  = {series|title} {season} {issue|pad3} ({year}){ext}
 rule135.priority= 135
 
 # 134) "Series Season # ## (of ##) (YYYY)" → Series Season # 0## (YYYY) (season with issue count)
-rule134.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4})\s+\(of\s+\d+\)\s+\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule134.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(of\s+\d+\)\s+\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule134.output  = {series|title} {season} {issue|pad3} ({year}){ext}
 rule134.priority= 134
 
 # 133) "Series Season # ## (YYYY) ..." → Series Season # 0## (YYYY) (season patterns with extra info)
-rule133.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
+rule133.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
 rule133.output  = {series|title} {season} {issue|pad3} ({year}){ext}
 rule133.priority= 133
 
 # 132) "Series Season # ##" → Series Season # 0## (no year)
-rule132.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4})(?P<ext>\.\w+)?$
+rule132.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
 rule132.output  = {series|title} {season} {issue|pad3}{ext}
 rule132.priority= 132
 
 # 131) "Series Season # #" → Series Season # 0# (single digit issue)
-rule131.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+0?(?P<issue>\d{1})(?P<ext>\.\w+)?$
+rule131.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+0?(?P<issue>\d{1}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
 rule131.output  = {series|title} {season} {issue|pad3}{ext}
 rule131.priority= 131
 
 # 125) "Series_v#_(extra)_(YYYY)_##_(of_##)_(group)" → Series v# 0## (YYYY) (with underscores and extra info)
-rule125.pattern = ^(?P<series>[^_]+)_(?P<volume>v\d{1,3})_\([^)]*\)_\((?P<year>\d{4})\)_(?P<issue>\d{1,4})_\(of_\d+\)_\([^)]*\)(?P<ext>\.\w+)?$
+rule125.pattern = ^(?P<series>[^_]+)_(?P<volume>v\d{1,3})_\([^)]*\)_\((?P<year>\d{4})\)_(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)_\(of_\d+\)_\([^)]*\)(?P<ext>\.\w+)?$
 rule125.output  = {series|title} {volume} {issue|pad3} ({year}){ext}
 rule125.priority= 125
 
 # 120) "Series #### ## (of ##) (YYYY)" → Series #### 0## (YYYY) (series name with numbers)
-rule120.pattern = ^(?P<series>.*\s+\d+)\s+(?P<issue>\d{1,4})\s+\(of\s+\d+\)\s+\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule120.pattern = ^(?P<series>.*\s+\d+)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(of\s+\d+\)\s+\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule120.output  = {series|title} {issue|pad3} ({year}){ext}
 rule120.priority= 120
 
 # 117) "Series (YYYY) ###" → Series 0### (YYYY) (year before issue - reversed order)
-rule117.pattern = ^(?P<series>.*?)\s+\((?P<year>\d{4})\)\s+(?P<issue>\d{1,4})(?P<ext>\.\w+)?$
+rule117.pattern = ^(?P<series>.*?)\s+\((?P<year>\d{4})\)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
 rule117.output  = {series|title} {issue|pad3} ({year}){ext}
 rule117.priority= 117
 
 # 115) "Series # ### (YYYY)" → Series # 0### (YYYY) (where # is part of series name, NOT volume or season)
-rule115.pattern = ^(?P<series>.*\s+\d+)(?!\s+(?:v\d+|Season\s+\d{1,3}))\s+(?P<issue>\d{1,4})\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule115.pattern = ^(?P<series>.*\s+\d+)(?!\s+(?:v\d+|Season\s+\d{1,3}))\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule115.output  = {series|title} {issue|pad3} ({year}){ext}
 rule115.priority= 115
 
 # 110) "Series International/Annual v# ### (YYYY)" → Keep full name as-is
-rule110.pattern = ^(?P<series>.*?(?:International|Annual).*?)\s+(?P<volume>v\d+\s+)?(?P<special>Annual\s+)?(?P<issue>\d{1,4})\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule110.pattern = ^(?P<series>.*?(?:International|Annual).*?)\s+(?P<volume>v\d+\s+)?(?P<special>Annual\s+)?(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule110.output  = {series|title} {volume}{special}{issue|pad3} ({year}){ext}
 rule110.priority= 110
 
 # 105) "Series (YYYY-MM) ### (...)" → Series 0### (YYYY) - but NOT for International/Annual/Season/etc
-rule105.pattern = ^(?P<series>(?!.*(?:International|Annual|v\d+|Season\s+\d{1,3})).*?)\s*\((?P<year>\d{4})-\d{2}\)\s+(?P<issue>\d{1,4})(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
+rule105.pattern = ^(?P<series>(?!.*(?:International|Annual|v\d+|Season\s+\d{1,3})).*?)\s*\((?P<year>\d{4})-\d{2}\)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
 rule105.output  = {series|title} {issue|pad3} ({year}){ext}
 rule105.priority= 105
 
 # 100) "Series, YYYY ### ..." → Series 0### (YYYY)
-rule100.pattern = ^(?P<series>.*?),\s*(?P<year>\d{4})\s+(?P<issue>\d{1,4})(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
+rule100.pattern = ^(?P<series>.*?),\s*(?P<year>\d{4})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
 rule100.output  = {series|title} {issue|digits|pad3} ({year}){ext}
 rule100.priority= 100
 
@@ -83,42 +83,42 @@ rule90.output  = {series|title} {issue|digits|pad3} ({year}){ext}
 rule90.priority= 90
 
 # 85) Series-specific: 2000AD uses 4-digit issues
-rule85_2000ad.pattern = ^(?P<series>2000AD)\s*(?P<issue>\d{1,4}).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
+rule85_2000ad.pattern = ^(?P<series>2000AD)\s*(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
 rule85_2000ad.output  = {series} {issue|pad4} ({year}){ext}
 rule85_2000ad.priority= 85
 
 # 85) "Series v# ### (YYYYMM)..." → Series v# 0### (YYYY) (6-digit year-month in parens)
-rule85_yearmonth.pattern = ^(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4})\s+\((?P<yearmonth>\d{6})\).*(?P<ext>\.\w+)?$
+rule85_yearmonth.pattern = ^(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\((?P<yearmonth>\d{6})\).*(?P<ext>\.\w+)?$
 rule85_yearmonth.output  = {series|title} {volume} {issue|pad3} ({yearmonth|year4}){ext}
 rule85_yearmonth.priority= 85
 
 # 80) "Series v# ### (YYYY) ..." → Series v# 0### (YYYY)
-rule80.pattern = ^(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
+rule80.pattern = ^(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
 rule80.output  = {series|title} {volume} {issue|pad3} ({year}){ext}
 rule80.priority= 80
 
 # 70) "Series #### (YYYY) ..." → Series 0### (YYYY)
-rule70.pattern = ^(?P<series>.*?)\s*#(?P<issue>\d{1,4}).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
+rule70.pattern = ^(?P<series>.*?)\s*#(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
 rule70.output  = {series|title} {issue|pad3} ({year}){ext}
 rule70.priority= 70
 
 # 60) "Series ### (YYYY) ..." (no v or #) → Series 0### (YYYY)
-rule60.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4}).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
+rule60.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
 rule60.output  = {series|title} {issue|pad3} ({year}){ext}
 rule60.priority= 60
 
 # 55) "YYYYMM Series ### ()..." → Series 0### (YYYY) (yearmonth before series name, no volume)
-rule55.pattern = ^(?P<yearmonth>\d{6})\s+(?P<series>.*?)\s+(?P<issue>\d{1,4})\s+\(\s*\).*(?P<ext>\.\w+)?$
+rule55.pattern = ^(?P<yearmonth>\d{6})\s+(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(\s*\).*(?P<ext>\.\w+)?$
 rule55.output  = {series|title} {issue|pad3} ({yearmonth|year4}){ext}
 rule55.priority= 55
 
 # 50) "YYYYMM Series v# ###.ext" → Series v# 0### (YYYY).ext
-rule50.pattern = ^(?P<yearmonth>\d{6})\s+(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4})(?P<ext>\.\w+)?$
+rule50.pattern = ^(?P<yearmonth>\d{6})\s+(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
 rule50.output  = {series|title} {volume} {issue|pad3} ({yearmonth|year4}){ext}
 rule50.priority= 50
 
 # 40) "Series (YYYY) #### ..." → Series 0### (YYYY)
-rule40.pattern = ^(?P<series>.*?)\s*\((?P<year>\d{4})\)\s*#(?P<issue>\d{1,4}).*(?P<ext>\.\w+)?$
+rule40.pattern = ^(?P<series>.*?)\s*\((?P<year>\d{4})\)\s*#(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*(?P<ext>\.\w+)?$
 rule40.output  = {series|title} {issue|pad3} ({year}){ext}
 rule40.priority= 40
 
@@ -133,6 +133,6 @@ rule20.output  = {series|title} {issue|digits|pad3} ({year}){ext}
 rule20.priority= 20
 
 # 10) "Series ### extra_info YYYY" → Series 0### (YYYY) (edge case with extra metadata between issue and year)
-rule10.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4})\s+.*?\s+(?P<year>\d{4})(?P<ext>\.\w+)?$
+rule10.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+.*?\s+(?P<year>\d{4})(?P<ext>\.\w+)?$
 rule10.output  = {series|title} {issue|pad3} ({year}){ext}
 rule10.priority= 10

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -1396,8 +1396,14 @@ def match_structured(search: dict, result: dict) -> tuple[int, str]:
     result_range = result.get('issue_range')
 
     if result_range:
-        # Range pack - check if target issue is in range
-        if result_range[0] <= int(search_issue) <= result_range[1]:
+        # Range pack - check if target issue is in range. Ranges are integer-only;
+        # a decimal/suffix issue ("001.1"/"1.MU") can't be int()'d, so compare on
+        # its integer part and treat a non-numeric issue as out-of-range.
+        try:
+            search_issue_int = int(str(search_issue).split('.')[0])
+        except (ValueError, TypeError):
+            search_issue_int = None
+        if search_issue_int is not None and result_range[0] <= search_issue_int <= result_range[1]:
             score += 10  # Range contains target
             match_type = "fallback"
         else:
@@ -1783,7 +1789,9 @@ def _score_issue(
 
     # Confirmed issue mismatch
     if not issue_matched and series_match and not range_contains_target:
-        explicit = re.search(rf'(?:#|issue\s)0*(\d+(?:\.\d+)?)\b', title_lower, re.IGNORECASE)
+        # Capture an alphanumeric suffix too (".MU"/".NOW") so a correct suffix
+        # issue isn't falsely flagged as a mismatch against a numeric-only regex.
+        explicit = re.search(rf'(?:#|issue\s)0*(\d+(?:\.\w+)?)\b', title_lower, re.IGNORECASE)
         if explicit:
             found_num = explicit.group(1).lstrip('0') or '0'
             if found_num != issue_num:

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -1913,10 +1913,11 @@ def search_gcd_metadata():
             series_name = parsed['series_name'] or None
             year = parsed['year']
             if parsed['issue_number']:
-                try:
-                    issue_number = int(float(parsed['issue_number'].split('.')[0]))
-                except (ValueError, IndexError):
-                    issue_number = None
+                # Preserve any decimal/alpha suffix ("700.1"/"1.MU") so provider
+                # lookups can find point issues; parse_comic_filename already
+                # stripped leading zeros. Fall back to None only if unparseable.
+                raw_issue = str(parsed['issue_number']).strip()
+                issue_number = raw_issue if raw_issue else None
                 app_logger.debug(f"DEBUG: File parsed - series_name={series_name}, issue_number={issue_number}, year={year}")
             else:
                 issue_number = None
@@ -4124,19 +4125,30 @@ def search_comicvine_metadata():
         issue_number = None
         year = None
 
+        # Issue groups accept a decimal/alpha suffix (".1"/".MU"); name_without_ext
+        # has already had the file extension stripped, so widening is safe here.
         patterns = [
-            r'^(.+?)\s+(\d{3,4})\s+\((\d{4})\)',  # "Series 001 (2020)"
-            r'^(.+?)\s+#?(\d{1,4})\s*\((\d{4})\)', # "Series #1 (2020)" or "Series 1 (2020)"
-            r'^(.+?)\s+v\d+\s+(\d{1,4})\s*\((\d{4})\)', # "Series v1 001 (2020)"
-            r'^(.+?)\s+(\d{1,4})\s+\(of\s+\d+\)\s+\((\d{4})\)', # "Series 05 (of 12) (2020)"
-            r'^(.+?)\s+#?(\d{1,4})$',  # "Series 169" or "Series #169" (no year)
+            r'^(.+?)\s+(\d{3,4}(?:\.\w+)?)\s+\((\d{4})\)',  # "Series 001 (2020)"
+            r'^(.+?)\s+#?(\d{1,4}(?:\.\w+)?)\s*\((\d{4})\)', # "Series #1 (2020)" or "Series 1 (2020)"
+            r'^(.+?)\s+v\d+\s+(\d{1,4}(?:\.\w+)?)\s*\((\d{4})\)', # "Series v1 001 (2020)"
+            r'^(.+?)\s+(\d{1,4}(?:\.\w+)?)\s+\(of\s+\d+\)\s+\((\d{4})\)', # "Series 05 (of 12) (2020)"
+            r'^(.+?)\s+#?(\d{1,4}(?:\.\w+)?)$',  # "Series 169" or "Series #169" (no year)
         ]
+
+        def _strip_issue_leading_zeros(num):
+            # "001" -> "1", "007.1" -> "7.1", "001.MU" -> "1.MU"; keep the suffix.
+            head, dot, tail = num.partition(".")
+            try:
+                head = str(int(head))
+            except ValueError:
+                return num
+            return head + dot + tail
 
         for pattern in patterns:
             match = re.match(pattern, name_without_ext, re.IGNORECASE)
             if match:
                 series_name = match.group(1).strip()
-                issue_number = str(int(match.group(2)))  # Convert to int then back to string to remove leading zeros
+                issue_number = _strip_issue_leading_zeros(match.group(2))
                 year = int(match.group(3)) if len(match.groups()) >= 3 else None
                 app_logger.debug(f"DEBUG: File parsed - series_name={series_name}, issue_number={issue_number}, year={year}")
                 break

--- a/routes/series.py
+++ b/routes/series.py
@@ -216,11 +216,14 @@ def wanted():
         store_date = item["issue"].get("store_date") or "9999-99-99"
         series_name = item["series_name"] or ""
         issue_num = item["issue"].get("number") or ""
+        # Suffix-aware: sort "12", "12.1", "12.MU" together and in order instead
+        # of collapsing every decimal/suffix issue to the 999999 sentinel.
+        head, _, tail = str(issue_num).partition(".")
         try:
-            issue_num_int = int(issue_num)
+            issue_sort = (float(f"{int(head)}.{tail}") if tail.isdigit() else float(int(head)), tail)
         except (ValueError, TypeError):
-            issue_num_int = 999999
-        return (store_date, series_name, issue_num_int)
+            issue_sort = (999999.0, str(issue_num))
+        return (store_date, series_name, issue_sort)
 
     wanted_issues.sort(key=sort_key)
 

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -1004,6 +1004,31 @@ class TestScoreGetcomicsResult:
         score, _, _ = score_getcomics_result("Batman #1", "Batman", "001", 0)
         assert score >= 60  # series(30) + issue(30)
 
+    @pytest.mark.parametrize(
+        "title, issue",
+        [
+            ("Avengers #1.1 (2017)", "1.1"),
+            ("Avengers #001.1 (2017)", "1.1"),
+            ("Avengers #1.MU (2017)", "1.MU"),
+            ("Avengers 1.MU (2017)", "1.MU"),
+        ],
+        ids=["decimal_hash", "decimal_padded", "suffix_hash", "suffix_bare"],
+    )
+    def test_decimal_suffix_issue_matches(self, title, issue):
+        """Point issues ('1.1'/'1.MU') should match, not be dropped or mismatched."""
+        from models.getcomics import score_getcomics_result
+        score, _, match = score_getcomics_result(title, "Avengers", issue, 2017)
+        assert match is True
+        assert score >= 40
+
+    def test_suffix_issue_not_falsely_penalized(self):
+        """A correct '.MU' issue must not trigger the -40 confirmed-mismatch
+        penalty via a numeric-only regex (the point-issue scoring bug)."""
+        from models.getcomics import score_getcomics_result
+        correct, _, _ = score_getcomics_result("Avengers #1.MU (2017)", "Avengers", "1.MU", 2017)
+        wrong, _, _ = score_getcomics_result("Avengers #2.MU (2017)", "Avengers", "1.MU", 2017)
+        assert correct > wrong
+
     def test_annual_as_sub_series_penalty(self):
         """Annual variant should be penalized as sub-series (Issue #193)."""
         from models.getcomics import score_getcomics_result

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -80,6 +80,11 @@ class TestNormIssue:
         ("1234", "1234"),
         ("", ""),
         (None, ""),
+        # Decimal / alphanumeric suffixes preserved (not stripped to digits)
+        ("1.MU", "001.MU"),
+        ("700.1", "700.1"),
+        ("#5.NOW", "005.NOW"),
+        ("_12", "012"),
     ])
     def test_norm_issue(self, input_val, expected):
         from cbz_ops.rename import norm_issue
@@ -106,6 +111,12 @@ class TestPadIssueNumber:
         ("v12", "v12"),
         ("v123", "v123"),
         ("v1.5", "v01.5"),
+        # Alphanumeric (Marvel "point") suffixes preserved verbatim
+        ("1.MU", "001.MU"),
+        ("1.NOW", "001.NOW"),
+        ("5.INH", "005.INH"),
+        ("700.BEY", "700.BEY"),
+        ("12.AU", "012.AU"),
     ])
     def test_pad_issue_number(self, input_val, expected):
         from cbz_ops.rename import _pad_issue_number
@@ -477,6 +488,11 @@ class TestExtractComicValues:
         # Already-clean "Series Issue.ext" name with no year (output of an
         # earlier rename pass before metadata is available)
         ("Civil War - Unmasked 002.cbz", "Civil War - Unmasked", "002", ""),
+        # Decimal / alphanumeric suffix issues preserved through extraction
+        ("Avengers 1.MU (2017).cbz", "Avengers", "001.MU", "2017"),
+        ("Avengers 001.1 (2017).cbz", "Avengers", "001.1", "2017"),
+        # Already-clean name with alphanumeric suffix, no year
+        ("Avengers - Standoff 700.BEY.cbz", "Avengers - Standoff", "700.BEY", ""),
     ])
     def test_value_extraction(self, filename, expected_series, expected_issue, expected_year):
         from cbz_ops.rename import extract_comic_values
@@ -563,10 +579,25 @@ class TestGetRenamedFilename:
         ("Comic Name 051 (2018).cbz", "Comic Name 051 (2018).cbz"),
         # ISSUE_PATTERN with volume
         ("Comic Name v3 (2022).cbr", "Comic Name v3 (2022).cbr"),
+        # ISSUE_PATTERN with numeric decimal suffix (the reported bug)
+        ("Avengers 001.1 (2017) GetComics.INFO.cbz", "Avengers 001.1 (2017).cbz"),
+        # ISSUE_PATTERN with alphanumeric (Marvel "point") suffix
+        ("Avengers 1.MU (2017).cbz", "Avengers 001.MU (2017).cbz"),
+        # ISSUE_HASH_PATTERN with suffix
+        ("Batman #5.NOW (2014).cbz", "Batman 005.NOW (2014).cbz"),
+        # VOLUME_ISSUE_PATTERN with suffix
+        ("Comic Name v3 051.1 (2018).cbz", "Comic Name v3 051.1 (2018).cbz"),
     ])
     def test_post_clean_patterns(self, filename, expected):
         from cbz_ops.rename import get_renamed_filename
         assert get_renamed_filename(filename) == expected
+
+    def test_decimal_suffix_not_dropped(self):
+        """Regression: decimal/point issues must keep their suffix, not truncate
+        to the integer (Avengers 001.1 -> Avengers 001 was the reported bug)."""
+        from cbz_ops.rename import get_renamed_filename
+        assert get_renamed_filename("Avengers 001.1 (2017).cbz") == "Avengers 001.1 (2017).cbz"
+        assert get_renamed_filename("Avengers 1.MU (2017).cbz") == "Avengers 001.MU (2017).cbz"
 
     def test_fallback_pattern(self):
         from cbz_ops.rename import get_renamed_filename

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -429,6 +429,25 @@ class TestSmartRenameIssueTokens:
         # {issue_year} = ComicInfo Year (2026), distinct from the series year (1989)
         assert names == ["Sandman - 005 (2026).cbz"]
 
+    def test_decimal_issue_suffix_preserved(self, tmp_path):
+        # Point issues ("12.1", "1.MU") must keep their suffix end-to-end, not
+        # truncate to the integer. The stem has no file extension, so this also
+        # guards the ".1"-as-extension edge case in extract_comic_values.
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Avengers"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Avengers", volume=2, year=2016)
+        _write_cbz_with_comicinfo(d / "Avengers 12.1.cbz", year=2017, month=3)
+        _write_cbz_with_comicinfo(d / "Avengers 1.MU.cbz", year=2017, month=3)
+
+        pattern = "{series_name} - {issue_number} ({issue_year})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = sorted(f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok")
+        assert names == ["Avengers - 001.MU (2017).cbz", "Avengers - 012.1 (2017).cbz"]
+
     def test_missing_comicinfo_drops_issue_year_no_series_year(self, tmp_path):
         # {issue_year} must NOT fall back to the series start year.
         from cbz_ops.smart_rename import plan_smart_rename


### PR DESCRIPTION
## Problem

Comic "point" issues carry a suffix after the integer — a numeric decimal (`001.1`) or a Marvel tag (`1.MU`, `.NOW`, `.INH`, `.BEY`). One defect was copied across ~30 sites: issue numbers were captured with bare `\d{1,4}` groups (so the `.1`/`.MU` fell into the trailing text and was discarded) and/or normalized with `int()`/`:03d`, which strip anything non-numeric.

Reported symptom (from the download log):

```
/downloads/temp/Avengers 001.1 (2017) GetComics.INFO.cbr
  → /downloads/processed/Avengers 001 (2017).cbz   ❌ dropped the ".1"
```

It should produce `Avengers 001.1 (2017).cbz`. Publishers also ship alphanumeric forms like `Avengers 1.MU (2017).cbz`.

## Fix

Apply one rule everywhere: widen each issue capture group from `\d{1,N}` to `\d{1,N}(?:\.\w+)?`, and route padding through the existing suffix-safe `_pad_issue_number` (which already handled decimals). Suffix case is preserved as-is.

- **`cbz_ops/rename.py`** — widen module patterns; make `norm_issue` and the rule-engine `pad3`/`pad4` filters suffix-aware; swap `int():03d` in `extract_comic_values`/`get_renamed_filename`; add a clean `Series ### (YYYY)` extractor; fix a bare-stem `12.1`-as-extension edge case (`smart_rename` passes the stem).
- **`config/rename_rules.ini`** — the git-tracked rule engine intercepts *before* the default patterns, so its issue groups are widened too, with an extension-safe negative lookahead so `.cbz`/`.cbr` can't be swallowed into the issue.
- **`models/getcomics.py`** — the `_score_issue` confirmed-mismatch penalty now accepts alpha suffixes (a correct `.MU` result was being falsely penalized −40); the dead-code `match_structured` range no longer crashes on a decimal issue.
- **`routes/series.py`** — the wanted/upcoming sort no longer collapses every suffixed issue to the `999999` sentinel.
- **`routes/metadata.py`** — the two search-extraction paths preserve the suffix for provider/GCD point-issue lookups.

## Verification

End-to-end with the rule engine active:

| input | output |
|---|---|
| `Avengers 001.1 (2017) GetComics.INFO.cbz` | `Avengers 001.1 (2017).cbz` |
| `Avengers 1.MU (2017).cbz` | `Avengers 001.MU (2017).cbz` |
| `Batman #5.NOW (2014).cbz` | `Batman 005.NOW (2014).cbz` |

GetComics scoring now matches `#1.1`/`#1.MU` titles (match=True). Added decimal/suffix tests to `test_rename.py`, `test_getcomics.py`, and `test_smart_rename.py`. Full suite green (2204 passed; the one unrelated `TestConvertPreview::test_counts_recursively` failure is a pre-existing full-suite ordering flake that passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)