### PR TITLE
Map Metron "Script" credit role to Writer

### DIFF
--- a/models/metron.py
+++ b/models/metron.py
@@ -588,7 +588,7 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
 
     # Extract credits
     credits = _get_attr(issue_data, "credits", []) or []
-    writer = extract_credits_by_role(credits, ["Writer", "Story"])
+    writer = extract_credits_by_role(credits, ["Writer", "Script", "Story", "Plot"])
     penciller = extract_credits_by_role(credits, ["Penciller", "Artist", "Illustrator"])
     inker = extract_credits_by_role(credits, ["Inker"])
     colorist = extract_credits_by_role(credits, ["Colorist"])

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -404,6 +404,21 @@ class TestExtractCreditsByRole:
         result = extract_credits_by_role(credits, ["Writer"])
         assert result == ""
 
+    def test_script_role_maps_to_writer(self):
+        # Metron lists many writers under the "Script" role (e.g. Jeff Lemire
+        # credited as "Script, Cover" on Black Hammer #1). map_to_comicinfo must
+        # treat "Script" as a Writer role or the writer is dropped.
+        from models.metron import map_to_comicinfo
+
+        issue_data = {
+            "credits": [
+                {"creator": "Jeff Lemire", "role": [{"name": "Script"}, {"name": "Cover"}]},
+                {"creator": "Dean Ormston", "role": [{"name": "Pencils"}]},
+            ],
+        }
+        result = map_to_comicinfo(issue_data)
+        assert result["Writer"] == "Jeff Lemire"
+
 
 class TestCalculateComicWeek:
 


### PR DESCRIPTION
## Problem

When applying metadata from Metron, writers credited under the **"Script"** role were dropped from the Writer field. Metron lists many writers this way rather than under "Writer" — e.g. Jeff Lemire is credited as "Script, Cover" on [Black Hammer #1](https://metron.cloud/issue/black-hammer-2016-1/), so he was skipped entirely.

## Fix

Widened the writer role list in `map_to_comicinfo` (`models/metron.py`) from `["Writer", "Story"]` to `["Writer", "Script", "Story", "Plot"]`.

This aligns Metron with the other sources, which already handle it:
- **ComicVine** (`comicvine.py`) matches `"writer" in role or "script" in role`
- **GCD** (`gcd.py`, `gcd_api_provider.py`) matches `script`/`writer`/`plot`

The Metron provider delegates to this same `map_to_comicinfo`, so both single-file and batch metadata flows are covered.

## Tests

Added `test_script_role_maps_to_writer` in `tests/mocked/test_metron_model.py` using the Black Hammer example. Full Metron suite (59 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)