### PR TITLE
Batch bulk file renames into one queued, coalesced operation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3736,7 +3736,7 @@ def scan_filesystem_for_sync():
     return entries
 
 
-def update_index_on_move(old_path, new_path):
+def update_index_on_move(old_path, new_path, reconcile=True):
     """
     Update file index when a file or directory is moved.
     Handles three scenarios:
@@ -3749,6 +3749,10 @@ def update_index_on_move(old_path, new_path):
     Args:
         old_path: Original path
         new_path: New path after move
+        reconcile: When True (default), reconcile the affected series' wanted list
+            and collection-status cache inline. Batch callers pass False and run a
+            single coalesced reconcile per series after all moves, avoiding the
+            whole-series recompute firing once per file.
     """
     try:
         # Normalize paths for comparison
@@ -3809,11 +3813,12 @@ def update_index_on_move(old_path, new_path):
             # and refresh the collection-status cache. This is the reliable hook
             # for the manual Move File path (watchdog file events can be missed
             # on networked/Docker volumes).
-            try:
-                from helpers.collection import reconcile_wanted_for_path
-                reconcile_wanted_for_path(new_path)
-            except Exception as e:
-                app_logger.error(f"Wanted reconcile failed for {new_path}: {e}")
+            if reconcile:
+                try:
+                    from helpers.collection import reconcile_wanted_for_path
+                    reconcile_wanted_for_path(new_path)
+                except Exception as e:
+                    app_logger.error(f"Wanted reconcile failed for {new_path}: {e}")
             return
 
         # Scenario 2: Moving OUT OF /data -> DELETE from index
@@ -3906,12 +3911,13 @@ def update_index_on_move(old_path, new_path):
             # A file moved between series folders: reconcile both the source
             # (an issue may now be missing) and the destination (an issue may
             # now be satisfied).
-            try:
-                from helpers.collection import reconcile_wanted_for_path
-                reconcile_wanted_for_path(old_path)
-                reconcile_wanted_for_path(new_path)
-            except Exception as e:
-                app_logger.error(f"Wanted reconcile failed for move within /data: {e}")
+            if reconcile:
+                try:
+                    from helpers.collection import reconcile_wanted_for_path
+                    reconcile_wanted_for_path(old_path)
+                    reconcile_wanted_for_path(new_path)
+                except Exception as e:
+                    app_logger.error(f"Wanted reconcile failed for move within /data: {e}")
             return
 
         # Scenario 4: Both outside /data -> do nothing

--- a/routes/files.py
+++ b/routes/files.py
@@ -826,6 +826,108 @@ def custom_rename():
         return jsonify({"error": str(e)}), 500
 
 
+def _do_rename_batch(op_id, renames):
+    """Background thread: rename each file, then reconcile each affected series
+    exactly once.
+
+    Renaming inside /data via update_index_on_move normally reconciles the owning
+    series (invalidate + full re-match + bulk-save of every issue) on every call.
+    For a bulk rename that means the whole-series recompute fires once per file.
+    Here we defer it (reconcile=False), collect the touched series ids, and
+    reconcile each once at the end.
+    """
+    from app import update_index_on_move
+    from helpers.collection import _series_id_for_path, reconcile_wanted_for_series
+
+    with memory_context("file_rename"):
+        affected_series = set()
+        errors = []
+        renamed = 0
+        try:
+            for index, pair in enumerate(renames):
+                old_path = pair.get("old")
+                new_path = pair.get("new")
+                base = os.path.basename(new_path or old_path or "")
+                app_state.update_operation(op_id, current=index, detail=base)
+                try:
+                    if not old_path or not new_path:
+                        errors.append(f"Missing old or new path for entry {index}")
+                        continue
+                    if not os.path.exists(old_path):
+                        errors.append(f"Source does not exist: {os.path.basename(old_path)}")
+                        continue
+                    # Allow case-only renames on case-insensitive /data: the dest
+                    # "exists" but is the same inode as the source (see samefile guard).
+                    if os.path.exists(new_path) and not os.path.samefile(old_path, new_path):
+                        errors.append(f"Destination already exists: {os.path.basename(new_path)}")
+                        continue
+                    if is_critical_path(old_path) or is_critical_path(new_path):
+                        errors.append(f"Refused critical path: {os.path.basename(old_path)}")
+                        continue
+
+                    os.rename(old_path, new_path)
+                    # Defer reconcile; collect the series so we recompute once below.
+                    update_index_on_move(old_path, new_path, reconcile=False)
+                    for p in (old_path, new_path):
+                        sid = _series_id_for_path(p)
+                        if sid:
+                            affected_series.add(sid)
+                    renamed += 1
+                except Exception as e:
+                    app_logger.error(f"Batch rename failed for {old_path} -> {new_path}: {e}")
+                    errors.append(f"{os.path.basename(old_path or new_path or '')}: {e}")
+
+            # Coalesced reconcile: once per unique series, not once per file.
+            for sid in affected_series:
+                try:
+                    reconcile_wanted_for_series(sid)
+                except Exception as e:
+                    app_logger.error(f"Error reconciling wanted for series {sid}: {e}")
+
+            detail = f"Renamed {renamed} file(s)"
+            if errors:
+                detail += f", {len(errors)} error(s)"
+            app_state.update_operation(op_id, current=len(renames), detail=detail)
+            app_state.complete_operation(op_id, error=bool(errors))
+            app_logger.info(
+                f"Batch rename complete: {renamed} renamed, {len(errors)} error(s), "
+                f"{len(affected_series)} series reconciled"
+            )
+        except Exception:
+            app_logger.exception("Batch rename worker error")
+            app_state.complete_operation(op_id, error=True)
+
+
+@files_bp.route('/custom-rename-batch', methods=['POST'])
+def custom_rename_batch():
+    """
+    Rename many files in one request. Spawns a background thread that renames each
+    file and reconciles each affected series once (instead of once per file), and
+    returns immediately with an op_id surfaced in the nav operations indicator.
+
+    Body: { "renames": [ {"old": ..., "new": ...}, ... ] }
+    """
+    data = request.get_json(silent=True) or {}
+    renames = data.get('renames')
+
+    if not isinstance(renames, list) or not renames:
+        return jsonify({"success": False, "error": "No renames provided"}), 400
+
+    # Reject the whole batch if any entry targets a critical path (defense in
+    # depth; per-entry guards in the worker catch anything that slips through).
+    for pair in renames:
+        if not isinstance(pair, dict) or not pair.get('old') or not pair.get('new'):
+            return jsonify({"success": False, "error": "Each rename needs old and new paths"}), 400
+        if is_critical_path(pair['old']):
+            return jsonify({"success": False, "error": get_critical_path_error_message(pair['old'], "rename")}), 403
+        if is_critical_path(pair['new']):
+            return jsonify({"success": False, "error": get_critical_path_error_message(pair['new'], "rename to")}), 403
+
+    op_id = app_state.register_operation("rename", f"{len(renames)} files", total=len(renames))
+    threading.Thread(target=_do_rename_batch, args=(op_id, renames), daemon=True).start()
+    return jsonify({"success": True, "op_id": op_id})
+
+
 # =============================================================================
 # Crop
 # =============================================================================

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -2378,6 +2378,28 @@ function waitForMoveCompletion(opIds, label, itemCount) {
   setTimeout(() => clearInterval(interval), 1800000); // 30min safety
 }
 
+// Poll /api/operations until a batch-rename op finishes, then toast and refresh.
+// The heavy work runs in a background thread server-side, so the UI stays responsive.
+function waitForRenameCompletion(opId, itemCount, refreshFn) {
+  const interval = setInterval(() => {
+    fetch('/api/operations').then(r => r.json()).then(data => {
+      const ops = data.operations || [];
+      const op = ops.find(o => o.id === opId);
+      if (op && op.status === 'running') return;
+      clearInterval(interval);
+      if (op && op.status === 'error') {
+        CLU.showToast('Rename Errors', `Some of ${itemCount} rename(s) failed`, 'warning');
+      } else {
+        CLU.showToast('Rename Complete',
+          itemCount === 1 ? 'Successfully renamed 1 file' : `Successfully renamed ${itemCount} files`,
+          'success');
+      }
+      if (typeof refreshFn === 'function') refreshFn();
+    }).catch(() => {});
+  }, 2000);
+  setTimeout(() => clearInterval(interval), 1800000); // 30min safety
+}
+
 function moveSingleItem(sourcePath, targetFolder) {
   let actualPath = typeof sourcePath === 'object' ? sourcePath.path || sourcePath.name : sourcePath;
   let fileName = actualPath.split('/').pop();
@@ -3054,52 +3076,38 @@ function executeCustomRename() {
   document.getElementById('executeRenameBtn').disabled = true;
   document.getElementById('executeRenameBtn').textContent = 'Renaming...';
 
-  // Execute renames
-  const renamePromises = fileList.map(file => {
-    const newPath = `${currentRenameDirectory}/${file.newName}`;
-    return fetch('/custom-rename', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        old: file.oldPath,
-        new: newPath
-      })
-    });
-  });
+  const renames = fileList.map(file => ({
+    old: file.oldPath,
+    new: `${currentRenameDirectory}/${file.newName}`
+  }));
+  const directory = currentRenameDirectory;
+  const panel = currentRenamePanel;
+  const count = renames.length;
 
-  Promise.all(renamePromises)
-    .then(responses => {
-      const errors = [];
-      responses.forEach((response, index) => {
-        if (!response.ok) {
-          errors.push(`Failed to rename ${fileList[index].oldName}`);
-        }
-      });
-
-      if (errors.length > 0) {
-        alert('Some files could not be renamed:\n' + errors.join('\n'));
-      } else {
-        // Show success message in modal before closing
-        const renamePreviewList = document.getElementById('renamePreviewList');
-        renamePreviewList.innerHTML = `
-              <div class="alert alert-success text-center">
-                <i class="bi bi-check-circle-fill me-2"></i>
-                <strong>Success!</strong> Renamed ${fileList.length} files.
-              </div>
-            `;
-        document.getElementById('previewRenameBtn').style.display = 'none';
-        document.getElementById('executeRenameBtn').style.display = 'none';
-
-        // Auto-close modal after 2 seconds
-        setTimeout(() => {
-          customRenameModal.hide();
-        }, 2000);
+  // One batched request: the server renames all files in a background thread and
+  // reconciles each affected series once (progress shown in the nav ops indicator).
+  fetch('/custom-rename-batch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ renames })
+  })
+    .then(response => response.json())
+    .then(data => {
+      if (!data.success) {
+        alert('Rename failed: ' + (data.error || 'Unknown error'));
+        return;
       }
-
-      // Refresh directory listing - use loadDownloads since that's what shows files
-      loadDownloads(currentRenameDirectory, currentRenamePanel);
+      const renamePreviewList = document.getElementById('renamePreviewList');
+      renamePreviewList.innerHTML = `
+            <div class="alert alert-success text-center">
+              <i class="bi bi-check-circle-fill me-2"></i>
+              <strong>Started!</strong> Renaming ${count} files…
+            </div>
+          `;
+      document.getElementById('previewRenameBtn').style.display = 'none';
+      document.getElementById('executeRenameBtn').style.display = 'none';
+      setTimeout(() => customRenameModal.hide(), 1500);
+      waitForRenameCompletion(data.op_id, count, () => loadDownloads(directory, panel));
     })
     .catch(error => {
       console.error('Error during rename operation:', error);
@@ -3240,52 +3248,36 @@ function executeReplaceText() {
   document.getElementById('executeReplaceBtn').disabled = true;
   document.getElementById('executeReplaceBtn').textContent = 'Replacing...';
 
-  // Execute renames
-  const renamePromises = replaceFileList.map(file => {
-    const newPath = `${currentReplaceDirectory}/${file.newName}`;
-    return fetch('/custom-rename', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        old: file.oldPath,
-        new: newPath
-      })
-    });
-  });
+  const renames = replaceFileList.map(file => ({
+    old: file.oldPath,
+    new: `${currentReplaceDirectory}/${file.newName}`
+  }));
+  const directory = currentReplaceDirectory;
+  const panel = currentReplacePanel;
+  const count = renames.length;
 
-  Promise.all(renamePromises)
-    .then(responses => {
-      const errors = [];
-      responses.forEach((response, index) => {
-        if (!response.ok) {
-          errors.push(`Failed to rename ${replaceFileList[index].oldName}`);
-        }
-      });
-
-      if (errors.length > 0) {
-        alert('Some files could not be renamed:\n' + errors.join('\n'));
-      } else {
-        // Show success message in modal before closing
-        const replacePreviewList = document.getElementById('replacePreviewList');
-        replacePreviewList.innerHTML = `
-              <div class="alert alert-success text-center">
-                <i class="bi bi-check-circle-fill me-2"></i>
-                <strong>Success!</strong> Replaced text in ${replaceFileList.length} files.
-              </div>
-            `;
-        document.getElementById('previewReplaceBtn').style.display = 'none';
-        document.getElementById('executeReplaceBtn').style.display = 'none';
-
-        // Auto-close modal after 2 seconds
-        setTimeout(() => {
-          replaceTextModal.hide();
-        }, 2000);
+  fetch('/custom-rename-batch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ renames })
+  })
+    .then(response => response.json())
+    .then(data => {
+      if (!data.success) {
+        alert('Replace failed: ' + (data.error || 'Unknown error'));
+        return;
       }
-
-      // Refresh directory listing - use loadDownloads since that's what shows files
-      loadDownloads(currentReplaceDirectory, currentReplacePanel);
+      const replacePreviewList = document.getElementById('replacePreviewList');
+      replacePreviewList.innerHTML = `
+            <div class="alert alert-success text-center">
+              <i class="bi bi-check-circle-fill me-2"></i>
+              <strong>Started!</strong> Replacing text in ${count} files…
+            </div>
+          `;
+      document.getElementById('previewReplaceBtn').style.display = 'none';
+      document.getElementById('executeReplaceBtn').style.display = 'none';
+      setTimeout(() => replaceTextModal.hide(), 1500);
+      waitForRenameCompletion(data.op_id, count, () => loadDownloads(directory, panel));
     })
     .catch(error => {
       console.error('Error during replace operation:', error);
@@ -3499,48 +3491,28 @@ function executeRenameFiles() {
   document.getElementById('executeRenameFilesBtn').disabled = true;
   document.getElementById('executeRenameFilesBtn').textContent = 'Renaming...';
 
-  // Execute renames
-  const renamePromises = seriesFileList.map(file => {
-    const newPath = `${currentSeriesRenameDirectory}/${file.newName}`;
-    return fetch('/custom-rename', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        old: file.oldPath,
-        new: newPath
-      })
-    })
-      .then(response => response.json())
-      .then(data => {
-        if (!data.success) {
-          throw new Error(`Failed to rename ${file.originalName}: ${data.error}`);
-        }
-        return data;
-      });
-  });
+  const renames = seriesFileList.map(file => ({
+    old: file.oldPath,
+    new: `${currentSeriesRenameDirectory}/${file.newName}`
+  }));
+  const directory = currentSeriesRenameDirectory;
+  const panel = currentSeriesRenamePanel;
+  const count = renames.length;
 
-  Promise.all(renamePromises)
-    .then(results => {
-      console.log('All series renames completed:', results);
-
-      // Check if all renames were successful
-      const failedRenames = results.filter(result => !result.success);
-
-      if (failedRenames.length > 0) {
-        CLU.showToast('Partial Success', `Some files could not be renamed. ${failedRenames.length} failures.`, 'warning');
-      } else {
-        CLU.showToast('Rename Complete', `Successfully renamed ${results.length} files with new series name.`, 'success');
-
-        // Auto-close modal after 2 seconds
-        setTimeout(() => {
-          renameFilesModal.hide();
-        }, 2000);
+  fetch('/custom-rename-batch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ renames })
+  })
+    .then(response => response.json())
+    .then(data => {
+      if (!data.success) {
+        CLU.showToast('Rename Error', data.error || 'Unknown error', 'error');
+        return;
       }
-
-      // Refresh directory listing
-      loadDownloads(currentSeriesRenameDirectory, currentSeriesRenamePanel);
+      CLU.showToast('Rename Started', `Renaming ${count} files with new series name…`, 'info');
+      setTimeout(() => renameFilesModal.hide(), 1500);
+      waitForRenameCompletion(data.op_id, count, () => loadDownloads(directory, panel));
     })
     .catch(error => {
       console.error('Error during series rename operation:', error);

--- a/templates/base.html
+++ b/templates/base.html
@@ -171,7 +171,7 @@
             return b.started_at - a.started_at;
           });
 
-          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable' };
+          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable', rename: 'bi-input-cursor-text' };
           let html = '';
           ops.forEach(op => {
             const icon = iconMap[op.op_type] || 'bi-gear';

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -267,6 +267,136 @@ class TestCustomRename:
         assert resp.status_code == 400
 
 
+class TestCustomRenameBatch:
+
+    def test_empty_renames(self, client):
+        resp = client.post("/custom-rename-batch", json={"renames": []})
+        assert resp.status_code == 400
+
+    def test_missing_pair_fields(self, client):
+        resp = client.post("/custom-rename-batch",
+                           json={"renames": [{"old": "/a/x.cbz"}]})
+        assert resp.status_code == 400
+
+    @patch("routes.files.get_critical_path_error_message", return_value="Protected")
+    @patch("routes.files.is_critical_path", return_value=True)
+    def test_critical_path_rejected(self, mock_crit, mock_msg, client):
+        resp = client.post("/custom-rename-batch",
+                           json={"renames": [{"old": "/a/x.cbz", "new": "/a/y.cbz"}]})
+        assert resp.status_code == 403
+
+    @patch("routes.files.is_critical_path", return_value=False)
+    @patch("routes.files.app_state")
+    @patch("routes.files.threading.Thread")
+    def test_success_returns_op_id(self, mock_thread, mock_app_state, mock_crit, client, tmp_path):
+        renames = [
+            {"old": str(tmp_path / "old0.cbz"), "new": str(tmp_path / "new0.cbz")},
+            {"old": str(tmp_path / "old1.cbz"), "new": str(tmp_path / "new1.cbz")},
+        ]
+        mock_app_state.register_operation.return_value = "op-rn-1"
+
+        resp = client.post("/custom-rename-batch", json={"renames": renames})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["op_id"] == "op-rn-1"
+        mock_app_state.register_operation.assert_called_once_with(
+            "rename", "2 files", total=2)
+        mock_thread.assert_called_once()
+        mock_thread.return_value.start.assert_called_once()
+
+
+class TestRenameBatchWorker:
+    """The worker must rename every file but reconcile each series only once."""
+
+    @patch("routes.files.app_state")
+    def test_coalesces_reconcile_per_series(self, mock_app_state, tmp_path):
+        from routes.files import _do_rename_batch
+
+        pairs = []
+        renames = []
+        for i in range(3):
+            old = tmp_path / f"old{i}.cbz"
+            old.write_bytes(b"x")
+            new = tmp_path / f"new{i}.cbz"
+            renames.append({"old": str(old), "new": str(new)})
+            pairs.append((old, new))
+
+        fake_app = types.ModuleType("app")
+        fake_app.update_index_on_move = MagicMock()
+        recon = MagicMock()
+
+        with patch.dict("sys.modules", {"app": fake_app}), \
+             patch("helpers.collection._series_id_for_path", return_value="S1"), \
+             patch("helpers.collection.reconcile_wanted_for_series", recon):
+            _do_rename_batch("op-1", renames)
+
+        # Every file renamed on disk.
+        for old, new in pairs:
+            assert not old.exists()
+            assert new.exists()
+
+        # One affected series -> reconciled exactly once, not once per file.
+        recon.assert_called_once_with("S1")
+
+        # Index update deferred its own reconcile for every file.
+        assert fake_app.update_index_on_move.call_count == 3
+        for call in fake_app.update_index_on_move.call_args_list:
+            assert call.kwargs.get("reconcile") is False
+
+        mock_app_state.complete_operation.assert_called_once()
+        assert mock_app_state.complete_operation.call_args.kwargs.get("error") is False
+
+    @patch("routes.files.app_state")
+    def test_case_only_rename_not_rejected(self, mock_app_state, tmp_path):
+        # A case-only rename: on case-insensitive /data the dest path "exists"
+        # but is the same inode, so samefile() must let it through.
+        from routes.files import _do_rename_batch
+
+        old = tmp_path / "gen13.cbz"
+        old.write_bytes(b"x")
+        renames = [{"old": str(old), "new": str(tmp_path / "GEN13.cbz")}]
+
+        fake_app = types.ModuleType("app")
+        fake_app.update_index_on_move = MagicMock()
+
+        with patch.dict("sys.modules", {"app": fake_app}), \
+             patch("helpers.collection._series_id_for_path", return_value="S1"), \
+             patch("helpers.collection.reconcile_wanted_for_series", MagicMock()):
+            _do_rename_batch("op-3", renames)
+
+        # os.rename ran (index update called), and the batch reported no error.
+        fake_app.update_index_on_move.assert_called_once()
+        assert mock_app_state.complete_operation.call_args.kwargs.get("error") is False
+
+    @patch("routes.files.app_state")
+    def test_partial_failure_reported_without_aborting(self, mock_app_state, tmp_path):
+        from routes.files import _do_rename_batch
+
+        good_old = tmp_path / "good.cbz"
+        good_old.write_bytes(b"x")
+        good_new = tmp_path / "good_renamed.cbz"
+
+        renames = [
+            {"old": str(tmp_path / "missing.cbz"), "new": str(tmp_path / "whatever.cbz")},
+            {"old": str(good_old), "new": str(good_new)},
+        ]
+
+        fake_app = types.ModuleType("app")
+        fake_app.update_index_on_move = MagicMock()
+
+        with patch.dict("sys.modules", {"app": fake_app}), \
+             patch("helpers.collection._series_id_for_path", return_value="S1"), \
+             patch("helpers.collection.reconcile_wanted_for_series", MagicMock()):
+            _do_rename_batch("op-2", renames)
+
+        # The valid rename still happened despite the earlier missing-source entry.
+        assert good_new.exists()
+        # Batch completed but flagged the error.
+        mock_app_state.complete_operation.assert_called_once()
+        assert mock_app_state.complete_operation.call_args.kwargs.get("error") is True
+
+
 class TestSmartRenamePreview:
 
     def test_missing_directory(self, client):


### PR DESCRIPTION
## Problem

Renaming 50+ files in the File Manager was slow and flooded the logs with repeated whole-series cache work (`Invalidated 80… / Saved 80… / Cached 80…`). Two compounding causes:

1. **Per-file fan-out** — `executeRenameFiles`, `executeCustomRename`, and `executeReplaceText` in `static/js/files.js` each fired one `POST /custom-rename` per file via `Promise.all`. 50 files = 50 concurrent requests.
2. **Inline whole-series reconcile, twice per file** — each request's `update_index_on_move` (`app.py`) reconciled the owning series for both the old and new path, and each reconcile wipes + re-matches + bulk-saves **every** issue in the series. Same-series bulk rename ≈ **100 full-series recomputes** contending on SQLite.

## Fix

A single batched, backgrounded operation surfaced in the existing nav `#ops-indicator`:

- **`app.py`** — `update_index_on_move` gains `reconcile=True` (default preserves every existing caller — Move, single rename, watcher). The inline `reconcile_wanted_for_path` calls in scenarios 1 and 3 are now guarded by it.
- **`routes/files.py`** — new `POST /custom-rename-batch` registers a `"rename"` operation and spawns `_do_rename_batch` (modeled on `_do_move`/`/move`). The worker renames each file with `reconcile=False`, collects affected series ids, then reconciles **each unique series once**. Includes a `samefile` guard so case-only renames on case-insensitive `/data` aren't falsely rejected; per-file failures are reported without aborting the batch. Legacy `/custom-rename` is untouched.
- **`static/js/files.js`** — the three bulk executors now send one batch request, close the modal immediately, and poll for completion via a new `waitForRenameCompletion` helper (mirrors `waitForMoveCompletion`).
- **`templates/base.html`** — added a `rename` icon to the ops-indicator `iconMap`.

**Net effect:** the per-series cache cascade fires once instead of once (×2) per file, 50 concurrent SQLite-contending requests become one background op, and the UI returns instantly.

This reuses the existing operations registry (`core/app_state.py` → `/api/operations` → `#ops-indicator`), laying groundwork to extend the same queue to moves/crops/converts.

## Tests

- `TestCustomRenameBatch` — empty / malformed / critical-path rejection, success returns `op_id`.
- `TestRenameBatchWorker` — core regression: 3 renames → **exactly one** `reconcile_wanted_for_series`, all `update_index_on_move` calls with `reconcile=False`; plus partial-failure and case-only rename paths.
- Full suite green (2412 passed; the lone `test_timeline` error is a pre-existing full-suite ordering flake, passes in isolation).

## Verification not yet done

Manual UI walkthrough: rename a 50+ file batch, confirm the modal closes immediately, a `rename` entry appears in the nav queue, and the log cascade collapses to a single per-series block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)