### PR TITLE
Speed up wanted-issue TARGET scan with single-pass matcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -747,189 +747,121 @@ def process_incoming_wanted_issues():
     if not files:
         return
 
+    # Match all wanted issues against the TARGET files in a single pass. The
+    # helper opens each archive at most once and memoizes per-series name,
+    # alias, and regex work, replacing the old per-issue x per-file re-scan.
+    matches = match_wanted_issues_to_files(wanted, files, match_pattern)
+
     moved_count = 0
     affected_series = set()  # Track series that had files moved
-    # GetComics search aliases let a series match files stored under an
-    # alternative name (e.g. series "Thor" with alias "Mortal Thor" so
-    # 'Mortal Thor 011.cbz' matches). Cache per series name — one DB hit each.
-    from models.getcomics import get_series_aliases
-    alias_cache = {}
-    for issue in wanted:
-        db_series_name = issue["series_name"]
-        issue_number = issue["number"]
+    for match in matches:
+        issue = match["issue"]
+        actual_series_name = match["series_name"]
+        filename = match["filename"]
+        src = match["src"]
         mapped_path = issue["mapped_path"]
 
-        # Get actual series name from existing files in the series folder
-        # This handles cases like "The Ultimates" in DB but "Ultimates" in filenames
-        actual_series_name = get_series_name_from_files(mapped_path, db_series_name)
-        if actual_series_name != db_series_name:
-            app_logger.debug(
-                f"Using file-based name: '{actual_series_name}' instead of '{db_series_name}'"
-            )
-
-        # Names to match against: the file-derived series name plus any
-        # GetComics search aliases configured for this series.
-        if db_series_name not in alias_cache:
-            try:
-                raw_aliases = get_series_aliases(db_series_name) or ""
-            except Exception as e:
-                app_logger.debug(
-                    f"Failed to load aliases for '{db_series_name}': {e}"
-                )
-                raw_aliases = ""
-            alias_cache[db_series_name] = [
-                a.strip() for a in raw_aliases.split(",") if a.strip()
-            ]
-
-        match_names = build_series_match_names(
-            actual_series_name, alias_cache[db_series_name]
+        app_logger.info(
+            f"✓ Match found: '{filename}' matches "
+            f"'{actual_series_name} #{issue['number']}'"
         )
 
-        # Generate a regex per candidate name (without year)
-        regexes = []
-        for name in match_names:
-            r = generate_filename_pattern(match_pattern, name, issue_number)
-            if r:
-                regexes.append(r)
-        if not regexes:
-            app_logger.info(
-                f"Failed to generate pattern for: {actual_series_name} #{issue_number}"
-            )
+        # Found a match - move first, then rename
+        dest_dir = mapped_path
+
+        # Debug: Log paths and existence checks
+        app_logger.debug(
+            f"  Source path: {src} (exists: {os.path.exists(src)})"
+        )
+        app_logger.debug(
+            f"  Dest dir: {dest_dir} (exists: {os.path.exists(dest_dir)}, isdir: {os.path.isdir(dest_dir) if os.path.exists(dest_dir) else 'N/A'})"
+        )
+
+        if not os.path.exists(src):
+            app_logger.warning(f"Source file missing: {src}")
             continue
 
-        if len(match_names) > 1:
-            app_logger.info(
-                f"Checking: '{actual_series_name}' #{issue_number} "
-                f"(+{len(match_names) - 1} alias(es): {', '.join(match_names[1:])})"
-            )
-        else:
-            app_logger.info(
-                f"Checking: '{actual_series_name}' #{issue_number} | regex: {regexes[0].pattern}"
-            )
+        if not os.path.exists(dest_dir):
+            app_logger.warning(f"Series folder missing: {dest_dir}")
+            continue
 
-        for filename, src in files[:]:  # Copy list to allow removal
-            match_result = any(r.match(filename) for r in regexes)
+        # Move file with original name first
+        temp_dest = os.path.join(dest_dir, filename)
 
-            # Fallback: try ComicInfo.xml if regex didn't match
-            if not match_result and filename.lower().endswith((".cbz", ".zip")):
-                comicinfo = extract_comicinfo(src)
-                if comicinfo and comicinfo.get("number"):
-                    meta_num = str(comicinfo["number"]).strip().lstrip("0") or "0"
-                    check_num = str(issue_number).strip().lstrip("0") or "0"
-                    if meta_num == check_num:
-                        meta_series = (comicinfo.get("series") or "").lower()
-                        if meta_series and any(
-                            n.lower() in meta_series or meta_series in n.lower()
-                            for n in match_names
-                        ):
-                            match_result = True
+        try:
+            shutil.move(src, temp_dest)
+            app_logger.info(f"Moved: {filename} -> {dest_dir}")
+            moved_count += 1
+            affected_series.add(issue["series_id"])
 
-            app_logger.debug(
-                f"  Testing '{filename}' -> {'MATCH' if match_result else 'no match'}"
-            )
-            if match_result:
-                app_logger.info(
-                    f"✓ Match found: '{filename}' matches '{actual_series_name} #{issue_number}'"
+            # Index the file right away so later rename/metadata steps
+            # can update the entry instead of warning "not found"
+            try:
+                file_stat = os.stat(temp_dest)
+                add_file_index_entry(
+                    name=filename,
+                    path=temp_dest,
+                    entry_type="file",
+                    size=file_stat.st_size,
+                    parent=dest_dir,
+                    modified_at=file_stat.st_mtime,
+                )
+            except Exception as e:
+                app_logger.error(
+                    f"Failed to add {temp_dest} to file index: {e}"
                 )
 
-                # Found a match - move first, then rename
-                dest_dir = mapped_path
+            # Only rename if AUTO_RENAME_MONITOR is enabled
+            auto_rename_monitor = config.getboolean(
+                "SETTINGS", "AUTO_RENAME_MONITOR", fallback=True
+            )
+            final_path = temp_dest
+            if auto_rename_monitor:
+                from cbz_ops.rename import get_renamed_filename
 
-                # Debug: Log paths and existence checks
-                app_logger.debug(
-                    f"  Source path: {src} (exists: {os.path.exists(src)})"
-                )
-                app_logger.debug(
-                    f"  Dest dir: {dest_dir} (exists: {os.path.exists(dest_dir)}, isdir: {os.path.isdir(dest_dir) if os.path.exists(dest_dir) else 'N/A'})"
-                )
-
-                if not os.path.exists(src):
-                    app_logger.warning(f"Source file missing: {src}")
-                    continue
-
-                if not os.path.exists(dest_dir):
-                    app_logger.warning(f"Series folder missing: {dest_dir}")
-                    continue
-
-                # Move file with original name first
-                temp_dest = os.path.join(dest_dir, filename)
-
-                try:
-                    shutil.move(src, temp_dest)
-                    app_logger.info(f"Moved: {filename} -> {dest_dir}")
-                    files.remove((filename, src))
-                    moved_count += 1
-                    affected_series.add(issue["series_id"])
-
-                    # Index the file right away so later rename/metadata steps
-                    # can update the entry instead of warning "not found"
-                    try:
-                        file_stat = os.stat(temp_dest)
-                        add_file_index_entry(
-                            name=filename,
-                            path=temp_dest,
-                            entry_type="file",
-                            size=file_stat.st_size,
-                            parent=dest_dir,
-                            modified_at=file_stat.st_mtime,
-                        )
-                    except Exception as e:
-                        app_logger.error(
-                            f"Failed to add {temp_dest} to file index: {e}"
-                        )
-
-                    # Only rename if AUTO_RENAME_MONITOR is enabled
-                    auto_rename_monitor = config.getboolean(
-                        "SETTINGS", "AUTO_RENAME_MONITOR", fallback=True
+                new_filename = get_renamed_filename(filename, file_path=temp_dest)
+                if new_filename and new_filename != filename:
+                    final_path = os.path.join(dest_dir, new_filename)
+                    os.rename(temp_dest, final_path)
+                    app_logger.info(f"Renamed: {filename} -> {new_filename}")
+                    update_file_index_entry(
+                        temp_dest,
+                        name=new_filename,
+                        new_path=final_path,
+                        parent=dest_dir,
                     )
-                    final_path = temp_dest
-                    if auto_rename_monitor:
-                        from cbz_ops.rename import get_renamed_filename
 
-                        new_filename = get_renamed_filename(filename, file_path=temp_dest)
-                        if new_filename and new_filename != filename:
-                            final_path = os.path.join(dest_dir, new_filename)
-                            os.rename(temp_dest, final_path)
-                            app_logger.info(f"Renamed: {filename} -> {new_filename}")
-                            update_file_index_entry(
-                                temp_dest,
-                                name=new_filename,
-                                new_path=final_path,
-                                parent=dest_dir,
-                            )
+            # Auto-fetch metadata (try Metron first, then ComicVine as fallback)
+            app_logger.info(f"Auto-fetching metadata for: {final_path}")
+            pre_fetch_path = final_path
+            final_path = auto_fetch_metron_metadata(final_path)
+            final_path = auto_fetch_comicvine_metadata(final_path)
 
-                    # Auto-fetch metadata (try Metron first, then ComicVine as fallback)
-                    app_logger.info(f"Auto-fetching metadata for: {final_path}")
-                    pre_fetch_path = final_path
-                    final_path = auto_fetch_metron_metadata(final_path)
-                    final_path = auto_fetch_comicvine_metadata(final_path)
+            # Refresh the index entry (upsert) — metadata injection
+            # changes size, and the fetchers may have renamed the file
+            try:
+                file_stat = os.stat(final_path)
+                add_file_index_entry(
+                    name=os.path.basename(final_path),
+                    path=final_path,
+                    entry_type="file",
+                    size=file_stat.st_size,
+                    parent=os.path.dirname(final_path),
+                    modified_at=file_stat.st_mtime,
+                )
+                # Drop a stale row left behind when a fetcher renamed
+                # the file without updating the index (ComicVine path)
+                if final_path != pre_fetch_path and not os.path.exists(
+                    pre_fetch_path
+                ):
+                    delete_file_index_entry(pre_fetch_path)
+            except Exception as e:
+                app_logger.error(
+                    f"Failed to add {final_path} to file index: {e}"
+                )
 
-                    # Refresh the index entry (upsert) — metadata injection
-                    # changes size, and the fetchers may have renamed the file
-                    try:
-                        file_stat = os.stat(final_path)
-                        add_file_index_entry(
-                            name=os.path.basename(final_path),
-                            path=final_path,
-                            entry_type="file",
-                            size=file_stat.st_size,
-                            parent=os.path.dirname(final_path),
-                            modified_at=file_stat.st_mtime,
-                        )
-                        # Drop a stale row left behind when a fetcher renamed
-                        # the file without updating the index (ComicVine path)
-                        if final_path != pre_fetch_path and not os.path.exists(
-                            pre_fetch_path
-                        ):
-                            delete_file_index_entry(pre_fetch_path)
-                    except Exception as e:
-                        app_logger.error(
-                            f"Failed to add {final_path} to file index: {e}"
-                        )
-
-                except Exception as e:
-                    app_logger.error(f"Failed to move/rename {filename}: {e}")
-                break
+        except Exception as e:
+            app_logger.error(f"Failed to move/rename {filename}: {e}")
 
     if moved_count > 0:
         app_logger.info(
@@ -2468,6 +2400,7 @@ from helpers.collection import (
     get_series_name_from_files,
     extract_comicinfo,
     match_issues_to_collection,
+    match_wanted_issues_to_files,
 )
 from helpers import is_hidden
 

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from core.config import config
 from core.app_logging import app_logger
 
@@ -321,6 +322,161 @@ def extract_comicinfo(file_path):
     return None
 
 
+def extract_comicinfo_cached(file_path, cache):
+    """Return the ComicInfo dict for ``file_path``, opening the archive at most once.
+
+    ``cache`` is a caller-owned dict mapping path -> parsed dict (``{}`` when the
+    file has no readable ComicInfo.xml). Non-CBZ/ZIP paths resolve to ``{}``
+    without a disk read. This lets a scan open each archive a single time
+    instead of once per wanted issue (the previous O(issues x files) cost).
+    """
+    cached = cache.get(file_path)
+    if cached is not None:
+        return cached
+    if not file_path.lower().endswith((".cbz", ".zip")):
+        cache[file_path] = {}
+        return cache[file_path]
+    cache[file_path] = extract_comicinfo(file_path) or {}
+    return cache[file_path]
+
+
+def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None):
+    """Match wanted issues against a pool of files without touching the filesystem.
+
+    Replaces the old ``for each wanted issue: for each file`` scan (which
+    rebuilt the folder-derived series name, reloaded aliases, recompiled the
+    regex, and re-opened every archive on every iteration). Here all per-file
+    work (ComicInfo.xml) happens at most once, and all per-series work
+    (folder-derived name, aliases, compiled regexes) is memoized, so the cost
+    drops to roughly O(issues + files) archive/directory reads.
+
+    Matching semantics are identical to the previous inline loop: a filename
+    regex built from ``match_pattern`` (year/month/title already stripped by the
+    caller), with a ComicInfo.xml fallback that compares the normalized issue
+    number plus a loose series-name substring. Each file is matched to at most
+    one wanted issue, wanted issues are considered in order, and for each the
+    first matching remaining file wins.
+
+    Args:
+        wanted: Iterable of dicts with ``series_name``, ``number``, ``mapped_path``
+            (and any extra keys the caller needs, e.g. ``series_id``).
+        files: Iterable of ``(filename, full_path)`` tuples.
+        match_pattern: Rename pattern with year/month/title tokens removed.
+        alias_lookup: Callable ``name -> comma-separated aliases``; defaults to
+            ``models.getcomics.get_series_aliases``. Injectable for tests.
+
+    Returns:
+        List of dicts ``{"issue", "series_name", "filename", "src"}`` — one per
+        matched file, in the order matches were found.
+    """
+    if alias_lookup is None:
+        from models.getcomics import get_series_aliases
+        alias_lookup = get_series_aliases
+
+    debug = app_logger.isEnabledFor(logging.DEBUG)
+
+    # Per-series memoization (many wanted issues share one folder / name).
+    series_name_cache = {}   # mapped_path -> folder-derived series name
+    alias_cache = {}         # db_series_name -> [alias, ...]
+    match_names_cache = {}   # (mapped_path, db_series_name) -> [name, ...]
+    regex_cache = {}         # (name, issue_number) -> compiled regex or None
+    # Per-file ComicInfo memo (archive opened at most once).
+    comicinfo_cache = {}
+
+    remaining = list(files)  # (filename, src) tuples; matched files removed
+    matches = []
+
+    for issue in wanted:
+        db_series_name = issue["series_name"]
+        issue_number = issue["number"]
+        mapped_path = issue["mapped_path"]
+
+        # Folder-derived name — once per folder, not once per issue.
+        if mapped_path not in series_name_cache:
+            series_name_cache[mapped_path] = get_series_name_from_files(
+                mapped_path, db_series_name
+            )
+        actual_series_name = series_name_cache[mapped_path]
+
+        # Aliases — once per DB series name.
+        if db_series_name not in alias_cache:
+            try:
+                raw_aliases = alias_lookup(db_series_name) or ""
+            except Exception as e:
+                app_logger.debug(f"Failed to load aliases for '{db_series_name}': {e}")
+                raw_aliases = ""
+            alias_cache[db_series_name] = [
+                a.strip() for a in raw_aliases.split(",") if a.strip()
+            ]
+
+        mn_key = (mapped_path, db_series_name)
+        if mn_key not in match_names_cache:
+            match_names_cache[mn_key] = build_series_match_names(
+                actual_series_name, alias_cache[db_series_name]
+            )
+        match_names = match_names_cache[mn_key]
+
+        # Compiled regexes — cached per (name, issue) so a repeated series/issue
+        # (e.g. via aliases) doesn't recompile.
+        regexes = []
+        for name in match_names:
+            rk = (name, str(issue_number))
+            if rk not in regex_cache:
+                regex_cache[rk] = generate_filename_pattern(
+                    match_pattern, name, issue_number
+                )
+            r = regex_cache[rk]
+            if r:
+                regexes.append(r)
+        if not regexes:
+            app_logger.debug(
+                f"Failed to generate pattern for: {actual_series_name} #{issue_number}"
+            )
+            continue
+
+        if debug:
+            app_logger.debug(f"Checking: '{actual_series_name}' #{issue_number}")
+
+        check_num = str(issue_number).strip().lstrip("0") or "0"
+        matched = None
+        for filename, src in remaining:
+            match_result = any(r.match(filename) for r in regexes)
+
+            # Fallback: ComicInfo.xml (archive opened at most once per file).
+            if not match_result:
+                ci = extract_comicinfo_cached(src, comicinfo_cache)
+                if ci and ci.get("number"):
+                    meta_num = str(ci["number"]).strip().lstrip("0") or "0"
+                    if meta_num == check_num:
+                        meta_series = (ci.get("series") or "").lower()
+                        if meta_series and any(
+                            n.lower() in meta_series or meta_series in n.lower()
+                            for n in match_names
+                        ):
+                            match_result = True
+
+            if debug:
+                app_logger.debug(
+                    f"  Testing '{filename}' -> {'MATCH' if match_result else 'no match'}"
+                )
+            if match_result:
+                matched = (filename, src)
+                break
+
+        if matched:
+            remaining.remove(matched)
+            matches.append(
+                {
+                    "issue": issue,
+                    "series_name": actual_series_name,
+                    "filename": matched[0],
+                    "src": matched[1],
+                }
+            )
+
+    return matches
+
+
 def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True):
     """
     Match Metron issues to local files in the mapped directory with caching.
@@ -427,7 +583,6 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
                     'filename': filename,
                     'path': file_path,
                     'mtime': mtime,
-                    'comicinfo': None  # Lazy-loaded
                 }
     except Exception as e:
         app_logger.error(f"Error scanning directory {mapped_path}: {e}")
@@ -439,6 +594,9 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
 
     # Step 4: Match each issue
     cache_entries = []
+    # ComicInfo.xml is read at most once per file across all issues (shared with
+    # the scan path via extract_comicinfo_cached).
+    comicinfo_cache = {}
 
     for issue in issues:
         issue_num = str(getattr(issue, 'number', '') or (issue.get('number', '') if isinstance(issue, dict) else ''))
@@ -465,11 +623,8 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
         # 4b: Fallback to ComicInfo.xml matching
         if not match_found:
             for file_path, metadata in file_metadata.items():
-                # Lazy-load ComicInfo.xml only when needed
-                if metadata['comicinfo'] is None:
-                    metadata['comicinfo'] = extract_comicinfo(file_path) or {}
-
-                ci = metadata['comicinfo']
+                # Lazy-load ComicInfo.xml only when needed (once per file).
+                ci = extract_comicinfo_cached(file_path, comicinfo_cache)
                 if ci.get('number'):
                     # Normalize issue numbers for comparison
                     meta_num = str(ci['number']).strip().lstrip('0') or '0'

--- a/tests/unit/test_match_wanted_to_files.py
+++ b/tests/unit/test_match_wanted_to_files.py
@@ -1,0 +1,252 @@
+"""Tests for helpers.collection.match_wanted_issues_to_files and its
+per-file ComicInfo memoizer.
+
+This is the single-pass matcher that replaced the old per-issue x per-file
+re-scan in process_incoming_wanted_issues(). The tests lock in both the
+matching behavior (filename regex, ComicInfo fallback, aliases, one-file-per-
+issue) and the optimization guarantee (each archive is opened at most once).
+"""
+import io
+import os
+import zipfile
+
+import pytest
+
+from helpers.collection import (
+    match_wanted_issues_to_files,
+    extract_comicinfo_cached,
+)
+
+# Year/month/title-stripped pattern, exactly as process_incoming_wanted_issues
+# feeds it to the matcher.
+PATTERN = "{series_name} {issue_number}"
+
+
+# ---- helpers ------------------------------------------------------------
+
+def _touch(path, data=b"stub"):
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+def _make_cbz_with_comicinfo(path, series, number):
+    """Write a minimal CBZ carrying a ComicInfo.xml with series/number."""
+    xml = (
+        '<?xml version="1.0"?>'
+        f"<ComicInfo><Series>{series}</Series>"
+        f"<Number>{number}</Number></ComicInfo>"
+    )
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("ComicInfo.xml", xml)
+        zf.writestr("001.jpg", b"\xff\xd8\xff")
+
+
+def _wanted(series_name, number, mapped_path, series_id=1):
+    return {
+        "series_name": series_name,
+        "number": number,
+        "mapped_path": mapped_path,
+        "series_id": series_id,
+    }
+
+
+def _no_aliases(_name):
+    return ""
+
+
+# ---- filename matching --------------------------------------------------
+
+class TestFilenameMatching:
+
+    def test_matches_by_filename(self, tmp_path):
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        f = str(tmp_path / "Batman 005 (2020).cbz")
+        _touch(f)
+
+        wanted = [_wanted("Batman", "5", str(series_dir))]
+        files = [("Batman 005 (2020).cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1
+        assert matches[0]["src"] == f
+        assert matches[0]["issue"]["number"] == "5"
+
+    def test_no_match_leaves_empty(self, tmp_path):
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        f = str(tmp_path / "Superman 005 (2020).cbz")
+        _touch(f)
+
+        wanted = [_wanted("Batman", "5", str(series_dir))]
+        files = [("Superman 005 (2020).cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert matches == []
+
+    def test_wrong_issue_number_does_not_match(self, tmp_path):
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        f = str(tmp_path / "Batman 007 (2020).cbz")
+        _touch(f)
+
+        wanted = [_wanted("Batman", "5", str(series_dir))]
+        files = [("Batman 007 (2020).cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert matches == []
+
+    def test_folder_derived_name_matches_the_prefix(self, tmp_path):
+        # DB name "The Ultimates" but files on disk say "Ultimates" -- the
+        # folder-derived name plus the-prefix flexibility should still match.
+        series_dir = tmp_path / "Ultimates"
+        series_dir.mkdir()
+        _touch(str(series_dir / "Ultimates 001 (2024).cbz"))  # sample existing file
+
+        target = str(tmp_path / "Ultimates 002 (2024).cbz")
+        _touch(target)
+
+        wanted = [_wanted("The Ultimates", "2", str(series_dir))]
+        files = [("Ultimates 002 (2024).cbz", target)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1
+        assert matches[0]["src"] == target
+
+
+# ---- alias matching -----------------------------------------------------
+
+class TestAliasMatching:
+
+    def test_matches_via_alias(self, tmp_path):
+        series_dir = tmp_path / "Thor"
+        series_dir.mkdir()
+        f = str(tmp_path / "Mortal Thor 011 (2024).cbz")
+        _touch(f)
+
+        wanted = [_wanted("Thor", "11", str(series_dir))]
+        files = [("Mortal Thor 011 (2024).cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=lambda n: "Mortal Thor"
+        )
+        assert len(matches) == 1
+        assert matches[0]["src"] == f
+
+
+# ---- ComicInfo fallback -------------------------------------------------
+
+class TestComicInfoFallback:
+
+    def test_matches_via_comicinfo_when_filename_unhelpful(self, tmp_path):
+        series_dir = tmp_path / "Saga"
+        series_dir.mkdir()
+        f = str(tmp_path / "download_xyz.cbz")  # filename gives no clue
+        _make_cbz_with_comicinfo(f, series="Saga", number="12")
+
+        wanted = [_wanted("Saga", "12", str(series_dir))]
+        files = [("download_xyz.cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1
+        assert matches[0]["src"] == f
+
+    def test_comicinfo_wrong_number_rejected(self, tmp_path):
+        series_dir = tmp_path / "Saga"
+        series_dir.mkdir()
+        f = str(tmp_path / "download_xyz.cbz")
+        _make_cbz_with_comicinfo(f, series="Saga", number="99")
+
+        wanted = [_wanted("Saga", "12", str(series_dir))]
+        files = [("download_xyz.cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert matches == []
+
+
+# ---- one file per issue -------------------------------------------------
+
+class TestOneFilePerIssue:
+
+    def test_file_matched_to_first_issue_only(self, tmp_path):
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        f = str(tmp_path / "Batman 005 (2020).cbz")
+        _touch(f)
+
+        # Two identical wanted rows for #5; only one file exists.
+        wanted = [
+            _wanted("Batman", "5", str(series_dir)),
+            _wanted("Batman", "5", str(series_dir)),
+        ]
+        files = [("Batman 005 (2020).cbz", f)]
+
+        matches = match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1
+
+
+# ---- optimization guarantee: archive opened at most once ----------------
+
+class TestArchiveOpenedOnce:
+
+    def test_each_archive_opened_at_most_once(self, tmp_path, monkeypatch):
+        import helpers.collection as collection
+
+        series_dir = tmp_path / "Saga"
+        series_dir.mkdir()
+        # A file that never matches by filename, so the ComicInfo fallback is
+        # consulted for every wanted issue -- the pre-optimization hot path.
+        f = str(tmp_path / "nomatch.cbz")
+        _make_cbz_with_comicinfo(f, series="Nothing", number="0")
+
+        calls = {"n": 0}
+        real = collection.extract_comicinfo
+
+        def counting(path):
+            calls["n"] += 1
+            return real(path)
+
+        monkeypatch.setattr(collection, "extract_comicinfo", counting)
+
+        # 20 wanted issues, all forcing the fallback against the one file.
+        wanted = [_wanted("Saga", str(i), str(series_dir)) for i in range(1, 21)]
+        files = [("nomatch.cbz", f)]
+
+        match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+        # Without memoization this would be ~20; with it, exactly 1.
+        assert calls["n"] == 1
+
+
+class TestExtractComicInfoCached:
+
+    def test_reads_once_and_caches(self, tmp_path):
+        f = str(tmp_path / "x.cbz")
+        _make_cbz_with_comicinfo(f, series="Saga", number="1")
+        cache = {}
+        first = extract_comicinfo_cached(f, cache)
+        assert first.get("number") == "1"
+        assert f in cache
+        # Second call returns the cached object (identity preserved).
+        assert extract_comicinfo_cached(f, cache) is first
+
+    def test_non_archive_returns_empty_without_read(self, tmp_path):
+        f = str(tmp_path / "x.cbr")  # not cbz/zip -> no disk read
+        cache = {}
+        assert extract_comicinfo_cached(f, cache) == {}
+        assert cache[f] == {}


### PR DESCRIPTION
## Problem

When a download lands in the TARGET folder — from the scheduled auto-download job, a UI download, or the **Scan Download Directory** button — `process_incoming_wanted_issues()` matches the "Wanted" issues against the TARGET files. It was structured as **for each wanted issue → for each file**, and inside that nested loop it repeated per-file work on every pass:

- **`extract_comicinfo()` opened the actual CBZ/ZIP archive on every no-match** — with no caching, up to ~O(issues × files) zip-open + XML-parse operations. For a real library (446 wanted × 55 files ≈ **24,500 archive opens**) this dominated runtime and turned scans into multi-minute jobs.
- **`get_series_name_from_files()` ran `os.listdir` once per wanted issue**, though ~30 issues typically share one folder.
- **A DEBUG log line was eagerly formatted + written for every (issue, file) pair** (~24,500 `Testing '…' -> no match` lines).

The regex comparisons themselves were never the bottleneck — the redundant I/O and logging were.

## Fix

Extract the matching into a pure, memoized helper `match_wanted_issues_to_files()` in `helpers/collection.py`, and keep the file-moving side effects in `app.py`:

- Each archive's ComicInfo is read **at most once** via a new shared `extract_comicinfo_cached()`.
- Each folder's derived series name, aliases, and compiled regexes are memoized (once per series, not once per issue).
- The per-pair DEBUG log is gated behind `isEnabledFor(DEBUG)` so it isn't formatted ~24,500 times in normal operation.
- `app.py` now calls the helper once, then loops the returned matches doing the unchanged move / index / rename / metadata-fetch / reconcile steps.
- `match_issues_to_collection()` (the `/wanted` page + Refresh path) shares the same ComicInfo memoizer for consistency.

**Matching semantics are unchanged** — same filename regex, same ComicInfo fallback, same alias handling, same one-file-per-issue ordering. This is purely deduplication of repeated work.

Net effect: archive opens drop from ~O(issues × files) to ≤ O(files); directory reads from O(issues) to O(series); log formatting from ~O(issues × files) to O(matches).

### Scope

- No `api.py` changes, no schema changes, no download-following feature.

## Tests

- New `tests/unit/test_match_wanted_to_files.py` (11 tests): filename match, ComicInfo fallback, alias match, "The"-prefix folder-name match, no-match, wrong-issue rejection, one-file-per-issue, and an assertion that **each archive is opened exactly once** across 20 wanted issues (locks in the optimization).
- Existing coverage for the touched paths passes (`test_reconcile_wanted`, `test_library_automap`, `test_filename_pattern`, `test_series_name_from_files`).
- Full suite: **2407 passed, 6 skipped** (only the known env-only `test_pdf.py` failures excluded — missing `pdf2image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)