### PR TITLE
Delete empty folders in TARGET after files are moved out

### DIFF
--- a/app.py
+++ b/app.py
@@ -945,6 +945,11 @@ def process_incoming_wanted_issues():
 
         for series_id in affected_series:
             reconcile_wanted_for_series(series_id)
+
+        # Files were just moved out of TARGET into series folders, which can leave
+        # empty download wrapper folders behind (common with Usenet single-file
+        # downloads). Sweep them after a short debounced delay.
+        schedule_target_cleanup()
     else:
         app_logger.info("No wanted issues matched files in TARGET folder")
 
@@ -2480,6 +2485,35 @@ def get_target_dir_live():
     ``user_preferences`` via ``load_flask_config()``.
     """
     return app.config.get("TARGET") or "/downloads/processed"
+
+
+def schedule_target_cleanup(delay_seconds=10):
+    """Schedule a debounced sweep of empty folders in TARGET after a move out of it.
+
+    Uses a fixed job id + ``replace_existing`` so a batch of moves collapses into a
+    single sweep that runs ``delay_seconds`` after the last move.
+    """
+    target = get_target_dir_live()
+    if not target or not os.path.isdir(target):
+        return
+    from apscheduler.triggers.date import DateTrigger
+
+    run_time = datetime.now() + timedelta(seconds=delay_seconds)
+    app_state.scheduler.add_job(
+        _run_target_cleanup,
+        trigger=DateTrigger(run_date=run_time),
+        id="target_empty_dir_cleanup",
+        name="TARGET Empty Folder Cleanup",
+        replace_existing=True,
+    )
+
+
+def _run_target_cleanup():
+    from helpers import prune_empty_dirs
+
+    target = get_target_dir_live()
+    if target:
+        prune_empty_dirs(target)
 
 
 # Moved to helpers/library.py - re-exported for backward compatibility

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -64,6 +64,42 @@ def is_hidden(filepath):
             pass
     return False
 
+
+def prune_empty_dirs(root):
+    """Remove directories under ``root`` that are empty or contain only hidden junk.
+
+    A folder is deleted when it holds no non-hidden entries; any hidden/system junk
+    (dotfiles, ``@eaDir`` subtrees, etc.) it contains is removed first. Walks
+    bottom-up so nested and batch-emptied folders collapse in a single pass. Never
+    removes ``root`` itself. Returns the number of directories removed.
+    """
+    root_abs = os.path.abspath(root)
+    if not os.path.isdir(root_abs):
+        return 0
+    removed = 0
+    for cur, _dirs, _files in os.walk(root_abs, topdown=False):
+        cur_abs = os.path.abspath(cur)
+        if cur_abs == root_abs:
+            continue  # never delete the root itself
+        try:
+            entries = os.listdir(cur_abs)
+            # A single non-hidden entry keeps the folder alive.
+            if any(not is_hidden(os.path.join(cur_abs, e)) for e in entries):
+                continue
+            # Only hidden junk (or nothing) remains — clear it, then the folder.
+            for e in entries:
+                p = os.path.join(cur_abs, e)
+                if os.path.isdir(p) and not os.path.islink(p):
+                    shutil.rmtree(p, ignore_errors=True)
+                else:
+                    os.remove(p)
+            os.rmdir(cur_abs)
+            removed += 1
+            app_logger.info(f"Deleted empty TARGET sub-directory: {cur_abs}")
+        except Exception as e:
+            app_logger.error(f"Error pruning directory {cur_abs}: {e}")
+    return removed
+
 #########################
 #  Path Segment Safety  #
 #########################

--- a/routes/files.py
+++ b/routes/files.py
@@ -61,7 +61,8 @@ def _do_move(op_id, source, destination, is_file):
     """Background thread: perform move + post-move tasks, updating app_state."""
     from app import auto_fetch_metron_metadata, auto_fetch_comicvine_metadata, \
                      auto_fetch_comicvine_sqlite_metadata, \
-                     log_file_if_in_data, update_index_on_move
+                     log_file_if_in_data, update_index_on_move, \
+                     get_target_dir_live, schedule_target_cleanup
     dispatch = {
         'metron': auto_fetch_metron_metadata,
         'comicvine': auto_fetch_comicvine_metadata,
@@ -93,6 +94,19 @@ def _do_move(op_id, source, destination, is_file):
             update_index_on_move(source, final_path if is_file else destination)
             app_state.complete_operation(op_id)
             app_logger.info(f"Background move complete: {source} -> {final_path if is_file else destination}")
+
+            # If the source was inside TARGET, moving it out may have left an empty
+            # download wrapper folder behind. Schedule a debounced sweep restricted
+            # to TARGET. Never let a scheduling hiccup fail the move.
+            try:
+                target = get_target_dir_live()
+                if target:
+                    t_abs = os.path.abspath(target)
+                    src_abs = os.path.abspath(source)
+                    if src_abs == t_abs or src_abs.startswith(t_abs + os.sep):
+                        schedule_target_cleanup()
+            except Exception:
+                app_logger.debug("Target cleanup scheduling skipped", exc_info=True)
         except Exception as e:
             app_logger.exception(f"Background move error: {source} -> {destination}")
             app_state.complete_operation(op_id, error=True)

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -119,6 +119,8 @@ class TestDoMoveDispatch:
         fake_app.auto_fetch_comicvine_sqlite_metadata = make("comicvine_sqlite")
         fake_app.log_file_if_in_data = lambda p: None
         fake_app.update_index_on_move = lambda *a, **k: None
+        fake_app.get_target_dir_live = lambda: "/downloads/processed"
+        fake_app.schedule_target_cleanup = lambda *a, **k: None
 
         from routes.files import _do_move
         old_app = sys.modules.get("app")
@@ -143,6 +145,45 @@ class TestDoMoveDispatch:
     def test_file_dispatch_legacy_order(self):
         assert self._run_file_move(["metron", "comicvine"]) == \
             ["metron", "comicvine"]
+
+
+class TestDoMoveTargetCleanup:
+    """_do_move schedules an empty-folder sweep only when the source was in TARGET."""
+
+    def _run(self, source, target):
+        cleanup_calls = []
+
+        fake_app = types.ModuleType("app")
+        fake_app.auto_fetch_metron_metadata = lambda p: p
+        fake_app.auto_fetch_comicvine_metadata = lambda p: p
+        fake_app.auto_fetch_comicvine_sqlite_metadata = lambda p: p
+        fake_app.log_file_if_in_data = lambda p: None
+        fake_app.update_index_on_move = lambda *a, **k: None
+        fake_app.get_target_dir_live = lambda: target
+        fake_app.schedule_target_cleanup = lambda *a, **k: cleanup_calls.append(True)
+
+        from routes.files import _do_move
+        old_app = sys.modules.get("app")
+        sys.modules["app"] = fake_app
+        try:
+            with patch("routes.files._move_metadata_order", return_value=["metron"]), \
+                 patch("routes.files.shutil.move"), \
+                 patch("routes.files.app_state"), \
+                 patch("routes.files.memory_context"):
+                _do_move("op1", source, "/data/lib/a.cbz", is_file=True)
+        finally:
+            if old_app is not None:
+                sys.modules["app"] = old_app
+            else:
+                sys.modules.pop("app", None)
+        return cleanup_calls
+
+    def test_schedules_cleanup_when_source_under_target(self):
+        assert self._run("/downloads/processed/Batman 1/a.cbz",
+                         "/downloads/processed") == [True]
+
+    def test_no_cleanup_when_source_outside_target(self):
+        assert self._run("/data/lib/a.cbz", "/downloads/processed") == []
 
 
 class TestFolderSize:

--- a/tests/unit/test_prune_empty_dirs.py
+++ b/tests/unit/test_prune_empty_dirs.py
@@ -1,0 +1,85 @@
+"""Unit tests for helpers.prune_empty_dirs (empty/junk folder sweep in TARGET)."""
+
+import os
+
+from helpers import prune_empty_dirs
+
+
+class TestPruneEmptyDirs:
+
+    def test_removes_truly_empty_folder(self, tmp_path):
+        root = tmp_path / "processed"
+        empty = root / "Batman 1"
+        empty.mkdir(parents=True)
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert not empty.exists()
+        assert root.exists()
+
+    def test_keeps_folder_with_real_file(self, tmp_path):
+        root = tmp_path / "processed"
+        keep = root / "Series"
+        keep.mkdir(parents=True)
+        (keep / "issue.cbz").write_bytes(b"x")
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert (keep / "issue.cbz").exists()
+
+    def test_removes_folder_with_only_hidden_junk(self, tmp_path):
+        # Use always-hidden names (leading '.'/'_') so the result does not depend
+        # on the DB-backed configurable hidden-directory set.
+        root = tmp_path / "processed"
+        junk = root / "Batman 1"
+        junk.mkdir(parents=True)
+        (junk / ".DS_Store").write_bytes(b"x")
+        hidden_sub = junk / ".thumbnails"
+        hidden_sub.mkdir()
+        (hidden_sub / "thumb.jpg").write_bytes(b"y")
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert not junk.exists()
+
+    def test_removes_folder_with_configured_hidden_dir(self, tmp_path, monkeypatch):
+        # @eaDir-style names are only hidden when in the configured set; pin it.
+        import helpers
+        monkeypatch.setattr(helpers, "_hidden_directories", {"@eaDir"})
+        root = tmp_path / "processed"
+        junk = root / "Batman 1"
+        eadir = junk / "@eaDir"
+        eadir.mkdir(parents=True)
+        (eadir / "thumb.jpg").write_bytes(b"y")
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert not junk.exists()
+
+    def test_collapses_nested_empty_folders(self, tmp_path):
+        root = tmp_path / "processed"
+        nested = root / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+
+        removed = prune_empty_dirs(str(root))
+        assert removed == 3
+        assert not (root / "a").exists()
+        assert root.exists()
+
+    def test_never_removes_root_even_when_empty(self, tmp_path):
+        root = tmp_path / "processed"
+        root.mkdir()
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert root.exists()
+
+    def test_mixed_removes_only_empty(self, tmp_path):
+        root = tmp_path / "processed"
+        empty = root / "Emptied Wrapper"
+        empty.mkdir(parents=True)
+        populated = root / "Series"
+        populated.mkdir()
+        (populated / "issue.cbz").write_bytes(b"x")
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert not empty.exists()
+        assert populated.exists()
+
+    def test_missing_root_is_noop(self, tmp_path):
+        assert prune_empty_dirs(str(tmp_path / "does-not-exist")) == 0


### PR DESCRIPTION
## Summary

With the new Usenet (newsgroup) download support, users end up with empty folders accumulating in TARGET (`/downloads/processed`). Most Usenet downloads are a single comic file zipped inside a folder of the same name; when the folder monitor moves that into TARGET, the wrapping folder is recreated there. Once the comic is later moved **out** of TARGET — manually via the file browser or automatically by the Wanted match process — the wrapping folder is left behind empty.

This PR cleans up those empty folders after a short delay, restricted to the TARGET folder.

## Changes

- **`helpers/prune_empty_dirs(root)`** — a bottom-up (`os.walk(topdown=False)`) sweep that removes any directory holding no non-hidden entries, clearing hidden/system junk (dotfiles, hidden subtrees, configured names like `@eaDir`) first. Never removes `root` itself. Reuses the existing `is_hidden` helper.
- **`app.py` — `schedule_target_cleanup()` / `_run_target_cleanup()`** — debounced scheduler using the existing APScheduler `DateTrigger` pattern. A fixed job id + `replace_existing=True` collapses a batch of moves into a single sweep firing ~10s after the last move. Wired into `process_incoming_wanted_issues()`.
- **`routes/files.py` — `_do_move()`** — schedules the same sweep after a manual move, but only when the source was inside TARGET (unrelated `/data` moves don't trigger a sweep). Wrapped so a scheduling hiccup never fails the move.

## Behavior

- Deletable folder = empty **or** contains only hidden/system junk (junk removed first).
- Delay = 10 seconds, debounced.
- Always on (no config toggle).
- Scope restricted to TARGET; TARGET itself is never removed.

## Tests

- New `tests/unit/test_prune_empty_dirs.py` (8 cases): truly-empty removal, real-file retention, hidden-only removal, configured `@eaDir` removal, nested collapse, root-never-removed, mixed, missing-root no-op.
- Extended `tests/routes/test_files_routes.py` with `TestDoMoveTargetCleanup` asserting the sweep is scheduled only when the source is under TARGET.

Full suite: 2360 passed; the only failures are the pre-existing env-only `test_pdf.py` cases (missing `pdf2image` locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
