### PR TITLE
Default Monitor off for complete, ended series on Scan Library import

### DIFF
--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -515,6 +515,46 @@ def apply_automap(items, api=None):
     return {"applied": applied, "failed": failed, "applied_ids": applied_ids}
 
 
+# Series statuses that mean no further issues are expected. A fully-owned
+# series in one of these states has nothing left to search for, so it is
+# defaulted to unmonitored on import (see _maybe_default_monitor_off).
+_ENDED_MONITOR_OFF_STATUSES = {"cancelled", "canceled", "completed"}
+
+
+def _series_field(series_info, key):
+    """Read a field off a series that may be a dict or an object."""
+    if isinstance(series_info, dict):
+        return series_info.get(key)
+    return getattr(series_info, key, None)
+
+
+def _maybe_default_monitor_off(series_id, series_info, match_status):
+    """Default Monitor off for a freshly-imported, complete, ended series.
+
+    Called only from the Scan Library import path (via ``_sync_and_match``). When
+    every known issue is owned AND the series status is Cancelled/Completed, flip
+    a monitored series to unmonitored — a finished, fully-collected series won't
+    gain new issues and needn't be searched. We only ever turn monitoring off
+    (never back on), so a user's earlier choice is preserved on re-scan.
+    """
+    from core.database import get_series_monitored, set_series_monitored
+
+    status = (_series_field(series_info, "status") or "").strip().lower()
+    if status not in _ENDED_MONITOR_OFF_STATUSES:
+        return
+    if not match_status or not all(
+        s.get("found") for s in match_status.values()
+    ):
+        return  # some issue still missing -- keep monitoring it
+    if not get_series_monitored(series_id):
+        return  # already unmonitored -- leave the user's choice alone
+    if set_series_monitored(series_id, False):
+        app_logger.info(
+            f"automap: series {series_id} is complete and '{status}'; "
+            "defaulting Monitor off"
+        )
+
+
 def _sync_and_match(api, series_id):
     """Bring a mapped series up to date and compute its collection match.
 
@@ -548,9 +588,10 @@ def _sync_and_match(api, series_id):
 
         series_info = get_series_by_id(series_id)
         if series_info and issues:
-            match_issues_to_collection(
+            match_status = match_issues_to_collection(
                 mapped_path, issues, series_info, use_cache=False
             )
+            _maybe_default_monitor_off(series_id, series_info, match_status)
     except Exception as e:
         app_logger.warning(f"automap: sync+match failed for {series_id}: {e}")
 

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -392,6 +392,58 @@ class TestSyncAndMatch:
         reg.assert_not_called()
 
 
+class TestDefaultMonitorOff:
+    """On import, a fully-owned Cancelled/Completed series defaults Monitor off."""
+
+    def _sync(self, tmp_path, series, match_status, *, monitored=True):
+        folder = str(tmp_path)
+        with patch("core.database.get_series_mapping", return_value=folder), \
+             patch("core.database.get_issues_for_series", return_value=[{"number": "1"}]), \
+             patch("core.database.get_series_by_id", return_value=series), \
+             patch("helpers.collection.match_issues_to_collection",
+                   return_value=match_status), \
+             patch("core.database.get_series_monitored", return_value=monitored), \
+             patch("core.database.set_series_monitored") as set_mon:
+            library_automap._sync_and_match(api=None, series_id=series["id"])
+        return set_mon
+
+    def test_off_when_complete_and_cancelled(self, tmp_path):
+        series = {"id": 1, "name": "Y The Last Man", "status": "Cancelled"}
+        status = {"1": {"found": True}, "2": {"found": True}}
+        set_mon = self._sync(tmp_path, series, status)
+        set_mon.assert_called_once_with(1, False)
+
+    def test_off_when_complete_and_completed(self, tmp_path):
+        series = {"id": 2, "name": "Watchmen", "status": "Completed"}
+        status = {"1": {"found": True}}
+        set_mon = self._sync(tmp_path, series, status)
+        set_mon.assert_called_once_with(2, False)
+
+    def test_left_on_when_ongoing(self, tmp_path):
+        series = {"id": 3, "name": "Batman", "status": "Ongoing"}
+        status = {"1": {"found": True}}
+        set_mon = self._sync(tmp_path, series, status)
+        set_mon.assert_not_called()
+
+    def test_left_on_when_issue_missing(self, tmp_path):
+        series = {"id": 4, "name": "Saga", "status": "Cancelled"}
+        status = {"1": {"found": True}, "2": {"found": False}}
+        set_mon = self._sync(tmp_path, series, status)
+        set_mon.assert_not_called()
+
+    def test_no_change_when_already_unmonitored(self, tmp_path):
+        series = {"id": 5, "name": "Preacher", "status": "Completed"}
+        status = {"1": {"found": True}}
+        set_mon = self._sync(tmp_path, series, status, monitored=False)
+        set_mon.assert_not_called()
+
+    def test_status_match_is_case_insensitive(self, tmp_path):
+        series = {"id": 6, "name": "Sandman", "status": "COMPLETED"}
+        status = {"1": {"found": True}}
+        set_mon = self._sync(tmp_path, series, status)
+        set_mon.assert_called_once_with(6, False)
+
+
 class TestApplyExtra:
     def test_falls_back_to_sidecar_when_no_api(self, tmp_path):
         folder = _make_folder(


### PR DESCRIPTION
## What

When **Scan Library** (`#scanLibraryBtn` on the Pull List) imports a series, this defaults its **Monitor** flag to **off** when the series is **fully owned** _and_ its status is **Cancelled** or **Completed**. A finished, fully-collected series won't gain new issues, so there's nothing to search for.

## Why

A completed run that the user already owns in full shouldn't sit in the monitored set generating searches. This makes the sensible default automatic at import time. Monitor remains a per-series user override (`/api/series/<id>/monitored`) that can be re-enabled at any time.

## How

Hooked into `_sync_and_match` in `models/library_automap.py` — the single Scan Library import path (both the review/apply flow and the background scan tail reach it). After the collection match is computed, `_maybe_default_monitor_off` applies a conservative gate:

- Only when **every** known issue is found (a single missing issue keeps monitoring on).
- Only when status is `cancelled`/`canceled`/`completed` (case-insensitive).
- **Only ever turns monitoring off, never back on** — a user's earlier choice is preserved on re-scan.
- No-ops when the series is already unmonitored.

Backend/data change only; the Pull List already renders the existing "Not monitored" badge on the next load.

## Tests

Adds `TestDefaultMonitorOff` in `tests/mocked/test_library_automap.py` (6 cases): off when complete+Cancelled, off when complete+Completed, left on when Ongoing, left on when an issue is missing, no-op when already unmonitored, and case-insensitive status matching. Full `test_library_automap.py` suite passes (52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)