### PR TITLE
Fix "Illegal seek" CBZ write failures on FUSE/mergerfs /data mounts

### DIFF
--- a/cbz_ops/add.py
+++ b/cbz_ops/add.py
@@ -4,6 +4,7 @@ import zipfile
 import shutil
 from PIL import Image, ImageFilter
 from core.app_logging import app_logger
+from helpers import open_zip_for_write
 
 
 def handle_cbz_file(file_path):
@@ -45,7 +46,7 @@ def handle_cbz_file(file_path):
         os.rename(zip_path, bak_file_path)
 
         # Step 6: Compress the folder contents back into a .cbz file
-        with zipfile.ZipFile(file_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(file_path) as zf:
             for root, _, files in os.walk(folder_name):
                 for file in files:
                     file_path_in_folder = os.path.join(root, file)

--- a/cbz_ops/convert.py
+++ b/cbz_ops/convert.py
@@ -6,7 +6,7 @@ import shutil
 import time
 from core.app_logging import app_logger
 from core.config import config, load_config
-from helpers import is_hidden, extract_rar_with_unar
+from helpers import is_hidden, extract_rar_with_unar, open_zip_for_write
 from cbz_ops.single_file import _flatten_single_wrapper_dir
 
 load_config()
@@ -117,7 +117,7 @@ def convert_single_rar_file(rar_path, zip_path, temp_extraction_dir):
         app_logger.info(f"Step 3/3: Creating CBZ file...")
         processed_files = 0
         
-        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(zip_path) as zf:
             for extract_root, extract_dirs, extract_files in os.walk(temp_extraction_dir):
                 # Skip hidden directories within the extraction folder.
                 extract_dirs[:] = [d for d in extract_dirs if not is_hidden(os.path.join(extract_root, d))]
@@ -125,7 +125,7 @@ def convert_single_rar_file(rar_path, zip_path, temp_extraction_dir):
                     file_path_inner = os.path.join(extract_root, extract_file)
                     if is_hidden(file_path_inner):
                         continue
-                    
+
                     arcname = os.path.relpath(file_path_inner, temp_extraction_dir)
                     zf.write(file_path_inner, arcname)
                     

--- a/cbz_ops/crop.py
+++ b/cbz_ops/crop.py
@@ -5,6 +5,7 @@ import shutil
 from PIL import Image, ImageFilter
 from core.app_logging import app_logger
 from core.config import config, load_config
+from helpers import open_zip_for_write
 
 load_config()
 skipped_exts = config.get("SETTINGS", "SKIPPED_FILES", fallback="")
@@ -64,7 +65,7 @@ def handle_cbz_file(file_path):
         # Sort the file list by arcname (alphabetical order)
         file_list.sort(key=lambda x: x[0])
         
-        with zipfile.ZipFile(file_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(file_path) as zf:
             for arcname, file_path_in_folder in file_list:
                 zf.write(file_path_in_folder, arcname)
 

--- a/cbz_ops/edit.py
+++ b/cbz_ops/edit.py
@@ -9,7 +9,7 @@ from flask import render_template_string, request, jsonify
 from PIL import Image
 from core.app_logging import app_logger
 from core.config import config, load_config
-from helpers import create_thumbnail_streaming, safe_image_open
+from helpers import create_thumbnail_streaming, safe_image_open, open_zip_for_write
 import gc
 
 
@@ -317,7 +317,7 @@ def save_cbz():
         
         # Step 7: Re-compress the folder contents into a .cbz file (sorted).
         # Use streaming approach to avoid loading all files into memory
-        with zipfile.ZipFile(original_file_path, 'w', zipfile.ZIP_DEFLATED, compresslevel=6) as cbz:
+        with open_zip_for_write(original_file_path, zipfile.ZIP_DEFLATED, compresslevel=6) as cbz:
             # Collect all files first
             file_list = []
             for root, _, files in os.walk(folder_name):

--- a/cbz_ops/enhance_single.py
+++ b/cbz_ops/enhance_single.py
@@ -1,5 +1,5 @@
 from PIL import Image, ImageEnhance, ImageFilter
-from helpers import is_hidden, unzip_file, enhance_image, enhance_image_streaming, safe_image_open
+from helpers import is_hidden, unzip_file, enhance_image, enhance_image_streaming, safe_image_open, open_zip_for_write
 import os
 import zipfile
 import shutil
@@ -180,7 +180,7 @@ def create_enhanced_cbz(extracted_dir, enhanced_cbz_path):
     Create enhanced CBZ file using streaming approach.
     """
     try:
-        with zipfile.ZipFile(enhanced_cbz_path, 'w', zipfile.ZIP_DEFLATED, compresslevel=6) as cbz_file:
+        with open_zip_for_write(enhanced_cbz_path, zipfile.ZIP_DEFLATED, compresslevel=6) as cbz_file:
             # Collect all files first
             file_list = []
             for root, _, files in os.walk(extracted_dir):

--- a/cbz_ops/pdf.py
+++ b/cbz_ops/pdf.py
@@ -4,7 +4,7 @@ import zipfile
 from pdf2image import convert_from_path, pdfinfo_from_path
 from core.app_logging import app_logger
 from PIL import Image
-from helpers import is_hidden
+from helpers import is_hidden, open_zip_for_write
 import gc
 import tempfile
 import shutil
@@ -140,7 +140,7 @@ def create_cbz_file(output_folder, cbz_path):
     Create CBZ file using streaming approach to avoid loading all files into memory.
     """
     try:
-        with zipfile.ZipFile(cbz_path, 'w', zipfile.ZIP_STORED) as cbz:
+        with open_zip_for_write(cbz_path, zipfile.ZIP_STORED) as cbz:
             # Walk through the folder and add files one by one
             for folder_root, _, folder_files in os.walk(output_folder):
                 for folder_file in folder_files:

--- a/cbz_ops/rebuild.py
+++ b/cbz_ops/rebuild.py
@@ -6,7 +6,7 @@ import shutil
 import time
 from core.app_logging import app_logger
 from core.config import config, load_config
-from helpers import is_hidden, extract_rar_with_unar
+from helpers import is_hidden, extract_rar_with_unar, open_zip_for_write
 
 load_config()
 
@@ -88,7 +88,7 @@ def convert_single_rar_file(rar_path, zip_path, temp_extraction_dir):
         app_logger.info(f"Step 3/3: Creating CBZ file...")
         processed_files = 0
         
-        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(zip_path) as zf:
             for extract_root, extract_dirs, extract_files in os.walk(temp_extraction_dir):
                 # Skip hidden directories within the extraction folder.
                 extract_dirs[:] = [d for d in extract_dirs if not is_hidden(os.path.join(extract_root, d))]
@@ -184,7 +184,7 @@ def rebuild_single_cbz_file(cbz_path, directory):
         shutil.move(new_zip_file, bak_file)
         
         cbz_file = os.path.join(directory, base_name + ".cbz")
-        with zipfile.ZipFile(cbz_file, 'w', zipfile.ZIP_DEFLATED) as zip_ref:
+        with open_zip_for_write(cbz_file) as zip_ref:
             file_count = 0
             total_files = 0
 
@@ -235,9 +235,8 @@ def rebuild_single_cbz_file(cbz_path, directory):
         
         # Remove backup file
         os.remove(bak_file)
-
-        from helpers import match_parent_permissions
-        match_parent_permissions(cbz_file)
+        # Permissions are matched by open_zip_for_write when the archive is moved
+        # into place.
 
         app_logger.info(f"Successfully rebuilt: {filename}")
         return True

--- a/cbz_ops/remove.py
+++ b/cbz_ops/remove.py
@@ -5,6 +5,7 @@ import shutil
 import re
 from PIL import Image, ImageFilter, features
 from core.app_logging import app_logger
+from helpers import open_zip_for_write
 
 # Define supported image extensions
 SUPPORTED_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.bmp', '.gif', '.png', '.webp']
@@ -88,7 +89,7 @@ def handle_cbz_file(file_path):
         os.rename(zip_path, bak_file_path)
 
         # Step 6: Compress the folder contents back into a .cbz file
-        with zipfile.ZipFile(file_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(file_path) as zf:
             for root, _, files in os.walk(folder_name):
                 for file in files:
                     file_ext = os.path.splitext(file)[1].lower()

--- a/cbz_ops/single_file.py
+++ b/cbz_ops/single_file.py
@@ -6,7 +6,7 @@ import shutil
 import time
 from core.app_logging import app_logger
 from core.config import config, load_config
-from helpers import extract_rar_with_unar
+from helpers import extract_rar_with_unar, open_zip_for_write
 
 load_config()
 
@@ -94,7 +94,7 @@ def convert_single_rar_file(rar_path, cbz_path, temp_extraction_dir):
         app_logger.info(f"Step 3/3: Creating CBZ file...")
         processed_files = 0
         
-        with zipfile.ZipFile(cbz_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(cbz_path) as zf:
             for extract_root, extract_dirs, extract_files in os.walk(temp_extraction_dir):
                 for extract_file in extract_files:
                     file_path_inner = os.path.join(extract_root, extract_file)
@@ -126,9 +126,9 @@ def convert_single_rar_file(rar_path, cbz_path, temp_extraction_dir):
                     if is_large_file and processed_files % max(1, total_files // 10) == 0:
                         progress_percent = (processed_files / total_files) * 100
                         app_logger.info(f"Compression progress: {progress_percent:.1f}% ({processed_files}/{total_files} files)")
-        
-        from helpers import match_parent_permissions
-        match_parent_permissions(cbz_path)
+
+        # Permissions are matched by open_zip_for_write when the archive is moved
+        # into place.
 
         app_logger.info(f"Successfully converted: {os.path.basename(rar_path)}")
 
@@ -230,7 +230,7 @@ def rebuild_single_cbz_file(cbz_path):
         bak_file_path = zip_path + '.bak'
         shutil.move(zip_path, bak_file_path)
         
-        with zipfile.ZipFile(cbz_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        with open_zip_for_write(cbz_path) as zf:
             file_count = 0
             total_files = 0
 
@@ -276,8 +276,8 @@ def rebuild_single_cbz_file(cbz_path):
         if os.path.exists(folder_name):
             shutil.rmtree(folder_name)
 
-        from helpers import match_parent_permissions
-        match_parent_permissions(cbz_path)
+        # Permissions are matched by open_zip_for_write when the archive is moved
+        # into place.
 
         app_logger.info(f"Successfully rebuilt: {filename}")
         

--- a/core/comicinfo.py
+++ b/core/comicinfo.py
@@ -340,36 +340,35 @@ def update_comicinfo_in_zip(zip_path: str, updates: dict):
     if ext.lower() not in ['.zip', '.cbz']:
         raise ValueError("Only .zip or .cbz files are supported by this function.")
 
-    temp_zip_path = zip_path + ".tmpzip"
+    from helpers import open_zip_for_write
 
-    with zipfile.ZipFile(zip_path, 'r') as old_zip, \
-         zipfile.ZipFile(temp_zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as new_zip:
+    # open_zip_for_write assembles the archive on a local volume and moves it
+    # into place (never seeking the data mount, which can raise
+    # "OSError: [Errno 29] Illegal seek" on mergerfs/network/FUSE), then matches
+    # parent-folder permissions. The source is read and closed inside — before
+    # the move.
+    with open_zip_for_write(zip_path) as new_zip:
+        with zipfile.ZipFile(zip_path, 'r') as old_zip:
+            comicinfo_path = find_comicinfo_in_zip(old_zip)
 
-        comicinfo_path = find_comicinfo_in_zip(old_zip)
+            for item in old_zip.infolist():
+                if comicinfo_path and item.filename == comicinfo_path:
+                    # 1. Read the XML data from the old zip
+                    xml_data = old_zip.read(item.filename)
 
-        for item in old_zip.infolist():
-            if comicinfo_path and item.filename == comicinfo_path:
-                # 1. Read the XML data from the old zip
-                xml_data = old_zip.read(item.filename)
+                    # 2. Pass it to our separate function for updates
+                    updated_xml_data = update_comicinfo_xml(xml_data, updates)
 
-                # 2. Pass it to our separate function for updates
-                updated_xml_data = update_comicinfo_xml(xml_data, updates)
+                    # 3. Write the updated file into the new zip
+                    new_zip.writestr(item, updated_xml_data)
+                else:
+                    # Copy all other files as-is
+                    new_zip.writestr(item, old_zip.read(item.filename))
 
-                # 3. Write the updated file into the new zip
-                new_zip.writestr(item, updated_xml_data)
-            else:
-                # Copy all other files as-is
-                new_zip.writestr(item, old_zip.read(item.filename))
-
-        if comicinfo_path is None:
-            empty_xml = b'<?xml version="1.0" encoding="utf-8"?><ComicInfo/>'
-            new_xml = update_comicinfo_xml(empty_xml, updates)
-            new_zip.writestr('ComicInfo.xml', new_xml)
-
-    # Replace the original ZIP/CBZ with the updated one
-    os.replace(temp_zip_path, zip_path)
-    from helpers import match_parent_permissions
-    match_parent_permissions(zip_path)
+            if comicinfo_path is None:
+                empty_xml = b'<?xml version="1.0" encoding="utf-8"?><ComicInfo/>'
+                new_xml = update_comicinfo_xml(empty_xml, updates)
+                new_zip.writestr('ComicInfo.xml', new_xml)
 
 
 def bulk_update_comicinfo_in_zips(items, progress_callback=None, max_workers=4):
@@ -377,7 +376,7 @@ def bulk_update_comicinfo_in_zips(items, progress_callback=None, max_workers=4):
 
     :param items: Iterable of (zip_path, updates_dict) tuples. Paths must be
                   distinct — parallel calls on the same file would race on the
-                  shared .tmpzip sidecar.
+                  final move into place.
     :param progress_callback: Optional callable(completed_count, total, path, error)
                               invoked once per file as it finishes. `error` is
                               None on success, an Exception otherwise.

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -5,6 +5,7 @@
 import os
 import re
 import stat
+import tempfile
 import zipfile
 from PIL import Image, ImageEnhance, ImageFilter, ImageOps
 import math
@@ -162,6 +163,74 @@ def match_parent_permissions(path):
                 pass
     except OSError:
         pass
+
+
+def _zip_assembly_dir():
+    """Local, seekable directory for staging archives before they're moved onto
+    the data volume.
+
+    Prefers ``CACHE_DIR/tmp`` — a real local volume (SQLite lives there, so it
+    must support seek/locking). Falls back to the system temp dir if that can't
+    be created for any reason. Returns ``None`` to mean "use the system default".
+    """
+    try:
+        from core.config import config
+        cache_dir = config.get("SETTINGS", "CACHE_DIR", fallback="/cache")
+        tmp_root = os.path.join(cache_dir, "tmp")
+        os.makedirs(tmp_root, exist_ok=True)
+        return tmp_root
+    except Exception:
+        return None
+
+
+@contextmanager
+def open_zip_for_write(dest_path, compression=zipfile.ZIP_DEFLATED,
+                       set_permissions=True, **zip_kwargs):
+    """Yield a ``zipfile.ZipFile`` open for writing on local storage, then move
+    the finished archive onto ``dest_path``.
+
+    Assemble the archive on a local (seekable) volume rather than writing it
+    straight onto the data mount. Mounts commonly used for ``/data`` (mergerfs /
+    network / FUSE) may not support ``seek()`` on a file that is still being
+    written, and ``zipfile`` must seek backward to patch local headers and write
+    the central directory when it finalizes the archive. Writing directly there
+    raises ``OSError: [Errno 29] Illegal seek`` at close. Moving the completed
+    file into place is a sequential copy that never seeks the destination.
+
+    On success ``dest_path`` inherits its parent folder's permissions (unless
+    ``set_permissions=False``). If the body or the move raises, the temp file is
+    removed and ``dest_path`` is left untouched.
+
+    Usage mirrors ``zipfile.ZipFile``::
+
+        with open_zip_for_write(cbz_path) as zf:
+            zf.write(img_path, arcname)
+            zf.writestr(zip_info, data)
+
+    ``compression`` and any extra keyword args (e.g. ``compresslevel``) are
+    forwarded to ``zipfile.ZipFile``.
+    """
+    suffix = os.path.splitext(dest_path)[1] or ".zip"
+    tmp_dir = _zip_assembly_dir()
+    fd, tmp_path = tempfile.mkstemp(suffix=suffix, prefix="clu_zip_", dir=tmp_dir)
+    os.close(fd)
+    moved = False
+    try:
+        with zipfile.ZipFile(tmp_path, 'w', compression, **zip_kwargs) as zf:
+            yield zf
+        # The archive is fully written and closed on the local (seekable)
+        # volume; move it onto the destination, which is a plain sequential copy
+        # when the temp and destination live on different devices.
+        shutil.move(tmp_path, dest_path)
+        moved = True
+        if set_permissions:
+            match_parent_permissions(dest_path)
+    finally:
+        if not moved and os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 #########################
 #   Folder Thumbnails   #

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -1290,40 +1290,32 @@ def add_comicinfo_to_archive(file_path: str, xml_content) -> bool:
         True on success, False on failure
     """
     import zipfile
-    import tempfile
+    from helpers import open_zip_for_write
 
-    temp_path = None
     try:
-        # Create temp file on the SAME filesystem as the target so shutil.move
-        # is an atomic rename rather than a cross-device copy that would stamp
-        # mkstemp's 0600 mode onto the library file.
-        temp_fd, temp_path = tempfile.mkstemp(suffix='.cbz', dir=os.path.dirname(file_path) or ".")
-        os.close(temp_fd)
-
-        with zipfile.ZipFile(file_path, 'r') as zin:
-            with zipfile.ZipFile(temp_path, 'w', zipfile.ZIP_DEFLATED) as zout:
+        # open_zip_for_write assembles the new archive on a local volume and
+        # moves it into place (never seeking the data mount, which can raise
+        # "OSError: [Errno 29] Illegal seek" on mergerfs/network/FUSE), then
+        # matches the destination's parent-folder permissions. The source is
+        # read and closed inside — before the move — so ordering is safe.
+        with open_zip_for_write(file_path) as zout:
+            with zipfile.ZipFile(file_path, 'r') as zin:
                 for item in zin.infolist():
                     # Skip existing ComicInfo.xml (any case, any nesting level)
                     if os.path.basename(item.filename).lower() == 'comicinfo.xml':
                         continue
                     zout.writestr(item, zin.read(item.filename))
 
-                # Add new ComicInfo.xml - handle both str and bytes
-                if isinstance(xml_content, bytes):
-                    zout.writestr('ComicInfo.xml', xml_content)
-                else:
-                    zout.writestr('ComicInfo.xml', xml_content.encode('utf-8'))
+            # Add new ComicInfo.xml - handle both str and bytes
+            if isinstance(xml_content, bytes):
+                zout.writestr('ComicInfo.xml', xml_content)
+            else:
+                zout.writestr('ComicInfo.xml', xml_content.encode('utf-8'))
 
-        # Replace original with temp
-        shutil.move(temp_path, file_path)
-        from helpers import match_parent_permissions
-        match_parent_permissions(file_path)
         return True
 
     except Exception as e:
         app_logger.error(f"Error adding ComicInfo.xml to {file_path}: {e}")
-        if temp_path and os.path.exists(temp_path):
-            os.remove(temp_path)
         return False
 
 

--- a/models/update_xml.py
+++ b/models/update_xml.py
@@ -6,8 +6,8 @@ import zipfile
 import shutil
 import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as SafeET
-from tempfile import NamedTemporaryFile
 from core.comicinfo import find_comicinfo_in_zip
+from helpers import open_zip_for_write
 
 
 def update_field_in_cbz_files(folder_path: str, field: str, value: str) -> dict:
@@ -32,7 +32,6 @@ def update_field_in_cbz_files(folder_path: str, field: str, value: str) -> dict:
             continue
 
         cbz_path = os.path.join(folder_path, filename)
-        temp_path = None
 
         try:
             with zipfile.ZipFile(cbz_path, "r") as zf:
@@ -58,32 +57,27 @@ def update_field_in_cbz_files(folder_path: str, field: str, value: str) -> dict:
             elem.text = str(value)
             new_xml_bytes = ET.tostring(root, encoding="utf-8", xml_declaration=True)
 
-            # Create temp file in same directory
-            with NamedTemporaryFile(dir=folder_path, delete=False) as tmp_file:
-                temp_path = tmp_file.name
+            # open_zip_for_write assembles the archive on a local volume and
+            # moves it into place (never seeking the data mount, which can raise
+            # "OSError: [Errno 29] Illegal seek" on mergerfs/network/FUSE), then
+            # matches parent-folder permissions. The source is read and closed
+            # inside — before the move.
+            with open_zip_for_write(cbz_path) as zf_out:
+                with zipfile.ZipFile(cbz_path, "r") as zf_in:
+                    for item in zf_in.infolist():
+                        if item.filename == comicinfo_path:
+                            zf_out.writestr(item, new_xml_bytes)
+                        else:
+                            with zf_in.open(item.filename) as source, \
+                                 zf_out.open(item, "w") as target:
+                                shutil.copyfileobj(source, target)
 
-            with zipfile.ZipFile(cbz_path, "r") as zf_in, \
-                 zipfile.ZipFile(temp_path, "w", compression=zipfile.ZIP_DEFLATED) as zf_out:
-
-                for item in zf_in.infolist():
-                    if item.filename == comicinfo_path:
-                        zf_out.writestr(item, new_xml_bytes)
-                    else:
-                        with zf_in.open(item.filename) as source, \
-                             zf_out.open(item, "w") as target:
-                            shutil.copyfileobj(source, target)
-
-            os.replace(temp_path, cbz_path)
-            from helpers import match_parent_permissions
-            match_parent_permissions(cbz_path)
             result['updated'] += 1
             result['details'].append({'file': filename, 'status': 'updated'})
 
         except Exception as e:
             result['errors'] += 1
             result['details'].append({'file': filename, 'status': 'error', 'reason': str(e)})
-            if temp_path and os.path.exists(temp_path):
-                os.remove(temp_path)
 
     return result
 

--- a/routes/bulk_metadata.py
+++ b/routes/bulk_metadata.py
@@ -994,19 +994,18 @@ def audit_revert_multiple():
 
 def _strip_comicinfo_from_cbz(file_path):
     """Rewrite a CBZ in place without its ComicInfo.xml entries."""
-    file_dir = os.path.dirname(file_path) or '.'
-    base_name = os.path.splitext(os.path.basename(file_path))[0]
-    temp_zip = os.path.join(file_dir, f".tmp_revert_{base_name}_{os.getpid()}.cbz")
+    from helpers import open_zip_for_write
 
-    with zipfile.ZipFile(file_path, 'r') as src:
-        with zipfile.ZipFile(temp_zip, 'w', zipfile.ZIP_DEFLATED) as dst:
+    # open_zip_for_write assembles on a local volume and moves the result into
+    # place (never seeking the data mount, which can raise "OSError: [Errno 29]
+    # Illegal seek" on mergerfs/network/FUSE), then matches parent-folder
+    # permissions. The source is read and closed inside — before the move.
+    with open_zip_for_write(file_path) as dst:
+        with zipfile.ZipFile(file_path, 'r') as src:
             for info in src.infolist():
                 if os.path.basename(info.filename).lower() == 'comicinfo.xml':
                     continue
                 dst.writestr(info, src.read(info.filename))
-    os.replace(temp_zip, file_path)
-    from helpers import match_parent_permissions
-    match_parent_permissions(file_path)
 
 
 # ----------------------------------------------------------------------------

--- a/routes/files.py
+++ b/routes/files.py
@@ -467,8 +467,12 @@ def combine_cbz():
             output_path = os.path.join(directory, f"{output_name} ({counter}).cbz")
             counter += 1
 
-        # Compress temp dir to CBZ
-        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        # Compress temp dir to CBZ. open_zip_for_write assembles on a local
+        # volume and moves the result into place, so we never seek the data
+        # mount (which can raise "OSError: [Errno 29] Illegal seek" on
+        # mergerfs/network/FUSE), and it matches parent-folder permissions.
+        from helpers import open_zip_for_write
+        with open_zip_for_write(output_path) as zf:
             extracted_files = sorted(os.listdir(temp_dir))
             for filename in extracted_files:
                 file_path_full = os.path.join(temp_dir, filename)

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -216,9 +216,11 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
     file_dir = os.path.dirname(file_path) or '.'
     base_name = os.path.splitext(os.path.basename(file_path))[0]
 
-    # Create temporary extraction directory
+    # Create temporary extraction directory (sequential writes are fine on the
+    # data volume, so extract in place next to the source file).
     temp_extract_dir = os.path.join(file_dir, f".tmp_extract_{base_name}_{os.getpid()}")
-    temp_zip_path = os.path.join(file_dir, f".tmp_{base_name}_{os.getpid()}.cbz")
+
+    from helpers import open_zip_for_write
 
     try:
         # Step 1: Extract all files to temporary directory
@@ -270,8 +272,11 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
         with open(comicinfo_path, 'wb') as f:
             f.write(comicinfo_xml_bytes)
 
-        # Step 3: Recompress everything into new CBZ (sorted for consistency)
-        with zipfile.ZipFile(temp_zip_path, 'w', zipfile.ZIP_DEFLATED) as dst:
+        # Step 3: Recompress everything into new CBZ (sorted for consistency).
+        # open_zip_for_write assembles on a local volume and moves the finished
+        # archive onto file_path, so we never seek the data mount (which can
+        # raise "OSError: [Errno 29] Illegal seek" on mergerfs/network/FUSE).
+        with open_zip_for_write(file_path) as dst:
             # Get all files and sort them
             all_files = []
             for root_dir, dirs, files in os.walk(temp_extract_dir):
@@ -287,11 +292,6 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
             for file_path_full, arcname in all_files:
                 dst.write(file_path_full, arcname)
 
-        # Step 4: Replace original file
-        os.replace(temp_zip_path, file_path)
-        from helpers import match_parent_permissions
-        match_parent_permissions(file_path)
-
     except zipfile.BadZipFile as e:
         # Handle the case where a .cbz file is actually a RAR file
         if "File is not a zip file" in str(e) or "BadZipFile" in str(e):
@@ -300,11 +300,6 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
             # Clean up any partial extraction
             if os.path.exists(temp_extract_dir):
                 shutil.rmtree(temp_extract_dir, ignore_errors=True)
-            if os.path.exists(temp_zip_path):
-                try:
-                    os.unlink(temp_zip_path)
-                except:
-                    pass
 
             # Rename to .rar for conversion
             rar_file = os.path.join(file_dir, base_name + ".rar")
@@ -337,15 +332,9 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
             raise
 
     finally:
-        # Clean up temp directory
+        # Clean up temp directory (open_zip_for_write cleans up its own temp).
         if os.path.exists(temp_extract_dir):
             shutil.rmtree(temp_extract_dir, ignore_errors=True)
-        # Clean up temp zip if it still exists
-        if os.path.exists(temp_zip_path):
-            try:
-                os.unlink(temp_zip_path)
-            except:
-                pass
 
 
 # =============================================================================
@@ -431,26 +420,24 @@ def _remove_comicinfo_from_cbz(file_path):
         return {"success": False, "error": "File is not a CBZ"}
 
     try:
-        temp_zip_path = file_path + ".tmpzip"
-        comicinfo_found = False
+        from helpers import open_zip_for_write
 
-        with zipfile.ZipFile(file_path, 'r') as old_zip, \
-             zipfile.ZipFile(temp_zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as new_zip:
-
-            for item in old_zip.infolist():
-                if os.path.basename(item.filename).lower() == "comicinfo.xml":
-                    comicinfo_found = True
-                    continue
-                else:
-                    new_zip.writestr(item, old_zip.read(item.filename))
-
+        # Bail out before rewriting if there's nothing to remove.
+        with zipfile.ZipFile(file_path, 'r') as z:
+            comicinfo_found = any(
+                os.path.basename(n).lower() == "comicinfo.xml" for n in z.namelist()
+            )
         if not comicinfo_found:
-            os.remove(temp_zip_path)
             return {"success": False, "error": "ComicInfo.xml not found in CBZ"}
 
-        os.replace(temp_zip_path, file_path)
-        from helpers import match_parent_permissions
-        match_parent_permissions(file_path)
+        # open_zip_for_write assembles locally and moves the result into place,
+        # so the source archive is fully read and closed before the move.
+        with open_zip_for_write(file_path) as new_zip:
+            with zipfile.ZipFile(file_path, 'r') as old_zip:
+                for item in old_zip.infolist():
+                    if os.path.basename(item.filename).lower() == "comicinfo.xml":
+                        continue
+                    new_zip.writestr(item, old_zip.read(item.filename))
 
         from core.database import set_has_comicinfo
         set_has_comicinfo(file_path, 0)
@@ -460,8 +447,6 @@ def _remove_comicinfo_from_cbz(file_path):
 
     except Exception as e:
         app_logger.error(f"Error removing ComicInfo.xml from {file_path}: {e}")
-        if os.path.exists(file_path + ".tmpzip"):
-            os.remove(file_path + ".tmpzip")
         return {"success": False, "error": str(e)}
 
 

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -127,6 +127,70 @@ def _make_cbz(path, with_comicinfo=True):
             zf.writestr("ComicInfo.xml", "<ComicInfo><Series>Test</Series></ComicInfo>")
 
 
+class TestAddComicInfoToCbz:
+    """Round-trip tests for add_comicinfo_to_cbz (real archive assembly)."""
+
+    def _patch_cache_dir(self, cache_dir):
+        """Point CACHE_DIR at a local temp dir so assembly happens off /data."""
+        from routes import metadata
+
+        real_get = metadata.config.get
+
+        def fake_get(section, option, *args, **kwargs):
+            if section == "SETTINGS" and option == "CACHE_DIR":
+                return str(cache_dir)
+            return real_get(section, option, *args, **kwargs)
+
+        return patch.object(metadata.config, "get", side_effect=fake_get)
+
+    def test_inserts_comicinfo_at_root_and_preserves_images(self, tmp_path):
+        from routes.metadata import add_comicinfo_to_cbz
+
+        cbz_path = str(tmp_path / "Batman 001.cbz")
+        _make_cbz(cbz_path, with_comicinfo=False)
+
+        xml = b"<ComicInfo><Series>Batman</Series><Number>1</Number></ComicInfo>"
+        with self._patch_cache_dir(tmp_path / "cache"), \
+             patch("helpers.match_parent_permissions"):
+            add_comicinfo_to_cbz(cbz_path, xml)
+
+        with zipfile.ZipFile(cbz_path, "r") as zf:
+            names = zf.namelist()
+            assert "ComicInfo.xml" in names, "ComicInfo.xml must be at archive root"
+            assert "page_001.png" in names, "original images must be preserved"
+            assert zf.read("ComicInfo.xml") == xml
+
+    def test_replaces_existing_comicinfo(self, tmp_path):
+        from routes.metadata import add_comicinfo_to_cbz
+
+        cbz_path = str(tmp_path / "Batman 002.cbz")
+        _make_cbz(cbz_path, with_comicinfo=True)  # starts with a stub ComicInfo.xml
+
+        xml = b"<ComicInfo><Series>New</Series></ComicInfo>"
+        with self._patch_cache_dir(tmp_path / "cache"), \
+             patch("helpers.match_parent_permissions"):
+            add_comicinfo_to_cbz(cbz_path, xml)
+
+        with zipfile.ZipFile(cbz_path, "r") as zf:
+            # Exactly one ComicInfo.xml (case-insensitive), holding the new bytes.
+            ci = [n for n in zf.namelist() if os.path.basename(n).lower() == "comicinfo.xml"]
+            assert len(ci) == 1
+            assert zf.read(ci[0]) == xml
+
+    def test_leaves_no_temp_artifacts(self, tmp_path):
+        from routes.metadata import add_comicinfo_to_cbz
+
+        cbz_path = str(tmp_path / "Batman 003.cbz")
+        _make_cbz(cbz_path, with_comicinfo=False)
+
+        with self._patch_cache_dir(tmp_path / "cache"), \
+             patch("helpers.match_parent_permissions"):
+            add_comicinfo_to_cbz(cbz_path, b"<ComicInfo/>")
+
+        leftovers = [n for n in os.listdir(tmp_path) if n.startswith(".tmp")]
+        assert leftovers == [], f"temp extraction dirs not cleaned up: {leftovers}"
+
+
 class TestRemoveComicInfoHelper:
 
     @patch("core.database.set_has_comicinfo")

--- a/tests/unit/test_zip_writer.py
+++ b/tests/unit/test_zip_writer.py
@@ -1,0 +1,118 @@
+"""Tests for helpers.open_zip_for_write -- the shared "assemble locally, then
+move onto the data volume" archive writer.
+
+The helper exists so CBZ writes never rely on the destination mount being
+seekable: some backends used for /data (mergerfs / network / FUSE) raise
+"OSError: [Errno 29] Illegal seek" when zipfile seeks back to finalize an
+archive written directly onto them. Assembling on a local volume and moving the
+finished file into place avoids that.
+"""
+import os
+import zipfile
+
+import pytest
+
+import helpers
+
+
+@pytest.fixture
+def local_staging(tmp_path, monkeypatch):
+    """Force the staging dir onto a real local temp dir under tmp_path, and
+    confirm assembly actually happens there (not on the destination path)."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    monkeypatch.setattr(helpers, "_zip_assembly_dir", lambda: str(staging))
+    monkeypatch.setattr(helpers, "match_parent_permissions", lambda p: None)
+    return staging
+
+
+def test_writes_and_moves_into_place(tmp_path, local_staging):
+    dest = tmp_path / "out.cbz"
+    with helpers.open_zip_for_write(str(dest)) as zf:
+        zf.writestr("001.jpg", b"img-a")
+        zf.writestr("002.jpg", b"img-b")
+
+    assert dest.exists()
+    with zipfile.ZipFile(str(dest)) as zf:
+        assert zf.namelist() == ["001.jpg", "002.jpg"]
+        assert zf.read("002.jpg") == b"img-b"
+
+
+def test_assembles_on_staging_not_destination(tmp_path, local_staging):
+    """Mid-write, the archive must live in the staging dir, and the destination
+    must not yet exist -- proving nothing is written/seeked on the dest volume."""
+    dest = tmp_path / "out.cbz"
+    with helpers.open_zip_for_write(str(dest)) as zf:
+        zf.writestr("001.jpg", b"x")
+        assert not dest.exists(), "destination must not exist until the move"
+        staged = os.listdir(local_staging)
+        assert staged, "archive should be assembled in the staging dir"
+
+    assert dest.exists()
+    assert os.listdir(local_staging) == [], "staging temp must be moved out"
+
+
+def test_supports_write_from_disk(tmp_path, local_staging):
+    src = tmp_path / "page.jpg"
+    src.write_bytes(b"disk-bytes")
+    dest = tmp_path / "out.cbz"
+
+    with helpers.open_zip_for_write(str(dest)) as zf:
+        zf.write(str(src), "page.jpg")
+
+    with zipfile.ZipFile(str(dest)) as zf:
+        assert zf.read("page.jpg") == b"disk-bytes"
+
+
+def test_forwards_compression_and_compresslevel(tmp_path, local_staging):
+    dest = tmp_path / "stored.cbz"
+    with helpers.open_zip_for_write(str(dest), zipfile.ZIP_STORED) as zf:
+        zf.writestr("001.jpg", b"raw")
+    with zipfile.ZipFile(str(dest)) as zf:
+        assert zf.getinfo("001.jpg").compress_type == zipfile.ZIP_STORED
+
+    dest2 = tmp_path / "deflated.cbz"
+    with helpers.open_zip_for_write(str(dest2), zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        zf.writestr("001.jpg", b"data" * 100)
+    with zipfile.ZipFile(str(dest2)) as zf:
+        assert zf.getinfo("001.jpg").compress_type == zipfile.ZIP_DEFLATED
+
+
+def test_failure_leaves_destination_untouched_and_cleans_temp(tmp_path, local_staging):
+    dest = tmp_path / "out.cbz"
+    dest.write_bytes(b"original-contents")
+
+    with pytest.raises(RuntimeError):
+        with helpers.open_zip_for_write(str(dest)) as zf:
+            zf.writestr("001.jpg", b"x")
+            raise RuntimeError("boom")
+
+    # Original destination is untouched (no partial overwrite) ...
+    assert dest.read_bytes() == b"original-contents"
+    # ... and the staging temp was cleaned up.
+    assert os.listdir(local_staging) == []
+
+
+def test_overwrites_existing_destination_on_success(tmp_path, local_staging):
+    dest = tmp_path / "out.cbz"
+    dest.write_bytes(b"stale")
+
+    with helpers.open_zip_for_write(str(dest)) as zf:
+        zf.writestr("new.jpg", b"fresh")
+
+    with zipfile.ZipFile(str(dest)) as zf:
+        assert zf.namelist() == ["new.jpg"]
+
+
+def test_calls_match_parent_permissions_on_success(tmp_path, monkeypatch):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    monkeypatch.setattr(helpers, "_zip_assembly_dir", lambda: str(staging))
+    called = []
+    monkeypatch.setattr(helpers, "match_parent_permissions", lambda p: called.append(p))
+
+    dest = tmp_path / "out.cbz"
+    with helpers.open_zip_for_write(str(dest)) as zf:
+        zf.writestr("001.jpg", b"x")
+
+    assert called == [str(dest)]


### PR DESCRIPTION
## Problem

Writing a CBZ/zip **directly onto the `/data` mount** could fail with `OSError: [Errno 29] Illegal seek`. Mounts commonly used for `/data` (mergerfs / network / FUSE) support sequential writes but not `seek()` on a file that is still being written, and `zipfile` must seek backward to patch local headers and write the central directory when it finalizes an archive. Extraction succeeds, then the archive blows up at close.

Reported in the wild: a ComicVine search-metadata run extracted OK, then died finalizing the rewrite with nested `fp.seek(...)` → ESPIPE tracebacks (Python 3.14, Linux, `MONITOR=yes`).

## Fix

Add `helpers.open_zip_for_write(dest_path, compression=…, **zip_kwargs)` — a context manager that:

- yields a `zipfile.ZipFile` open on a **local, seekable** staging dir (`CACHE_DIR/tmp`, where SQLite already lives; falls back to the system temp dir),
- `shutil.move`s the finished archive into place — a sequential copy that never seeks the destination volume,
- matches parent-folder permissions on the result,
- and, on any failure in the body or the move, removes the temp and leaves the destination untouched.

Then route **every non-test, non-in-memory zip write destined for `/data`** through it:

- All 11 `cbz_ops/` writes: `add`, `remove`, `crop`, `convert`, `rebuild` (×2), `single_file` (×2), `pdf` (`ZIP_STORED`), `enhance_single` (`compresslevel=6`), `edit` (`compresslevel=6`)
- `routes/metadata.py`: `add_comicinfo_to_cbz`, `_remove_comicinfo_from_cbz`
- `models/comicvine.py`: `add_comicinfo_to_archive`
- `models/update_xml.py`: `update_field_in_cbz_files`
- `core/comicinfo.py`: `update_comicinfo_in_zip`
- `routes/bulk_metadata.py`: `_strip_comicinfo_from_cbz`
- `routes/files.py`: combine-CBZ

### Notes

- **Ordering:** for in-place rewrites, `open_zip_for_write` is the *outer* context and the `zipfile.ZipFile(src, 'r')` read is the *inner* one, so the source is fully read and closed **before** the move onto its own path (safe on all platforms).
- **Permissions:** the `cbz_ops/` writes that previously never called `match_parent_permissions` now do, via the helper — consistent with the existing "every CBZ write must match parent perms" invariant, and redundant explicit calls in `single_file.py`/`rebuild.py` were removed.
- **Deliberately left alone** (not `/data`): `app.py` BytesIO download zips, `core/database.py` backups (local `CACHE_DIR`), `core/debug_package.py` BytesIO.

## Tests

- `tests/unit/test_zip_writer.py` (new, 7 tests): round-trip, assembles-on-staging-not-destination, disk-source `write`, compression/`compresslevel` forwarding, failure leaves destination untouched + cleans temp, overwrite-on-success, permission-matching.
- `tests/routes/test_metadata_routes.py` (new `TestAddComicInfoToCbz`, 3 tests): real archive round-trip for `add_comicinfo_to_cbz` — ComicInfo.xml at root with images preserved, replaces an existing ComicInfo.xml, no temp artifacts left behind.

Full suite: **2379 passed, 6 skipped**. The only failures are the 13 pre-existing `tests/mocked/test_pdf.py` cases, which fail with `ModuleNotFoundError: No module named 'pdf2image'` (local env baseline, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
