### PR TITLE
Add newsgroup (Usenet) download support

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,6 +308,9 @@ app.register_blueprint(bulk_metadata_bp)
 from routes.source_wall import source_wall_bp
 
 app.register_blueprint(source_wall_bp)
+from routes.download_clients import download_clients_bp
+
+app.register_blueprint(download_clients_bp)
 
 # Start unified scheduler
 app_state.scheduler.start()

--- a/app.py
+++ b/app.py
@@ -993,6 +993,14 @@ def scheduled_getcomics_download(dry_run=False):
         download_count = 0
         search_count = 0
 
+        # Usenet source wiring (PR 2). When Usenet is enabled and a client +
+        # indexer are configured, it either precedes GetComics (tried first,
+        # skipping GetComics on a hit) or acts as a fallback when GetComics
+        # finds nothing. Evaluated once per run.
+        from models import usenet as usenet_mod
+        usenet_on = usenet_mod.usenet_enabled_and_configured()
+        usenet_first = usenet_on and usenet_mod.usenet_precedes_getcomics()
+
         # Get all mapped series
         mapped_series = get_all_mapped_series()
 
@@ -1118,6 +1126,45 @@ def scheduled_getcomics_download(dry_run=False):
                             pass
                 except Exception:
                     pass  # Proactive refresh is best-effort
+
+                # Usenet first: try indexers before GetComics; on a hit, submit
+                # to the client and skip GetComics for this issue.
+                if usenet_on and usenet_first:
+                    u = usenet_mod.try_download_for_issue(
+                        series_name, issue_num,
+                        issue_year=issue_year,
+                        series_volume=series_volume,
+                        series_year=series_year,
+                        publisher_name=publisher_name,
+                        search_variants=search_variants,
+                        series_aliases=series_aliases,
+                        dry_run=bool(dry_run),
+                    )
+                    if dry_run and u.get("status") == "match_found":
+                        simulation_results.append({
+                            "series": series_name,
+                            "issue": issue_num,
+                            "issue_year": issue_year,
+                            "series_volume": series_volume,
+                            "search_context": search_context,
+                            "source": "usenet",
+                            "best_accept": u.get("chosen"),
+                            "best_fallback": None,
+                            "all_results": u.get("all_results", []),
+                            "status": "match_found",
+                        })
+                        continue
+                    if not dry_run and u.get("submitted"):
+                        download_count += 1
+                        app_logger.info(
+                            f"Submitted Usenet download for {series_name} #{issue_num}: "
+                            f"{u['chosen']['filename']} {search_context}"
+                        )
+                        continue
+
+                # Track queue count so we can tell whether GetComics queued
+                # anything for this issue (used by the Usenet fallback below).
+                gc_count_before = download_count
 
                 results = search_getcomics_for_issue(
                     series_name=series_name,
@@ -1396,6 +1443,26 @@ def scheduled_getcomics_download(dry_run=False):
                             "all_results": scored_results,
                             "status": "no_match",
                         })
+
+                # Usenet fallback: GetComics queued nothing for this issue, so
+                # try the indexers before moving on to the next issue.
+                if (usenet_on and not usenet_first and not dry_run
+                        and download_count == gc_count_before):
+                    u = usenet_mod.try_download_for_issue(
+                        series_name, issue_num,
+                        issue_year=issue_year,
+                        series_volume=series_volume,
+                        series_year=series_year,
+                        publisher_name=publisher_name,
+                        search_variants=search_variants,
+                        series_aliases=series_aliases,
+                    )
+                    if u.get("submitted"):
+                        download_count += 1
+                        app_logger.info(
+                            f"Submitted Usenet fallback for {series_name} #{issue_num}: "
+                            f"{u['chosen']['filename']} {search_context}"
+                        )
 
         # Update last run timestamp
         update_last_getcomics_run()

--- a/core/database.py
+++ b/core/database.py
@@ -864,6 +864,43 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_library_providers_library ON library_providers(library_id)"
         )
 
+        # Create download_clients table (encrypted Usenet client config).
+        # One row per client type; is_active picks the single live client.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS download_clients (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                client_type TEXT NOT NULL UNIQUE,
+                config_encrypted BLOB NOT NULL,
+                config_nonce BLOB NOT NULL,
+                is_active INTEGER DEFAULT 0,
+                is_valid INTEGER DEFAULT 0,
+                last_tested TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Create indexers table (id-keyed, priority-ordered list of indexers).
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS indexers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                indexer_type TEXT NOT NULL DEFAULT 'newznab',
+                url TEXT NOT NULL,
+                config_encrypted BLOB NOT NULL,
+                config_nonce BLOB NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                enabled INTEGER DEFAULT 1,
+                is_valid INTEGER DEFAULT 0,
+                last_tested TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_indexers_priority ON indexers(priority)"
+        )
+
         # Create provider_cache table (unified cache for all providers)
         c.execute("""
             CREATE TABLE IF NOT EXISTS provider_cache (
@@ -9851,6 +9888,409 @@ def register_provider_configured(provider_type: str, is_valid: bool = True) -> b
         return True
     except Exception as e:
         app_logger.error(f"Failed to register provider {provider_type}: {e}")
+        return False
+
+
+# =============================================================================
+# Download Client Functions (encrypted Usenet client config)
+# =============================================================================
+
+
+def save_download_client_config(client_type: str, config: dict) -> bool:
+    """Save encrypted download-client config (INSERT or UPDATE by client_type)."""
+    try:
+        from models.providers.crypto import encrypt_credentials, is_crypto_available
+
+        if not is_crypto_available():
+            app_logger.error(
+                "Cannot save download client: cryptography library not available"
+            )
+            return False
+
+        ciphertext, nonce = encrypt_credentials(config)
+        conn = get_db_connection()
+        conn.execute(
+            """
+            INSERT INTO download_clients (client_type, config_encrypted, config_nonce, updated_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(client_type) DO UPDATE SET
+                config_encrypted = excluded.config_encrypted,
+                config_nonce = excluded.config_nonce,
+                updated_at = CURRENT_TIMESTAMP
+        """,
+            (client_type, ciphertext, nonce),
+        )
+        conn.commit()
+        conn.close()
+        app_logger.info(f"Saved config for download client: {client_type}")
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to save download client config for {client_type}: {e}")
+        return False
+
+
+def get_download_client_config(client_type: str) -> Optional[dict]:
+    """Get decrypted download-client config, or None if not found."""
+    try:
+        from models.providers.crypto import decrypt_credentials, is_crypto_available
+
+        if not is_crypto_available():
+            app_logger.error(
+                "Cannot get download client: cryptography library not available"
+            )
+            return None
+
+        conn = get_db_connection()
+        row = conn.execute(
+            """
+            SELECT config_encrypted, config_nonce
+            FROM download_clients WHERE client_type = ?
+        """,
+            (client_type,),
+        ).fetchone()
+        conn.close()
+
+        if not row:
+            return None
+        return decrypt_credentials(row["config_encrypted"], row["config_nonce"])
+    except Exception as e:
+        app_logger.error(f"Failed to get download client config for {client_type}: {e}")
+        return None
+
+
+def get_download_client_config_masked(client_type: str) -> Optional[dict]:
+    """Get masked download-client config (safe for frontend display)."""
+    try:
+        from models.providers.crypto import mask_credentials_dict
+
+        config = get_download_client_config(client_type)
+        if not config:
+            return None
+        return mask_credentials_dict(config)
+    except Exception as e:
+        app_logger.error(f"Failed to get masked download client config for {client_type}: {e}")
+        return None
+
+
+def get_all_download_clients_status() -> list:
+    """Get status of all configured download clients (without decrypting)."""
+    try:
+        conn = get_db_connection()
+        rows = conn.execute("""
+            SELECT client_type, is_active, is_valid, last_tested, updated_at
+            FROM download_clients
+            ORDER BY client_type
+        """).fetchall()
+        conn.close()
+        return [dict(row) for row in rows]
+    except Exception as e:
+        app_logger.error(f"Failed to get download clients status: {e}")
+        return []
+
+
+def update_download_client_validity(client_type: str, is_valid: bool) -> bool:
+    """Update a download client's connection-test result."""
+    try:
+        conn = get_db_connection()
+        conn.execute(
+            """
+            UPDATE download_clients
+            SET is_valid = ?, last_tested = CURRENT_TIMESTAMP
+            WHERE client_type = ?
+        """,
+            (1 if is_valid else 0, client_type),
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to update download client validity for {client_type}: {e}")
+        return False
+
+
+def set_active_download_client(client_type: str) -> bool:
+    """Mark one client active, clearing is_active on all others (single-active)."""
+    try:
+        conn = get_db_connection()
+        conn.execute("UPDATE download_clients SET is_active = 0")
+        conn.execute(
+            "UPDATE download_clients SET is_active = 1 WHERE client_type = ?",
+            (client_type,),
+        )
+        conn.commit()
+        conn.close()
+        app_logger.info(f"Set active download client: {client_type}")
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to set active download client {client_type}: {e}")
+        return False
+
+
+def get_active_download_client() -> Optional[dict]:
+    """Return {client_type, config} for the active client (PR 2 entry point)."""
+    try:
+        conn = get_db_connection()
+        row = conn.execute("""
+            SELECT client_type FROM download_clients WHERE is_active = 1 LIMIT 1
+        """).fetchone()
+        conn.close()
+        if not row:
+            return None
+        client_type = row["client_type"]
+        config = get_download_client_config(client_type)
+        if config is None:
+            return None
+        return {"client_type": client_type, "config": config}
+    except Exception as e:
+        app_logger.error(f"Failed to get active download client: {e}")
+        return None
+
+
+def delete_download_client_config(client_type: str) -> bool:
+    """Delete a download client's config."""
+    try:
+        conn = get_db_connection()
+        conn.execute(
+            "DELETE FROM download_clients WHERE client_type = ?", (client_type,)
+        )
+        conn.commit()
+        conn.close()
+        app_logger.info(f"Deleted config for download client: {client_type}")
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to delete download client config for {client_type}: {e}")
+        return False
+
+
+# =============================================================================
+# Indexer Functions (id-keyed, priority-ordered, encrypted api_key/config)
+# =============================================================================
+
+
+def add_indexer(
+    name: str,
+    url: str,
+    config: dict,
+    priority: int = 0,
+    enabled: bool = True,
+    indexer_type: str = "newznab",
+) -> Optional[int]:
+    """Add an indexer; returns the new id, or None on failure.
+
+    ``config`` holds the encrypted fields (e.g. api_key, categories).
+    """
+    try:
+        from models.providers.crypto import encrypt_credentials, is_crypto_available
+
+        if not is_crypto_available():
+            app_logger.error("Cannot add indexer: cryptography library not available")
+            return None
+
+        ciphertext, nonce = encrypt_credentials(config or {})
+        conn = get_db_connection()
+        cur = conn.execute(
+            """
+            INSERT INTO indexers
+                (name, indexer_type, url, config_encrypted, config_nonce, priority, enabled)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+            (name, indexer_type, url, ciphertext, nonce, priority, 1 if enabled else 0),
+        )
+        new_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        app_logger.info(f"Added indexer '{name}' (id={new_id})")
+        return new_id
+    except Exception as e:
+        app_logger.error(f"Failed to add indexer '{name}': {e}")
+        return None
+
+
+def update_indexer(
+    indexer_id: int,
+    name: Optional[str] = None,
+    url: Optional[str] = None,
+    config: Optional[dict] = None,
+    priority: Optional[int] = None,
+    enabled: Optional[bool] = None,
+) -> bool:
+    """Partial update of an indexer; re-encrypts only if ``config`` is given."""
+    try:
+        fields = []
+        params = []
+        if name is not None:
+            fields.append("name = ?")
+            params.append(name)
+        if url is not None:
+            fields.append("url = ?")
+            params.append(url)
+        if priority is not None:
+            fields.append("priority = ?")
+            params.append(priority)
+        if enabled is not None:
+            fields.append("enabled = ?")
+            params.append(1 if enabled else 0)
+        if config is not None:
+            from models.providers.crypto import encrypt_credentials, is_crypto_available
+
+            if not is_crypto_available():
+                app_logger.error("Cannot update indexer: cryptography library not available")
+                return False
+            ciphertext, nonce = encrypt_credentials(config)
+            fields.append("config_encrypted = ?")
+            params.append(ciphertext)
+            fields.append("config_nonce = ?")
+            params.append(nonce)
+
+        if not fields:
+            return True  # nothing to update
+
+        fields.append("updated_at = CURRENT_TIMESTAMP")
+        params.append(indexer_id)
+        conn = get_db_connection()
+        conn.execute(
+            f"UPDATE indexers SET {', '.join(fields)} WHERE id = ?", params
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to update indexer {indexer_id}: {e}")
+        return False
+
+
+def _indexer_row_to_dict(row, config: Optional[dict]) -> dict:
+    """Merge an indexers row with its (decrypted or masked) config dict."""
+    data = {
+        "id": row["id"],
+        "name": row["name"],
+        "indexer_type": row["indexer_type"],
+        "url": row["url"],
+        "priority": row["priority"],
+        "enabled": row["enabled"] == 1,
+        "is_valid": row["is_valid"] == 1,
+        "last_tested": row["last_tested"],
+    }
+    if config:
+        data.update(config)
+    return data
+
+
+def get_indexer(indexer_id: int) -> Optional[dict]:
+    """Get a single indexer with its decrypted config, or None if not found."""
+    try:
+        from models.providers.crypto import decrypt_credentials, is_crypto_available
+
+        conn = get_db_connection()
+        row = conn.execute(
+            "SELECT * FROM indexers WHERE id = ?", (indexer_id,)
+        ).fetchone()
+        conn.close()
+        if not row:
+            return None
+        config = None
+        if is_crypto_available():
+            config = decrypt_credentials(row["config_encrypted"], row["config_nonce"])
+        return _indexer_row_to_dict(row, config)
+    except Exception as e:
+        app_logger.error(f"Failed to get indexer {indexer_id}: {e}")
+        return None
+
+
+def get_indexer_masked(indexer_id: int) -> Optional[dict]:
+    """Get a single indexer with masked secrets (safe for display)."""
+    try:
+        from models.providers.crypto import mask_credentials_dict
+
+        data = get_indexer(indexer_id)
+        if not data:
+            return None
+        secret_keys = {"api_key", "categories"}
+        secrets = {k: data[k] for k in secret_keys if k in data}
+        masked = mask_credentials_dict(secrets)
+        data.update(masked)
+        return data
+    except Exception as e:
+        app_logger.error(f"Failed to get masked indexer {indexer_id}: {e}")
+        return None
+
+
+def get_all_indexers() -> list:
+    """Get all indexers (masked), ordered by priority."""
+    try:
+        conn = get_db_connection()
+        rows = conn.execute(
+            "SELECT id FROM indexers ORDER BY priority ASC, id ASC"
+        ).fetchall()
+        conn.close()
+        return [m for m in (get_indexer_masked(r["id"]) for r in rows) if m]
+    except Exception as e:
+        app_logger.error(f"Failed to get all indexers: {e}")
+        return []
+
+
+def get_enabled_indexers() -> list:
+    """Get enabled indexers with decrypted config, ordered by priority (PR 2)."""
+    try:
+        conn = get_db_connection()
+        rows = conn.execute(
+            "SELECT id FROM indexers WHERE enabled = 1 ORDER BY priority ASC, id ASC"
+        ).fetchall()
+        conn.close()
+        return [d for d in (get_indexer(r["id"]) for r in rows) if d]
+    except Exception as e:
+        app_logger.error(f"Failed to get enabled indexers: {e}")
+        return []
+
+
+def update_indexer_validity(indexer_id: int, is_valid: bool) -> bool:
+    """Update an indexer's connection-test result."""
+    try:
+        conn = get_db_connection()
+        conn.execute(
+            """
+            UPDATE indexers
+            SET is_valid = ?, last_tested = CURRENT_TIMESTAMP
+            WHERE id = ?
+        """,
+            (1 if is_valid else 0, indexer_id),
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to update indexer validity for {indexer_id}: {e}")
+        return False
+
+
+def set_indexer_order(ordered_ids: list) -> bool:
+    """Reassign priority by position in ``ordered_ids`` (index 0 = highest)."""
+    try:
+        conn = get_db_connection()
+        for position, indexer_id in enumerate(ordered_ids):
+            conn.execute(
+                "UPDATE indexers SET priority = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (position, indexer_id),
+            )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to set indexer order: {e}")
+        return False
+
+
+def delete_indexer(indexer_id: int) -> bool:
+    """Delete an indexer by id."""
+    try:
+        conn = get_db_connection()
+        conn.execute("DELETE FROM indexers WHERE id = ?", (indexer_id,))
+        conn.commit()
+        conn.close()
+        app_logger.info(f"Deleted indexer {indexer_id}")
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to delete indexer {indexer_id}: {e}")
         return False
 
 

--- a/models/download_clients/__init__.py
+++ b/models/download_clients/__init__.py
@@ -1,0 +1,116 @@
+"""
+Download Client Registry and Factory.
+
+Download clients register themselves using the @register_download_client
+decorator, and instances are created via get_download_client() or
+get_download_client_by_name().
+
+Usage:
+    from models.download_clients import (
+        register_download_client, get_download_client, ClientType,
+    )
+
+    @register_download_client
+    class SABnzbdClient(BaseDownloadClient):
+        client_type = ClientType.SABNZBD
+        ...
+
+    client = get_download_client(ClientType.SABNZBD, config)
+    client.test_connection()
+"""
+from typing import Dict, List, Optional, Type
+
+from .base import (
+    BaseDownloadClient,
+    ClientType,
+    DownloadClientConfig,
+    DownloadStatus,
+    NZBSubmitResult,
+)
+
+# Registry of download client implementations
+_DOWNLOAD_CLIENT_REGISTRY: Dict[ClientType, Type[BaseDownloadClient]] = {}
+
+
+def register_download_client(
+    client_class: Type[BaseDownloadClient],
+) -> Type[BaseDownloadClient]:
+    """Decorator to register a download client implementation."""
+    if not hasattr(client_class, "client_type"):
+        raise ValueError(
+            f"Download client class {client_class.__name__} must define client_type"
+        )
+    _DOWNLOAD_CLIENT_REGISTRY[client_class.client_type] = client_class
+    return client_class
+
+
+def get_download_client(
+    client_type: ClientType,
+    config: Optional[DownloadClientConfig] = None,
+) -> BaseDownloadClient:
+    """Factory function to create a download client instance."""
+    if client_type not in _DOWNLOAD_CLIENT_REGISTRY:
+        raise ValueError(f"Unknown download client type: {client_type.value}")
+    return _DOWNLOAD_CLIENT_REGISTRY[client_type](config)
+
+
+def get_download_client_by_name(
+    name: str,
+    config: Optional[DownloadClientConfig] = None,
+) -> BaseDownloadClient:
+    """Factory function to create a download client instance by string name."""
+    try:
+        client_type = ClientType(name.lower())
+    except ValueError:
+        raise ValueError(f"Unknown download client: {name}")
+    return get_download_client(client_type, config)
+
+
+def get_available_download_clients() -> List[Dict]:
+    """Get list of available download clients with their configuration details."""
+    return [
+        {
+            "type": c.client_type.value,
+            "name": c.display_name,
+            "config_fields": c.config_fields,
+            "requires_auth": c.requires_auth,
+        }
+        for c in _DOWNLOAD_CLIENT_REGISTRY.values()
+    ]
+
+
+def get_download_client_class(
+    client_type: ClientType,
+) -> Optional[Type[BaseDownloadClient]]:
+    """Get the download client class for a given type without instantiating."""
+    return _DOWNLOAD_CLIENT_REGISTRY.get(client_type)
+
+
+def is_download_client_registered(client_type: ClientType) -> bool:
+    """Check if a download client type is registered."""
+    return client_type in _DOWNLOAD_CLIENT_REGISTRY
+
+
+# Import client implementations to register them (triggers @register_download_client)
+from .sabnzbd_client import SABnzbdClient
+from .nzbget_client import NZBGetClient
+
+
+__all__ = [
+    # Base classes and types
+    "BaseDownloadClient",
+    "ClientType",
+    "DownloadClientConfig",
+    "DownloadStatus",
+    "NZBSubmitResult",
+    # Registry functions
+    "register_download_client",
+    "get_download_client",
+    "get_download_client_by_name",
+    "get_available_download_clients",
+    "get_download_client_class",
+    "is_download_client_registered",
+    # Client implementations
+    "SABnzbdClient",
+    "NZBGetClient",
+]

--- a/models/download_clients/base.py
+++ b/models/download_clients/base.py
@@ -1,0 +1,185 @@
+"""
+Base classes and data types for Usenet download clients.
+
+This module defines the abstract base class that all download clients
+(SABnzbd, NZBGet) must implement, along with unified data classes for
+client configuration and download status.
+
+PR 1 implements ``test_connection`` fully. NZB submission and status
+polling (``add_nzb``, ``get_history``, ``get_status``) are defined as
+forward-compatible seams for PR 2 and raise ``NotImplementedError``.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+
+class ClientType(Enum):
+    """Enumeration of supported download clients."""
+    SABNZBD = "sabnzbd"
+    NZBGET = "nzbget"
+
+
+@dataclass
+class DownloadClientConfig:
+    """Connection/config for a Usenet download client."""
+    host: Optional[str] = None
+    port: Optional[int] = None
+    api_key: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    category: Optional[str] = None
+    priority: Optional[int] = None
+    use_ssl: bool = False
+    url_base: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary, excluding None values."""
+        return {k: v for k, v in {
+            "host": self.host,
+            "port": self.port,
+            "api_key": self.api_key,
+            "username": self.username,
+            "password": self.password,
+            "category": self.category,
+            "priority": self.priority,
+            "use_ssl": self.use_ssl,
+            "url_base": self.url_base,
+        }.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DownloadClientConfig":
+        """Create from dictionary."""
+        return cls(
+            host=data.get("host"),
+            port=data.get("port"),
+            api_key=data.get("api_key"),
+            username=data.get("username"),
+            password=data.get("password"),
+            category=data.get("category"),
+            priority=data.get("priority"),
+            use_ssl=bool(data.get("use_ssl", False)),
+            url_base=data.get("url_base"),
+        )
+
+
+@dataclass
+class NZBSubmitResult:
+    """Result of submitting an NZB to a download client (PR 2 seam)."""
+    client_id: Optional[str] = None
+    success: bool = False
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "client_id": self.client_id,
+            "success": self.success,
+            "error": self.error,
+        }
+
+
+@dataclass
+class DownloadStatus:
+    """Status of a download tracked by a client (PR 2 seam).
+
+    ``storage_path`` is the completed file/directory the PR 2 mover will
+    consume to hand the finished download to CLU's WATCH folder.
+    """
+    client_id: str
+    name: Optional[str] = None
+    status: Optional[str] = None
+    percent: Optional[float] = None
+    category: Optional[str] = None
+    storage_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "client_id": self.client_id,
+            "name": self.name,
+            "status": self.status,
+            "percent": self.percent,
+            "category": self.category,
+            "storage_path": self.storage_path,
+        }
+
+
+class BaseDownloadClient(ABC):
+    """
+    Abstract base class for all Usenet download clients.
+
+    Subclasses set the class attributes and implement ``test_connection``.
+    """
+
+    # Class attributes to be overridden by subclasses
+    client_type: ClientType
+    display_name: str
+    config_fields: List[str] = []
+    requires_auth: bool = True
+
+    def __init__(self, config: Optional[DownloadClientConfig] = None):
+        """Initialize the client with optional connection config."""
+        self.config = config
+        # Populated by test_connection() on failure so callers can surface a
+        # human-readable reason (connection refused, 401, bad response, ...).
+        self.last_error: Optional[str] = None
+
+    def _base_url(self) -> str:
+        """Build the base URL ``scheme://host:port[/url_base]`` from config.
+
+        If the user already embedded a scheme and/or ``:port`` in the host
+        field, those are honored and not duplicated.
+        """
+        cfg = self.config or DownloadClientConfig()
+        host = (cfg.host or "localhost").strip().rstrip("/")
+
+        # Honor a scheme embedded in the host field, else derive from use_ssl.
+        if "://" in host:
+            scheme, host = host.split("://", 1)
+        else:
+            scheme = "https" if cfg.use_ssl else "http"
+
+        base = f"{scheme}://{host}"
+        # Only append the port if the host does not already carry one.
+        if cfg.port and ":" not in host:
+            base = f"{base}:{cfg.port}"
+        if cfg.url_base:
+            base = f"{base}/{cfg.url_base.strip('/')}"
+        return base
+
+    @abstractmethod
+    def test_connection(self) -> bool:
+        """
+        Verify connectivity and credentials to the download client.
+
+        Returns:
+            True if connection is successful, False otherwise
+        """
+        pass
+
+    def add_nzb(
+        self,
+        nzb: Union[bytes, str],
+        name: str,
+        category: Optional[str] = None,
+        priority: Optional[int] = None,
+    ) -> NZBSubmitResult:
+        """Submit an NZB (bytes) or NZB URL (str) to the client. PR 2 seam."""
+        raise NotImplementedError("add_nzb is implemented in PR 2")
+
+    def get_history(self) -> List[DownloadStatus]:
+        """Return completed downloads (for the PR 2 poller/mover). PR 2 seam."""
+        raise NotImplementedError("get_history is implemented in PR 2")
+
+    def get_status(self, client_id: str) -> Optional[DownloadStatus]:
+        """Return the status of a single download by client id. PR 2 seam."""
+        raise NotImplementedError("get_status is implemented in PR 2")
+
+    def get_client_info(self) -> Dict[str, Any]:
+        """Get client metadata for API responses."""
+        return {
+            "type": self.client_type.value,
+            "name": self.display_name,
+            "config_fields": self.config_fields,
+            "requires_auth": self.requires_auth,
+        }

--- a/models/download_clients/nzbget_client.py
+++ b/models/download_clients/nzbget_client.py
@@ -6,14 +6,25 @@ Talks to an NZBGet instance over its JSON-RPC API. PR 1 implements
 
 API reference: https://nzbget.net/api/
 """
-from typing import Optional, Union
+import base64
+from typing import List, Optional, Union
 
 from core.app_logging import app_logger
-from .base import BaseDownloadClient, ClientType, NZBSubmitResult
+from .base import BaseDownloadClient, ClientType, DownloadStatus, NZBSubmitResult
 from . import register_download_client
 
 # Short timeout so a wrong host/port fails fast instead of hanging the UI.
 _TIMEOUT = 10
+
+
+def _normalize_nzbget_status(raw: str) -> str:
+    """Map an NZBGet history Status string to complete/failed/downloading."""
+    up = (raw or "").upper()
+    if up.startswith("SUCCESS"):
+        return "complete"
+    if up.startswith(("FAILURE", "DELETED", "WARNING")):
+        return "failed"
+    return "downloading"
 
 
 @register_download_client
@@ -93,15 +104,93 @@ class NZBGetClient(BaseDownloadClient):
             app_logger.error(f"NZBGet connection test failed: {e}")
             return False
 
-    def add_nzb(self, nzb: Union[bytes, str], name, category=None, priority=None) -> NZBSubmitResult:
-        # PR2: JSON-RPC append(filename, base64_nzb, category, priority, ...).
-        raise NotImplementedError("add_nzb is implemented in PR 2")
+    def _rpc(self, method: str, params: list):
+        """Call an NZBGet JSON-RPC method; return the result or raise."""
+        import requests
 
-    def get_history(self):
-        # PR2: JSON-RPC history(True) + listgroups(); DestDir/FinalDir =
-        # completed path consumed by the mover.
-        raise NotImplementedError("get_history is implemented in PR 2")
+        cfg = self.config
+        auth = None
+        if cfg and (cfg.username or cfg.password):
+            auth = (cfg.username or "", cfg.password or "")
+        resp = requests.post(
+            f"{self._base_url()}/jsonrpc",
+            json={"method": method, "params": params, "id": 1},
+            auth=auth,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, dict) and data.get("error"):
+            err = data["error"]
+            msg = err.get("message") if isinstance(err, dict) else str(err)
+            raise RuntimeError(f"NZBGet {method} error: {msg}")
+        return data.get("result")
 
-    def get_status(self, client_id: str):
-        # PR2: JSON-RPC listgroups() filtered by NZBID, then history(True).
-        raise NotImplementedError("get_status is implemented in PR 2")
+    def add_nzb(
+        self,
+        nzb: Union[bytes, str],
+        name: str,
+        category: Optional[str] = None,
+        priority: Optional[int] = None,
+    ) -> NZBSubmitResult:
+        """Submit an NZB via append(). ``nzb`` may be raw bytes or a URL string."""
+        self.last_error = None
+        cfg = self.config
+        cat = category if category is not None else (cfg.category if cfg else None)
+        prio = priority if priority is not None else (cfg.priority if cfg else None)
+        # NZBGet append() detects a URL in the content field; bytes must be base64.
+        content = nzb if isinstance(nzb, str) else base64.b64encode(nzb).decode("ascii")
+        # append(NZBFilename, NZBContent, Category, Priority, AddToTop,
+        #        AddPaused, DupeKey, DupeScore, DupeMode, PPParameters)
+        # The trailing PPParameters array is required by modern NZBGet (v13+);
+        # omitting it fails with "Invalid parameter (Parameters)".
+        params = [name, content, cat or "", int(prio) if prio is not None else 0,
+                  False, False, "", 0, "SCORE", []]
+        try:
+            nzbid = self._rpc("append", params)
+            if isinstance(nzbid, int) and nzbid > 0:
+                return NZBSubmitResult(client_id=str(nzbid), success=True)
+            self.last_error = f"NZBGet append returned {nzbid}"
+            return NZBSubmitResult(success=False, error=self.last_error)
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"NZBGet add_nzb failed: {e}")
+            return NZBSubmitResult(success=False, error=str(e))
+
+    def get_history(self) -> List[DownloadStatus]:
+        """Return completed/failed downloads from NZBGet history."""
+        try:
+            rows = self._rpc("history", [True]) or []
+            out = []
+            for r in rows:
+                out.append(DownloadStatus(
+                    client_id=str(r.get("NZBID", "")),
+                    name=r.get("Name"),
+                    status=_normalize_nzbget_status(r.get("Status", "")),
+                    category=r.get("Category") or None,
+                    storage_path=r.get("FinalDir") or r.get("DestDir") or None,
+                ))
+            return out
+        except Exception as e:
+            app_logger.error(f"NZBGet get_history failed: {e}")
+            return []
+
+    def get_status(self, client_id: str) -> Optional[DownloadStatus]:
+        """Return the status of a single download by NZBID (active then history)."""
+        try:
+            for g in self._rpc("listgroups", [0]) or []:
+                if str(g.get("NZBID", "")) == str(client_id):
+                    remaining = g.get("RemainingSizeMB") or 0
+                    total = (g.get("FileSizeMB") or 0) or 1
+                    pct = max(0.0, min(100.0, (1 - remaining / total) * 100))
+                    return DownloadStatus(
+                        client_id=str(client_id), name=g.get("NZBName"),
+                        status="downloading", percent=pct, category=g.get("Category"),
+                    )
+        except Exception as e:
+            app_logger.error(f"NZBGet get_status listgroups failed: {e}")
+
+        for h in self.get_history():
+            if h.client_id == str(client_id):
+                return h
+        return None

--- a/models/download_clients/nzbget_client.py
+++ b/models/download_clients/nzbget_client.py
@@ -1,0 +1,107 @@
+"""
+NZBGet Download Client Adapter.
+
+Talks to an NZBGet instance over its JSON-RPC API. PR 1 implements
+``test_connection``; submission/status are PR 2 seams.
+
+API reference: https://nzbget.net/api/
+"""
+from typing import Optional, Union
+
+from core.app_logging import app_logger
+from .base import BaseDownloadClient, ClientType, NZBSubmitResult
+from . import register_download_client
+
+# Short timeout so a wrong host/port fails fast instead of hanging the UI.
+_TIMEOUT = 10
+
+
+@register_download_client
+class NZBGetClient(BaseDownloadClient):
+    """NZBGet download client using the JSON-RPC API."""
+
+    client_type = ClientType.NZBGET
+    display_name = "NZBGet"
+    requires_auth = True
+    config_fields = [
+        "host",
+        "port",
+        "username",
+        "password",
+        "category",
+        "priority",
+        "use_ssl",
+        "url_base",
+    ]
+
+    def test_connection(self) -> bool:
+        """Verify the NZBGet host is reachable and credentials are valid.
+
+        Calls the ``version`` JSON-RPC method. Username/password are optional
+        (NZBGet may run with authentication disabled, as with Sonarr/Radarr);
+        Basic auth is only sent when credentials are provided.
+        """
+        self.last_error = None
+        cfg = self.config
+        if not cfg:
+            self.last_error = "No configuration provided"
+            return False
+
+        url = f"{self._base_url()}/jsonrpc"
+        try:
+            import requests
+
+            auth = None
+            if cfg.username or cfg.password:
+                auth = (cfg.username or "", cfg.password or "")
+
+            resp = requests.post(
+                url,
+                json={"method": "version", "params": [], "id": 1},
+                auth=auth,
+                timeout=_TIMEOUT,
+            )
+            if resp.status_code == 401:
+                self.last_error = "401 Unauthorized — check username/password"
+                return False
+            if resp.status_code != 200:
+                self.last_error = f"HTTP {resp.status_code} from {url}"
+                return False
+            try:
+                data = resp.json()
+            except ValueError:
+                self.last_error = (
+                    f"Non-JSON response from {url} — is this an NZBGet JSON-RPC endpoint?"
+                )
+                return False
+            if isinstance(data, dict) and data.get("result") is not None:
+                return True
+            self.last_error = f"Unexpected JSON-RPC response: {data}"
+            return False
+        except requests.exceptions.ConnectionError:
+            self.last_error = (
+                f"Could not connect to {url} — check the host/port are reachable "
+                f"from the CLU container (localhost inside Docker is the container "
+                f"itself, not your homeserver)"
+            )
+            return False
+        except requests.exceptions.Timeout:
+            self.last_error = f"Timed out connecting to {url}"
+            return False
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"NZBGet connection test failed: {e}")
+            return False
+
+    def add_nzb(self, nzb: Union[bytes, str], name, category=None, priority=None) -> NZBSubmitResult:
+        # PR2: JSON-RPC append(filename, base64_nzb, category, priority, ...).
+        raise NotImplementedError("add_nzb is implemented in PR 2")
+
+    def get_history(self):
+        # PR2: JSON-RPC history(True) + listgroups(); DestDir/FinalDir =
+        # completed path consumed by the mover.
+        raise NotImplementedError("get_history is implemented in PR 2")
+
+    def get_status(self, client_id: str):
+        # PR2: JSON-RPC listgroups() filtered by NZBID, then history(True).
+        raise NotImplementedError("get_status is implemented in PR 2")

--- a/models/download_clients/sabnzbd_client.py
+++ b/models/download_clients/sabnzbd_client.py
@@ -6,11 +6,21 @@ Talks to a SABnzbd instance over its HTTP API. PR 1 implements
 
 API reference: https://sabnzbd.org/wiki/advanced/api
 """
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from core.app_logging import app_logger
-from .base import BaseDownloadClient, ClientType, NZBSubmitResult
+from .base import BaseDownloadClient, ClientType, DownloadStatus, NZBSubmitResult
 from . import register_download_client
+
+
+def _normalize_sab_status(raw: str) -> str:
+    """Map a SABnzbd status string to complete/failed/downloading."""
+    low = (raw or "").lower()
+    if low == "completed":
+        return "complete"
+    if low == "failed":
+        return "failed"
+    return "downloading"
 
 # Short timeout so a wrong host/port fails fast instead of hanging the UI.
 _TIMEOUT = 10
@@ -93,16 +103,110 @@ class SABnzbdClient(BaseDownloadClient):
             app_logger.error(f"SABnzbd connection test failed: {e}")
             return False
 
-    def add_nzb(self, nzb: Union[bytes, str], name, category=None, priority=None) -> NZBSubmitResult:
-        # PR2: POST mode=addfile (nzb bytes) or GET mode=addurl&name=<nzburl>,
-        # params apikey, cat=<category>, priority. Read the completed path from
-        # mode=history&output=json (the `storage` field) for the mover.
-        raise NotImplementedError("add_nzb is implemented in PR 2")
+    def add_nzb(
+        self,
+        nzb: Union[bytes, str],
+        name: str,
+        category: Optional[str] = None,
+        priority: Optional[int] = None,
+    ) -> NZBSubmitResult:
+        """Submit an NZB URL (str, via addurl) or NZB bytes (via addfile)."""
+        self.last_error = None
+        cfg = self.config
+        if not cfg or not cfg.api_key:
+            return NZBSubmitResult(success=False, error="API key is required")
 
-    def get_history(self):
-        # PR2: GET mode=history&output=json -> slots[].storage (completed path).
-        raise NotImplementedError("get_history is implemented in PR 2")
+        cat = category if category is not None else cfg.category
+        prio = priority if priority is not None else cfg.priority
+        url = f"{self._base_url()}/api"
+        params = {"apikey": cfg.api_key, "output": "json", "nzbname": name}
+        if cat:
+            params["cat"] = cat
+        if prio is not None:
+            params["priority"] = prio
+        try:
+            import requests
 
-    def get_status(self, client_id: str):
-        # PR2: GET mode=queue / mode=history filtered by nzo_id.
-        raise NotImplementedError("get_status is implemented in PR 2")
+            if isinstance(nzb, str):
+                params["mode"] = "addurl"
+                params["name"] = nzb
+                resp = requests.get(url, params=params, timeout=_TIMEOUT)
+            else:
+                params["mode"] = "addfile"
+                files = {"name": (name, nzb, "application/x-nzb")}
+                resp = requests.post(url, params=params, files=files, timeout=_TIMEOUT)
+            resp.raise_for_status()
+            data = resp.json()
+            if not data.get("status", False):
+                self.last_error = str(data.get("error") or data)
+                return NZBSubmitResult(success=False, error=self.last_error)
+            nzo_ids = data.get("nzo_ids") or []
+            return NZBSubmitResult(client_id=nzo_ids[0] if nzo_ids else None, success=True)
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"SABnzbd add_nzb failed: {e}")
+            return NZBSubmitResult(success=False, error=str(e))
+
+    def get_history(self) -> List[DownloadStatus]:
+        """Return completed/failed downloads from SABnzbd history."""
+        cfg = self.config
+        if not cfg or not cfg.api_key:
+            return []
+        url = f"{self._base_url()}/api"
+        try:
+            import requests
+
+            resp = requests.get(
+                url,
+                params={"mode": "history", "output": "json", "apikey": cfg.api_key},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+            slots = (resp.json().get("history") or {}).get("slots") or []
+            out = []
+            for s in slots:
+                out.append(DownloadStatus(
+                    client_id=s.get("nzo_id", ""),
+                    name=s.get("name"),
+                    status=_normalize_sab_status(s.get("status", "")),
+                    category=s.get("category"),
+                    storage_path=s.get("storage") or None,
+                ))
+            return out
+        except Exception as e:
+            app_logger.error(f"SABnzbd get_history failed: {e}")
+            return []
+
+    def get_status(self, client_id: str) -> Optional[DownloadStatus]:
+        """Return the status of a single download by nzo_id (queue then history)."""
+        cfg = self.config
+        if not cfg or not cfg.api_key:
+            return None
+        url = f"{self._base_url()}/api"
+        try:
+            import requests
+
+            resp = requests.get(
+                url,
+                params={"mode": "queue", "output": "json", "apikey": cfg.api_key},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+            for s in (resp.json().get("queue") or {}).get("slots") or []:
+                if s.get("nzo_id") == client_id:
+                    pct = None
+                    try:
+                        pct = float(s.get("percentage"))
+                    except (TypeError, ValueError):
+                        pct = None
+                    return DownloadStatus(
+                        client_id=client_id, name=s.get("filename"),
+                        status="downloading", percent=pct, category=s.get("cat"),
+                    )
+        except Exception as e:
+            app_logger.error(f"SABnzbd get_status queue lookup failed: {e}")
+
+        for h in self.get_history():
+            if h.client_id == client_id:
+                return h
+        return None

--- a/models/download_clients/sabnzbd_client.py
+++ b/models/download_clients/sabnzbd_client.py
@@ -1,0 +1,108 @@
+"""
+SABnzbd Download Client Adapter.
+
+Talks to a SABnzbd instance over its HTTP API. PR 1 implements
+``test_connection``; submission/status are PR 2 seams.
+
+API reference: https://sabnzbd.org/wiki/advanced/api
+"""
+from typing import Optional, Union
+
+from core.app_logging import app_logger
+from .base import BaseDownloadClient, ClientType, NZBSubmitResult
+from . import register_download_client
+
+# Short timeout so a wrong host/port fails fast instead of hanging the UI.
+_TIMEOUT = 10
+
+
+@register_download_client
+class SABnzbdClient(BaseDownloadClient):
+    """SABnzbd download client using the HTTP API."""
+
+    client_type = ClientType.SABNZBD
+    display_name = "SABnzbd"
+    requires_auth = True
+    config_fields = [
+        "host",
+        "port",
+        "api_key",
+        "category",
+        "priority",
+        "use_ssl",
+        "url_base",
+    ]
+
+    def test_connection(self) -> bool:
+        """Verify the SABnzbd host is reachable and the API key is valid.
+
+        Queries ``mode=queue``; a bad API key returns ``{"error": ...}``
+        while a good one returns a payload containing ``"queue"``.
+        """
+        self.last_error = None
+        cfg = self.config
+        if not cfg or not cfg.api_key:
+            self.last_error = "API key is required"
+            return False
+
+        url = f"{self._base_url()}/api"
+        try:
+            import requests
+
+            resp = requests.get(
+                url,
+                params={
+                    "mode": "queue",
+                    "output": "json",
+                    "apikey": cfg.api_key,
+                },
+                timeout=_TIMEOUT,
+            )
+            if resp.status_code != 200:
+                self.last_error = f"HTTP {resp.status_code} from {url}"
+                return False
+            try:
+                data = resp.json()
+            except ValueError:
+                self.last_error = (
+                    f"Non-JSON response from {url} — is this a SABnzbd API endpoint?"
+                )
+                return False
+            if not isinstance(data, dict):
+                self.last_error = f"Unexpected response from {url}"
+                return False
+            if data.get("error"):
+                self.last_error = str(data["error"])
+                return False
+            if "queue" in data:
+                return True
+            self.last_error = "Response did not contain a queue — check the API key"
+            return False
+        except requests.exceptions.ConnectionError:
+            self.last_error = (
+                f"Could not connect to {url} — check the host/port are reachable "
+                f"from the CLU container (localhost inside Docker is the container "
+                f"itself, not your homeserver)"
+            )
+            return False
+        except requests.exceptions.Timeout:
+            self.last_error = f"Timed out connecting to {url}"
+            return False
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"SABnzbd connection test failed: {e}")
+            return False
+
+    def add_nzb(self, nzb: Union[bytes, str], name, category=None, priority=None) -> NZBSubmitResult:
+        # PR2: POST mode=addfile (nzb bytes) or GET mode=addurl&name=<nzburl>,
+        # params apikey, cat=<category>, priority. Read the completed path from
+        # mode=history&output=json (the `storage` field) for the mover.
+        raise NotImplementedError("add_nzb is implemented in PR 2")
+
+    def get_history(self):
+        # PR2: GET mode=history&output=json -> slots[].storage (completed path).
+        raise NotImplementedError("get_history is implemented in PR 2")
+
+    def get_status(self, client_id: str):
+        # PR2: GET mode=queue / mode=history filtered by nzo_id.
+        raise NotImplementedError("get_status is implemented in PR 2")

--- a/models/indexers/__init__.py
+++ b/models/indexers/__init__.py
@@ -1,0 +1,69 @@
+"""
+Indexer Registry and Factory.
+
+Indexers register themselves using the @register_indexer decorator, and
+instances are created via get_indexer_impl().
+
+Usage:
+    from models.indexers import register_indexer, get_indexer_impl, IndexerType
+
+    @register_indexer
+    class NewznabIndexer(BaseIndexer):
+        indexer_type = IndexerType.NEWZNAB
+        ...
+
+    indexer = get_indexer_impl(IndexerType.NEWZNAB, config)
+    indexer.test_connection()
+"""
+from typing import Dict, List, Type
+
+from .base import (
+    BaseIndexer,
+    IndexerConfig,
+    IndexerType,
+    NZBSearchResult,
+)
+
+# Registry of indexer implementations
+_INDEXER_REGISTRY: Dict[IndexerType, Type[BaseIndexer]] = {}
+
+
+def register_indexer(indexer_class: Type[BaseIndexer]) -> Type[BaseIndexer]:
+    """Decorator to register an indexer implementation."""
+    if not hasattr(indexer_class, "indexer_type"):
+        raise ValueError(
+            f"Indexer class {indexer_class.__name__} must define indexer_type"
+        )
+    _INDEXER_REGISTRY[indexer_class.indexer_type] = indexer_class
+    return indexer_class
+
+
+def get_indexer_impl(indexer_type: IndexerType, config: IndexerConfig) -> BaseIndexer:
+    """Factory function to create an indexer instance."""
+    if indexer_type not in _INDEXER_REGISTRY:
+        raise ValueError(f"Unknown indexer type: {indexer_type.value}")
+    return _INDEXER_REGISTRY[indexer_type](config)
+
+
+def get_available_indexer_types() -> List[Dict]:
+    """Get list of available indexer types."""
+    return [
+        {"type": i.indexer_type.value, "name": i.display_name}
+        for i in _INDEXER_REGISTRY.values()
+    ]
+
+
+# Import indexer implementations to register them (triggers @register_indexer)
+from .newznab_indexer import NewznabIndexer
+
+
+__all__ = [
+    "BaseIndexer",
+    "IndexerConfig",
+    "IndexerType",
+    "NZBSearchResult",
+    "register_indexer",
+    "get_indexer_impl",
+    "get_available_indexer_types",
+    "NewznabIndexer",
+]

--- a/models/indexers/base.py
+++ b/models/indexers/base.py
@@ -1,0 +1,105 @@
+"""
+Base classes and data types for Usenet indexers.
+
+Defines the abstract base class that all indexers (Newznab-compatible)
+must implement, plus unified data classes for indexer config and search
+results.
+
+PR 1 implements ``test_connection`` fully. ``search`` is a forward-
+compatible seam for PR 2 and raises ``NotImplementedError``.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class IndexerType(Enum):
+    """Enumeration of supported indexer protocols."""
+    NEWZNAB = "newznab"
+
+
+@dataclass
+class IndexerConfig:
+    """Configuration for a single indexer."""
+    name: str
+    url: str
+    api_key: Optional[str] = None
+    categories: Optional[str] = None  # comma-separated, e.g. "7000,7030"
+    enabled: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "url": self.url,
+            "api_key": self.api_key,
+            "categories": self.categories,
+            "enabled": self.enabled,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "IndexerConfig":
+        return cls(
+            name=data.get("name", ""),
+            url=data.get("url", ""),
+            api_key=data.get("api_key"),
+            categories=data.get("categories"),
+            enabled=bool(data.get("enabled", True)),
+        )
+
+
+@dataclass
+class NZBSearchResult:
+    """A single NZB search result (PR 2 scoring input).
+
+    Field names are kept close to what the GetComics scorer consumes
+    (``title``, ``size``) so PR 2 needs only a thin adapter.
+    """
+    indexer_id: int
+    indexer_name: str
+    title: str
+    nzb_url: str
+    size: Optional[int] = None
+    categories: Optional[str] = None
+    pubdate: Optional[str] = None
+    guid: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "indexer_id": self.indexer_id,
+            "indexer_name": self.indexer_name,
+            "title": self.title,
+            "nzb_url": self.nzb_url,
+            "size": self.size,
+            "categories": self.categories,
+            "pubdate": self.pubdate,
+            "guid": self.guid,
+        }
+
+
+class BaseIndexer(ABC):
+    """Abstract base class for all indexers."""
+
+    # Class attributes to be overridden by subclasses
+    indexer_type: IndexerType
+    display_name: str
+
+    def __init__(self, config: IndexerConfig):
+        self.config = config
+        # Populated by test_connection() on failure for a readable reason.
+        self.last_error: Optional[str] = None
+
+    @abstractmethod
+    def test_connection(self) -> bool:
+        """Verify the indexer URL is reachable and the API key is valid."""
+        pass
+
+    @abstractmethod
+    def search(
+        self,
+        query: str,
+        categories: Optional[List[str]] = None,
+        limit: int = 100,
+    ) -> List[NZBSearchResult]:
+        """Search the indexer for NZBs matching the query. PR 2 seam."""
+        pass

--- a/models/indexers/base.py
+++ b/models/indexers/base.py
@@ -100,6 +100,11 @@ class BaseIndexer(ABC):
         query: str,
         categories: Optional[List[str]] = None,
         limit: int = 100,
+        indexer_id: int = 0,
     ) -> List[NZBSearchResult]:
-        """Search the indexer for NZBs matching the query. PR 2 seam."""
+        """Search the indexer for NZBs matching the query.
+
+        ``indexer_id`` is stamped onto each result so downstream code can map a
+        chosen result back to its stored indexer row.
+        """
         pass

--- a/models/indexers/newznab_indexer.py
+++ b/models/indexers/newznab_indexer.py
@@ -26,8 +26,9 @@ class NewznabIndexer(BaseIndexer):
     def test_connection(self) -> bool:
         """Verify the indexer URL is reachable and the API key is valid.
 
-        Runs an empty ``t=search`` (which validates the API key); a bad
-        key returns a Newznab ``<error code="100" .../>`` element.
+        Uses ``t=caps`` (the Newznab capabilities call), which requires no
+        query — some indexers reject an empty ``t=search`` with a "Missing
+        parameter" error. A bad API key returns a Newznab ``<error .../>``.
         """
         self.last_error = None
         cfg = self.config
@@ -43,11 +44,9 @@ class NewznabIndexer(BaseIndexer):
             resp = requests.get(
                 url,
                 params={
-                    "t": "search",
-                    "q": "",
+                    "t": "caps",
                     "apikey": cfg.api_key or "",
                     "o": "xml",
-                    "limit": 1,
                 },
                 timeout=_TIMEOUT,
             )
@@ -79,9 +78,123 @@ class NewznabIndexer(BaseIndexer):
         query: str,
         categories: Optional[List[str]] = None,
         limit: int = 100,
+        indexer_id: int = 0,
     ) -> List[NZBSearchResult]:
-        # PR2: GET /api?t=search&q=<query>&apikey=<key>&cat=<categories>&o=xml.
-        # Parse <item> -> <enclosure url=... type="application/x-nzb"/> for
-        # nzb_url and <newznab:attr name="size"> into NZBSearchResult, then
-        # feed titles into the existing GetComics scorer.
-        raise NotImplementedError("search is implemented in PR 2")
+        """Run a Newznab ``t=search`` and parse results into NZBSearchResult."""
+        self.last_error = None
+        cfg = self.config
+        if not cfg or not cfg.url:
+            self.last_error = "Indexer URL is required"
+            return []
+
+        # Default to the Newznab comics category (7030) — CLU only wants comics,
+        # and some indexers reject an uncategorised search.
+        cats = categories or (
+            [c.strip() for c in cfg.categories.split(",") if c.strip()]
+            if cfg.categories else ["7030"]
+        )
+        url = f"{cfg.url.rstrip('/')}/api"
+        params = {
+            "t": "search",
+            "q": query,
+            "apikey": cfg.api_key or "",
+            "o": "xml",
+            "limit": limit,
+        }
+        if cats:
+            params["cat"] = ",".join(cats)
+        try:
+            import requests
+            from defusedxml import ElementTree
+
+            resp = requests.get(url, params=params, timeout=_TIMEOUT)
+            if resp.status_code != 200:
+                self.last_error = f"HTTP {resp.status_code} from {url}"
+                app_logger.warning(
+                    f"Newznab '{cfg.name}': q='{query}' -> {self.last_error}"
+                )
+                return []
+            root = ElementTree.fromstring(resp.content)
+            if root.tag.split("}")[-1].lower() == "error":
+                self.last_error = (
+                    root.get("description") or root.get("code") or "indexer error"
+                )
+                app_logger.warning(
+                    f"Newznab '{cfg.name}': q='{query}' -> error: {self.last_error}"
+                )
+                return []
+            items, results = self._parse_items(root, indexer_id)
+            app_logger.info(
+                f"Newznab '{cfg.name}': q='{query}' -> {items} item(s), "
+                f"{len(results)} usable"
+            )
+            if items and not results:
+                self.last_error = (
+                    f"{items} item(s) returned but none had a usable NZB link"
+                )
+            return results
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"Newznab search failed for '{cfg.name}': {e}")
+            return []
+
+    def _parse_items(self, root, indexer_id: int):
+        """Parse RSS <item> nodes; return (item_count, [NZBSearchResult])."""
+        def _local(tag):
+            return tag.split("}")[-1].lower()
+
+        results = []
+        item_count = 0
+        for item in root.iter():
+            if _local(item.tag) != "item":
+                continue
+            item_count += 1
+            title = None
+            nzb_url = None
+            link = None
+            size = None
+            pubdate = None
+            guid = None
+            for child in item:
+                name = _local(child.tag)
+                if name == "title":
+                    title = (child.text or "").strip()
+                elif name == "pubdate":
+                    pubdate = (child.text or "").strip()
+                elif name == "guid":
+                    guid = (child.text or "").strip()
+                elif name == "link":
+                    link = (child.text or "").strip()
+                elif name == "enclosure":
+                    ctype = child.get("type", "")
+                    if "nzb" in ctype or not nzb_url:
+                        nzb_url = child.get("url")
+                    length = child.get("length")
+                    if length and size is None:
+                        try:
+                            size = int(length)
+                        except ValueError:
+                            pass
+                elif name == "attr":
+                    # <newznab:attr name="size" value="123"/>
+                    if child.get("name") == "size":
+                        try:
+                            size = int(child.get("value"))
+                        except (TypeError, ValueError):
+                            pass
+            # Some Newznab variants omit <enclosure> and put the NZB download
+            # URL in <link> instead — fall back to it so items aren't dropped.
+            if not nzb_url and link:
+                nzb_url = link
+            if title and nzb_url:
+                results.append(NZBSearchResult(
+                    indexer_id=indexer_id,
+                    indexer_name=self.config.name,
+                    title=title,
+                    nzb_url=nzb_url,
+                    size=size,
+                    categories=self.config.categories,
+                    pubdate=pubdate,
+                    guid=guid,
+                ))
+        return item_count, results

--- a/models/indexers/newznab_indexer.py
+++ b/models/indexers/newznab_indexer.py
@@ -1,0 +1,87 @@
+"""
+Newznab Indexer Adapter.
+
+Queries a Newznab-compatible indexer over its HTTP API. PR 1 implements
+``test_connection``; ``search`` is a PR 2 seam.
+
+API reference: https://newznab.readthedocs.io/en/latest/misc/api/
+"""
+from typing import List, Optional
+
+from core.app_logging import app_logger
+from .base import BaseIndexer, IndexerType, NZBSearchResult
+from . import register_indexer
+
+# Short timeout so an unreachable indexer fails fast instead of hanging the UI.
+_TIMEOUT = 15
+
+
+@register_indexer
+class NewznabIndexer(BaseIndexer):
+    """Newznab-compatible indexer."""
+
+    indexer_type = IndexerType.NEWZNAB
+    display_name = "Newznab"
+
+    def test_connection(self) -> bool:
+        """Verify the indexer URL is reachable and the API key is valid.
+
+        Runs an empty ``t=search`` (which validates the API key); a bad
+        key returns a Newznab ``<error code="100" .../>`` element.
+        """
+        self.last_error = None
+        cfg = self.config
+        if not cfg or not cfg.url:
+            self.last_error = "Indexer URL is required"
+            return False
+
+        url = f"{cfg.url.rstrip('/')}/api"
+        try:
+            import requests
+            from defusedxml import ElementTree
+
+            resp = requests.get(
+                url,
+                params={
+                    "t": "search",
+                    "q": "",
+                    "apikey": cfg.api_key or "",
+                    "o": "xml",
+                    "limit": 1,
+                },
+                timeout=_TIMEOUT,
+            )
+            if resp.status_code != 200:
+                self.last_error = f"HTTP {resp.status_code} from {url}"
+                return False
+
+            root = ElementTree.fromstring(resp.content)
+            # A Newznab error response is a top-level <error .../> element.
+            tag = root.tag.split("}")[-1].lower()
+            if tag == "error":
+                desc = root.get("description") or root.get("code") or "indexer error"
+                self.last_error = f"Indexer rejected the request: {desc}"
+                return False
+            return True
+        except requests.exceptions.ConnectionError:
+            self.last_error = f"Could not connect to {url}"
+            return False
+        except requests.exceptions.Timeout:
+            self.last_error = f"Timed out connecting to {url}"
+            return False
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"Newznab connection test failed: {e}")
+            return False
+
+    def search(
+        self,
+        query: str,
+        categories: Optional[List[str]] = None,
+        limit: int = 100,
+    ) -> List[NZBSearchResult]:
+        # PR2: GET /api?t=search&q=<query>&apikey=<key>&cat=<categories>&o=xml.
+        # Parse <item> -> <enclosure url=... type="application/x-nzb"/> for
+        # nzb_url and <newznab:attr name="size"> into NZBSearchResult, then
+        # feed titles into the existing GetComics scorer.
+        raise NotImplementedError("search is implemented in PR 2")

--- a/models/usenet.py
+++ b/models/usenet.py
@@ -1,0 +1,529 @@
+"""
+Usenet download orchestration (PR 2).
+
+Wires the download-client and indexer building blocks into the download
+flow: search enabled indexers for a wanted issue, score results with the
+existing GetComics scorer, submit the winner to the active download
+client, and — once the client reports completion — move the finished
+comic file(s) into the WATCH folder so the existing monitor pipeline
+imports them.
+
+This module never touches ``api.py``. It reads the WATCH path via
+``core.config`` (the same source ``api.py`` uses) and lands files there;
+the folder monitor handles convert/rename/import from that point on.
+"""
+import json
+import os
+import shutil
+import threading
+import time
+import uuid
+
+from core.app_logging import app_logger
+
+# Comic/container extensions we hand off to the WATCH pipeline.
+_COMIC_EXTS = {".cbz", ".cbr", ".cbt", ".pdf", ".zip", ".rar"}
+
+# How often the completion poller checks client history.
+_POLL_INTERVAL = 15
+
+# In-memory tracking of submitted Usenet jobs, keyed by our download_id.
+# Each value: {client_type, client_id, filename, status, error, series, issue}.
+usenet_downloads: dict = {}
+_jobs_lock = threading.Lock()
+_poller_thread = None
+_poller_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def get_source_priority() -> list:
+    """Return the ordered download-source list (default GetComics only).
+
+    Stored as a JSON list under the ``download_source_priority`` preference.
+    """
+    try:
+        from core.database import get_user_preference
+
+        raw = get_user_preference("download_source_priority", default=None)
+        if not raw:
+            return ["getcomics"]
+        value = json.loads(raw) if isinstance(raw, str) else raw
+        if isinstance(value, list) and value:
+            return [str(s) for s in value]
+    except Exception:
+        pass
+    return ["getcomics"]
+
+
+def usenet_enabled_and_configured() -> bool:
+    """True if Usenet is a source AND a client is active AND an indexer is enabled."""
+    if "usenet" not in get_source_priority():
+        return False
+    try:
+        from core.database import get_active_download_client, get_enabled_indexers
+
+        return bool(get_active_download_client()) and bool(get_enabled_indexers())
+    except Exception:
+        return False
+
+
+def usenet_precedes_getcomics() -> bool:
+    """True if 'usenet' ranks before 'getcomics' in the source priority."""
+    order = get_source_priority()
+    un = order.index("usenet") if "usenet" in order else 999
+    gc = order.index("getcomics") if "getcomics" in order else 999
+    return un < gc
+
+
+def _watch_dir() -> str:
+    """Resolve the WATCH staging path the same way api.py does."""
+    try:
+        from core.config import get_watch_dir
+
+        watch = get_watch_dir()
+        if watch:
+            return watch
+    except Exception:
+        pass
+    try:
+        from core.config import config
+
+        return config.get("SETTINGS", "WATCH", fallback="") or ""
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Search + scoring
+# ---------------------------------------------------------------------------
+
+def search_usenet_for_issue(
+    series_name,
+    issue_num,
+    issue_year=None,
+    series_volume=None,
+    series_year=None,
+    publisher_name=None,
+    search_variants=None,
+    series_aliases=None,
+    limit=100,
+):
+    """Search enabled indexers for an issue and score the results.
+
+    Returns a dict with ``chosen`` ((result, score) or None), ``tier``,
+    ``best_accept``, ``best_fallback`` and ``all_results`` (scored dicts),
+    mirroring the GetComics engine's decision shape.
+    """
+    from core.database import get_enabled_indexers
+    from models.getcomics import score_getcomics_result, accept_result
+    from models.indexers import IndexerConfig, IndexerType, get_indexer_impl
+
+    queries = _build_queries(series_name, issue_num)
+
+    raw_results = []
+    errors = []
+    seen = set()
+    for idx in get_enabled_indexers():
+        name = idx.get("name", "")
+        try:
+            cfg = IndexerConfig(
+                name=name,
+                url=idx.get("url", ""),
+                api_key=idx.get("api_key"),
+                categories=idx.get("categories"),
+                enabled=idx.get("enabled", True),
+            )
+            impl = get_indexer_impl(
+                IndexerType(idx.get("indexer_type", "newznab")), cfg
+            )
+            found_any = False
+            for q in queries:
+                found = impl.search(q, limit=limit, indexer_id=idx.get("id", 0))
+                for r in found:
+                    key = r.nzb_url or r.guid or r.title
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    raw_results.append(r)
+                    found_any = True
+            if not found_any and getattr(impl, "last_error", None):
+                errors.append(f"{name}: {impl.last_error}")
+        except Exception as e:
+            app_logger.error(f"Indexer search failed for {name}: {e}")
+            errors.append(f"{name}: {e}")
+
+    app_logger.info(
+        f"Usenet search {series_name} #{issue_num}: tried {queries} -> "
+        f"{len(raw_results)} unique result(s)"
+        + (f"; errors: {errors}" if errors else "")
+    )
+
+    best_accept = None
+    best_fallback = None
+    single_found = False
+    scored = []
+
+    for r in raw_results:
+        score, is_range, series_match = score_getcomics_result(
+            r.title, series_name, issue_num, issue_year,
+            accept_variants=search_variants,
+            series_volume=series_volume,
+            volume_year=series_year,
+            publisher_name=publisher_name,
+            series_aliases=series_aliases,
+        )
+        decision = accept_result(
+            score, is_range, series_match, single_issue_found=single_found
+        )
+        scored.append({
+            "title": r.title,
+            "nzb_url": r.nzb_url,
+            "indexer_id": r.indexer_id,
+            "indexer_name": r.indexer_name,
+            "size": r.size,
+            "score": score,
+            "decision": decision,
+        })
+        if decision == "ACCEPT":
+            if best_accept is None or score > best_accept[1]:
+                best_accept = (r, score)
+            single_found = True
+        elif decision == "FALLBACK" and best_fallback is None:
+            best_fallback = (r, score)
+
+    chosen = best_accept or best_fallback
+    return {
+        "chosen": chosen,
+        "tier": "direct match" if best_accept else ("range fallback" if best_fallback else None),
+        "best_accept": best_accept,
+        "best_fallback": best_fallback,
+        "all_results": scored,
+        "errors": errors,
+    }
+
+
+def _build_queries(series_name, issue_num) -> list:
+    """Build indexer query variants for a series/issue.
+
+    Releases commonly zero-pad the issue number (e.g. "004", "#4"), so we try
+    the raw number plus 2- and 3-digit padded forms. Order matters only for
+    logging; results are de-duplicated by NZB URL.
+    """
+    s = str(issue_num or "").strip()
+    variants = []
+    if s:
+        variants.append(s)
+        if s.isdigit():
+            n = int(s)
+            for width in (2, 3):
+                p = str(n).zfill(width)
+                if p not in variants:
+                    variants.append(p)
+    else:
+        variants.append("")
+    base = series_name.strip()
+    return [f"{base} {v}".strip() for v in variants]
+
+
+# ---------------------------------------------------------------------------
+# Submission + completion tracking
+# ---------------------------------------------------------------------------
+
+def _fetch_nzb(url):
+    """Download an NZB from ``url``; return bytes if it looks like an NZB, else None."""
+    try:
+        import requests
+
+        resp = requests.get(url, timeout=30)
+        if resp.status_code != 200 or not resp.content:
+            app_logger.warning(f"Usenet: NZB fetch HTTP {resp.status_code} for {url}")
+            return None
+        head = resp.content.lstrip()[:256].lower()
+        if b"<?xml" in head or b"<nzb" in head:
+            return resp.content
+        app_logger.warning(
+            f"Usenet: fetched URL did not return an NZB (looks like a page): {url}"
+        )
+        return None
+    except Exception as e:
+        app_logger.error(f"Usenet: NZB fetch failed for {url}: {e}")
+        return None
+
+
+def _make_filename(series_name, issue_num, chosen_result, tier) -> str:
+    """Build the destination filename (range packs keep the release title)."""
+    if tier == "range fallback":
+        raw = chosen_result.title
+    else:
+        raw = f"{series_name} {issue_num}"
+    return raw.replace("/", "-").replace("\\", "-").replace("#", "").strip() + ".cbz"
+
+
+def try_download_for_issue(
+    series_name,
+    issue_num,
+    *,
+    issue_year=None,
+    series_volume=None,
+    series_year=None,
+    publisher_name=None,
+    search_variants=None,
+    series_aliases=None,
+    dry_run=False,
+):
+    """Search Usenet for an issue and (unless dry_run) submit the best match.
+
+    Returns a dict describing the outcome: ``status`` (no_results/no_match/
+    match_found/submitted/submit_failed), ``chosen`` (None or a summary dict),
+    ``all_results`` (scored), and ``download_id`` when submitted.
+    """
+    res = search_usenet_for_issue(
+        series_name, issue_num,
+        issue_year=issue_year,
+        series_volume=series_volume,
+        series_year=series_year,
+        publisher_name=publisher_name,
+        search_variants=search_variants,
+        series_aliases=series_aliases,
+    )
+    out = {
+        "source": "usenet",
+        "chosen": None,
+        "submitted": False,
+        "download_id": None,
+        "all_results": res["all_results"],
+        "status": "no_results" if not res["all_results"] else "no_match",
+    }
+    chosen = res["chosen"]
+    if not chosen:
+        return out
+
+    result, score = chosen
+    filename = _make_filename(series_name, issue_num, result, res["tier"])
+    out["chosen"] = {
+        "title": result.title,
+        "nzb_url": result.nzb_url,
+        "indexer_name": result.indexer_name,
+        "score": score,
+        "tier": res["tier"],
+        "filename": filename,
+    }
+    out["status"] = "match_found"
+    if dry_run:
+        return out
+
+    download_id = grab_nzb(result.nzb_url, filename, series=series_name, issue=issue_num)
+    out["submitted"] = bool(download_id)
+    out["download_id"] = download_id
+    out["status"] = "submitted" if download_id else "submit_failed"
+    return out
+
+
+def grab_nzb(nzb_url, filename, series=None, issue=None):
+    """Submit an NZB URL to the active download client and start tracking.
+
+    Returns the tracking ``download_id`` on success, or None on failure.
+    """
+    from core.database import get_active_download_client
+    from models.download_clients import get_download_client_by_name, DownloadClientConfig
+
+    active = get_active_download_client()
+    if not active:
+        app_logger.warning("Usenet grab requested but no active download client")
+        return None
+
+    client_type = active["client_type"]
+    cfg = active["config"] or {}
+    client = get_download_client_by_name(client_type, DownloadClientConfig.from_dict(cfg))
+
+    # Fetch the NZB ourselves and submit the real content. This is more reliable
+    # than handing the client a URL to fetch (some clients/versions fetch poorly,
+    # and an indexer <link> can be a details page rather than the NZB). Falls back
+    # to the URL if the fetch doesn't yield an NZB.
+    payload = _fetch_nzb(nzb_url) or nzb_url
+
+    result = client.add_nzb(payload, filename)
+    if not result.success:
+        app_logger.error(f"Usenet grab failed ({client_type}): {result.error}")
+        return None
+
+    download_id = str(uuid.uuid4())
+    with _jobs_lock:
+        usenet_downloads[download_id] = {
+            "client_type": client_type,
+            "client_id": result.client_id,
+            "filename": filename,
+            "status": "downloading",
+            "error": None,
+            "series": series,
+            "issue": issue,
+        }
+    app_logger.info(
+        f"Submitted NZB to {client_type} for {filename} (client_id={result.client_id})"
+    )
+    _ensure_poller()
+    return download_id
+
+
+def get_usenet_downloads() -> list:
+    """Return a snapshot of tracked Usenet downloads (for status display)."""
+    with _jobs_lock:
+        return [dict(download_id=k, **v) for k, v in usenet_downloads.items()]
+
+
+def _ensure_poller():
+    """Start the completion poller thread if it isn't already running."""
+    global _poller_thread
+    with _poller_lock:
+        if _poller_thread is not None and _poller_thread.is_alive():
+            return
+        _poller_thread = threading.Thread(
+            target=_poll_loop, name="usenet-poller", daemon=True
+        )
+        _poller_thread.start()
+
+
+def _pending_jobs():
+    with _jobs_lock:
+        return {k: dict(v) for k, v in usenet_downloads.items()
+                if v["status"] == "downloading"}
+
+
+def _poll_loop():
+    """Poll the active client's history until all jobs reach a terminal state."""
+    idle_rounds = 0
+    while True:
+        pending = _pending_jobs()
+        if not pending:
+            idle_rounds += 1
+            if idle_rounds >= 2:
+                return
+            time.sleep(_POLL_INTERVAL)
+            continue
+        idle_rounds = 0
+
+        # Group pending jobs by client type; fetch each client's history once.
+        histories = {}
+        for job in pending.values():
+            ct = job["client_type"]
+            if ct not in histories:
+                histories[ct] = _history_for(ct)
+
+        for download_id, job in pending.items():
+            hist = histories.get(job["client_type"]) or {}
+            status = hist.get(str(job["client_id"]))
+            if status is None:
+                continue  # still downloading / not yet in history
+            if status.status == "complete":
+                imported = _import_completed(status.storage_path, job["filename"])
+                _set_status(download_id, "complete" if imported else "complete_no_move")
+            elif status.status == "failed":
+                _set_status(download_id, "failed", error="Download failed at client")
+
+        time.sleep(_POLL_INTERVAL)
+
+
+def _history_for(client_type):
+    """Return {client_id: DownloadStatus} for a client type, or {} on error."""
+    try:
+        from core.database import get_download_client_config
+        from models.download_clients import (
+            get_download_client_by_name, DownloadClientConfig,
+        )
+
+        cfg = get_download_client_config(client_type)
+        if not cfg:
+            return {}
+        client = get_download_client_by_name(
+            client_type, DownloadClientConfig.from_dict(cfg)
+        )
+        return {h.client_id: h for h in client.get_history()}
+    except Exception as e:
+        app_logger.error(f"Usenet history fetch failed for {client_type}: {e}")
+        return {}
+
+
+def _set_status(download_id, status, error=None):
+    with _jobs_lock:
+        if download_id in usenet_downloads:
+            usenet_downloads[download_id]["status"] = status
+            usenet_downloads[download_id]["error"] = error
+
+
+def _import_completed(storage_path, filename) -> bool:
+    """Move completed comic file(s) from the client's storage into WATCH.
+
+    Returns True if the file(s) are (or already are) in the pipeline. Returns
+    False when the completed path is not accessible to CLU — in that case the
+    client must be configured to complete directly into a monitored folder.
+    """
+    watch = _watch_dir()
+    if not watch or not os.path.isdir(watch):
+        app_logger.error("Usenet import: WATCH folder is not configured/accessible")
+        return False
+    if not storage_path:
+        app_logger.warning(
+            f"Usenet import: no storage path for {filename}; relying on the client's "
+            f"completed folder being a monitored path"
+        )
+        return False
+
+    watch_abs = os.path.abspath(watch)
+    src_abs = os.path.abspath(storage_path)
+
+    if not os.path.exists(src_abs):
+        app_logger.warning(
+            f"Usenet import: completed path {storage_path} is not accessible from CLU "
+            f"(is it on a shared volume?) — relying on the monitored folder"
+        )
+        return False
+
+    # Already inside WATCH -> the folder monitor will pick it up.
+    if src_abs == watch_abs or src_abs.startswith(watch_abs + os.sep):
+        return True
+
+    moved = 0
+    if os.path.isfile(src_abs):
+        if os.path.splitext(src_abs)[1].lower() in _COMIC_EXTS:
+            moved += _move_into_watch(src_abs, watch)
+    else:
+        for root, _dirs, files in os.walk(src_abs):
+            for f in files:
+                if os.path.splitext(f)[1].lower() in _COMIC_EXTS:
+                    moved += _move_into_watch(os.path.join(root, f), watch)
+
+    if moved:
+        app_logger.info(f"Usenet import: moved {moved} file(s) into WATCH for {filename}")
+        return True
+    app_logger.warning(f"Usenet import: no comic files found under {storage_path}")
+    return False
+
+
+def _move_into_watch(src_file, watch) -> int:
+    """Move a single file into WATCH with a unique name; return 1/0."""
+    try:
+        dest = _unique_path(os.path.join(watch, os.path.basename(src_file)))
+        shutil.move(src_file, dest)
+        try:
+            from helpers import match_parent_permissions
+            match_parent_permissions(dest)
+        except Exception:
+            pass
+        return 1
+    except Exception as e:
+        app_logger.error(f"Usenet import: failed to move {src_file}: {e}")
+        return 0
+
+
+def _unique_path(path) -> str:
+    """Return ``path`` or a ' (n)'-suffixed variant that does not exist."""
+    if not os.path.exists(path):
+        return path
+    base, ext = os.path.splitext(path)
+    n = 1
+    while os.path.exists(f"{base} ({n}){ext}"):
+        n += 1
+    return f"{base} ({n}){ext}"

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -209,9 +209,11 @@ def create_indexer():
         if not name or not url:
             return jsonify({"error": "name and url are required"}), 400
 
+        # Default to the Newznab comics category (7030) since CLU only wants
+        # books/comics — narrows results and avoids indexers that require a cat.
         config = {
             "api_key": data.get('api_key'),
-            "categories": data.get('categories'),
+            "categories": (data.get('categories') or '').strip() or '7030',
         }
         new_id = add_indexer(
             name=name,
@@ -349,4 +351,93 @@ def test_indexer(indexer_id):
         return jsonify({"success": True, "valid": False, "error": reason})
     except Exception as e:
         app_logger.error(f"Error testing indexer: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+# =============================================================================
+# Usenet download status
+# =============================================================================
+
+@download_clients_bp.route('/api/usenet/downloads', methods=['GET'])
+def list_usenet_downloads():
+    """List in-memory Usenet downloads and their current status."""
+    try:
+        from models.usenet import get_usenet_downloads
+
+        return jsonify({"success": True, "downloads": get_usenet_downloads()})
+    except Exception as e:
+        app_logger.error(f"Error listing usenet downloads: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/usenet/search', methods=['POST'])
+def usenet_search():
+    """Manual Usenet search for a series/issue across enabled indexers.
+
+    Returns every scored result (not just accepted ones) so the user can pick,
+    sorted best-first, plus whether Usenet is configured/prioritized.
+    """
+    try:
+        from core.database import get_active_download_client, get_enabled_indexers
+        from models.usenet import (
+            search_usenet_for_issue,
+            usenet_precedes_getcomics,
+        )
+
+        data = request.get_json() or {}
+        series = (data.get('series') or '').strip()
+        issue = str(data.get('issue') or '').strip()
+        if not series:
+            return jsonify({"error": "series is required"}), 400
+
+        # Searching only needs indexers; an active client is needed only to grab.
+        has_indexers = bool(get_enabled_indexers())
+        has_client = bool(get_active_download_client())
+
+        results = []
+        errors = []
+        if has_indexers:
+            res = search_usenet_for_issue(
+                series, issue,
+                issue_year=data.get('issue_year'),
+                series_volume=data.get('series_volume'),
+            )
+            results = sorted(res.get("all_results", []),
+                             key=lambda r: r.get("score", 0), reverse=True)
+            errors = res.get("errors", [])
+        return jsonify({
+            "success": True,
+            "results": results,
+            "errors": errors,
+            "has_indexers": has_indexers,
+            "has_client": has_client,
+            "usenet_first": usenet_precedes_getcomics(),
+        })
+    except Exception as e:
+        app_logger.error(f"Error searching usenet: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/usenet/grab', methods=['POST'])
+def usenet_grab():
+    """Submit a chosen NZB URL to the active download client."""
+    try:
+        from models.usenet import grab_nzb
+
+        data = request.get_json() or {}
+        nzb_url = data.get('nzb_url')
+        filename = data.get('filename')
+        if not nzb_url or not filename:
+            return jsonify({"error": "nzb_url and filename are required"}), 400
+
+        download_id = grab_nzb(
+            nzb_url, filename,
+            series=data.get('series'), issue=data.get('issue'),
+        )
+        if download_id:
+            return jsonify({"success": True, "download_id": download_id})
+        return jsonify({"success": False,
+                        "error": "No active download client, or the client rejected the NZB"}), 502
+    except Exception as e:
+        app_logger.error(f"Error grabbing NZB: {e}")
         return jsonify({"error": str(e)}), 500

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -1,0 +1,352 @@
+"""
+Download Clients Blueprint.
+
+Provides routes for configuring Usenet download clients (SABnzbd, NZBGet)
+and Newznab indexers, plus connection testing. Mirrors the metadata
+provider routes in routes/metadata.py.
+
+Model and database imports are performed lazily inside each function so the
+blueprint imports cheaply and tests can patch dependencies.
+"""
+from flask import Blueprint, jsonify, request
+
+from core.app_logging import app_logger
+
+download_clients_bp = Blueprint('download_clients', __name__)
+
+
+# =============================================================================
+# Download Clients
+# =============================================================================
+
+@download_clients_bp.route('/api/download-clients', methods=['GET'])
+def list_download_clients():
+    """List available download clients merged with their configured status."""
+    try:
+        from models.download_clients import get_available_download_clients
+        from core.database import (
+            get_all_download_clients_status,
+            get_download_client_config_masked,
+        )
+
+        clients = get_available_download_clients()
+        status_by_type = {s['client_type']: s for s in get_all_download_clients_status()}
+
+        for c in clients:
+            status = status_by_type.get(c['type'], {})
+            c['has_config'] = c['type'] in status_by_type
+            c['is_active'] = status.get('is_active', 0) == 1
+            c['is_valid'] = status.get('is_valid', 0) == 1
+            c['last_tested'] = status.get('last_tested')
+            c['config_masked'] = (
+                get_download_client_config_masked(c['type']) if c['has_config'] else None
+            )
+
+        return jsonify({"success": True, "clients": clients})
+    except Exception as e:
+        app_logger.error(f"Error listing download clients: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+def _validate_client_type(client_type):
+    """Return True if client_type is a known ClientType, else False."""
+    from models.download_clients import ClientType
+    try:
+        ClientType(client_type)
+        return True
+    except ValueError:
+        return False
+
+
+@download_clients_bp.route('/api/download-clients/<client_type>/config', methods=['GET'])
+def get_download_client_config_route(client_type):
+    """Get masked config for a download client (safe for display)."""
+    try:
+        from core.database import get_download_client_config_masked
+
+        if not _validate_client_type(client_type):
+            return jsonify({"error": f"Unknown client type: {client_type}"}), 400
+
+        masked = get_download_client_config_masked(client_type)
+        if not masked:
+            return jsonify({"success": True, "has_config": False, "config": {}})
+        return jsonify({"success": True, "has_config": True, "config": masked})
+    except Exception as e:
+        app_logger.error(f"Error getting download client config: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/download-clients/<client_type>/config', methods=['POST'])
+def save_download_client_config_route(client_type):
+    """Save config for a download client."""
+    try:
+        from core.database import save_download_client_config
+
+        if not _validate_client_type(client_type):
+            return jsonify({"error": f"Unknown client type: {client_type}"}), 400
+
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No config provided"}), 400
+
+        success = save_download_client_config(client_type, data)
+        if success:
+            return jsonify({"success": True, "message": f"Config saved for {client_type}"})
+        return jsonify({"error": "Failed to save config"}), 500
+    except Exception as e:
+        app_logger.error(f"Error saving download client config: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/download-clients/<client_type>/config', methods=['DELETE'])
+def delete_download_client_config_route(client_type):
+    """Delete a download client's config."""
+    try:
+        from core.database import delete_download_client_config
+
+        if not _validate_client_type(client_type):
+            return jsonify({"error": f"Unknown client type: {client_type}"}), 400
+
+        success = delete_download_client_config(client_type)
+        if success:
+            return jsonify({"success": True, "message": f"Config deleted for {client_type}"})
+        return jsonify({"error": "Failed to delete config"}), 500
+    except Exception as e:
+        app_logger.error(f"Error deleting download client config: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/download-clients/<client_type>/test', methods=['POST'])
+def test_download_client(client_type):
+    """Test connection to a download client using saved config."""
+    try:
+        from core.database import (
+            get_download_client_config,
+            update_download_client_validity,
+        )
+        from models.download_clients import (
+            get_download_client_by_name,
+            DownloadClientConfig,
+        )
+
+        if not _validate_client_type(client_type):
+            return jsonify({"error": f"Unknown client type: {client_type}"}), 400
+
+        config_dict = get_download_client_config(client_type)
+        if not config_dict:
+            return jsonify({"success": False, "error": "No config configured"}), 400
+
+        client = get_download_client_by_name(
+            client_type, DownloadClientConfig.from_dict(config_dict)
+        )
+        is_valid = client.test_connection()
+        update_download_client_validity(client_type, is_valid)
+
+        if is_valid:
+            return jsonify({"success": True, "valid": True,
+                            "message": f"Connection to {client_type} successful"})
+        reason = getattr(client, "last_error", None) or f"Connection to {client_type} failed"
+        return jsonify({"success": True, "valid": False, "error": reason})
+    except Exception as e:
+        app_logger.error(f"Error testing download client: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/download-clients/<client_type>/activate', methods=['POST'])
+def activate_download_client(client_type):
+    """Mark a download client as the single active client."""
+    try:
+        from core.database import (
+            get_download_client_config,
+            set_active_download_client,
+        )
+
+        if not _validate_client_type(client_type):
+            return jsonify({"error": f"Unknown client type: {client_type}"}), 400
+
+        if not get_download_client_config(client_type):
+            return jsonify({"error": "Client is not configured"}), 400
+
+        success = set_active_download_client(client_type)
+        if success:
+            return jsonify({"success": True, "active": client_type})
+        return jsonify({"error": "Failed to activate client"}), 500
+    except Exception as e:
+        app_logger.error(f"Error activating download client: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+# =============================================================================
+# Indexers
+# =============================================================================
+
+@download_clients_bp.route('/api/indexers', methods=['GET'])
+def list_indexers():
+    """List all configured indexers (masked) and available indexer types."""
+    try:
+        from core.database import get_all_indexers
+        from models.indexers import get_available_indexer_types
+
+        return jsonify({
+            "success": True,
+            "indexers": get_all_indexers(),
+            "types": get_available_indexer_types(),
+        })
+    except Exception as e:
+        app_logger.error(f"Error listing indexers: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/indexers', methods=['POST'])
+def create_indexer():
+    """Add a new indexer."""
+    try:
+        from core.database import add_indexer
+
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        url = (data.get('url') or '').strip()
+        if not name or not url:
+            return jsonify({"error": "name and url are required"}), 400
+
+        config = {
+            "api_key": data.get('api_key'),
+            "categories": data.get('categories'),
+        }
+        new_id = add_indexer(
+            name=name,
+            url=url,
+            config=config,
+            priority=data.get('priority', 0),
+            enabled=data.get('enabled', True),
+            indexer_type=data.get('indexer_type', 'newznab'),
+        )
+        if new_id is None:
+            return jsonify({"error": "Failed to add indexer"}), 500
+        return jsonify({"success": True, "id": new_id})
+    except Exception as e:
+        app_logger.error(f"Error creating indexer: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/indexers/<int:indexer_id>', methods=['GET'])
+def get_indexer_route(indexer_id):
+    """Get a single indexer (masked)."""
+    try:
+        from core.database import get_indexer_masked
+
+        indexer = get_indexer_masked(indexer_id)
+        if not indexer:
+            return jsonify({"error": "Indexer not found"}), 404
+        return jsonify({"success": True, "indexer": indexer})
+    except Exception as e:
+        app_logger.error(f"Error getting indexer: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/indexers/<int:indexer_id>', methods=['PUT'])
+def update_indexer_route(indexer_id):
+    """Update an indexer (partial). Only re-encrypts secrets if provided."""
+    try:
+        from core.database import get_indexer, update_indexer
+
+        if not get_indexer(indexer_id):
+            return jsonify({"error": "Indexer not found"}), 404
+
+        data = request.get_json() or {}
+        # Build the encrypted config only if a secret field is present so that
+        # a metadata-only edit doesn't wipe the stored api_key.
+        config = None
+        if 'api_key' in data or 'categories' in data:
+            existing = get_indexer(indexer_id) or {}
+            config = {
+                "api_key": data.get('api_key', existing.get('api_key')),
+                "categories": data.get('categories', existing.get('categories')),
+            }
+
+        success = update_indexer(
+            indexer_id,
+            name=data.get('name'),
+            url=data.get('url'),
+            config=config,
+            priority=data.get('priority'),
+            enabled=data.get('enabled'),
+        )
+        if success:
+            return jsonify({"success": True})
+        return jsonify({"error": "Failed to update indexer"}), 500
+    except Exception as e:
+        app_logger.error(f"Error updating indexer: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/indexers/<int:indexer_id>', methods=['DELETE'])
+def delete_indexer_route(indexer_id):
+    """Delete an indexer."""
+    try:
+        from core.database import delete_indexer, get_indexer
+
+        if not get_indexer(indexer_id):
+            return jsonify({"error": "Indexer not found"}), 404
+
+        success = delete_indexer(indexer_id)
+        if success:
+            return jsonify({"success": True})
+        return jsonify({"error": "Failed to delete indexer"}), 500
+    except Exception as e:
+        app_logger.error(f"Error deleting indexer: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/indexers/reorder', methods=['POST'])
+def reorder_indexers():
+    """Reorder indexers by a list of ids (index 0 = highest priority)."""
+    try:
+        from core.database import set_indexer_order
+
+        data = request.get_json() or {}
+        order = data.get('order')
+        if not isinstance(order, list):
+            return jsonify({"error": "Missing 'order' list"}), 400
+
+        success = set_indexer_order(order)
+        if success:
+            return jsonify({"success": True})
+        return jsonify({"error": "Failed to reorder indexers"}), 500
+    except Exception as e:
+        app_logger.error(f"Error reordering indexers: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/indexers/<int:indexer_id>/test', methods=['POST'])
+def test_indexer(indexer_id):
+    """Test connection to an indexer using saved config."""
+    try:
+        from core.database import get_indexer, update_indexer_validity
+        from models.indexers import get_indexer_impl, IndexerConfig, IndexerType
+
+        indexer = get_indexer(indexer_id)
+        if not indexer:
+            return jsonify({"error": "Indexer not found"}), 404
+
+        config = IndexerConfig(
+            name=indexer.get('name', ''),
+            url=indexer.get('url', ''),
+            api_key=indexer.get('api_key'),
+            categories=indexer.get('categories'),
+            enabled=indexer.get('enabled', True),
+        )
+        impl = get_indexer_impl(
+            IndexerType(indexer.get('indexer_type', 'newznab')), config
+        )
+        is_valid = impl.test_connection()
+        update_indexer_validity(indexer_id, is_valid)
+
+        if is_valid:
+            return jsonify({"success": True, "valid": True,
+                            "message": f"Connection to {config.name} successful"})
+        reason = getattr(impl, "last_error", None) or f"Connection to {config.name} failed"
+        return jsonify({"success": True, "valid": False, "error": reason})
+    except Exception as e:
+        app_logger.error(f"Error testing indexer: {e}")
+        return jsonify({"error": str(e)}), 500

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -173,6 +173,11 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
 
     mapped_series = get_all_mapped_series()
 
+    # Usenet source wiring (mirrors scheduled_getcomics_download).
+    from models import usenet as usenet_mod
+    _usenet_on = usenet_mod.usenet_enabled_and_configured()
+    _usenet_first = _usenet_on and usenet_mod.usenet_precedes_getcomics()
+
     # If target_series_id is set, filter to just that series
     if target_series_id:
         mapped_series = [s for s in mapped_series if s["id"] == target_series_id]
@@ -228,6 +233,27 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
             if issue_year:
                 ctx_parts.append(str(issue_year))
             search_context = "[" + ", ".join(ctx_parts) + "]"
+
+            # Usenet first (simulation): mirror the auto-download preference —
+            # if Usenet precedes GetComics and finds a match, show it and skip
+            # the GetComics search for this issue.
+            if _usenet_on and _usenet_first:
+                u = usenet_mod.try_download_for_issue(
+                    series_name, issue_num,
+                    issue_year=issue_year, series_volume=series_volume,
+                    series_year=series_year, publisher_name=publisher_name,
+                    search_variants=search_variants, series_aliases=series_aliases,
+                    dry_run=True,
+                )
+                if u.get("status") == "match_found":
+                    simulation_results.append({
+                        "series": series_name, "issue": issue_num, "issue_year": issue_year,
+                        "series_volume": series_volume, "search_context": search_context,
+                        "source": "usenet",
+                        "best_accept": u.get("chosen"), "best_fallback": None,
+                        "all_results": u.get("all_results", []), "status": "match_found",
+                    })
+                    continue
 
             results = search_getcomics_for_issue(
                 series_name=series_name,

--- a/templates/config.html
+++ b/templates/config.html
@@ -50,6 +50,11 @@
                     Providers</button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="download-clients-tab" data-bs-toggle="tab"
+                    data-bs-target="#download-clients" type="button" role="tab" aria-controls="download-clients"
+                    aria-selected="false">Download Clients</button>
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="system-perf-tab" data-bs-toggle="tab" data-bs-target="#system-perf"
                     type="button" role="tab" aria-controls="system-perf" aria-selected="false">System and
                     Performance</button>
@@ -1055,6 +1060,111 @@
                                 <span class="visually-hidden">Loading...</span>
                             </div>
                             <span class="ms-2">Loading library settings...</span>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- ========================================== -->
+            <!-- TAB: Download Clients (Usenet) -->
+            <!-- ========================================== -->
+            <div class="tab-pane fade" id="download-clients" role="tabpanel" aria-labelledby="download-clients-tab">
+
+                <!-- Download Clients -->
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <h4>Download Clients</h4>
+                    <p class="text-muted">Configure a Usenet download client (SABnzbd or NZBGet). Credentials are
+                        stored encrypted. Mark one client as active — completed downloads are handed to your library.</p>
+
+                    <div id="downloadClientsList" class="mb-3">
+                        <div class="text-center py-3">
+                            <div class="spinner-border spinner-border-sm" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                            <span class="ms-2">Loading download clients...</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Indexers -->
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h4 class="mb-0">Indexers</h4>
+                        <button type="button" class="btn btn-primary btn-sm" onclick="openIndexerModal()">
+                            <i class="bi bi-plus-lg me-1"></i>Add Indexer
+                        </button>
+                    </div>
+                    <p class="text-muted">Add one or more Newznab-compatible indexers. Drag priority with the arrows —
+                        higher indexers are searched first. API keys are stored encrypted.</p>
+
+                    <div id="indexersList" class="mb-3">
+                        <div class="text-center py-3">
+                            <div class="spinner-border spinner-border-sm" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                            <span class="ms-2">Loading indexers...</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Source Priority -->
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <h4>Source Priority</h4>
+                    <p class="text-muted">Order in which download sources are tried when searching for issues.
+                        Used by the auto-download engine.</p>
+
+                    <div id="sourcePriorityList" class="mb-3">
+                        <div class="text-center py-3">
+                            <div class="spinner-border spinner-border-sm" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                            <span class="ms-2">Loading source priority...</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Indexer Add/Edit Modal -->
+                <div class="modal fade" id="indexerModal" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="indexerModalTitle">Add Indexer</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <input type="hidden" id="indexerId">
+                                <div class="mb-2">
+                                    <label for="indexerName" class="form-label small">Name</label>
+                                    <input type="text" class="form-control form-control-sm" id="indexerName"
+                                        placeholder="e.g. NZBgeek">
+                                </div>
+                                <div class="mb-2">
+                                    <label for="indexerUrl" class="form-label small">URL</label>
+                                    <input type="text" class="form-control form-control-sm" id="indexerUrl"
+                                        placeholder="https://api.nzbgeek.info">
+                                </div>
+                                <div class="mb-2">
+                                    <label for="indexerApiKey" class="form-label small">API Key</label>
+                                    <input type="password" class="form-control form-control-sm" id="indexerApiKey"
+                                        placeholder="Enter API key" autocomplete="off">
+                                </div>
+                                <div class="mb-2">
+                                    <label for="indexerCategories" class="form-label small">Categories (optional)</label>
+                                    <input type="text" class="form-control form-control-sm" id="indexerCategories"
+                                        placeholder="e.g. 7000,7030">
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="indexerEnabled" checked>
+                                    <label class="form-check-label small" for="indexerEnabled">Enabled</label>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-primary btn-sm" onclick="saveIndexer()">
+                                    <i class="bi bi-floppy me-1"></i>Save
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -2961,6 +3071,9 @@
         loadLibraries();
         loadProviders();
         loadLibraryProviders();
+        loadDownloadClients();
+        loadIndexers();
+        loadSourcePriority();
     });
 
     async function loadLibraries() {
@@ -3623,6 +3736,461 @@
             }
         } catch (e) {
             showToast('Error deleting credentials: ' + e.message, 'error');
+        }
+    }
+
+    // =====================================================================
+    // Download Clients (Usenet) — registry-driven, mirrors the provider tab
+    // =====================================================================
+
+    function generateClientFields(client) {
+        let html = '';
+        for (const field of client.config_fields) {
+            const fieldId = `client-${client.type}-${field}`;
+            const fieldLabel = field.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            const masked = client.config_masked && client.config_masked[field] != null
+                ? client.config_masked[field] : '';
+
+            if (field === 'use_ssl') {
+                const checked = client.config_masked && client.config_masked.use_ssl ? 'checked' : '';
+                html += `
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" id="${fieldId}" name="${field}" ${checked}>
+                        <label class="form-check-label small" for="${fieldId}">Use SSL</label>
+                    </div>`;
+                continue;
+            }
+
+            const isPassword = field.toLowerCase().includes('password')
+                || field.toLowerCase().includes('key') || field.toLowerCase().includes('api');
+            const inputType = isPassword ? 'password' : (field === 'port' || field === 'priority' ? 'number' : 'text');
+            html += `
+                <div class="mb-2">
+                    <label for="${fieldId}" class="form-label small">${fieldLabel}</label>
+                    <div class="input-group input-group-sm">
+                        <input type="${inputType}" class="form-control ${isPassword ? 'password-field' : ''}"
+                               id="${fieldId}" name="${field}" placeholder="${masked || 'Enter ' + fieldLabel.toLowerCase()}"
+                               ${client.has_config ? 'data-has-existing="true"' : ''} autocomplete="off">
+                        ${isPassword ? `
+                        <button class="btn btn-outline-secondary toggle-password" type="button" data-target="${fieldId}">
+                            <i class="bi bi-eye"></i>
+                        </button>` : ''}
+                    </div>
+                </div>`;
+        }
+        return html;
+    }
+
+    async function loadDownloadClients() {
+        const container = document.getElementById('downloadClientsList');
+        if (!container) return;
+        try {
+            const response = await fetch('/api/download-clients');
+            const data = await readJsonResponse(response);
+            if (!data.success) {
+                container.innerHTML = '<div class="alert alert-danger">Failed to load download clients</div>';
+                return;
+            }
+            if (!data.clients.length) {
+                container.innerHTML = '<div class="alert alert-warning">No download clients available</div>';
+                return;
+            }
+
+            let html = '<div class="row">';
+            for (const client of data.clients) {
+                let statusBadge;
+                if (client.is_active) {
+                    statusBadge = '<span class="badge bg-success"><i class="bi bi-broadcast me-1"></i>Active</span>';
+                } else if (client.is_valid) {
+                    statusBadge = '<span class="badge bg-info"><i class="bi bi-check-circle me-1"></i>Connected</span>';
+                } else if (client.has_config) {
+                    statusBadge = '<span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>Not Verified</span>';
+                } else {
+                    statusBadge = '<span class="badge bg-secondary"><i class="bi bi-x-circle me-1"></i>Not Configured</span>';
+                }
+                const lastTested = client.last_tested
+                    ? `<small class="text-muted">Last tested: ${new Date(client.last_tested).toLocaleString()}</small>` : '';
+
+                html += `
+                <div class="col-md-6 mb-3">
+                    <div class="card h-100">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <strong>${escapeHtml(client.name)}</strong>
+                            ${statusBadge}
+                        </div>
+                        <div class="card-body">
+                            <form id="client-form-${client.type}" onsubmit="saveDownloadClientConfig('${client.type}', event); return false;">
+                                ${generateClientFields(client)}
+                                <div class="mt-3 d-flex gap-2 flex-wrap">
+                                    <button type="submit" class="btn btn-primary btn-sm">
+                                        <i class="bi bi-floppy me-1"></i>Save
+                                    </button>
+                                    <button type="button" class="btn btn-outline-info btn-sm" onclick="testDownloadClientConnection('${client.type}')">
+                                        <i class="bi bi-lightning me-1"></i>Test
+                                    </button>
+                                    ${client.has_config && !client.is_active ? `
+                                    <button type="button" class="btn btn-outline-success btn-sm" onclick="activateDownloadClient('${client.type}')">
+                                        <i class="bi bi-broadcast me-1"></i>Set Active
+                                    </button>` : ''}
+                                    ${client.has_config ? `
+                                    <button type="button" class="btn btn-outline-danger btn-sm" onclick="deleteDownloadClientConfig('${client.type}')">
+                                        <i class="bi bi-trash me-1"></i>Delete
+                                    </button>` : ''}
+                                </div>
+                            </form>
+                            ${lastTested}
+                        </div>
+                    </div>
+                </div>`;
+            }
+            html += '</div>';
+            container.innerHTML = html;
+            initPasswordToggles(container);
+        } catch (e) {
+            container.innerHTML = '<div class="alert alert-danger">Error loading download clients: ' + escapeHtml(e.message) + '</div>';
+        }
+    }
+
+    async function saveDownloadClientConfig(clientType, event) {
+        if (event) { event.preventDefault(); event.stopPropagation(); }
+        const form = document.getElementById(`client-form-${clientType}`);
+        const submitBtn = form.querySelector('button[type="submit"]');
+        const originalBtnHtml = submitBtn.innerHTML;
+        submitBtn.disabled = true;
+        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
+
+        const config = {};
+        form.querySelectorAll('input').forEach(input => {
+            if (input.type === 'checkbox') {
+                config[input.name] = input.checked;
+            } else if (input.value.trim()) {
+                const v = input.value.trim();
+                config[input.name] = (input.type === 'number') ? Number(v) : v;
+            }
+        });
+
+        try {
+            const response = await fetch(`/api/download-clients/${clientType}/config`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(config)
+            });
+            const data = await readJsonResponse(response);
+            if (data.success) {
+                showToast(`Config saved for ${clientType}`, 'success');
+                loadDownloadClients();
+            } else {
+                showToast('Error: ' + (data.error || 'Failed to save config'), 'error');
+            }
+        } catch (e) {
+            showToast('Error saving config: ' + e.message, 'error');
+        } finally {
+            submitBtn.disabled = false;
+            submitBtn.innerHTML = originalBtnHtml;
+        }
+        return false;
+    }
+
+    async function testDownloadClientConnection(clientType) {
+        const btn = event.target.closest('button');
+        const originalHtml = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Testing...';
+        try {
+            const response = await fetch(`/api/download-clients/${clientType}/test`, { method: 'POST' });
+            const data = await readJsonResponse(response);
+            if (data.success && data.valid) {
+                showToast(`Connection to ${clientType} successful!`, 'success');
+                setTimeout(loadDownloadClients, 1200);
+            } else {
+                btn.innerHTML = originalHtml;
+                btn.disabled = false;
+                showToast('Connection test failed: ' + (data.error || 'Unknown error'), 'error');
+            }
+        } catch (e) {
+            btn.innerHTML = originalHtml;
+            btn.disabled = false;
+            showToast('Error testing connection: ' + e.message, 'error');
+        }
+    }
+
+    async function activateDownloadClient(clientType) {
+        try {
+            const response = await fetch(`/api/download-clients/${clientType}/activate`, { method: 'POST' });
+            const data = await readJsonResponse(response);
+            if (data.success) {
+                showToast(`${clientType} is now the active client`, 'success');
+                loadDownloadClients();
+            } else {
+                showToast('Error: ' + (data.error || 'Failed to activate client'), 'error');
+            }
+        } catch (e) {
+            showToast('Error activating client: ' + e.message, 'error');
+        }
+    }
+
+    async function deleteDownloadClientConfig(clientType) {
+        if (!confirm('Delete the configuration for this download client?')) return;
+        try {
+            const response = await fetch(`/api/download-clients/${clientType}/config`, { method: 'DELETE' });
+            const data = await readJsonResponse(response);
+            if (data.success) {
+                showToast(`Config deleted for ${clientType}`, 'success');
+                loadDownloadClients();
+            } else {
+                showToast('Error: ' + (data.error || 'Failed to delete config'), 'error');
+            }
+        } catch (e) {
+            showToast('Error deleting config: ' + e.message, 'error');
+        }
+    }
+
+    // =====================================================================
+    // Indexers
+    // =====================================================================
+
+    let indexerModal = null;
+
+    function openIndexerModal(indexer) {
+        if (!indexerModal) {
+            indexerModal = new bootstrap.Modal(document.getElementById('indexerModal'));
+        }
+        document.getElementById('indexerModalTitle').textContent = indexer ? 'Edit Indexer' : 'Add Indexer';
+        document.getElementById('indexerId').value = indexer ? indexer.id : '';
+        document.getElementById('indexerName').value = indexer ? (indexer.name || '') : '';
+        document.getElementById('indexerUrl').value = indexer ? (indexer.url || '') : '';
+        document.getElementById('indexerApiKey').value = '';
+        document.getElementById('indexerApiKey').placeholder =
+            indexer && indexer.api_key ? indexer.api_key : 'Enter API key';
+        document.getElementById('indexerCategories').value = indexer && indexer.categories ? indexer.categories : '';
+        document.getElementById('indexerEnabled').checked = indexer ? !!indexer.enabled : true;
+        indexerModal.show();
+    }
+
+    async function loadIndexers() {
+        const container = document.getElementById('indexersList');
+        if (!container) return;
+        try {
+            const response = await fetch('/api/indexers');
+            const data = await readJsonResponse(response);
+            if (!data.success) {
+                container.innerHTML = '<div class="alert alert-danger">Failed to load indexers</div>';
+                return;
+            }
+            if (!data.indexers.length) {
+                container.innerHTML = '<div class="alert alert-info">No indexers configured yet. Click "Add Indexer" to get started.</div>';
+                return;
+            }
+
+            window._indexerCache = {};
+            let html = '<div class="list-group">';
+            data.indexers.forEach((idx, i) => {
+                window._indexerCache[idx.id] = idx;
+                const statusBadge = idx.is_valid
+                    ? '<span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Connected</span>'
+                    : '<span class="badge bg-secondary">Not Verified</span>';
+                const enabledBadge = idx.enabled
+                    ? '<span class="badge bg-info ms-1">Enabled</span>'
+                    : '<span class="badge bg-secondary ms-1">Disabled</span>';
+                html += `
+                    <div class="list-group-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div>
+                                <strong>${escapeHtml(idx.name)}</strong> ${statusBadge} ${enabledBadge}
+                                <br><small class="text-muted">${escapeHtml(idx.url)}</small>
+                            </div>
+                            <div class="btn-group btn-group-sm">
+                                <button type="button" class="btn btn-outline-secondary" title="Move up"
+                                    onclick="moveIndexer(${idx.id}, -1)" ${i === 0 ? 'disabled' : ''}>
+                                    <i class="bi bi-arrow-up"></i>
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" title="Move down"
+                                    onclick="moveIndexer(${idx.id}, 1)" ${i === data.indexers.length - 1 ? 'disabled' : ''}>
+                                    <i class="bi bi-arrow-down"></i>
+                                </button>
+                                <button type="button" class="btn btn-outline-info" onclick="testIndexer(${idx.id})">
+                                    <i class="bi bi-lightning"></i>
+                                </button>
+                                <button type="button" class="btn btn-outline-primary" onclick="openIndexerModal(window._indexerCache[${idx.id}])">
+                                    <i class="bi bi-pencil"></i>
+                                </button>
+                                <button type="button" class="btn btn-outline-danger" onclick="deleteIndexer(${idx.id})">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>`;
+            });
+            html += '</div>';
+            container.innerHTML = html;
+            window._indexerOrder = data.indexers.map(i => i.id);
+        } catch (e) {
+            container.innerHTML = '<div class="alert alert-danger">Error loading indexers: ' + escapeHtml(e.message) + '</div>';
+        }
+    }
+
+    async function saveIndexer() {
+        const id = document.getElementById('indexerId').value;
+        const payload = {
+            name: document.getElementById('indexerName').value.trim(),
+            url: document.getElementById('indexerUrl').value.trim(),
+            categories: document.getElementById('indexerCategories').value.trim(),
+            enabled: document.getElementById('indexerEnabled').checked,
+        };
+        const apiKey = document.getElementById('indexerApiKey').value.trim();
+        if (apiKey) payload.api_key = apiKey;
+        if (!payload.name || !payload.url) {
+            showToast('Name and URL are required', 'warning');
+            return;
+        }
+        try {
+            const url = id ? `/api/indexers/${id}` : '/api/indexers';
+            const method = id ? 'PUT' : 'POST';
+            const response = await fetch(url, {
+                method,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            const data = await readJsonResponse(response);
+            if (data.success) {
+                showToast('Indexer saved', 'success');
+                indexerModal.hide();
+                loadIndexers();
+            } else {
+                showToast('Error: ' + (data.error || 'Failed to save indexer'), 'error');
+            }
+        } catch (e) {
+            showToast('Error saving indexer: ' + e.message, 'error');
+        }
+    }
+
+    async function testIndexer(indexerId) {
+        const btn = event.target.closest('button');
+        const originalHtml = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+        try {
+            const response = await fetch(`/api/indexers/${indexerId}/test`, { method: 'POST' });
+            const data = await readJsonResponse(response);
+            if (data.success && data.valid) {
+                showToast('Indexer connection successful!', 'success');
+                setTimeout(loadIndexers, 1200);
+            } else {
+                btn.innerHTML = originalHtml;
+                btn.disabled = false;
+                showToast('Indexer test failed: ' + (data.error || 'Unknown error'), 'error');
+            }
+        } catch (e) {
+            btn.innerHTML = originalHtml;
+            btn.disabled = false;
+            showToast('Error testing indexer: ' + e.message, 'error');
+        }
+    }
+
+    async function deleteIndexer(indexerId) {
+        if (!confirm('Delete this indexer?')) return;
+        try {
+            const response = await fetch(`/api/indexers/${indexerId}`, { method: 'DELETE' });
+            const data = await readJsonResponse(response);
+            if (data.success) {
+                showToast('Indexer deleted', 'success');
+                loadIndexers();
+            } else {
+                showToast('Error: ' + (data.error || 'Failed to delete indexer'), 'error');
+            }
+        } catch (e) {
+            showToast('Error deleting indexer: ' + e.message, 'error');
+        }
+    }
+
+    async function moveIndexer(indexerId, direction) {
+        const order = window._indexerOrder || [];
+        const idx = order.indexOf(indexerId);
+        if (idx === -1) return;
+        const swap = idx + direction;
+        if (swap < 0 || swap >= order.length) return;
+        [order[idx], order[swap]] = [order[swap], order[idx]];
+        try {
+            const response = await fetch('/api/indexers/reorder', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ order })
+            });
+            const data = await readJsonResponse(response);
+            if (data.success) {
+                loadIndexers();
+            } else {
+                showToast('Error: ' + (data.error || 'Failed to reorder'), 'error');
+            }
+        } catch (e) {
+            showToast('Error reordering indexers: ' + e.message, 'error');
+        }
+    }
+
+    // =====================================================================
+    // Source Priority (user preference: download_source_priority)
+    // =====================================================================
+
+    const SOURCE_LABELS = { usenet: 'Usenet (Indexers)', getcomics: 'GetComics' };
+
+    async function loadSourcePriority() {
+        const container = document.getElementById('sourcePriorityList');
+        if (!container) return;
+        let order = ['getcomics', 'usenet'];
+        try {
+            const resp = await fetch('/api/preferences/download_source_priority');
+            const data = await resp.json();
+            if (data.success && data.value) {
+                const parsed = typeof data.value === 'string' ? JSON.parse(data.value) : data.value;
+                if (Array.isArray(parsed) && parsed.length) {
+                    // Keep known sources, append any missing ones.
+                    order = parsed.filter(s => SOURCE_LABELS[s]);
+                    for (const s of Object.keys(SOURCE_LABELS)) {
+                        if (!order.includes(s)) order.push(s);
+                    }
+                }
+            }
+        } catch (e) { /* fall back to default order */ }
+
+        window._sourceOrder = order;
+        let html = '<div class="list-group">';
+        order.forEach((src, i) => {
+            html += `
+                <div class="list-group-item d-flex justify-content-between align-items-center">
+                    <span><i class="bi bi-list-ol me-2"></i>${i + 1}. ${escapeHtml(SOURCE_LABELS[src] || src)}</span>
+                    <div class="btn-group btn-group-sm">
+                        <button type="button" class="btn btn-outline-secondary" onclick="moveSource(${i}, -1)" ${i === 0 ? 'disabled' : ''}>
+                            <i class="bi bi-arrow-up"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" onclick="moveSource(${i}, 1)" ${i === order.length - 1 ? 'disabled' : ''}>
+                            <i class="bi bi-arrow-down"></i>
+                        </button>
+                    </div>
+                </div>`;
+        });
+        html += '</div>';
+        container.innerHTML = html;
+    }
+
+    async function moveSource(index, direction) {
+        const order = window._sourceOrder || [];
+        const swap = index + direction;
+        if (swap < 0 || swap >= order.length) return;
+        [order[index], order[swap]] = [order[swap], order[index]];
+        try {
+            const resp = await fetch('/api/preferences/download_source_priority', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value: JSON.stringify(order), category: 'downloads' })
+            });
+            const data = await resp.json();
+            if (data.success) {
+                loadSourcePriority();
+            } else {
+                showToast('Error saving source priority: ' + (data.error || 'Unknown error'), 'error');
+            }
+        } catch (e) {
+            showToast('Error saving source priority: ' + e.message, 'error');
         }
     }
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -3962,7 +3962,7 @@
         document.getElementById('indexerApiKey').value = '';
         document.getElementById('indexerApiKey').placeholder =
             indexer && indexer.api_key ? indexer.api_key : 'Enter API key';
-        document.getElementById('indexerCategories').value = indexer && indexer.categories ? indexer.categories : '';
+        document.getElementById('indexerCategories').value = indexer && indexer.categories ? indexer.categories : '7030';
         document.getElementById('indexerEnabled').checked = indexer ? !!indexer.enabled : true;
         indexerModal.show();
     }

--- a/templates/series.html
+++ b/templates/series.html
@@ -848,7 +848,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title fw-bold">
-                    <i class="bi bi-search me-2"></i>Search GetComics
+                    <i class="bi bi-search me-2"></i>Search Sources
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
@@ -1088,31 +1088,42 @@
         resultsDiv.innerHTML = `
         <div class="text-center py-4">
             <div class="spinner-border text-primary"></div>
-            <p class="mt-2">Searching GetComics...</p>
+            <p class="mt-2">Searching...</p>
         </div>`;
 
+        // Query both sources; render them in Source Priority order.
+        const [gc, un] = await Promise.all([
+            buildGetComicsSection(query),
+            buildUsenetSection(),
+        ]);
+
+        let combined = un.usenetFirst ? (un.html + gc.html) : (gc.html + un.html);
+        if (!combined.trim()) {
+            combined = `
+            <div class="text-center text-muted py-4">
+                <i class="bi bi-emoji-frown display-4 opacity-25"></i>
+                <p class="mt-2">No results found</p>
+            </div>`;
+        }
+        resultsDiv.innerHTML = combined;
+    }
+
+    function sectionHeader(label, icon) {
+        return `<div class="text-muted small fw-bold text-uppercase mb-2 mt-1">
+                    <i class="bi bi-${icon} me-1"></i>${label}</div>`;
+    }
+
+    async function buildGetComicsSection(query) {
         try {
             const resp = await fetch(`/api/getcomics/search?q=${encodeURIComponent(query)}`);
             const data = await resp.json();
-
             if (!data.success) {
-                resultsDiv.innerHTML = `<div class="alert alert-danger">${escapeHtmlGC(data.error)}</div>`;
-                return;
+                return { html: `<div class="alert alert-danger">${escapeHtmlGC(data.error)}</div>` };
             }
+            if (!data.results.length) return { html: '' };
 
-            if (data.results.length === 0) {
-                resultsDiv.innerHTML = `
-                <div class="text-center text-muted py-4">
-                    <i class="bi bi-emoji-frown display-4 opacity-25"></i>
-                    <p class="mt-2">No results found</p>
-                </div>`;
-                return;
-            }
-
-            // Sort results - expected match at top
             const sorted = sortResultsGC(data.results, currentSearchSeries, currentSearchIssue);
-
-            resultsDiv.innerHTML = sorted.map((r, idx) => `
+            const cards = sorted.map((r, idx) => `
             <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
                 <div class="card-body d-flex align-items-center gap-3 py-2">
                     ${r.image ? `<img src="${escapeHtmlGC(r.image)}" style="width:50px;height:75px;object-fit:cover;" class="rounded" onerror="this.style.display='none'">` : '<div style="width:50px"></div>'}
@@ -1124,11 +1135,104 @@
                         <i class="bi bi-download"></i>
                     </button>
                 </div>
-            </div>
-        `).join('');
-
+            </div>`).join('');
+            return { html: sectionHeader('GetComics', 'globe') + cards };
         } catch (e) {
-            resultsDiv.innerHTML = `<div class="alert alert-danger">Error: ${escapeHtmlGC(e.message)}</div>`;
+            return { html: `<div class="alert alert-danger">GetComics error: ${escapeHtmlGC(e.message)}</div>` };
+        }
+    }
+
+    async function buildUsenetSection() {
+        try {
+            const resp = await fetch('/api/usenet/search', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ series: currentSearchSeries, issue: currentSearchIssue }),
+            });
+            const data = await resp.json();
+            const usenetFirst = !!data.usenet_first;
+
+            // No indexers configured -> Usenet isn't set up; stay quiet.
+            if (!data.success || !data.has_indexers) {
+                return { html: '', usenetFirst };
+            }
+
+            const header = sectionHeader('Usenet (Indexers)', 'hdd-network');
+            const clientNote = data.has_client ? '' :
+                `<div class="alert alert-warning py-2 small mb-2">
+                    <i class="bi bi-exclamation-triangle me-1"></i>No active download client — set one active
+                    on the Download Clients tab to send NZBs.</div>`;
+            const errNote = (data.errors && data.errors.length)
+                ? `<div class="alert alert-danger py-2 small mb-2">
+                    <i class="bi bi-exclamation-octagon me-1"></i>${data.errors.map(escapeHtmlGC).join('<br>')}</div>`
+                : '';
+
+            if (!data.results || !data.results.length) {
+                return {
+                    html: header + clientNote + errNote +
+                        `<div class="text-muted small mb-2">No Usenet results found.</div>`,
+                    usenetFirst,
+                };
+            }
+
+            const fmtSize = (b) => b ? (b / (1024 * 1024)).toFixed(0) + ' MB' : '';
+            const cards = data.results.map((r) => {
+                const badge = r.decision === 'ACCEPT'
+                    ? '<span class="badge bg-success ms-1">Match</span>'
+                    : (r.decision === 'FALLBACK'
+                        ? '<span class="badge bg-warning text-dark ms-1">Pack</span>' : '');
+                return `
+            <div class="card mb-2">
+                <div class="card-body d-flex align-items-center gap-3 py-2">
+                    <div class="flex-grow-1 overflow-hidden">
+                        <div class="fw-bold text-truncate" title="${escapeHtmlGC(r.title)}">${escapeHtmlGC(r.title)}${badge}</div>
+                        <small class="text-muted text-truncate d-block">${escapeHtmlGC(r.indexer_name || '')} ${fmtSize(r.size)} · score ${r.score}</small>
+                    </div>
+                    <button class="btn btn-sm btn-primary flex-shrink-0" onclick="grabUsenet(this, '${escapeJsGC(r.nzb_url)}')" title="Send to download client" ${data.has_client ? '' : 'disabled'}>
+                        <i class="bi bi-cloud-download"></i>
+                    </button>
+                </div>
+            </div>`;
+            }).join('');
+            return { html: header + clientNote + errNote + cards, usenetFirst };
+        } catch (e) {
+            return { html: `<div class="alert alert-danger">Usenet error: ${escapeHtmlGC(e.message)}</div>`, usenetFirst: false };
+        }
+    }
+
+    async function grabUsenet(btn, nzbUrl) {
+        // File under the series/issue so wanted-matching picks it up.
+        const base = `${currentSearchSeries} ${currentSearchIssue}`.trim();
+        const filename = base.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
+
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+        try {
+            const resp = await fetch('/api/usenet/grab', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    nzb_url: nzbUrl, filename: filename,
+                    series: currentSearchSeries, issue: currentSearchIssue,
+                }),
+            });
+            const data = await resp.json();
+            if (data.success) {
+                btn.innerHTML = '<i class="bi bi-check"></i>';
+                btn.classList.remove('btn-primary');
+                btn.classList.add('btn-success');
+                showToastGC('Sent to download client!', 'success');
+                markIssueRowDownloading(currentSearchIssue);
+                setTimeout(() => getcomicsModal.hide(), 500);
+            } else {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="bi bi-cloud-download"></i>';
+                showToastGC('Error: ' + (data.error || 'grab failed'), 'danger');
+            }
+        } catch (e) {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-cloud-download"></i>';
+            showToastGC('Error: ' + e.message, 'danger');
         }
     }
 

--- a/tests/integration/test_database_clients.py
+++ b/tests/integration/test_database_clients.py
@@ -1,0 +1,149 @@
+"""Tests for download-client and indexer DB accessors (encrypted config)."""
+import pytest
+
+# cryptography may not be installed locally
+crypto_available = False
+try:
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    crypto_available = True
+except ImportError:
+    pass
+
+skip_no_crypto = pytest.mark.skipif(
+    not crypto_available, reason="cryptography package not installed"
+)
+
+
+class TestDownloadClientConfig:
+
+    @skip_no_crypto
+    def test_save_and_get(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            get_download_client_config,
+        )
+        cfg = {"host": "localhost", "port": 8080, "api_key": "SECRETKEY1234", "category": "comics"}
+        assert save_download_client_config("sabnzbd", cfg) is True
+        got = get_download_client_config("sabnzbd")
+        assert got == cfg
+
+    @skip_no_crypto
+    def test_masked(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            get_download_client_config_masked,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "abcdefghijklmnop"})
+        masked = get_download_client_config_masked("sabnzbd")
+        assert "..." in masked["api_key"]
+        assert masked["api_key"] != "abcdefghijklmnop"
+
+    @skip_no_crypto
+    def test_update_validity(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            update_download_client_validity,
+            get_all_download_clients_status,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "k"})
+        update_download_client_validity("sabnzbd", True)
+        status = next(s for s in get_all_download_clients_status()
+                      if s["client_type"] == "sabnzbd")
+        assert status["is_valid"] == 1
+
+    @skip_no_crypto
+    def test_single_active_invariant(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            set_active_download_client,
+            get_all_download_clients_status,
+            get_active_download_client,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "k1"})
+        save_download_client_config("nzbget", {"username": "u", "password": "p"})
+        set_active_download_client("sabnzbd")
+        set_active_download_client("nzbget")
+        statuses = get_all_download_clients_status()
+        assert sum(s["is_active"] for s in statuses) == 1
+        active = get_active_download_client()
+        assert active["client_type"] == "nzbget"
+        assert active["config"]["username"] == "u"
+
+    @skip_no_crypto
+    def test_delete(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            delete_download_client_config,
+            get_download_client_config,
+        )
+        save_download_client_config("nzbget", {"username": "u"})
+        delete_download_client_config("nzbget")
+        assert get_download_client_config("nzbget") is None
+
+    def test_get_nonexistent(self, db_connection):
+        from core.database import get_download_client_config
+        assert get_download_client_config("sabnzbd") is None
+
+
+class TestIndexers:
+
+    @skip_no_crypto
+    def test_add_and_get(self, db_connection):
+        from core.database import add_indexer, get_indexer
+        iid = add_indexer("NZBgeek", "https://api.nzbgeek.info",
+                          {"api_key": "KEYAAAA1111", "categories": "7000"}, priority=0)
+        assert isinstance(iid, int)
+        got = get_indexer(iid)
+        assert got["name"] == "NZBgeek"
+        assert got["api_key"] == "KEYAAAA1111"
+        assert got["categories"] == "7000"
+        assert got["enabled"] is True
+
+    @skip_no_crypto
+    def test_masked(self, db_connection):
+        from core.database import add_indexer, get_indexer_masked
+        iid = add_indexer("X", "https://x", {"api_key": "abcdefghijklmnop"})
+        masked = get_indexer_masked(iid)
+        assert "..." in masked["api_key"]
+        assert masked["name"] == "X"
+
+    @skip_no_crypto
+    def test_partial_update_keeps_secret(self, db_connection):
+        from core.database import add_indexer, update_indexer, get_indexer
+        iid = add_indexer("X", "https://x", {"api_key": "KEEPME1234"})
+        # Metadata-only update must not wipe the api_key.
+        update_indexer(iid, name="Renamed")
+        got = get_indexer(iid)
+        assert got["name"] == "Renamed"
+        assert got["api_key"] == "KEEPME1234"
+
+    @skip_no_crypto
+    def test_reorder(self, db_connection):
+        from core.database import add_indexer, set_indexer_order, get_all_indexers
+        a = add_indexer("A", "https://a", {}, priority=0)
+        b = add_indexer("B", "https://b", {}, priority=1)
+        set_indexer_order([b, a])
+        order = [(x["id"], x["priority"]) for x in get_all_indexers()]
+        assert order[0][0] == b and order[0][1] == 0
+        assert order[1][0] == a and order[1][1] == 1
+
+    @skip_no_crypto
+    def test_enabled_filter(self, db_connection):
+        from core.database import add_indexer, update_indexer, get_enabled_indexers
+        a = add_indexer("A", "https://a", {}, enabled=True)
+        b = add_indexer("B", "https://b", {}, enabled=True)
+        update_indexer(a, enabled=False)
+        enabled_ids = [x["id"] for x in get_enabled_indexers()]
+        assert b in enabled_ids
+        assert a not in enabled_ids
+
+    @skip_no_crypto
+    def test_validity_and_delete(self, db_connection):
+        from core.database import (
+            add_indexer, update_indexer_validity, get_indexer, delete_indexer,
+        )
+        iid = add_indexer("A", "https://a", {})
+        update_indexer_validity(iid, True)
+        assert get_indexer(iid)["is_valid"] is True
+        delete_indexer(iid)
+        assert get_indexer(iid) is None

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -62,6 +62,8 @@ class TestTablesExist:
         "komga_sync_log",
         "komga_library_mappings",
         "schedules",
+        "download_clients",
+        "indexers",
     ]
 
     @pytest.mark.parametrize("table_name", EXPECTED_TABLES)
@@ -137,6 +139,7 @@ class TestIndexesExist:
         "idx_wanted_issues_series",
         "idx_browse_cache_path",
         "idx_komga_sync_book",
+        "idx_indexers_priority",
     ]
 
     @pytest.mark.parametrize("index_name", EXPECTED_INDEXES)

--- a/tests/mocked/test_newznab_indexer.py
+++ b/tests/mocked/test_newznab_indexer.py
@@ -1,0 +1,66 @@
+"""Tests for models/indexers/newznab_indexer.py -- mocked HTTP + XML."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from models.indexers import IndexerConfig, IndexerType, get_indexer_impl
+
+VALID_SEARCH_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <item>
+      <title>Batman 001 (2020)</title>
+      <enclosure url="https://indexer.example/getnzb/abc.nzb" type="application/x-nzb"/>
+    </item>
+  </channel>
+</rss>
+"""
+
+ERROR_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<error code="100" description="Incorrect user credentials"/>
+"""
+
+MALFORMED_XML = b"<rss><channel><item></rss"
+
+
+def _indexer(**cfg):
+    defaults = {"name": "NZBgeek", "url": "https://api.nzbgeek.info", "api_key": "KEY"}
+    defaults.update(cfg)
+    return get_indexer_impl(IndexerType.NEWZNAB, IndexerConfig(**defaults))
+
+
+class TestNewznabTestConnection:
+
+    @patch("requests.get")
+    def test_valid(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=VALID_SEARCH_XML)
+        assert _indexer().test_connection() is True
+
+    @patch("requests.get")
+    def test_error_response(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=ERROR_XML)
+        assert _indexer().test_connection() is False
+
+    @patch("requests.get")
+    def test_non_200(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=500, content=b"")
+        assert _indexer().test_connection() is False
+
+    @patch("requests.get")
+    def test_malformed_xml(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=MALFORMED_XML)
+        assert _indexer().test_connection() is False
+
+    @patch("requests.get", side_effect=Exception("dns failure"))
+    def test_exception_swallowed(self, mock_get):
+        assert _indexer().test_connection() is False
+
+    def test_missing_url(self):
+        assert _indexer(url="").test_connection() is False
+
+
+class TestNewznabSearchSeam:
+
+    def test_search_not_implemented(self):
+        # Locks the PR 2 seam so it can't silently ship half-wired.
+        with pytest.raises(NotImplementedError):
+            _indexer().search("batman")

--- a/tests/mocked/test_newznab_indexer.py
+++ b/tests/mocked/test_newznab_indexer.py
@@ -15,6 +15,10 @@ VALID_SEARCH_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 </rss>
 """
 
+CAPS_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<caps><server version="1.0"/><categories/></caps>
+"""
+
 ERROR_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <error code="100" description="Incorrect user credentials"/>
 """
@@ -32,8 +36,10 @@ class TestNewznabTestConnection:
 
     @patch("requests.get")
     def test_valid(self, mock_get):
-        mock_get.return_value = MagicMock(status_code=200, content=VALID_SEARCH_XML)
+        mock_get.return_value = MagicMock(status_code=200, content=CAPS_XML)
         assert _indexer().test_connection() is True
+        # Connection test uses t=caps (no query) to avoid "Missing parameter".
+        assert mock_get.call_args.kwargs["params"]["t"] == "caps"
 
     @patch("requests.get")
     def test_error_response(self, mock_get):
@@ -58,9 +64,50 @@ class TestNewznabTestConnection:
         assert _indexer(url="").test_connection() is False
 
 
-class TestNewznabSearchSeam:
+class TestNewznabSearch:
 
-    def test_search_not_implemented(self):
-        # Locks the PR 2 seam so it can't silently ship half-wired.
-        with pytest.raises(NotImplementedError):
-            _indexer().search("batman")
+    @patch("requests.get")
+    def test_parses_items(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=VALID_SEARCH_XML)
+        results = _indexer().search("batman", indexer_id=3)
+        assert len(results) == 1
+        r = results[0]
+        assert r.title == "Batman 001 (2020)"
+        assert r.nzb_url == "https://indexer.example/getnzb/abc.nzb"
+        assert r.indexer_id == 3
+
+    @patch("requests.get")
+    def test_error_returns_empty(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=ERROR_XML)
+        results = _indexer().search("batman")
+        assert results == []
+        assert _indexer().config is not None
+
+    @patch("requests.get", side_effect=Exception("boom"))
+    def test_exception_returns_empty(self, mock_get):
+        assert _indexer().search("batman") == []
+
+    @patch("requests.get")
+    def test_categories_passed(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=VALID_SEARCH_XML)
+        _indexer(categories="7000,7030").search("batman")
+        assert mock_get.call_args.kwargs["params"]["cat"] == "7000,7030"
+
+    @patch("requests.get")
+    def test_defaults_to_comics_category(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=VALID_SEARCH_XML)
+        _indexer(categories=None).search("batman")
+        assert mock_get.call_args.kwargs["params"]["cat"] == "7030"
+
+    @patch("requests.get")
+    def test_link_fallback_when_no_enclosure(self, mock_get):
+        # Some Newznab variants omit <enclosure> and put the NZB URL in <link>.
+        xml = b"""<?xml version="1.0"?>
+        <rss><channel><item>
+          <title>Treehouse of Horror 004 (2024)</title>
+          <link>https://althub.co.za/getnzb/xyz.nzb</link>
+        </item></channel></rss>"""
+        mock_get.return_value = MagicMock(status_code=200, content=xml)
+        results = _indexer().search("treehouse of horror 04")
+        assert len(results) == 1
+        assert results[0].nzb_url == "https://althub.co.za/getnzb/xyz.nzb"

--- a/tests/mocked/test_nzbget_client.py
+++ b/tests/mocked/test_nzbget_client.py
@@ -1,0 +1,82 @@
+"""Tests for models/download_clients/nzbget_client.py -- mocked HTTP."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from models.download_clients import (
+    ClientType,
+    DownloadClientConfig,
+    get_download_client,
+)
+
+
+def _client(**cfg):
+    defaults = {"host": "localhost", "port": 6789, "username": "nzbget", "password": "pw"}
+    defaults.update(cfg)
+    return get_download_client(ClientType.NZBGET, DownloadClientConfig(**defaults))
+
+
+class TestNZBGetTestConnection:
+
+    @patch("requests.post")
+    def test_valid_version(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"result": "21.1", "id": 1}))
+        assert _client().test_connection() is True
+        # Basic auth built from username/password, hitting /jsonrpc
+        _, kwargs = mock_post.call_args
+        assert kwargs["auth"] == ("nzbget", "pw")
+        assert mock_post.call_args[0][0].endswith("/jsonrpc")
+
+    @patch("requests.post")
+    def test_401(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=401,
+                                           json=MagicMock(return_value={}))
+        assert _client().test_connection() is False
+
+    @patch("requests.post")
+    def test_bad_json(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, json=MagicMock(side_effect=ValueError("no json")))
+        assert _client().test_connection() is False
+
+    @patch("requests.post", side_effect=Exception("connection refused"))
+    def test_exception_swallowed(self, mock_post):
+        c = _client()
+        assert c.test_connection() is False
+        assert c.last_error  # a readable reason is recorded
+
+    @patch("requests.post")
+    def test_no_auth_when_credentials_blank(self, mock_post):
+        # NZBGet with auth disabled (like Sonarr/Radarr): no Basic auth sent.
+        mock_post.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"result": "21.1"}))
+        c = _client(username=None, password=None)
+        assert c.test_connection() is True
+        assert mock_post.call_args.kwargs["auth"] is None
+
+    @patch("requests.post")
+    def test_401_sets_reason(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=401,
+                                           json=MagicMock(return_value={}))
+        c = _client()
+        assert c.test_connection() is False
+        assert "401" in c.last_error
+
+
+class TestNZBGetMetadata:
+
+    def test_config_fields(self):
+        cls = get_download_client(ClientType.NZBGET).__class__
+        assert "username" in cls.config_fields
+        assert "password" in cls.config_fields
+
+    def test_ssl_base_url(self):
+        c = _client(use_ssl=True, url_base="nzbget")
+        assert c._base_url() == "https://localhost:6789/nzbget"
+
+    def test_pr2_stubs_raise(self):
+        c = _client()
+        with pytest.raises(NotImplementedError):
+            c.add_nzb(b"", "x.nzb")
+        with pytest.raises(NotImplementedError):
+            c.get_status("1")

--- a/tests/mocked/test_nzbget_client.py
+++ b/tests/mocked/test_nzbget_client.py
@@ -74,9 +74,69 @@ class TestNZBGetMetadata:
         c = _client(use_ssl=True, url_base="nzbget")
         assert c._base_url() == "https://localhost:6789/nzbget"
 
-    def test_pr2_stubs_raise(self):
-        c = _client()
-        with pytest.raises(NotImplementedError):
-            c.add_nzb(b"", "x.nzb")
-        with pytest.raises(NotImplementedError):
-            c.get_status("1")
+
+class TestNZBGetSubmit:
+
+    @patch("requests.post")
+    def test_add_url(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"result": 7}))
+        res = _client(category="comics").add_nzb("https://x/a.nzb", "Batman 1.cbz")
+        assert res.success is True
+        assert res.client_id == "7"
+        body = mock_post.call_args.kwargs["json"]
+        assert body["method"] == "append"
+        # append params: [name, content(url), category, priority, ...]
+        assert body["params"][1] == "https://x/a.nzb"
+        assert body["params"][2] == "comics"
+        # Modern NZBGet requires the trailing PPParameters array.
+        assert body["params"][-1] == []
+        assert len(body["params"]) == 10
+
+    @patch("requests.post")
+    def test_add_bytes_base64(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"result": 9}))
+        res = _client().add_nzb(b"<nzb/>", "Batman 1.cbz")
+        assert res.success is True
+        import base64
+        assert mock_post.call_args.kwargs["json"]["params"][1] == \
+            base64.b64encode(b"<nzb/>").decode("ascii")
+
+    @patch("requests.post")
+    def test_add_failure(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"result": 0}))
+        res = _client().add_nzb("https://x/a.nzb", "x.cbz")
+        assert res.success is False
+
+    @patch("requests.post")
+    def test_add_surfaces_jsonrpc_error(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={
+                "error": {"code": -32602, "message": "Invalid parameters"}, "id": 1}))
+        res = _client().add_nzb(b"<nzb/>", "x.cbz")
+        assert res.success is False
+        assert "Invalid parameters" in res.error
+
+
+class TestNZBGetHistory:
+
+    @patch("requests.post")
+    def test_history_maps_status(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"result": [
+                {"NZBID": 7, "Name": "Batman 1", "Status": "SUCCESS/ALL",
+                 "FinalDir": "/done/Batman 1", "Category": "comics"},
+                {"NZBID": 8, "Name": "Superman 5", "Status": "FAILURE/UNPACK",
+                 "DestDir": "/int/Superman 5"},
+            ]}))
+        by_id = {h.client_id: h for h in _client().get_history()}
+        assert by_id["7"].status == "complete"
+        assert by_id["7"].storage_path == "/done/Batman 1"
+        assert by_id["8"].status == "failed"

--- a/tests/mocked/test_sabnzbd_client.py
+++ b/tests/mocked/test_sabnzbd_client.py
@@ -1,0 +1,65 @@
+"""Tests for models/download_clients/sabnzbd_client.py -- mocked HTTP."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from models.download_clients import (
+    ClientType,
+    DownloadClientConfig,
+    get_download_client,
+)
+
+
+def _client(**cfg):
+    defaults = {"host": "localhost", "port": 8080, "api_key": "KEY123"}
+    defaults.update(cfg)
+    return get_download_client(ClientType.SABNZBD, DownloadClientConfig(**defaults))
+
+
+class TestSABnzbdTestConnection:
+
+    @patch("requests.get")
+    def test_valid_queue(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"queue": {"slots": []}}))
+        assert _client().test_connection() is True
+
+    @patch("requests.get")
+    def test_bad_api_key(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"error": "API Key Incorrect"}))
+        assert _client().test_connection() is False
+
+    @patch("requests.get")
+    def test_non_200(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=403,
+                                          json=MagicMock(return_value={}))
+        assert _client().test_connection() is False
+
+    @patch("requests.get", side_effect=Exception("timeout"))
+    def test_exception_swallowed(self, mock_get):
+        # Must not raise -- a bad host returns False, not an exception.
+        assert _client().test_connection() is False
+
+    def test_missing_api_key(self):
+        assert _client(api_key=None).test_connection() is False
+
+
+class TestSABnzbdMetadata:
+
+    def test_config_fields(self):
+        cls = get_download_client(ClientType.SABNZBD).__class__
+        assert "host" in cls.config_fields
+        assert "api_key" in cls.config_fields
+
+    def test_client_info(self):
+        info = _client().get_client_info()
+        assert info["type"] == "sabnzbd"
+        assert info["name"] == "SABnzbd"
+        assert "config_fields" in info
+
+    def test_pr2_stubs_raise(self):
+        c = _client()
+        with pytest.raises(NotImplementedError):
+            c.add_nzb(b"", "x.nzb")
+        with pytest.raises(NotImplementedError):
+            c.get_history()

--- a/tests/mocked/test_sabnzbd_client.py
+++ b/tests/mocked/test_sabnzbd_client.py
@@ -57,9 +57,68 @@ class TestSABnzbdMetadata:
         assert info["name"] == "SABnzbd"
         assert "config_fields" in info
 
-    def test_pr2_stubs_raise(self):
-        c = _client()
-        with pytest.raises(NotImplementedError):
-            c.add_nzb(b"", "x.nzb")
-        with pytest.raises(NotImplementedError):
-            c.get_history()
+
+class TestSABnzbdSubmit:
+
+    @patch("requests.get")
+    def test_add_url(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"status": True, "nzo_ids": ["SABnzbd_nzo_a"]}))
+        res = _client(category="comics", priority=1).add_nzb(
+            "https://indexer/getnzb/a.nzb", "Batman 1.cbz")
+        assert res.success is True
+        assert res.client_id == "SABnzbd_nzo_a"
+        params = mock_get.call_args.kwargs["params"]
+        assert params["mode"] == "addurl"
+        assert params["cat"] == "comics"
+        assert params["priority"] == 1
+
+    @patch("requests.post")
+    def test_add_bytes_uses_addfile(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"status": True, "nzo_ids": ["nzo_b"]}))
+        res = _client().add_nzb(b"<nzb/>", "Batman 1.cbz")
+        assert res.success is True
+        assert mock_post.call_args.kwargs["params"]["mode"] == "addfile"
+        assert "files" in mock_post.call_args.kwargs
+
+    @patch("requests.get")
+    def test_add_failure(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"status": False, "error": "nope"}))
+        res = _client().add_nzb("https://x/a.nzb", "x.cbz")
+        assert res.success is False
+        assert res.error == "nope"
+
+
+class TestSABnzbdHistory:
+
+    @patch("requests.get")
+    def test_history_maps_status(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"history": {"slots": [
+                {"nzo_id": "a", "name": "Batman 1", "status": "Completed",
+                 "storage": "/done/Batman 1", "category": "comics"},
+                {"nzo_id": "b", "name": "Superman 5", "status": "Failed",
+                 "storage": "", "category": "comics"},
+            ]}}))
+        hist = _client().get_history()
+        by_id = {h.client_id: h for h in hist}
+        assert by_id["a"].status == "complete"
+        assert by_id["a"].storage_path == "/done/Batman 1"
+        assert by_id["b"].status == "failed"
+
+    @patch("requests.get")
+    def test_get_status_from_queue(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"queue": {"slots": [
+                {"nzo_id": "a", "filename": "Batman 1", "percentage": "42", "cat": "comics"},
+            ]}}))
+        st = _client().get_status("a")
+        assert st.status == "downloading"
+        assert st.percent == 42.0

--- a/tests/mocked/test_usenet.py
+++ b/tests/mocked/test_usenet.py
@@ -1,0 +1,184 @@
+"""Tests for models/usenet.py -- search/score, grab, import, source priority."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+import models.usenet as un
+from models.indexers import NZBSearchResult
+from models.download_clients import NZBSubmitResult
+
+
+class TestSourcePriority:
+
+    @patch("core.database.get_user_preference", return_value=None)
+    def test_default(self, mock_pref):
+        assert un.get_source_priority() == ["getcomics"]
+
+    @patch("core.database.get_user_preference", return_value='["usenet","getcomics"]')
+    def test_parsed_json_string(self, mock_pref):
+        assert un.get_source_priority() == ["usenet", "getcomics"]
+        assert un.usenet_precedes_getcomics() is True
+
+    @patch("core.database.get_user_preference", return_value=["getcomics", "usenet"])
+    def test_list_value(self, mock_pref):
+        assert un.usenet_precedes_getcomics() is False
+
+
+class TestUsenetConfigured:
+
+    @patch("core.database.get_enabled_indexers", return_value=[{"id": 1}])
+    @patch("core.database.get_active_download_client", return_value={"client_type": "sabnzbd", "config": {}})
+    @patch("core.database.get_user_preference", return_value='["usenet"]')
+    def test_configured(self, mock_pref, mock_active, mock_idx):
+        assert un.usenet_enabled_and_configured() is True
+
+    @patch("core.database.get_enabled_indexers", return_value=[])
+    @patch("core.database.get_active_download_client", return_value={"client_type": "sabnzbd", "config": {}})
+    @patch("core.database.get_user_preference", return_value='["usenet"]')
+    def test_no_indexer(self, mock_pref, mock_active, mock_idx):
+        assert un.usenet_enabled_and_configured() is False
+
+    @patch("core.database.get_user_preference", return_value='["getcomics"]')
+    def test_usenet_not_a_source(self, mock_pref):
+        assert un.usenet_enabled_and_configured() is False
+
+
+class TestBuildQueries:
+
+    def test_pads_numeric_issue(self):
+        qs = un._build_queries("Treehouse of Horror", "4")
+        assert qs == ["Treehouse of Horror 4", "Treehouse of Horror 04",
+                      "Treehouse of Horror 004"]
+
+    def test_non_numeric_issue(self):
+        qs = un._build_queries("Batman", "1.MU")
+        assert qs == ["Batman 1.MU"]
+
+
+class TestSearchAndScore:
+
+    @patch("models.indexers.get_indexer_impl")
+    @patch("core.database.get_enabled_indexers", return_value=[
+        {"id": 5, "name": "NZBgeek", "url": "https://x", "api_key": "k",
+         "categories": None, "enabled": True, "indexer_type": "newznab"},
+    ])
+    def test_finds_and_scores_match(self, mock_idx, mock_impl):
+        impl = MagicMock()
+        impl.search.return_value = [
+            NZBSearchResult(indexer_id=5, indexer_name="NZBgeek",
+                            title="Batman 001 (2020)",
+                            nzb_url="https://x/getnzb/a.nzb", size=100),
+        ]
+        mock_impl.return_value = impl
+        res = un.search_usenet_for_issue("Batman", "1", issue_year=2020)
+        assert res["chosen"] is not None
+        assert res["chosen"][0].nzb_url == "https://x/getnzb/a.nzb"
+        assert res["all_results"][0]["decision"] == "ACCEPT"
+
+    @patch("models.indexers.get_indexer_impl")
+    @patch("core.database.get_enabled_indexers", return_value=[
+        {"id": 5, "name": "NZBgeek", "url": "https://x", "api_key": "k",
+         "categories": None, "enabled": True, "indexer_type": "newznab"},
+    ])
+    def test_no_match(self, mock_idx, mock_impl):
+        impl = MagicMock()
+        impl.search.return_value = [
+            NZBSearchResult(indexer_id=5, indexer_name="NZBgeek",
+                            title="Completely Different Comic 99",
+                            nzb_url="https://x/z.nzb"),
+        ]
+        mock_impl.return_value = impl
+        res = un.search_usenet_for_issue("Batman", "1", issue_year=2020)
+        assert res["chosen"] is None
+
+
+class TestTryDownloadForIssue:
+
+    @patch("models.usenet.search_usenet_for_issue")
+    def test_dry_run_does_not_grab(self, mock_search):
+        result = NZBSearchResult(indexer_id=5, indexer_name="NZBgeek",
+                                 title="Batman 1", nzb_url="https://x/a.nzb")
+        mock_search.return_value = {
+            "chosen": (result, 90), "tier": "direct match",
+            "best_accept": (result, 90), "best_fallback": None, "all_results": [{}],
+        }
+        out = un.try_download_for_issue("Batman", "1", dry_run=True)
+        assert out["status"] == "match_found"
+        assert out["submitted"] is False
+        assert out["chosen"]["filename"] == "Batman 1.cbz"
+
+
+class TestGrabNzb:
+
+    @patch("models.usenet._fetch_nzb", return_value=b"<nzb/>")
+    @patch("models.usenet._ensure_poller")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "sabnzbd", "config": {"api_key": "k"}})
+    def test_grab_submits_fetched_bytes(self, mock_active, mock_get_client, mock_poller, mock_fetch):
+        client = MagicMock()
+        client.add_nzb.return_value = NZBSubmitResult(client_id="nzo_1", success=True)
+        mock_get_client.return_value = client
+        un.usenet_downloads.clear()
+        did = un.grab_nzb("https://x/a.nzb", "Batman 1.cbz", series="Batman", issue="1")
+        assert did is not None
+        assert un.usenet_downloads[did]["client_id"] == "nzo_1"
+        # Real NZB bytes were submitted, not the URL.
+        assert client.add_nzb.call_args[0][0] == b"<nzb/>"
+        mock_poller.assert_called_once()
+
+    @patch("models.usenet._fetch_nzb", return_value=None)
+    @patch("models.usenet._ensure_poller")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "sabnzbd", "config": {"api_key": "k"}})
+    def test_grab_falls_back_to_url(self, mock_active, mock_get_client, mock_poller, mock_fetch):
+        client = MagicMock()
+        client.add_nzb.return_value = NZBSubmitResult(client_id="nzo_1", success=True)
+        mock_get_client.return_value = client
+        un.usenet_downloads.clear()
+        did = un.grab_nzb("https://x/a.nzb", "Batman 1.cbz")
+        assert did is not None
+        assert client.add_nzb.call_args[0][0] == "https://x/a.nzb"
+
+    @patch("core.database.get_active_download_client", return_value=None)
+    def test_grab_no_active_client(self, mock_active):
+        assert un.grab_nzb("https://x/a.nzb", "x.cbz") is None
+
+    @patch("models.usenet._fetch_nzb", return_value=b"<nzb/>")
+    @patch("models.usenet._ensure_poller")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "sabnzbd", "config": {"api_key": "k"}})
+    def test_grab_submit_failure(self, mock_active, mock_get_client, mock_poller, mock_fetch):
+        client = MagicMock()
+        client.add_nzb.return_value = NZBSubmitResult(success=False, error="bad")
+        mock_get_client.return_value = client
+        assert un.grab_nzb("https://x/a.nzb", "x.cbz") is None
+
+
+class TestImportCompleted:
+
+    def test_moves_comic_into_watch(self, tmp_path, monkeypatch):
+        watch = tmp_path / "watch"
+        watch.mkdir()
+        done = tmp_path / "done" / "Batman 1"
+        done.mkdir(parents=True)
+        (done / "Batman 1.cbz").write_bytes(b"x")
+        (done / "readme.txt").write_bytes(b"junk")
+        monkeypatch.setattr(un, "_watch_dir", lambda: str(watch))
+
+        assert un._import_completed(str(done), "Batman 1.cbz") is True
+        assert (watch / "Batman 1.cbz").exists()
+        assert not (watch / "readme.txt").exists()
+
+    def test_already_in_watch_is_noop(self, tmp_path, monkeypatch):
+        watch = tmp_path / "watch"
+        (watch / "sub").mkdir(parents=True)
+        monkeypatch.setattr(un, "_watch_dir", lambda: str(watch))
+        assert un._import_completed(str(watch / "sub"), "x.cbz") is True
+
+    def test_inaccessible_path_returns_false(self, tmp_path, monkeypatch):
+        watch = tmp_path / "watch"
+        watch.mkdir()
+        monkeypatch.setattr(un, "_watch_dir", lambda: str(watch))
+        assert un._import_completed(str(tmp_path / "nope"), "x.cbz") is False

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -172,6 +172,7 @@ def app(db_connection, tmp_path):
     from routes.metadata import metadata_bp
     from routes.bulk_metadata import bulk_metadata_bp
     from routes.source_wall import source_wall_bp
+    from routes.download_clients import download_clients_bp
     from routes.api_v1 import api_v1_bp
     from routes.api_v1_docs import api_docs_bp
     from routes.admin import admin_bp
@@ -187,6 +188,7 @@ def app(db_connection, tmp_path):
     test_app.register_blueprint(metadata_bp)
     test_app.register_blueprint(bulk_metadata_bp)
     test_app.register_blueprint(source_wall_bp)
+    test_app.register_blueprint(download_clients_bp)
     test_app.register_blueprint(api_v1_bp)
     test_app.register_blueprint(api_docs_bp)
     test_app.register_blueprint(admin_bp)

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -1,0 +1,204 @@
+"""Tests for routes/download_clients.py -- Usenet client + indexer endpoints."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestListDownloadClients:
+
+    @patch("core.database.get_download_client_config_masked",
+           return_value={"host": "loca...host", "api_key": "SECR...1234"})
+    @patch("core.database.get_all_download_clients_status", return_value=[
+        {"client_type": "sabnzbd", "is_active": 1, "is_valid": 1, "last_tested": "2026-01-01"},
+    ])
+    def test_list_merges_status(self, mock_status, mock_masked, client):
+        resp = client.get("/api/download-clients")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        types = {c["type"]: c for c in data["clients"]}
+        assert "sabnzbd" in types and "nzbget" in types
+        assert types["sabnzbd"]["has_config"] is True
+        assert types["sabnzbd"]["is_active"] is True
+        assert types["sabnzbd"]["is_valid"] is True
+        assert types["sabnzbd"]["config_masked"] is not None
+        # nzbget has no status row -> not configured
+        assert types["nzbget"]["has_config"] is False
+        assert types["nzbget"]["config_masked"] is None
+        # config_fields drives the dynamic UI
+        assert "api_key" in types["sabnzbd"]["config_fields"]
+
+
+class TestDownloadClientConfig:
+
+    def test_unknown_type_get(self, client):
+        resp = client.get("/api/download-clients/bogus/config")
+        assert resp.status_code == 400
+
+    def test_unknown_type_post(self, client):
+        resp = client.post("/api/download-clients/bogus/config", json={"host": "x"})
+        assert resp.status_code == 400
+
+    @patch("core.database.save_download_client_config", return_value=True)
+    def test_save(self, mock_save, client):
+        resp = client.post("/api/download-clients/sabnzbd/config",
+                           json={"host": "localhost", "port": 8080, "api_key": "k"})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_save.assert_called_once()
+        assert mock_save.call_args[0][0] == "sabnzbd"
+
+    def test_save_empty_body(self, client):
+        resp = client.post("/api/download-clients/sabnzbd/config", json={})
+        assert resp.status_code == 400
+
+    @patch("core.database.get_download_client_config_masked",
+           return_value={"host": "loca...host", "api_key": "SECR...1234"})
+    def test_get_masked(self, mock_masked, client):
+        resp = client.get("/api/download-clients/sabnzbd/config")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_config"] is True
+        assert "..." in data["config"]["api_key"]
+
+    @patch("core.database.get_download_client_config_masked", return_value=None)
+    def test_get_missing(self, mock_masked, client):
+        resp = client.get("/api/download-clients/nzbget/config")
+        assert resp.status_code == 200
+        assert resp.get_json()["has_config"] is False
+
+    @patch("core.database.delete_download_client_config", return_value=True)
+    def test_delete(self, mock_del, client):
+        resp = client.delete("/api/download-clients/sabnzbd/config")
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+
+class TestDownloadClientTest:
+
+    @patch("core.database.update_download_client_validity")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_download_client_config", return_value={"host": "h", "api_key": "k"})
+    def test_success(self, mock_cfg, mock_get, mock_validity, client):
+        mock_get.return_value = MagicMock(test_connection=MagicMock(return_value=True))
+        resp = client.post("/api/download-clients/sabnzbd/test")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["valid"] is True
+        mock_validity.assert_called_once_with("sabnzbd", True)
+
+    @patch("core.database.update_download_client_validity")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_download_client_config", return_value={"host": "h", "api_key": "k"})
+    def test_failure(self, mock_cfg, mock_get, mock_validity, client):
+        mock_get.return_value = MagicMock(
+            test_connection=MagicMock(return_value=False), last_error=None)
+        resp = client.post("/api/download-clients/sabnzbd/test")
+        assert resp.status_code == 200
+        assert resp.get_json()["valid"] is False
+        mock_validity.assert_called_once_with("sabnzbd", False)
+
+    @patch("core.database.update_download_client_validity")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_download_client_config", return_value={"host": "h", "api_key": "k"})
+    def test_failure_surfaces_reason(self, mock_cfg, mock_get, mock_validity, client):
+        # The route should return the client's last_error, not a generic message.
+        mock_client = MagicMock(test_connection=MagicMock(return_value=False))
+        mock_client.last_error = "Could not connect to http://h:6789/jsonrpc"
+        mock_get.return_value = mock_client
+        resp = client.post("/api/download-clients/sabnzbd/test")
+        assert "Could not connect" in resp.get_json()["error"]
+
+    @patch("core.database.get_download_client_config", return_value=None)
+    def test_not_configured(self, mock_cfg, client):
+        resp = client.post("/api/download-clients/sabnzbd/test")
+        assert resp.status_code == 400
+
+
+class TestDownloadClientActivate:
+
+    @patch("core.database.set_active_download_client", return_value=True)
+    @patch("core.database.get_download_client_config", return_value={"host": "h"})
+    def test_activate(self, mock_cfg, mock_set, client):
+        resp = client.post("/api/download-clients/nzbget/activate")
+        assert resp.status_code == 200
+        assert resp.get_json()["active"] == "nzbget"
+        mock_set.assert_called_once_with("nzbget")
+
+    @patch("core.database.get_download_client_config", return_value=None)
+    def test_activate_unconfigured(self, mock_cfg, client):
+        resp = client.post("/api/download-clients/nzbget/activate")
+        assert resp.status_code == 400
+
+
+class TestIndexers:
+
+    @patch("core.database.get_all_indexers", return_value=[
+        {"id": 1, "name": "NZBgeek", "url": "https://x", "priority": 0,
+         "enabled": True, "is_valid": True, "api_key": "KEY...1111"},
+    ])
+    def test_list(self, mock_all, client):
+        resp = client.get("/api/indexers")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert len(data["indexers"]) == 1
+        assert any(t["type"] == "newznab" for t in data["types"])
+
+    @patch("core.database.add_indexer", return_value=7)
+    def test_create(self, mock_add, client):
+        resp = client.post("/api/indexers",
+                           json={"name": "NZBgeek", "url": "https://x", "api_key": "k"})
+        assert resp.status_code == 200
+        assert resp.get_json()["id"] == 7
+        mock_add.assert_called_once()
+
+    def test_create_missing_fields(self, client):
+        resp = client.post("/api/indexers", json={"name": "x"})
+        assert resp.status_code == 400
+
+    @patch("core.database.get_indexer_masked", return_value=None)
+    def test_get_404(self, mock_get, client):
+        resp = client.get("/api/indexers/999")
+        assert resp.status_code == 404
+
+    @patch("core.database.update_indexer", return_value=True)
+    @patch("core.database.get_indexer", return_value={"id": 1, "name": "old", "api_key": "k"})
+    def test_update(self, mock_get, mock_upd, client):
+        resp = client.put("/api/indexers/1", json={"name": "new"})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_upd.assert_called_once()
+
+    @patch("core.database.delete_indexer", return_value=True)
+    @patch("core.database.get_indexer", return_value={"id": 1})
+    def test_delete(self, mock_get, mock_del, client):
+        resp = client.delete("/api/indexers/1")
+        assert resp.status_code == 200
+        mock_del.assert_called_once_with(1)
+
+    @patch("core.database.set_indexer_order", return_value=True)
+    def test_reorder(self, mock_order, client):
+        resp = client.post("/api/indexers/reorder", json={"order": [3, 1, 2]})
+        assert resp.status_code == 200
+        mock_order.assert_called_once_with([3, 1, 2])
+
+    def test_reorder_missing_list(self, client):
+        resp = client.post("/api/indexers/reorder", json={})
+        assert resp.status_code == 400
+
+    @patch("core.database.update_indexer_validity")
+    @patch("models.indexers.get_indexer_impl")
+    @patch("core.database.get_indexer", return_value={
+        "id": 1, "name": "NZBgeek", "url": "https://x", "api_key": "k",
+        "categories": None, "enabled": True, "indexer_type": "newznab"})
+    def test_test_success(self, mock_get, mock_impl, mock_validity, client):
+        mock_impl.return_value = MagicMock(test_connection=MagicMock(return_value=True))
+        resp = client.post("/api/indexers/1/test")
+        assert resp.status_code == 200
+        assert resp.get_json()["valid"] is True
+        mock_validity.assert_called_once_with(1, True)
+
+    @patch("core.database.get_indexer", return_value=None)
+    def test_test_404(self, mock_get, client):
+        resp = client.post("/api/indexers/999/test")
+        assert resp.status_code == 404

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -152,6 +152,12 @@ class TestIndexers:
         assert resp.get_json()["id"] == 7
         mock_add.assert_called_once()
 
+    @patch("core.database.add_indexer", return_value=7)
+    def test_create_defaults_comics_category(self, mock_add, client):
+        client.post("/api/indexers",
+                    json={"name": "NZBgeek", "url": "https://x", "api_key": "k"})
+        assert mock_add.call_args.kwargs["config"]["categories"] == "7030"
+
     def test_create_missing_fields(self, client):
         resp = client.post("/api/indexers", json={"name": "x"})
         assert resp.status_code == 400
@@ -202,3 +208,68 @@ class TestIndexers:
     def test_test_404(self, mock_get, client):
         resp = client.post("/api/indexers/999/test")
         assert resp.status_code == 404
+
+
+class TestUsenetDownloads:
+
+    @patch("models.usenet.get_usenet_downloads", return_value=[
+        {"download_id": "x", "filename": "Batman 1.cbz", "status": "downloading"},
+    ])
+    def test_list(self, mock_dl, client):
+        resp = client.get("/api/usenet/downloads")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["downloads"][0]["filename"] == "Batman 1.cbz"
+
+    @patch("models.usenet.usenet_precedes_getcomics", return_value=True)
+    @patch("core.database.get_active_download_client", return_value={"client_type": "nzbget"})
+    @patch("core.database.get_enabled_indexers", return_value=[{"id": 1}])
+    @patch("models.usenet.search_usenet_for_issue", return_value={
+        "all_results": [
+            {"title": "Batman 002", "nzb_url": "u2", "score": 10, "decision": "REJECT"},
+            {"title": "Batman 001", "nzb_url": "u1", "score": 90, "decision": "ACCEPT"},
+        ],
+    })
+    def test_search(self, mock_search, mock_idx, mock_client, mock_first, client):
+        resp = client.post("/api/usenet/search", json={"series": "Batman", "issue": "1"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["usenet_first"] is True
+        assert data["has_indexers"] is True
+        assert data["has_client"] is True
+        # sorted best-first
+        assert data["results"][0]["nzb_url"] == "u1"
+
+    @patch("models.usenet.usenet_precedes_getcomics", return_value=False)
+    @patch("core.database.get_active_download_client", return_value=None)
+    @patch("core.database.get_enabled_indexers", return_value=[])
+    def test_search_no_indexers(self, mock_idx, mock_client, mock_first, client):
+        resp = client.post("/api/usenet/search", json={"series": "Batman", "issue": "1"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_indexers"] is False
+        assert data["results"] == []
+
+    def test_search_missing_series(self, client):
+        resp = client.post("/api/usenet/search", json={"issue": "1"})
+        assert resp.status_code == 400
+
+    @patch("models.usenet.grab_nzb", return_value="dl-123")
+    def test_grab(self, mock_grab, client):
+        resp = client.post("/api/usenet/grab",
+                           json={"nzb_url": "u1", "filename": "Batman 1.cbz",
+                                 "series": "Batman", "issue": "1"})
+        assert resp.status_code == 200
+        assert resp.get_json()["download_id"] == "dl-123"
+
+    def test_grab_missing_fields(self, client):
+        resp = client.post("/api/usenet/grab", json={"nzb_url": "u1"})
+        assert resp.status_code == 400
+
+    @patch("models.usenet.grab_nzb", return_value=None)
+    def test_grab_no_client(self, mock_grab, client):
+        resp = client.post("/api/usenet/grab",
+                           json={"nzb_url": "u1", "filename": "x.cbz"})
+        assert resp.status_code == 502


### PR DESCRIPTION
Adds Usenet/newsgroup download support alongside the existing GetComics.org path, so issue availability no longer depends on a single site. Delivered in two phases on this branch.

## PR 1 — Foundation (`07172cf`)
Mirrors the existing metadata-provider system (ABC + registry + AES-encrypted DB config + registry-driven config UI).
- `models/download_clients/` — `BaseDownloadClient` + registry; **SABnzbd** and **NZBGet** adapters.
- `models/indexers/` — `BaseIndexer` + registry; **Newznab** adapter.
- Encrypted DB tables `download_clients` (single-active) and `indexers` (priority-ordered), reusing `models/providers/crypto.py`.
- `routes/download_clients.py` — `/api/download-clients` + `/api/indexers` CRUD, connection testing, and activation.
- New **Download Clients** tab in `templates/config.html` (clients, indexers, source priority), rendered dynamically.
- Connection tests report a readable reason (connection refused / 401 / non-JSON / timeout); Newznab uses `t=caps`.

## PR 2 — Search, grab & auto-download (`4fb6c2e`)
- **Clients:** SABnzbd `add_nzb`/`get_history`/`get_status`; NZBGet `append` (base64 + required `PPParameters`) with JSON-RPC errors surfaced. Status normalized to complete/failed/downloading.
- **Indexers:** `NewznabIndexer.search` parses RSS items (`<enclosure>` or `<link>` fallback); searches default to the comics category `7030`.
- **`models/usenet.py`:** `search_usenet_for_issue` (reuses the GetComics scorer, tries zero-padded issue variants, dedupes, logs counts/errors), `grab_nzb` (fetches the NZB and submits real content to the active client), an in-memory tracker + background completion poller, and `_import_completed` that moves finished comics into WATCH via `core.config` — **`api.py` is never modified**.
- **Engine:** `scheduled_getcomics_download` and the simulation honor **Source Priority** (Usenet-first skips GetComics on a hit; otherwise Usenet is a fallback when GetComics queues nothing).
- **Manual search:** the per-issue modal now queries GetComics **and** Usenet in priority order, with per-indexer error surfacing and a grab button.
- Routes: `/api/usenet/search`, `/api/usenet/grab`, `/api/usenet/downloads`.

## Testing
New tests for clients, indexer parsing, the orchestrator, and routes. Full suite green: **2349 passed, 6 skipped** (the known env-only `test_pdf.py` set excluded). Verified end-to-end against a live NZBGet + Newznab indexer.

## Notes / possible follow-ups
- Completed-file handoff needs the client's completed folder visible to the CLU container (shared volume) or the category pointed at WATCH.
- Deferred: restart-durable download tracking (currently in-memory), live UI polling of `/api/usenet/downloads`, and appending the apikey to NZB URLs for indexers that omit it in the enclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)