### PR TITLE
Add configurable issue-number leading-zero

### DIFF
--- a/app.py
+++ b/app.py
@@ -6681,6 +6681,15 @@ def save_file_processing_config():
             data.get("customRenamePattern", ""),
             category="file_processing",
         )
+        # Issue-number leading-zero width: none | 3 | 4 (allowlist; default 3).
+        _issue_pad = str(data.get("issuePadWidth", "3")).strip().lower()
+        if _issue_pad not in ("none", "3", "4"):
+            _issue_pad = "3"
+        set_user_preference(
+            "issue_pad_width",
+            _issue_pad,
+            category="file_processing",
+        )
         set_user_preference(
             "smart_rename_preview_enabled",
             bool(data.get("smartRenamePreviewEnabled", True)),
@@ -7130,6 +7139,13 @@ def config_page():
         config["SETTINGS"]["ENABLE_AUTO_RENAME"] = str(
             request.form.get("enableAutoRename") == "on"
         )
+        # Issue-number leading-zero width: none | 3 | 4 (allowlist; default 3).
+        _issue_pad = str(request.form.get("issuePadWidth", "3")).strip().lower()
+        if _issue_pad not in ("none", "3", "4"):
+            _issue_pad = "3"
+        set_user_preference(
+            "issue_pad_width", _issue_pad, category="file_processing"
+        )
         config["SETTINGS"]["ENABLE_AUTO_MOVE"] = str(
             request.form.get("enableAutoMove") == "on"
         )
@@ -7250,6 +7266,7 @@ def config_page():
         metronPassword=_metron_creds.get("password", "") if _metron_creds else "",
         enableCustomRename=settings.get("ENABLE_CUSTOM_RENAME", "False") == "True",
         customRenamePattern=settings.get("CUSTOM_RENAME_PATTERN", ""),
+        issuePadWidth=str(get_user_preference("issue_pad_width", default="3") or "3"),
         renameCleanSpacesEnabled=get_user_preference(
             "rename_clean_spaces_enabled", default=False
         ),

--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -236,7 +236,7 @@ def smart_title_case(text: str) -> str:
     return " ".join(result)
 
 
-def _apply_filters(val: str, filters: list[str]) -> str:
+def _apply_filters(val: str, filters: list[str], width: int = 3) -> str:
     for f in filters:
         if f == "digits":
             val = re.sub(r"\D+", "", val or "")
@@ -244,8 +244,12 @@ def _apply_filters(val: str, filters: list[str]) -> str:
             # Extract first 4 digits (year from YYYYMM)
             val = re.sub(r"\D+", "", val or "")
             val = val[:4] if len(val) >= 4 else val
-        elif f == "pad3":
+        elif f == "pad":
+            # Configurable width from Custom Naming Settings (0 = strip zeros).
             # Suffix-aware: "1.MU" -> "001.MU", "12.1" -> "012.1", "1" -> "001".
+            val = _pad_issue_number(val, width) if val else val
+        elif f == "pad3":
+            # Fixed-width escape hatch (ignores the configured width).
             val = _pad_issue_number(val, 3) if val else val
         elif f == "pad4":
             val = _pad_issue_number(val, 4) if val else val
@@ -258,18 +262,18 @@ def _apply_filters(val: str, filters: list[str]) -> str:
     return val
 
 
-def _format_from_groups(fmt: str, groups: dict[str, str]) -> str:
+def _format_from_groups(fmt: str, groups: dict[str, str], width: int = 3) -> str:
     def repl(m):
-        spec = m.group(1)  # e.g. issue|digits|pad3
+        spec = m.group(1)  # e.g. issue|digits|pad
         parts = spec.split("|")
         key, filters = parts[0], parts[1:]
         val = groups.get(key, "")
-        return _apply_filters(val, filters)
+        return _apply_filters(val, filters, width)
 
     return re.sub(r"\{([^{}]+)\}", repl, fmt).strip()
 
 
-def try_rule_engine(filename: str, cfg_path="/config/rename_rules.ini"):
+def try_rule_engine(filename: str, cfg_path="/config/rename_rules.ini", width: int = 3):
     # Split ext safely in case rules don't capture it
     m = re.match(r"^(.*)(\.\w+)$", filename)
     if not m:
@@ -295,7 +299,7 @@ def try_rule_engine(filename: str, cfg_path="/config/rename_rules.ini"):
             name = key[:-8]  # strip ".pattern"
             pattern = cp["RENAME"][key]
             output = cp["RENAME"].get(
-                f"{name}.output", "{series} {issue|pad3} ({year}){ext}"
+                f"{name}.output", "{series} {issue|pad} ({year}){ext}"
             )
             prio = int(cp["RENAME"].get(f"{name}.priority", "100"))
             try:
@@ -328,7 +332,7 @@ def try_rule_engine(filename: str, cfg_path="/config/rename_rules.ini"):
             if len(ym_digits) >= 4:
                 g["year"] = ym_digits[:4]
 
-        new_name = _format_from_groups(outfmt, g)
+        new_name = _format_from_groups(outfmt, g, width)
         ext = g.get("ext", "")
         if ext and not new_name.endswith(ext):
             new_name += ext
@@ -345,20 +349,32 @@ def try_rule_engine(filename: str, cfg_path="/config/rename_rules.ini"):
 # -------------------------------------------------------------------
 
 
-def norm_issue(s):
+def norm_issue(s, width=3):
     # Strip a leading marker (#, _, whitespace) then preserve any decimal/alpha
     # suffix (e.g. "1.MU", "700.1") by delegating to the suffix-aware padder.
     stripped = (s or "").strip().lstrip("#_").strip()
     if re.fullmatch(r"\d{1,4}(?:\.\w+)?", stripped):
-        return _pad_issue_number(stripped)
-    # Fallback for anything else (weird archival tokens): old strip-digits behavior.
+        return _pad_issue_number(stripped, width)
+    # Fallback for anything else (weird archival tokens): strip to digits, then pad.
     digits = re.sub(r"\D+", "", s or "")
-    return f"{int(digits):03d}" if digits else ""
+    return _pad_issue_number(str(int(digits)), width) if digits else ""
+
+
+def _zpad(s, width):
+    """Zero-pad the integer part of an issue number to ``width``.
+
+    A width of 0 (or less) means "no padding": strip leading zeros to the natural
+    number (e.g. "044" -> "44", "003" -> "3", "0" -> "0"). This backs the "None"
+    option of the configurable issue-pad-width setting.
+    """
+    if width > 0:
+        return s.zfill(width)
+    return s.lstrip("0") or "0"
 
 
 def _pad_issue_number(num_str, width=3):
     """Zero-pad issue number, preserving any decimal suffix (e.g. '12.1' -> '012.1')
-    and volume prefix (e.g. 'v3' -> 'v03')."""
+    and volume prefix (e.g. 'v3' -> 'v03'). ``width`` <= 0 strips leading zeros."""
     num_str = num_str.strip()
     if not num_str:
         return ""
@@ -367,12 +383,31 @@ def _pad_issue_number(num_str, width=3):
         inner = num_str[1:]
         if "." in inner:
             parts = inner.split(".", 1)
-            return num_str[0] + parts[0].zfill(width - 1) + "." + parts[1]
-        return num_str[0] + inner.zfill(width - 1)
+            return num_str[0] + _zpad(parts[0], width - 1) + "." + parts[1]
+        return num_str[0] + _zpad(inner, width - 1)
     if "." in num_str:
         parts = num_str.split(".", 1)
-        return parts[0].zfill(width) + "." + parts[1]
-    return num_str.zfill(width)
+        return _zpad(parts[0], width) + "." + parts[1]
+    return _zpad(num_str, width)
+
+
+def load_issue_pad_width():
+    """Configured leading-zero width for issue numbers (Custom Naming Settings).
+
+    Returns an int width: 0 = "None" (strip leading zeros), otherwise the number
+    of digits to zero-pad to. Defaults to 3 (the historical behavior) and never
+    raises — any lookup failure falls back to 3.
+    """
+    try:
+        from core.database import get_user_preference
+
+        raw = str(get_user_preference("issue_pad_width", default="3") or "3").strip().lower()
+        if raw in ("none", "0", ""):
+            return 0
+        return int(raw) if raw.isdigit() else 3
+    except Exception as e:
+        app_logger.warning(f"Failed to load issue_pad_width, defaulting to 3: {e}")
+        return 3
 
 
 def _format_issue_month(month_raw):
@@ -753,11 +788,12 @@ def parse_comic_filename(filename, custom_pattern=None):
     return result
 
 
-def extract_comic_values(filename):
+def extract_comic_values(filename, width=3):
     """
     Extract comic values from filename using existing regex patterns.
     Returns a dictionary with keys: series_name, volume_number, year, issue_number
-    Missing values will be empty strings.
+    Missing values will be empty strings. ``width`` is the issue-number zero-pad
+    width (0 = strip leading zeros); it defaults to 3 for callers that don't care.
     """
     values = {
         "series_name": "",
@@ -782,7 +818,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.strip())
         values["volume_number"] = f"v{int(volume_num):02d}"
-        values["issue_number"] = f"{int(issue_num):03d}"
+        values["issue_number"] = _pad_issue_number(issue_num, width)
         values["year"] = year
         app_logger.info(
             f"Matched Volume/Issue keyword pattern: series={values['series_name']}, volume={values['volume_number']}, issue={values['issue_number']}, year={values['year']}"
@@ -803,11 +839,7 @@ def extract_comic_values(filename):
         year = issue_keyword_match.group("year")
 
         values["series_name"] = smart_title_case(series_name.strip())
-        if "." in issue_num:
-            parts = issue_num.split(".", 1)
-            values["issue_number"] = f"{int(parts[0]):03d}.{parts[1]}"
-        else:
-            values["issue_number"] = f"{int(issue_num):03d}"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".BEY"
         values["year"] = year
         app_logger.info(
             f"Matched Issue keyword pattern: series={values['series_name']}, issue={values['issue_number']}, year={values['year']}"
@@ -829,7 +861,7 @@ def extract_comic_values(filename):
         # Replace _-_ with space-hyphen-space, then replace remaining underscores with spaces
         clean_series = series_name.replace("_-_", " - ").replace("_", " ")
         values["series_name"] = smart_title_case(clean_series.strip())
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # width from config; preserves suffix
         values["year"] = year
         app_logger.info(
             f"Matched underscore pattern: series={values['series_name']}, issue={values['issue_number']}, year={values['year']}"
@@ -848,7 +880,7 @@ def extract_comic_values(filename):
         year = series_issue_extra_year_match.group("year")
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
-        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".MU"
         values["year"] = year
         return values
 
@@ -862,7 +894,7 @@ def extract_comic_values(filename):
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["volume_number"] = (volume or "").strip()
         values["year"] = year
-        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".MU"
         return values
 
     # Try to match Series # ### (YYYY) format (e.g., "Lady Killer 2 001 (2016)")
@@ -874,7 +906,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["year"] = year
-        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".MU"
         return values
 
     # Try to match "Series v# ### (YYYYMM)" format (e.g., "Astonishing v1 063 (195708).cbz")
@@ -889,7 +921,7 @@ def extract_comic_values(filename):
         )
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["volume_number"] = volume.strip()
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # width from config; preserves suffix
         values["year"] = yearmonth[:4]  # Extract YYYY from YYYYMM
         return values
 
@@ -902,7 +934,7 @@ def extract_comic_values(filename):
             yearmonth_series_issue_empty_match.groups()
         )
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # width from config; preserves suffix
         values["year"] = yearmonth[:4]  # Extract YYYY from YYYYMM
         return values
 
@@ -919,7 +951,7 @@ def extract_comic_values(filename):
             values["series_name"] = smart_title_case(
                 series_name.replace("_", " ").strip()
             )
-            values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+            values["issue_number"] = _pad_issue_number(issue_num, width)  # width from config; preserves suffix
             values["year"] = yearmonth[:4]  # Extract YYYY from YYYYMM
             return values
 
@@ -936,7 +968,7 @@ def extract_comic_values(filename):
         values["year"] = year_month[:4]
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["volume_number"] = volume.strip()
-        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".MU"
         return values
 
     # Try to match the Series Name YYYY-MM ( NN) (YYYY) format
@@ -948,7 +980,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["year"] = year
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # width from config; preserves suffix
         return values
 
     # Try to match the Series Name YYYY-MM-DD ( NN) (digital) format
@@ -962,7 +994,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["year"] = year
-        values["issue_number"] = f"{int(issue_num):03d}"  # Zero-pad to 3 digits
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # width from config; preserves suffix
         return values
 
     # Try to match the Series (YYYY-MM) ### format
@@ -974,7 +1006,7 @@ def extract_comic_values(filename):
 
         values["series_name"] = smart_title_case(series_name.replace("_", " ").strip())
         values["year"] = year
-        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".MU"
         return values
 
     # Try to match the Title, YYYY-MM-DD (#NN) format
@@ -989,7 +1021,7 @@ def extract_comic_values(filename):
         values["series_name"] = smart_title_case(raw_title.replace("_", " ").strip())
         # Remove the # prefix and zero-pad to 3 digits
         issue_num = hash_issue_num[1:]  # Remove the # prefix
-        values["issue_number"] = f"{int(issue_num):03d}"
+        values["issue_number"] = _pad_issue_number(issue_num, width)
         return values
 
     # Try to match the Title, YYYY-MM-DD (NN) format
@@ -1001,11 +1033,7 @@ def extract_comic_values(filename):
         values["year"] = year
         values["series_name"] = smart_title_case(raw_title.replace("_", " ").strip())
         # Handle issue numbers that may have underscore prefixes and zero-pad to 3 digits
-        if issue_num.startswith("_"):
-            numeric_part = issue_num[1:]  # Remove the underscore
-            values["issue_number"] = f"{int(numeric_part):03d}"
-        else:
-            values["issue_number"] = f"{int(issue_num):03d}"
+        values["issue_number"] = _pad_issue_number(issue_num.lstrip("_"), width)
         return values
 
     # Handle already-clean "Series Issue.ext" names with no year, e.g.
@@ -1028,7 +1056,7 @@ def extract_comic_values(filename):
         series_name = series_name.replace("_", " ").strip()
         series_name = re.sub(r"[#\-\s]+$", "", series_name).strip()
         values["series_name"] = smart_title_case(series_name)
-        values["issue_number"] = _pad_issue_number(issue_num)  # preserves ".1"/".MU"
+        values["issue_number"] = _pad_issue_number(issue_num, width)  # preserves ".1"/".MU"
         app_logger.info(
             f"Matched series/issue (no year) pattern: series={values['series_name']}, issue={values['issue_number']}"
         )
@@ -1074,7 +1102,7 @@ def extract_comic_values(filename):
         if match:
             # Zero-pad the issue number to 3 digits
             issue_num = match.group(1)
-            values["issue_number"] = f"{int(issue_num):03d}"
+            values["issue_number"] = _pad_issue_number(issue_num, width)
             break
 
     # If no issue number found with patterns, try to find any 4-digit number that's not a year
@@ -1090,8 +1118,8 @@ def extract_comic_values(filename):
 
             # If it's not surrounded by parentheses, it might be an issue number
             if not (before.rstrip().endswith("(") and after.lstrip().startswith(")")):
-                # Zero-pad the issue number to 3 digits
-                values["issue_number"] = f"{int(num):03d}"
+                # Zero-pad the issue number (width from config)
+                values["issue_number"] = _pad_issue_number(num, width)
                 break
 
     # Extract series name (everything before the issue number)
@@ -1222,6 +1250,7 @@ def rename_comic_from_metadata(file_path, metadata):
         # {issue_month_M}/{issue_month_m} = ComicInfo Month (the cover month)
         issue_month_M, issue_month_m = _format_issue_month(metadata.get("Month"))
 
+        pad_width = load_issue_pad_width()
         values = {
             "series_name": series,
             "volume_number": "",
@@ -1231,7 +1260,7 @@ def rename_comic_from_metadata(file_path, metadata):
             "issue_year": str(metadata.get("Year", "")),
             "issue_month_M": issue_month_M,
             "issue_month_m": issue_month_m,
-            "issue_number": _pad_issue_number(str(metadata.get("Number", ""))),
+            "issue_number": _pad_issue_number(str(metadata.get("Number", "")), pad_width),
             "issue_title": metadata.get("Title", "") or "",
         }
 
@@ -1466,6 +1495,10 @@ def get_renamed_filename(filename, file_path=None):
     """
     app_logger.info(f"Attempting to rename filename: {filename}")
 
+    # Configured issue-number zero-pad width (Custom Naming Settings). Resolved
+    # once and threaded through every padding site in this function.
+    pad_width = load_issue_pad_width()
+
     # ==========================================================
     # 0) Check for custom rename pattern (BEFORE all other logic)
     # ==========================================================
@@ -1488,7 +1521,7 @@ def get_renamed_filename(filename, file_path=None):
                 return filename
 
             # Extract comic values from the filename
-            comic_values = extract_comic_values(filename)
+            comic_values = extract_comic_values(filename, pad_width)
 
             # Manga volume names ("Series vNN (YYYY) ...") have no issue number, so
             # extract_comic_values fills volume/year but leaves series empty. Recover
@@ -1577,7 +1610,7 @@ def get_renamed_filename(filename, file_path=None):
 
     # Try declarative rule engine (hot-patchable via /config/rename_rules.ini)
     # This runs AFTER custom rename pattern check, so custom pattern takes precedence
-    rule_name = try_rule_engine(filename, "config/rename_rules.ini")
+    rule_name = try_rule_engine(filename, "config/rename_rules.ini", width=pad_width)
     if rule_name:
         return clean_final_filename(rule_name)
 
@@ -1590,7 +1623,7 @@ def get_renamed_filename(filename, file_path=None):
         app_logger.info(f"Matched ISSUE_YEAR_PARENTHESES_PATTERN for: {filename}")
         raw_title, issue_num, year, extra, extension = issue_year_paren_match.groups()
         clean_title = smart_title_case(raw_title.replace("_", " ").strip())
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
         new_filename = f"{clean_title} {final_issue} ({year}){extension}"
         return clean_final_filename(new_filename)
 
@@ -1611,10 +1644,10 @@ def get_renamed_filename(filename, file_path=None):
         if issue_num.startswith("_"):
             # Remove underscore and zero-pad the numeric part
             numeric_part = issue_num[1:]  # Remove the underscore
-            final_issue = norm_issue(issue_num)
+            final_issue = norm_issue(issue_num, pad_width)
         else:
             # Regular numeric issue number
-            final_issue = norm_issue(issue_num)
+            final_issue = norm_issue(issue_num, pad_width)
 
         new_filename = f"{clean_title} {final_issue} ({year}){extension}"
         return clean_final_filename(new_filename)
@@ -1635,7 +1668,7 @@ def get_renamed_filename(filename, file_path=None):
 
         # Remove the # from the issue number and zero-pad
         issue_num = hash_issue_num[1:]  # Remove the # prefix
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
 
         new_filename = f"{clean_title} {final_issue} ({year}){extension}"
         return clean_final_filename(new_filename)
@@ -1652,7 +1685,7 @@ def get_renamed_filename(filename, file_path=None):
         clean_title = smart_title_case(raw_title.replace("_", " ").strip())
         # Remove the # from the issue number and zero-pad
         issue_num = issue[1:]  # Remove the # prefix
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
         new_filename = f"{clean_title} {final_issue} ({year}){extension}"
         return clean_final_filename(new_filename)
 
@@ -1681,7 +1714,7 @@ def get_renamed_filename(filename, file_path=None):
         final_volume = volume.strip()
 
         # Zero-pad the issue number
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
 
         new_filename = (
             f"{clean_series} {final_volume} {final_issue} ({year}){extension}"
@@ -1703,7 +1736,7 @@ def get_renamed_filename(filename, file_path=None):
         clean_series = smart_title_case(series_name.replace("_", " ").strip())
 
         # Zero-pad the issue number
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
 
         new_filename = f"{clean_series} {final_issue} ({year}){extension}"
         return clean_final_filename(new_filename)
@@ -1725,7 +1758,7 @@ def get_renamed_filename(filename, file_path=None):
         clean_series = smart_title_case(series_name.replace("_", " ").strip())
 
         # Zero-pad the issue number
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
 
         new_filename = f"{clean_series} {final_issue} ({year}){extension}"
         return clean_final_filename(new_filename)
@@ -1752,7 +1785,7 @@ def get_renamed_filename(filename, file_path=None):
         if issue_part.lower().startswith("v"):
             final_issue = issue_part
         else:
-            final_issue = _pad_issue_number(issue_part)
+            final_issue = _pad_issue_number(issue_part, pad_width)
 
         # Look for the first 4-digit year in `middle`
         found_year = None
@@ -1782,7 +1815,7 @@ def get_renamed_filename(filename, file_path=None):
         raw_title, issue_num, middle, extension = hash_match.groups()
 
         clean_title = smart_title_case(raw_title.replace("_", " ").strip())
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
 
         # Try to pull a year out of any parentheses in `middle`
         found_year = None
@@ -1845,7 +1878,7 @@ def get_renamed_filename(filename, file_path=None):
         clean_title = smart_title_case(
             f"{raw_title.replace('_', ' ').strip()} {series_num}"
         )
-        final_issue = norm_issue(issue_num)
+        final_issue = norm_issue(issue_num, pad_width)
 
         # Pull out a 4-digit year if present
         found_year = None
@@ -1877,7 +1910,7 @@ def get_renamed_filename(filename, file_path=None):
         if issue_part.lower().startswith("v"):
             final_issue = issue_part  # e.g. 'v01'
         else:
-            final_issue = _pad_issue_number(issue_part)  # e.g. 1 -> 001, 1.MU -> 001.MU
+            final_issue = _pad_issue_number(issue_part, pad_width)  # e.g. 1 -> 001, 1.MU -> 001.MU
 
         # Attempt to find a 4-digit year in `middle`
         found_year = None

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -22,6 +22,7 @@ from cbz_ops.rename import (
     load_filename_cleanup_config,
     _format_issue_month,
     _pad_issue_number,
+    load_issue_pad_width,
 )
 from models.series_json import build_metadata, read_series_json, write_series_json
 from models import comicvine as cv_mod
@@ -318,7 +319,8 @@ def _plan_file(
                     "matched_term": term,
                 }
 
-    extracted = extract_comic_values(stem)
+    pad_width = load_issue_pad_width()
+    extracted = extract_comic_values(stem, pad_width)
     raw_issue = (extracted.get("issue_number") or "").strip()
     # Manga volume files ("Series vNN (YYYY)") carry no issue number. Only skip when
     # the pattern actually needs one; otherwise rename on volume/series alone.
@@ -326,7 +328,7 @@ def _plan_file(
     if not raw_issue and pattern_needs_issue:
         return {"old_path": file_path, "old_name": old_name, "status": "no_issue"}
 
-    issue = _pad_issue_number(raw_issue, width=3) if raw_issue else ""
+    issue = _pad_issue_number(raw_issue, width=pad_width) if raw_issue else ""
 
     # series.json holds one series-level volume for the whole series, but a manga
     # volume file's number ("v03") is per-file and lives only in the filename. When

--- a/config/rename_rules.ini
+++ b/config/rename_rules.ini
@@ -4,82 +4,82 @@
 # 145) "Series (YYYY) Volume ## Issue ###" → Series 0### (YYYY) (explicit Volume/Issue keywords)
 # e.g. "Top 10 (1999) Volume 01 Issue 010.cbz" → "Top 10 010 (1999).cbz"
 rule145.pattern = ^(?P<series>.*?)\s*\((?P<year>\d{4})\)\s*Volume\s*\d+\s*Issue\s*(?P<issue>\d+(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule145.output  = {series|title} {issue|pad3} ({year}){ext}
+rule145.output  = {series|title} {issue|pad} ({year}){ext}
 rule145.priority= 145
 
 # 130) "Series #### ## (of ##) (YYYY)" → Series #### 0## (YYYY) (series name with non-year 4-digit numbers like Marvel 1602)
 rule130.pattern = ^(?P<series>.*?\s+(?:1[0-8]\d{2}|19[0-3]\d|20[5-9]\d|2[1-9]\d{2}))\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(of\s+\d+\)\s+\((?P<year>19[4-9]\d|20[0-4]\d)\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule130.output  = {series|title} {issue|pad3} ({year}){ext}
+rule130.output  = {series|title} {issue|pad} ({year}){ext}
 rule130.priority= 130
 
 # 135) "Series Season # ## (YYYY)" → Series Season # 0## (YYYY) (season patterns)
 rule135.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule135.output  = {series|title} {season} {issue|pad3} ({year}){ext}
+rule135.output  = {series|title} {season} {issue|pad} ({year}){ext}
 rule135.priority= 135
 
 # 134) "Series Season # ## (of ##) (YYYY)" → Series Season # 0## (YYYY) (season with issue count)
 rule134.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(of\s+\d+\)\s+\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule134.output  = {series|title} {season} {issue|pad3} ({year}){ext}
+rule134.output  = {series|title} {season} {issue|pad} ({year}){ext}
 rule134.priority= 134
 
 # 133) "Series Season # ## (YYYY) ..." → Series Season # 0## (YYYY) (season patterns with extra info)
 rule133.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
-rule133.output  = {series|title} {season} {issue|pad3} ({year}){ext}
+rule133.output  = {series|title} {season} {issue|pad} ({year}){ext}
 rule133.priority= 133
 
 # 132) "Series Season # ##" → Series Season # 0## (no year)
 rule132.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
-rule132.output  = {series|title} {season} {issue|pad3}{ext}
+rule132.output  = {series|title} {season} {issue|pad}{ext}
 rule132.priority= 132
 
 # 131) "Series Season # #" → Series Season # 0# (single digit issue)
 rule131.pattern = ^(?P<series>.*?)\s+(?P<season>Season\s+\d{1,3})\s+0?(?P<issue>\d{1}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
-rule131.output  = {series|title} {season} {issue|pad3}{ext}
+rule131.output  = {series|title} {season} {issue|pad}{ext}
 rule131.priority= 131
 
 # 125) "Series_v#_(extra)_(YYYY)_##_(of_##)_(group)" → Series v# 0## (YYYY) (with underscores and extra info)
 rule125.pattern = ^(?P<series>[^_]+)_(?P<volume>v\d{1,3})_\([^)]*\)_\((?P<year>\d{4})\)_(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)_\(of_\d+\)_\([^)]*\)(?P<ext>\.\w+)?$
-rule125.output  = {series|title} {volume} {issue|pad3} ({year}){ext}
+rule125.output  = {series|title} {volume} {issue|pad} ({year}){ext}
 rule125.priority= 125
 
 # 120) "Series #### ## (of ##) (YYYY)" → Series #### 0## (YYYY) (series name with numbers)
 rule120.pattern = ^(?P<series>.*\s+\d+)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(of\s+\d+\)\s+\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule120.output  = {series|title} {issue|pad3} ({year}){ext}
+rule120.output  = {series|title} {issue|pad} ({year}){ext}
 rule120.priority= 120
 
 # 117) "Series (YYYY) ###" → Series 0### (YYYY) (year before issue - reversed order)
 rule117.pattern = ^(?P<series>.*?)\s+\((?P<year>\d{4})\)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
-rule117.output  = {series|title} {issue|pad3} ({year}){ext}
+rule117.output  = {series|title} {issue|pad} ({year}){ext}
 rule117.priority= 117
 
 # 115) "Series # ### (YYYY)" → Series # 0### (YYYY) (where # is part of series name, NOT volume or season)
 rule115.pattern = ^(?P<series>.*\s+\d+)(?!\s+(?:v\d+|Season\s+\d{1,3}))\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule115.output  = {series|title} {issue|pad3} ({year}){ext}
+rule115.output  = {series|title} {issue|pad} ({year}){ext}
 rule115.priority= 115
 
 # 110) "Series International/Annual v# ### (YYYY)" → Keep full name as-is
 rule110.pattern = ^(?P<series>.*?(?:International|Annual).*?)\s+(?P<volume>v\d+\s+)?(?P<special>Annual\s+)?(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule110.output  = {series|title} {volume}{special}{issue|pad3} ({year}){ext}
+rule110.output  = {series|title} {volume}{special}{issue|pad} ({year}){ext}
 rule110.priority= 110
 
 # 105) "Series (YYYY-MM) ### (...)" → Series 0### (YYYY) - but NOT for International/Annual/Season/etc
 rule105.pattern = ^(?P<series>(?!.*(?:International|Annual|v\d+|Season\s+\d{1,3})).*?)\s*\((?P<year>\d{4})-\d{2}\)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?:\s*\([^)]*\))*(?P<ext>\.\w+)?$
-rule105.output  = {series|title} {issue|pad3} ({year}){ext}
+rule105.output  = {series|title} {issue|pad} ({year}){ext}
 rule105.priority= 105
 
 # 100) "Series, YYYY ### ..." → Series 0### (YYYY)
 rule100.pattern = ^(?P<series>.*?),\s*(?P<year>\d{4})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
-rule100.output  = {series|title} {issue|digits|pad3} ({year}){ext}
+rule100.output  = {series|title} {issue|digits|pad} ({year}){ext}
 rule100.priority= 100
 
 # 95) "Series YYYY ### ..." (no comma) → Series 0### (YYYY)
 rule95.pattern = ^(?P<series>.*?)\s+(?P<year>\d{4})\s+(?P<issue>_?#?\d{1,4})(?:\s*\([^)]*\))?(?P<ext>\.\w+)?$
-rule95.output  = {series|title} {issue|digits|pad3} ({year}){ext}
+rule95.output  = {series|title} {issue|digits|pad} ({year}){ext}
 rule95.priority= 95
 
 # 90) "Series, YYYY-MM-DD (NN) ..." or "(_NN)" → Series 0NN (YYYY)
 rule90.pattern = ^(?P<series>.*?),\s*(?P<year>\d{4})-(?:\d{2})(?:-\d{2})?\s*\(\s*(?P<issue>_?#?\d{1,4})\s*\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
-rule90.output  = {series|title} {issue|digits|pad3} ({year}){ext}
+rule90.output  = {series|title} {issue|digits|pad} ({year}){ext}
 rule90.priority= 90
 
 # 85) Series-specific: 2000AD uses 4-digit issues
@@ -89,50 +89,50 @@ rule85_2000ad.priority= 85
 
 # 85) "Series v# ### (YYYYMM)..." → Series v# 0### (YYYY) (6-digit year-month in parens)
 rule85_yearmonth.pattern = ^(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\((?P<yearmonth>\d{6})\).*(?P<ext>\.\w+)?$
-rule85_yearmonth.output  = {series|title} {volume} {issue|pad3} ({yearmonth|year4}){ext}
+rule85_yearmonth.output  = {series|title} {volume} {issue|pad} ({yearmonth|year4}){ext}
 rule85_yearmonth.priority= 85
 
 # 80) "Series v# ### (YYYY) ..." → Series v# 0### (YYYY)
 rule80.pattern = ^(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
-rule80.output  = {series|title} {volume} {issue|pad3} ({year}){ext}
+rule80.output  = {series|title} {volume} {issue|pad} ({year}){ext}
 rule80.priority= 80
 
 # 70) "Series #### (YYYY) ..." → Series 0### (YYYY)
 rule70.pattern = ^(?P<series>.*?)\s*#(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
-rule70.output  = {series|title} {issue|pad3} ({year}){ext}
+rule70.output  = {series|title} {issue|pad} ({year}){ext}
 rule70.priority= 70
 
 # 60) "Series ### (YYYY) ..." (no v or #) → Series 0### (YYYY)
 rule60.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*\((?P<year>\d{4})\)(?:\s*\([^)]*\))*(?:\s*(?P<ext>\.\w+))?$
-rule60.output  = {series|title} {issue|pad3} ({year}){ext}
+rule60.output  = {series|title} {issue|pad} ({year}){ext}
 rule60.priority= 60
 
 # 55) "YYYYMM Series ### ()..." → Series 0### (YYYY) (yearmonth before series name, no volume)
 rule55.pattern = ^(?P<yearmonth>\d{6})\s+(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+\(\s*\).*(?P<ext>\.\w+)?$
-rule55.output  = {series|title} {issue|pad3} ({yearmonth|year4}){ext}
+rule55.output  = {series|title} {issue|pad} ({yearmonth|year4}){ext}
 rule55.priority= 55
 
 # 50) "YYYYMM Series v# ###.ext" → Series v# 0### (YYYY).ext
 rule50.pattern = ^(?P<yearmonth>\d{6})\s+(?P<series>.*?)\s+(?P<volume>v\d{1,3})\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)(?P<ext>\.\w+)?$
-rule50.output  = {series|title} {volume} {issue|pad3} ({yearmonth|year4}){ext}
+rule50.output  = {series|title} {volume} {issue|pad} ({yearmonth|year4}){ext}
 rule50.priority= 50
 
 # 40) "Series (YYYY) #### ..." → Series 0### (YYYY)
 rule40.pattern = ^(?P<series>.*?)\s*\((?P<year>\d{4})\)\s*#(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?).*(?P<ext>\.\w+)?$
-rule40.output  = {series|title} {issue|pad3} ({year}){ext}
+rule40.output  = {series|title} {issue|pad} ({year}){ext}
 rule40.priority= 40
 
 # 30) "Series YYYY-MM ( NN ) (YYYY) ..." → Series 0NN (YYYY)
 rule30.pattern = ^(?P<series>.*?)\s+(?P<year>\d{4})-\d{2}\s*\(\s*(?P<issue>_?\d{1,3})\s*\)\s*\((?:\d{4})\).*(?P<ext>\.\w+)?$
-rule30.output  = {series|title} {issue|digits|pad3} ({year}){ext}
+rule30.output  = {series|title} {issue|digits|pad} ({year}){ext}
 rule30.priority= 30
 
 # 20) "Series YYYY-MM-DD ( NN ) ..." → Series 0NN (YYYY)
 rule20.pattern = ^(?P<series>.*?)[,\s]+(?P<year>\d{4})-\d{2}-\d{2}\s*\(\s*(?P<issue>_?\d{1,3})\s*\)(?:\s*\([^)]*\))*\s*(?P<ext>\.\w+)$
-rule20.output  = {series|title} {issue|digits|pad3} ({year}){ext}
+rule20.output  = {series|title} {issue|digits|pad} ({year}){ext}
 rule20.priority= 20
 
 # 10) "Series ### extra_info YYYY" → Series 0### (YYYY) (edge case with extra metadata between issue and year)
 rule10.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)\s+.*?\s+(?P<year>\d{4})(?P<ext>\.\w+)?$
-rule10.output  = {series|title} {issue|pad3} ({year}){ext}
+rule10.output  = {series|title} {issue|pad} ({year}){ext}
 rule10.priority= 10

--- a/templates/config.html
+++ b/templates/config.html
@@ -428,6 +428,30 @@
                         </div>
                     </div>
 
+                    <!-- Issue Number Leading Zeros -->
+                    <div class="row mt-3">
+                        <div class="col-md-8">
+                            <label for="issuePadWidth" class="form-label">Issue Number Leading Zeros:</label>
+                            <select class="form-select" name="issuePadWidth" id="issuePadWidth">
+                                <option value="none" {% if issuePadWidth == 'none' %}selected{% endif %}>None — 44</option>
+                                <option value="3" {% if issuePadWidth == '3' %}selected{% endif %}>3 digits — 044 (default)</option>
+                                <option value="4" {% if issuePadWidth == '4' %}selected{% endif %}>4 digits — 0044</option>
+                            </select>
+                            <small class="form-text text-muted">
+                                How many digits to zero-pad issue numbers to when renaming.
+                                <code>None</code> strips leading zeros (44), <code>3</code> gives
+                                044, <code>4</code> gives 0044. Decimal/special issues keep their
+                                suffix (e.g. 44.MU → 044.MU). Applies to all rename logic.
+                            </small>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Example Preview:</label>
+                            <div class="border rounded p-2 bg-light">
+                                <small id="issuePadPreview">Avengers 044 (1996).cbz</small>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Custom Move Pattern -->
                     <div class="row mt-3">
                         <div class="col-md-8">
@@ -1717,6 +1741,7 @@
             deletedFiles: document.getElementById('deletedFiles')?.value || '',
             enableCustomRename: document.getElementById('enableCustomRename')?.checked || false,
             customRenamePattern: document.getElementById('customRenamePattern')?.value || '',
+            issuePadWidth: document.getElementById('issuePadWidth')?.value || '3',
             renameCleanSpacesEnabled: document.getElementById('renameCleanSpacesEnabled')?.checked || false,
             renameCleanSpacesMode: document.querySelector('input[name="renameCleanSpacesMode"]:checked')?.value || 'replace',
             renameCleanSpacesReplacement: document.getElementById('renameCleanSpacesReplacement')?.value || '_',
@@ -2112,6 +2137,7 @@
 
         // Initialize custom rename pattern preview
         initializeRenamePreview();
+        initializeIssuePadPreview();
 
         // Initialize custom move pattern preview
         initializeMovePreview();
@@ -2630,6 +2656,20 @@
             // Initial preview
             updateRenamePreview();
         }
+    }
+
+    function initializeIssuePadPreview() {
+        const sel = document.getElementById('issuePadWidth');
+        const out = document.getElementById('issuePadPreview');
+        if (!sel || !out) return;
+        const render = () => {
+            let issue = '44';               // "None" — no leading zeros
+            if (sel.value === '3') issue = '044';
+            else if (sel.value === '4') issue = '0044';
+            out.textContent = `Avengers ${issue} (1996).cbz`;
+        };
+        sel.addEventListener('change', render);
+        render();
     }
 
     function updateRenamePreview() {

--- a/tests/integration/test_issue_pad_width_pref.py
+++ b/tests/integration/test_issue_pad_width_pref.py
@@ -1,0 +1,31 @@
+"""The issue-pad-width preference round-trips through the DB.
+
+The config route (`/api/config/file-processing`) persists `issue_pad_width` via
+`set_user_preference`, and the renamer reads it via `load_issue_pad_width`. This
+verifies that write->read contract against a real SQLite database.
+"""
+import pytest
+
+from core.database import set_user_preference
+from cbz_ops.rename import load_issue_pad_width
+
+
+class TestIssuePadWidthPref:
+
+    @pytest.mark.parametrize("stored,expected", [
+        ("none", 0),
+        ("3", 3),
+        ("4", 4),
+    ])
+    def test_round_trip(self, db_connection, stored, expected):
+        set_user_preference("issue_pad_width", stored, category="file_processing")
+        assert load_issue_pad_width() == expected
+
+    def test_default_when_unset(self, db_connection):
+        # Nothing written -> renamer falls back to the historical width of 3.
+        assert load_issue_pad_width() == 3
+
+    def test_unexpected_value_falls_back(self, db_connection):
+        # A value outside the allowlist should not crash the renamer.
+        set_user_preference("issue_pad_width", "bogus", category="file_processing")
+        assert load_issue_pad_width() == 3

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -123,6 +123,99 @@ class TestPadIssueNumber:
         assert _pad_issue_number(input_val) == expected
 
 
+# ===== Configurable issue-number leading-zero width =====
+
+class TestIssuePadWidth:
+    """The Custom Naming Settings 'leading zeros' option (none / 3 / 4 digits)."""
+
+    @pytest.mark.parametrize("num,width,expected", [
+        ("44", 0, "44"), ("44", 3, "044"), ("44", 4, "0044"),
+        ("3", 0, "3"), ("3", 3, "003"), ("3", 4, "0003"),
+        ("044", 0, "44"),          # width 0 strips existing leading zeros
+        ("0044", 0, "44"), ("0", 0, "0"), ("0", 3, "000"),
+        ("44.MU", 0, "44.MU"), ("44.MU", 4, "0044.MU"),
+        ("12.1", 0, "12.1"), ("12.1", 4, "0012.1"),
+        ("v3", 0, "v3"), ("v3", 4, "v003"),
+    ])
+    def test_pad_issue_number_width(self, num, width, expected):
+        from cbz_ops.rename import _pad_issue_number
+        assert _pad_issue_number(num, width) == expected
+
+    @pytest.mark.parametrize("s,width,expected", [
+        ("44", 0, "44"), ("44", 4, "0044"),
+        ("#5.NOW", 0, "5.NOW"), ("#5.NOW", 4, "0005.NOW"),
+        ("_01", 0, "1"), ("_01", 4, "0001"),
+    ])
+    def test_norm_issue_width(self, s, width, expected):
+        from cbz_ops.rename import norm_issue
+        assert norm_issue(s, width) == expected
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("none", 0), ("0", 0),
+        ("", 3),           # empty/unset falls back to the default width
+        ("3", 3), ("4", 4), ("bogus", 3),
+    ])
+    def test_load_issue_pad_width(self, raw, expected):
+        from cbz_ops.rename import load_issue_pad_width
+        with patch("core.database.get_user_preference", return_value=raw):
+            assert load_issue_pad_width() == expected
+
+    def test_load_issue_pad_width_defaults_on_error(self):
+        from cbz_ops.rename import load_issue_pad_width
+        with patch("core.database.get_user_preference", side_effect=Exception("boom")):
+            assert load_issue_pad_width() == 3
+
+    def test_pad_filter_honors_width(self):
+        from cbz_ops.rename import _apply_filters
+        assert _apply_filters("44", ["pad"], width=0) == "44"
+        assert _apply_filters("44", ["pad"], width=3) == "044"
+        assert _apply_filters("44", ["pad"], width=4) == "0044"
+        # pad3/pad4 stay fixed-width escape hatches regardless of the configured width
+        assert _apply_filters("44", ["pad3"], width=0) == "044"
+        assert _apply_filters("44", ["pad4"], width=0) == "0044"
+
+    @pytest.mark.parametrize("width,expected", [
+        (0, "Avengers 44 (1996).cbz"),
+        (3, "Avengers 044 (1996).cbz"),
+        (4, "Avengers 0044 (1996).cbz"),
+    ])
+    def test_default_path_width(self, width, expected):
+        # Rule engine disabled (os.path.exists False) -> default ISSUE_PATTERN path.
+        from cbz_ops.rename import get_renamed_filename
+        with patch("cbz_ops.rename.load_custom_rename_config", return_value=(False, "")), \
+             patch("os.path.exists", return_value=False), \
+             patch("cbz_ops.rename.load_issue_pad_width", return_value=width):
+            assert get_renamed_filename("Avengers 44 (1996).cbz") == expected
+
+    def test_none_strips_existing_zeros(self):
+        from cbz_ops.rename import get_renamed_filename
+        with patch("cbz_ops.rename.load_custom_rename_config", return_value=(False, "")), \
+             patch("os.path.exists", return_value=False), \
+             patch("cbz_ops.rename.load_issue_pad_width", return_value=0):
+            assert get_renamed_filename("Avengers 044 (1996).cbz") == "Avengers 44 (1996).cbz"
+
+    def test_suffix_preserved_across_widths(self):
+        from cbz_ops.rename import get_renamed_filename
+        with patch("cbz_ops.rename.load_custom_rename_config", return_value=(False, "")), \
+             patch("os.path.exists", return_value=False), \
+             patch("cbz_ops.rename.load_issue_pad_width", return_value=4):
+            assert get_renamed_filename("Avengers 1.MU (2017).cbz") == "Avengers 0001.MU (2017).cbz"
+
+    def test_rule_engine_pad_filter_width(self, tmp_path):
+        # The {issue|pad} rule-engine filter honors the configured width.
+        from cbz_ops.rename import try_rule_engine
+        ini = tmp_path / "rules.ini"
+        ini.write_text(
+            "[RENAME]\n"
+            r"r.pattern = ^(?P<series>.*?)\s+(?P<issue>\d{1,4})\s*\((?P<year>\d{4})\).*(?P<ext>\.\w+)$" + "\n"
+            "r.output  = {series|title} {issue|pad} ({year}){ext}\n"
+            "r.priority= 100\n"
+        )
+        assert try_rule_engine("Avengers 44 (1996).cbz", str(ini), width=0) == "Avengers 44 (1996).cbz"
+        assert try_rule_engine("Avengers 44 (1996).cbz", str(ini), width=3) == "Avengers 044 (1996).cbz"
+        assert try_rule_engine("Avengers 44 (1996).cbz", str(ini), width=4) == "Avengers 0044 (1996).cbz"
+
+
 # ===== clean_final_filename =====
 
 class TestCleanFinalFilename:

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -429,6 +429,23 @@ class TestSmartRenameIssueTokens:
         # {issue_year} = ComicInfo Year (2026), distinct from the series year (1989)
         assert names == ["Sandman - 005 (2026).cbz"]
 
+    def test_issue_pad_width_honored(self, tmp_path):
+        # Configurable leading-zero width flows through smart rename (4-digit here).
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Avengers"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Avengers", volume=2, year=1996)
+        _write_cbz_with_comicinfo(d / "Avengers 44.cbz", year=1996, month=3)
+
+        pattern = "{series_name} {issue_number} ({issue_year})"
+        with _enable_custom_rename(pattern=pattern), \
+             patch("cbz_ops.smart_rename.load_issue_pad_width", return_value=4):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert names == ["Avengers 0044 (1996).cbz"]
+
     def test_decimal_issue_suffix_preserved(self, tmp_path):
         # Point issues ("12.1", "1.MU") must keep their suffix end-to-end, not
         # truncate to the integer. The stem has no file extension, so this also


### PR DESCRIPTION
## What & why

Adds an **Issue Number Leading Zeros** dropdown to Config → Custom Naming Settings so users can choose how issue numbers are zero-padded during rename. Today issue numbers are always padded to 3 digits (`Avengers 44 (1996).cbz` → `Avengers 044 (1996).cbz`); this makes that configurable.

| Option (stored `issue_pad_width`) | issue `44` | issue `3` | `044` (re-rename) |
|---|---|---|---|
| **None** (`none`) | `44` | `3` | `44` (strips existing zeros) |
| **3 digits** (`3`, default) | `044` | `003` | `044` |
| **4 digits** (`4`) | `0044` | `0003` | `0044` |

- Default when unset = `3` → **identical to today's behavior**.
- Decimal/alpha suffixes are preserved at every width (`44.MU` → `0044.MU`), reusing the suffix-aware `_pad_issue_number` from #418.
- The explicit **2000AD 4-digit rule is left untouched** (its issues are genuinely 4-digit).

## How it works

- `_pad_issue_number(num, width)` now treats `width <= 0` as "strip leading zeros" (via a small `_zpad` helper). New `load_issue_pad_width()` reads the preference lazily (defaults to 3, never raises).
- Width is resolved **once per rename** at each entry point (`get_renamed_filename`, `rename_comic_from_metadata`, `smart_rename._build_rename_entry`) and threaded through `norm_issue`, `extract_comic_values`, and the rule engine — keeping `_pad_issue_number` pure/testable.
- **Rule engine:** added a width-aware `{issue|pad}` filter; the shipped `config/rename_rules.ini` switches from `{issue|pad3}` → `{issue|pad}`. `pad3`/`pad4` remain fixed-width escape hatches, so `rule85_2000ad`'s `{issue|pad4}` is unchanged. This is what makes the setting take effect for setups whose renames flow through the rule engine.
- **Config plumbing** mirrors the existing `rename_clean_*` pattern: dropdown + JS collector + live preview in `config.html`, writes in both the AJAX and legacy-form handlers, and the GET render in `app.py`, with an allowlist that falls back to `3`.

## Testing

Full suite green (**2247 passed**, 6 POSIX-only skips; `test_pdf.py` env failures excluded per baseline). New coverage:
- `TestIssuePadWidth` in `test_rename.py` — padder, `norm_issue`, loader mapping, the `{issue|pad}` filter, default-path widths, None-strips-existing-zeros, and a temp-file rule-engine test.
- A smart-rename width case in `test_smart_rename.py`.
- `tests/integration/test_issue_pad_width_pref.py` — DB round-trip of the config→rename contract (the route harness deliberately avoids importing `app.py`, so this validates the write→read path directly).

Builds on #418 (decimal/suffix issue handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)