### PR TITLE
Add Split File feature: break multi-issue CBZs into single issues

### DIFF
--- a/cbz_ops/split.py
+++ b/cbz_ops/split.py
@@ -1,0 +1,295 @@
+"""
+Split a multi-issue CBZ into several single-issue CBZ files.
+
+The source archive collects several issues whose page images are named with a
+recognizable pattern, e.g.:
+
+    Cult of Dracula 003 - 0001.jpg   (series, issue 003, page 0001)
+    Cult of Dracula 004 - 0001.jpg
+
+The middle number is the issue; the trailing number is the page. This module
+auto-detects issue boundaries from those page filenames, and writes one
+image-only CBZ per issue.
+
+Unpacking is NON-destructive: the source .cbz is read in place and extracted to
+a unique temp folder, so the original is never renamed or modified (unlike the
+Edit flow's ``process_cbz_file``, which renames .cbz -> .zip).
+
+CBZ writes go through ``helpers.open_zip_for_write`` (assemble-local-then-move
+for FUSE/ESPIPE mounts, plus parent-permission matching) — never write a
+``zipfile.ZipFile`` directly onto the data mount.
+"""
+
+import os
+import re
+import gc
+import uuid
+import base64
+import shutil
+import zipfile
+from collections import Counter
+
+from core.app_logging import app_logger
+from helpers import create_thumbnail_streaming, open_zip_for_write, sanitize_path_segment
+from cbz_ops.edit import _safe_join, deletedFiles, skippedFiles
+
+IMAGE_EXTS = ('.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp')
+
+# Page-name parser: "<series> <issue> - <page>". Targets the names of the image
+# files *inside* the archive (not the archive filename, which cbz_ops/rename.py
+# handles). Issue may carry a decimal suffix (e.g. 003.1); page is trailing.
+PAGE_PATTERN = re.compile(
+    r'^(?P<series>.*?)\s+(?P<issue>\d{1,4}(?:\.\d+)?)\s*-\s*(?P<page>\d{1,4})$'
+)
+
+
+def _natural_key(s):
+    """Natural sort key so 'x 2' sorts before 'x 10'."""
+    return [int(t) if t.isdigit() else t.lower() for t in re.split(r'(\d+)', s)]
+
+
+def _parse_page(basename):
+    """Parse a page image basename into {series, issue, page} or None."""
+    stem = os.path.splitext(basename)[0].strip()
+    m = PAGE_PATTERN.match(stem)
+    if not m:
+        return None
+    return {
+        'series': m.group('series').strip(),
+        'issue': m.group('issue'),
+        'page': m.group('page'),
+    }
+
+
+def parse_issue_key(basename):
+    """Return the normalized issue token for a page basename, or None."""
+    parsed = _parse_page(basename)
+    return parsed['issue'] if parsed else None
+
+
+def _detect_series(rel_paths):
+    """Most common series prefix across parseable page names ('' if none)."""
+    names = Counter()
+    for rel in rel_paths:
+        parsed = _parse_page(os.path.basename(rel))
+        if parsed and parsed['series']:
+            names[parsed['series']] += 1
+    return names.most_common(1)[0][0] if names else ''
+
+
+def detect_groups(rel_paths):
+    """Group page rel_paths into consecutive issues by their issue key.
+
+    - Pages are naturally sorted by basename first.
+    - A new group starts each time the issue key changes.
+    - Pages with no parseable key attach to the current group. Leading
+      unmatched pages are absorbed into the first keyed group.
+    - When NO page has a key, a single group is returned (manual mode).
+
+    Returns an ordered list of {issue_key, page_rel_paths:[...]}.
+    """
+    ordered = sorted(rel_paths, key=lambda p: _natural_key(os.path.basename(p)))
+    groups = []
+    current = None
+    current_key = None
+    for rel in ordered:
+        key = parse_issue_key(os.path.basename(rel))
+        if current is None:
+            current = {'issue_key': key, 'page_rel_paths': [rel]}
+            current_key = key
+            continue
+        if key is not None and current_key is not None and key != current_key:
+            groups.append(current)
+            current = {'issue_key': key, 'page_rel_paths': [rel]}
+            current_key = key
+        else:
+            current['page_rel_paths'].append(rel)
+            if current_key is None and key is not None:
+                current_key = key
+                current['issue_key'] = key
+    if current is not None:
+        groups.append(current)
+    return groups
+
+
+def extract_for_split(file_path):
+    """Non-destructively extract a .cbz to a unique temp folder.
+
+    The original file is left in place (opened read-only). Junk files are
+    dropped and a single nested wrapper directory is collapsed, mirroring
+    cbz_ops/edit.py:process_cbz_file steps 4-5.
+
+    Returns {'folder_name': <where pages live>, 'root_folder': <temp dir to
+    remove>}. On any error the temp dir is removed and the error re-raised.
+    """
+    if not file_path.lower().endswith(('.cbz', '.zip')):
+        raise ValueError("Provided file is not a CBZ file.")
+
+    base_dir = os.path.dirname(os.path.abspath(file_path))
+    root_folder = os.path.join(base_dir, f".tmp_split_{os.getpid()}_{uuid.uuid4().hex[:8]}")
+    os.makedirs(root_folder, exist_ok=True)
+
+    try:
+        with zipfile.ZipFile(file_path, 'r') as zf:
+            for name in zf.namelist():
+                try:
+                    zf.extract(name, root_folder)
+                except Exception as e:
+                    app_logger.warning(f"Failed to extract {name}: {e}")
+                    continue
+
+        # Drop configured junk extensions before collapsing nested folders.
+        for root, _, files in os.walk(root_folder):
+            for f in files:
+                if os.path.splitext(f)[1].lower() in deletedFiles:
+                    try:
+                        os.remove(os.path.join(root, f))
+                    except Exception as e:
+                        app_logger.error(f"Error deleting file {f}: {e}")
+
+        # Collapse single nested wrapper directories.
+        folder_name = root_folder
+        while True:
+            inner = [d for d in os.listdir(folder_name)
+                     if os.path.isdir(os.path.join(folder_name, d))]
+            loose = [f for f in os.listdir(folder_name)
+                     if os.path.isfile(os.path.join(folder_name, f))]
+            if len(inner) == 1 and not loose:
+                folder_name = os.path.join(folder_name, inner[0])
+            else:
+                break
+
+        return {'folder_name': folder_name, 'root_folder': root_folder}
+    except Exception:
+        shutil.rmtree(root_folder, ignore_errors=True)
+        raise
+
+
+def _suggest_name(series, issue_key, file_path, n):
+    base = series or os.path.splitext(os.path.basename(file_path))[0]
+    name = f"{base} {issue_key}" if issue_key else f"{base} part {n}"
+    return sanitize_path_segment(name)
+
+
+def get_split_modal(file_path):
+    """Extract, build per-page thumbnails, and auto-detect issue groups.
+
+    Returns {groups, folder_name, root_folder, original_file_path,
+    suggested_folder}, where each group is
+    {issue_key, suggested_name, pages:[{filename, rel_path, img_data, issue_key}]}.
+    Cleans up the temp extraction dir if anything after extraction fails.
+    """
+    result = extract_for_split(file_path)
+    folder_name = result['folder_name']
+    root_folder = result['root_folder']
+
+    try:
+        rel_paths = []
+        for root, _, files in os.walk(folder_name):
+            for f in files:
+                ext = os.path.splitext(f)[1].lower()
+                if ext in skippedFiles:
+                    continue
+                if f.lower() == 'comicinfo.xml':
+                    continue
+                if ext not in IMAGE_EXTS:
+                    continue
+                rel_paths.append(os.path.relpath(os.path.join(root, f), folder_name))
+
+        groups = detect_groups(rel_paths)
+        series = _detect_series(rel_paths)
+
+        out_groups = []
+        count = 0
+        for g in groups:
+            pages = []
+            for rel in g['page_rel_paths']:
+                full = os.path.join(folder_name, rel)
+                img_data = None
+                try:
+                    thumb = create_thumbnail_streaming(full, max_size=(400, 600), quality=85)
+                    if thumb:
+                        img_data = "data:image/jpeg;base64," + base64.b64encode(thumb).decode('utf-8')
+                except Exception as e:
+                    app_logger.info(f"Thumbnail generation failed for '{rel}': {e}")
+                pages.append({
+                    'filename': os.path.basename(rel),
+                    'rel_path': rel,
+                    'img_data': img_data,
+                    'issue_key': g['issue_key'],
+                })
+                count += 1
+                if count % 10 == 0:
+                    gc.collect()
+
+            out_groups.append({
+                'issue_key': g['issue_key'],
+                'suggested_name': _suggest_name(series, g['issue_key'], file_path, len(out_groups) + 1),
+                'pages': pages,
+            })
+
+        suggested_folder = sanitize_path_segment(
+            series or os.path.splitext(os.path.basename(file_path))[0]
+        )
+
+        return {
+            'groups': out_groups,
+            'folder_name': folder_name,
+            'root_folder': root_folder,
+            'original_file_path': file_path,
+            'suggested_folder': suggested_folder,
+        }
+    except Exception:
+        shutil.rmtree(root_folder, ignore_errors=True)
+        raise
+
+
+def commit_split(folder_name, output_directory, groups):
+    """Write one image-only CBZ per group into output_directory.
+
+    Each group is {output_name, rel_paths:[...]}. Output names are sanitized and
+    collision-suffixed with " (1)", " (2)". Duplicate page basenames within a
+    group get an a/b/c suffix. No ComicInfo.xml is written.
+
+    Returns [{name, path, total_images}, ...]. Does not touch the DB or the temp
+    folder — the caller indexes outputs and cleans up.
+    """
+    os.makedirs(output_directory, exist_ok=True)
+    outputs = []
+
+    for g in groups:
+        name = sanitize_path_segment(g.get('output_name') or '') or 'Split'
+        output_path = os.path.join(output_directory, name + '.cbz')
+        counter = 1
+        while os.path.exists(output_path):
+            output_path = os.path.join(output_directory, f"{name} ({counter}).cbz")
+            counter += 1
+
+        file_counter = {}
+        total = 0
+        with open_zip_for_write(output_path) as zf:
+            ordered = sorted(g.get('rel_paths', []),
+                             key=lambda p: _natural_key(os.path.basename(p)))
+            for rel in ordered:
+                abs_path = _safe_join(folder_name, rel)
+                if not os.path.isfile(abs_path):
+                    continue
+                base = os.path.basename(rel)
+                name_part, ext = os.path.splitext(base)
+                if base in file_counter:
+                    suffix = chr(ord('a') + file_counter[base])
+                    arcname = f"{name_part}{suffix}{ext}"
+                    file_counter[base] += 1
+                else:
+                    arcname = base
+                    file_counter[base] = 1
+                zf.write(abs_path, arcname)
+                total += 1
+
+        outputs.append({
+            'name': os.path.basename(output_path),
+            'path': output_path,
+            'total_images': total,
+        })
+
+    return outputs

--- a/routes/files.py
+++ b/routes/files.py
@@ -514,6 +514,121 @@ def combine_cbz():
 
 
 # =============================================================================
+# Split CBZ
+# =============================================================================
+
+def _split_access_allowed(normalized_path):
+    """Same gate as combine: inside a library, or the watch/target dirs."""
+    from core.config import get_watch_dir, get_target_dir
+    watch_dir = get_watch_dir() or "/downloads/temp"
+    target_dir = get_target_dir() or "/downloads/processed"
+    return (is_valid_library_path(normalized_path) or
+            normalized_path.startswith(os.path.normpath(watch_dir)) or
+            normalized_path.startswith(os.path.normpath(target_dir)))
+
+
+@files_bp.route('/api/split-cbz/inspect', methods=['GET'])
+def split_inspect():
+    """Unpack a multi-issue CBZ and return auto-detected issue groups."""
+    file_path = request.args.get('file_path')
+    if not file_path:
+        return jsonify({"error": "file_path not specified"}), 400
+
+    normalized = os.path.normpath(file_path)
+    if not _split_access_allowed(normalized):
+        return jsonify({"error": "Access denied"}), 403
+    if not normalized.lower().endswith('.cbz'):
+        return jsonify({"error": "Only .cbz files can be split"}), 400
+    if not os.path.isfile(normalized):
+        return jsonify({"error": "File not found"}), 404
+
+    try:
+        from cbz_ops.split import get_split_modal
+        data = get_split_modal(normalized)
+        data['success'] = True
+        return jsonify(data)
+    except Exception as e:
+        app_logger.error(f"Error inspecting CBZ for split: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@files_bp.route('/api/split-cbz/commit', methods=['POST'])
+def split_commit():
+    """Write one single-issue CBZ per group into a new series subfolder."""
+    from cbz_ops.edit import _safe_join
+    from cbz_ops.split import commit_split
+    from helpers import sanitize_path_segment
+
+    data = request.get_json() or {}
+    folder_name = data.get('folder_name')
+    root_folder = data.get('root_folder') or folder_name
+    original_file_path = data.get('original_file_path')
+    output_folder_name = data.get('output_folder_name') or ''
+    groups = data.get('groups') or []
+
+    if not folder_name or not original_file_path:
+        return jsonify({"error": "Missing required data"}), 400
+    if not groups:
+        return jsonify({"error": "No groups provided"}), 400
+
+    for p in (folder_name, original_file_path):
+        if not _split_access_allowed(os.path.normpath(p)):
+            return jsonify({"error": "Access denied"}), 403
+
+    # Validate every page path (reject traversal) before touching disk.
+    commit_groups = []
+    for g in groups:
+        rels = g.get('rel_paths') or []
+        if not rels:
+            return jsonify({"error": "A group has no pages"}), 400
+        for rel in rels:
+            try:
+                _safe_join(folder_name, rel)
+            except ValueError:
+                return jsonify({"error": "Invalid page path"}), 400
+        commit_groups.append({'output_name': g.get('output_name'), 'rel_paths': rels})
+
+    folder_seg = (sanitize_path_segment(output_folder_name) or
+                  os.path.splitext(os.path.basename(original_file_path))[0])
+    parent_dir = os.path.dirname(original_file_path)
+    output_directory = os.path.join(parent_dir, folder_seg)
+
+    try:
+        outputs = commit_split(folder_name, output_directory, commit_groups)
+
+        # Index the new subfolder and each output so the UI updates immediately.
+        try:
+            add_file_index_entry(name=folder_seg, path=output_directory,
+                                 entry_type='directory', parent=parent_dir)
+        except Exception as index_error:
+            app_logger.warning(f"Failed to index split folder: {index_error}")
+        for o in outputs:
+            try:
+                add_file_index_entry(name=o['name'], path=o['path'], entry_type='file',
+                                     size=os.path.getsize(o['path']), parent=output_directory)
+            except Exception as index_error:
+                app_logger.warning(f"Failed to index split output {o['path']}: {index_error}")
+
+        # Remove the temp extraction dir. Original .cbz is left untouched.
+        try:
+            if root_folder and os.path.isdir(root_folder):
+                shutil.rmtree(root_folder)
+        except Exception as cleanup_error:
+            app_logger.warning(f"Failed to remove split temp dir {root_folder}: {cleanup_error}")
+
+        app_logger.info(f"Split {original_file_path} into {len(outputs)} issue(s) under {output_directory}")
+        return jsonify({
+            "success": True,
+            "output_folder": output_directory,
+            "output_files": outputs,
+            "count": len(outputs),
+        })
+    except Exception as e:
+        app_logger.error(f"Error splitting CBZ: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+# =============================================================================
 # Check Missing Files
 # =============================================================================
 

--- a/static/js/clu-cbz-split.js
+++ b/static/js/clu-cbz-split.js
@@ -1,0 +1,202 @@
+/**
+ * CLU CBZ Split Operations  –  clu-cbz-split.js
+ *
+ * Splits one multi-issue CBZ into several single-issue CBZs. Issue boundaries
+ * are auto-detected server-side from the page filenames; the user adjusts them
+ * client-side (no server round-trip until Split is clicked).
+ *
+ * Provides: CLU.renderSplitGroups, CLU.splitAt, CLU.mergeGroupUp,
+ *           CLU.updateGroupName, CLU.saveSplitCBZ
+ *
+ * Depends on: clu-utils.js (CLU.showToast, CLU.showError, CLU.showSuccess)
+ *
+ * External contract:
+ *   window._cluCbzSplit = { onSaveComplete(filePath) }
+ *
+ * DOM contracts:
+ *   #splitCBZModal (from modal_cbz_split.html)
+ *   #splitInlineContainer, #splitInlineFolderName, #splitInlineRootFolder,
+ *   #splitInlineOriginalFilePath, #splitOutputFolderName, #splitSummary
+ */
+(function () {
+  'use strict';
+
+  var CLU = window.CLU = window.CLU || {};
+
+  function _getContract() { return window._cluCbzSplit || {}; }
+
+  // ── Per-session state ───────────────────────────────────────────────────
+  CLU._splitState = null;
+
+  function _escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  CLU.renderSplitGroups = function (data) {
+    CLU._splitState = {
+      folderName: data.folder_name || '',
+      rootFolder: data.root_folder || '',
+      originalPath: data.original_file_path || '',
+      groups: (data.groups || []).map(function (g) {
+        return {
+          name: g.suggested_name || '',
+          pages: (g.pages || []).map(function (p) {
+            return { rel_path: p.rel_path, filename: p.filename, img_data: p.img_data };
+          })
+        };
+      })
+    };
+
+    document.getElementById('splitInlineFolderName').value = data.folder_name || '';
+    document.getElementById('splitInlineRootFolder').value = data.root_folder || '';
+    document.getElementById('splitInlineOriginalFilePath').value = data.original_file_path || '';
+    var folderInput = document.getElementById('splitOutputFolderName');
+    if (folderInput && !folderInput.value) folderInput.value = data.suggested_folder || '';
+
+    _render();
+  };
+
+  function _render() {
+    var st = CLU._splitState;
+    var container = document.getElementById('splitInlineContainer');
+    if (!st || !container) return;
+
+    var totalPages = 0;
+    var html = '';
+    st.groups.forEach(function (g, gi) {
+      totalPages += g.pages.length;
+      html += '<div class="split-group card mb-3" data-group="' + gi + '">';
+      html += '  <div class="card-header d-flex align-items-center gap-2 flex-wrap">';
+      html += '    <span class="badge bg-primary">Issue ' + (gi + 1) + '</span>';
+      html += '    <input type="text" class="form-control form-control-sm split-group-name" ' +
+              'style="max-width: 360px;" value="' + _escapeHtml(g.name) + '" ' +
+              'onchange="CLU.updateGroupName(' + gi + ', this.value)">';
+      html += '    <span class="text-muted small">' + g.pages.length + ' page' +
+              (g.pages.length === 1 ? '' : 's') + '</span>';
+      if (gi > 0) {
+        html += '    <button type="button" class="btn btn-sm btn-outline-secondary ms-auto" ' +
+                'onclick="CLU.mergeGroupUp(' + gi + ')" title="Merge into previous issue">' +
+                '<i class="bi bi-arrow-up-square"></i> Merge into previous</button>';
+      }
+      html += '  </div>';
+      html += '  <div class="card-body"><div class="row row-cols-2 row-cols-sm-3 row-cols-md-5 g-2">';
+      g.pages.forEach(function (p, pi) {
+        html += '<div class="col" data-rel-path="' + _escapeHtml(p.rel_path) + '">';
+        html += '  <div class="card h-100 split-page-card">';
+        html += '    <div class="split-thumb-wrap">';
+        html += p.img_data
+          ? '<img src="' + p.img_data + '" class="split-thumb" alt="' + _escapeHtml(p.filename) + '">'
+          : '<span class="text-muted small p-2">no preview</span>';
+        html += '    </div>';
+        html += '    <div class="card-body p-1">';
+        html += '      <p class="small text-break mb-1">' + _escapeHtml(p.filename) + '</p>';
+        if (pi > 0) {
+          html += '      <button type="button" class="btn btn-sm btn-outline-primary w-100" ' +
+                  'onclick="CLU.splitAt(' + gi + ',' + pi + ')" title="Start a new issue here">' +
+                  '<i class="bi bi-scissors"></i> New issue here</button>';
+        } else {
+          html += '      <span class="badge bg-success w-100">issue start</span>';
+        }
+        html += '    </div>';
+        html += '  </div>';
+        html += '</div>';
+      });
+      html += '  </div></div>';
+      html += '</div>';
+    });
+
+    container.innerHTML = html;
+
+    var summary = document.getElementById('splitSummary');
+    if (summary) {
+      summary.textContent = st.groups.length + ' issue' +
+        (st.groups.length === 1 ? '' : 's') + ' · ' + totalPages + ' pages';
+    }
+  }
+
+  CLU.updateGroupName = function (gi, value) {
+    var st = CLU._splitState;
+    if (st && st.groups[gi]) st.groups[gi].name = value;
+  };
+
+  // Move the page at pageIdx (and everything after it) into a new issue.
+  CLU.splitAt = function (groupIdx, pageIdx) {
+    var st = CLU._splitState;
+    if (!st || !st.groups[groupIdx] || pageIdx <= 0) return;
+    var g = st.groups[groupIdx];
+    var moved = g.pages.splice(pageIdx);
+    var folderInput = document.getElementById('splitOutputFolderName');
+    var base = (folderInput && folderInput.value) || 'Issue';
+    st.groups.splice(groupIdx + 1, 0, {
+      name: base + ' ' + (st.groups.length + 1),
+      pages: moved
+    });
+    _render();
+  };
+
+  CLU.mergeGroupUp = function (groupIdx) {
+    var st = CLU._splitState;
+    if (!st || groupIdx <= 0 || !st.groups[groupIdx]) return;
+    st.groups[groupIdx - 1].pages =
+      st.groups[groupIdx - 1].pages.concat(st.groups[groupIdx].pages);
+    st.groups.splice(groupIdx, 1);
+    _render();
+  };
+
+  CLU.saveSplitCBZ = function () {
+    var st = CLU._splitState;
+    if (!st) return;
+
+    var invalid = st.groups.filter(function (g) { return !g.name || !g.name.trim(); });
+    if (invalid.length) {
+      CLU.showToast('Missing name', 'Every issue needs an output filename.', 'error');
+      return;
+    }
+
+    var payload = {
+      folder_name: st.folderName,
+      root_folder: st.rootFolder,
+      original_file_path: st.originalPath,
+      output_folder_name: (document.getElementById('splitOutputFolderName') || {}).value || '',
+      groups: st.groups.map(function (g) {
+        return {
+          output_name: g.name.trim(),
+          rel_paths: g.pages.map(function (p) { return p.rel_path; })
+        };
+      })
+    };
+
+    var btn = document.getElementById('splitCommitBtn');
+    if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Splitting…'; }
+
+    fetch('/api/split-cbz/commit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+      .then(function (res) {
+        if (!res.ok || !res.data.success) {
+          throw new Error((res.data && res.data.error) || 'Split failed.');
+        }
+        CLU.showSuccess
+          ? CLU.showSuccess('Split complete', 'Created ' + res.data.count + ' issue file(s).')
+          : CLU.showToast('Success', 'Created ' + res.data.count + ' issue file(s).', 'success');
+        var modalEl = document.getElementById('splitCBZModal');
+        var modal = bootstrap.Modal.getInstance(modalEl);
+        if (modal) modal.hide();
+        var contract = _getContract();
+        if (typeof contract.onSaveComplete === 'function') {
+          contract.onSaveComplete(st.originalPath);
+        }
+      })
+      .catch(function (err) {
+        CLU.showToast('Error', err.message, 'error');
+      })
+      .finally(function () {
+        if (btn) { btn.disabled = false; btn.innerHTML = '<i class="bi bi-scissors"></i> Split'; }
+      });
+  };
+})();

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -853,6 +853,22 @@ function createListItem(itemName, fullPath, type, panel, isDraggable) {
       editItem.appendChild(editLink);
       dropdownMenu.appendChild(editItem);
 
+      // Split File option (CBZ only)
+      if (fileData.name.toLowerCase().endsWith('.cbz')) {
+        const splitItem = document.createElement("li");
+        const splitLink = document.createElement("a");
+        splitLink.className = "dropdown-item";
+        splitLink.href = "#";
+        splitLink.textContent = "Split File";
+        splitLink.onclick = (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          openSplitModal(fullPath);
+        };
+        splitItem.appendChild(splitLink);
+        dropdownMenu.appendChild(splitItem);
+      }
+
       // Rebuild option
       const rebuildItem = document.createElement("li");
       const rebuildLink = document.createElement("a");
@@ -6185,6 +6201,65 @@ function saveEditedCBZ() {
     }
   };
   CLU.saveEditedCBZ();
+}
+
+// ============================================================================
+// SPLIT MODAL
+// ============================================================================
+
+var currentSplitFilePath = null;
+
+/**
+ * Open the split modal for a multi-issue CBZ file.
+ * @param {string} filePath - Path to the CBZ file to split
+ */
+function openSplitModal(filePath) {
+  currentSplitFilePath = filePath;
+
+  const splitModal = new bootstrap.Modal(document.getElementById('splitCBZModal'));
+  const container = document.getElementById('splitInlineContainer');
+  const folderInput = document.getElementById('splitOutputFolderName');
+  if (folderInput) folderInput.value = '';
+
+  container.innerHTML = `<div class="d-flex justify-content-center my-3">
+                              <button class="btn btn-primary" type="button" disabled>
+                                  <span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>
+                                  Unpacking CBZ File ...
+                              </button>
+                          </div>`;
+
+  splitModal.show();
+
+  const filename = filePath.split('/').pop().split('\\').pop();
+  document.getElementById('splitCBZModalText').textContent = `Split ${filename}`;
+
+  fetch(`/api/split-cbz/inspect?file_path=${encodeURIComponent(filePath)}`)
+    .then(response => response.json().then(data => ({ ok: response.ok, data })))
+    .then(res => {
+      if (!res.ok || !res.data.success) {
+        throw new Error((res.data && res.data.error) || 'Failed to load split content.');
+      }
+      CLU.renderSplitGroups(res.data);
+    })
+    .catch(error => {
+      container.innerHTML = `<div class="alert alert-danger" role="alert">
+                                  <strong>Error:</strong> ${error.message}
+                              </div>`;
+      CLU.showToast('Error', error.message, 'error');
+    });
+}
+
+function saveSplitCBZ() {
+  window._cluCbzSplit = {
+    onSaveComplete: function (filePath) {
+      if (currentSourcePath && currentSplitFilePath && currentSplitFilePath.startsWith(currentSourcePath)) {
+        loadDirectories(currentSourcePath, 'source');
+      } else if (currentDestinationPath && currentSplitFilePath && currentSplitFilePath.startsWith(currentDestinationPath)) {
+        loadDirectories(currentDestinationPath, 'destination');
+      }
+    }
+  };
+  CLU.saveSplitCBZ();
 }
 
 // ============================================================================

--- a/templates/files.html
+++ b/templates/files.html
@@ -556,6 +556,7 @@
 <!-- End of Rename Confirmation Modal -->
 
 {% include 'partials/modal_cbz_edit.html' %}
+{% include 'partials/modal_cbz_split.html' %}
 {% include 'partials/modal_freeform_crop.html' %}
 <!-- Missing File Check Results Modal -->
 <div class="modal fade" id="missingFileCheckModal" tabindex="-1" aria-labelledby="missingFileCheckModalLabel"
@@ -659,6 +660,7 @@
 <script src="{{ url_for('static', filename='js/clu-metadata.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-crop.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-edit.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-cbz-split.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-info.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-update-xml.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-delete.js') }}?v={{ range(1000, 9999) | random }}"></script>

--- a/templates/partials/modal_cbz_split.html
+++ b/templates/partials/modal_cbz_split.html
@@ -1,0 +1,68 @@
+<!-- Split CBZ Modal – shared partial (clu-cbz-split.js) -->
+<style>
+  #splitCBZModal .split-thumb-wrap {
+    max-height: 220px;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bs-body-bg);
+  }
+  #splitCBZModal .split-thumb {
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+  }
+  #splitCBZModal .split-group {
+    border-left: 4px solid var(--bs-primary);
+  }
+  #splitCBZModal .split-page-card .card-body {
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+</style>
+<div class="modal fade" id="splitCBZModal" tabindex="-1" aria-labelledby="splitCBZModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-fullscreen">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title flex-grow-1" id="splitCBZModalLabel">
+          <span id="splitCBZModalText">Split&hellip;</span>
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-info small">
+          <i class="bi bi-scissors me-1"></i>
+          Issues are auto-detected from the page filenames. Click
+          <strong>New issue here</strong> on a page to start a new issue at that page, or
+          <strong>Merge into previous</strong> on an issue header to combine it upward.
+          Each issue is written as its own CBZ into the output folder below. The original
+          file is kept unchanged.
+        </div>
+        <div class="row g-2 align-items-end mb-3">
+          <div class="col-auto">
+            <label for="splitOutputFolderName" class="form-label small mb-0">Output folder</label>
+            <input type="text" class="form-control form-control-sm" id="splitOutputFolderName"
+                   placeholder="Series name" autocomplete="off" style="min-width: 320px;">
+            <div class="form-text">A subfolder created next to the original file.</div>
+          </div>
+        </div>
+        <div id="splitInlineContainer">
+          <!-- Grouped page grid rendered here by clu-cbz-split.js -->
+        </div>
+        <input type="hidden" id="splitInlineFolderName">
+        <input type="hidden" id="splitInlineRootFolder">
+        <input type="hidden" id="splitInlineOriginalFilePath">
+      </div>
+      <div class="modal-footer">
+        <span id="splitSummary" class="me-auto text-muted small"></span>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="splitCommitBtn" onclick="saveSplitCBZ()">
+          <i class="bi bi-scissors"></i> Split
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/tests/mocked/test_split.py
+++ b/tests/mocked/test_split.py
@@ -1,0 +1,155 @@
+"""Tests for cbz_ops/split.py -- split a multi-issue CBZ into single issues."""
+import io
+import os
+import zipfile
+import pytest
+
+
+def _png_bytes(color=(100, 100, 200)):
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (50, 75), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_multi_issue_cbz(path, issues, series="Cult of Dracula", nested=False):
+    """issues: dict of issue_str -> page_count. Names pages '<series> <issue> - NNNN.png'."""
+    prefix = "wrapper/" if nested else ""
+    with zipfile.ZipFile(str(path), "w") as zf:
+        for issue, pages in issues.items():
+            for p in range(1, pages + 1):
+                zf.writestr(f"{prefix}{series} {issue} - {p:04d}.png", _png_bytes())
+    return str(path)
+
+
+class TestParseIssueKey:
+
+    def test_canonical(self):
+        from cbz_ops.split import parse_issue_key
+        assert parse_issue_key("Cult of Dracula 003 - 0001.jpg") == "003"
+
+    def test_decimal_issue(self):
+        from cbz_ops.split import parse_issue_key
+        assert parse_issue_key("Series 003.1 - 0002.png") == "003.1"
+
+    def test_spacing_variants(self):
+        from cbz_ops.split import parse_issue_key
+        assert parse_issue_key("Series 4 -0007.jpg") == "4"
+        assert parse_issue_key("Series 4-0007.jpg") == "4"
+
+    def test_non_matching(self):
+        from cbz_ops.split import parse_issue_key
+        assert parse_issue_key("page_001.jpg") is None
+        assert parse_issue_key("cover.jpg") is None
+
+
+class TestDetectGroups:
+
+    def test_multi_issue_consecutive(self):
+        from cbz_ops.split import detect_groups
+        rels = [
+            "Cult of Dracula 003 - 0001.png",
+            "Cult of Dracula 003 - 0002.png",
+            "Cult of Dracula 004 - 0001.png",
+            "Cult of Dracula 005 - 0001.png",
+            "Cult of Dracula 005 - 0002.png",
+        ]
+        groups = detect_groups(rels)
+        assert [g["issue_key"] for g in groups] == ["003", "004", "005"]
+        assert [len(g["page_rel_paths"]) for g in groups] == [2, 1, 2]
+
+    def test_all_none_single_group(self):
+        from cbz_ops.split import detect_groups
+        rels = ["page_001.png", "page_002.png", "cover.png"]
+        groups = detect_groups(rels)
+        assert len(groups) == 1
+        assert len(groups[0]["page_rel_paths"]) == 3
+
+    def test_leading_unmatched_absorbed(self):
+        from cbz_ops.split import detect_groups
+        rels = [
+            "0000 intro.png",       # no issue key
+            "Series 003 - 0001.png",
+            "Series 003 - 0002.png",
+        ]
+        groups = detect_groups(rels)
+        assert len(groups) == 1
+        assert groups[0]["issue_key"] == "003"
+        assert len(groups[0]["page_rel_paths"]) == 3
+
+
+class TestExtractForSplit:
+
+    def test_leaves_original_and_extracts(self, tmp_path):
+        from cbz_ops.split import extract_for_split
+        cbz = _make_multi_issue_cbz(tmp_path / "collection.cbz", {"003": 2, "004": 1})
+        result = extract_for_split(cbz)
+
+        assert os.path.isfile(cbz)  # original untouched
+        folder = result["folder_name"]
+        pngs = [f for _, _, fs in os.walk(folder) for f in fs if f.endswith(".png")]
+        assert len(pngs) == 3
+        assert os.path.isdir(result["root_folder"])
+
+    def test_collapses_nested_wrapper(self, tmp_path):
+        from cbz_ops.split import extract_for_split
+        cbz = _make_multi_issue_cbz(tmp_path / "nested.cbz", {"001": 2}, nested=True)
+        result = extract_for_split(cbz)
+        # folder_name should point at the wrapper contents, not the outer temp dir
+        entries = os.listdir(result["folder_name"])
+        assert any(e.endswith(".png") for e in entries)
+
+
+class TestCommitSplit:
+
+    def test_writes_issue_files(self, tmp_path):
+        from cbz_ops.split import commit_split
+        folder = tmp_path / "extracted"
+        folder.mkdir()
+        (folder / "Series 003 - 0001.png").write_bytes(_png_bytes())
+        (folder / "Series 003 - 0002.png").write_bytes(_png_bytes())
+        (folder / "Series 004 - 0001.png").write_bytes(_png_bytes())
+
+        out_dir = tmp_path / "Series"
+        outputs = commit_split(str(folder), str(out_dir), [
+            {"output_name": "Series 003", "rel_paths": ["Series 003 - 0001.png", "Series 003 - 0002.png"]},
+            {"output_name": "Series 004", "rel_paths": ["Series 004 - 0001.png"]},
+        ])
+
+        assert len(outputs) == 2
+        assert outputs[0]["total_images"] == 2
+        for o in outputs:
+            assert os.path.isfile(o["path"])
+            with zipfile.ZipFile(o["path"]) as zf:
+                names = zf.namelist()
+                assert not any(n.lower().endswith("comicinfo.xml") for n in names)
+
+    def test_dedup_duplicate_basenames(self, tmp_path):
+        from cbz_ops.split import commit_split
+        folder = tmp_path / "extracted"
+        (folder / "sub").mkdir(parents=True)
+        (folder / "img.png").write_bytes(_png_bytes())
+        (folder / "sub" / "img.png").write_bytes(_png_bytes())
+
+        out_dir = tmp_path / "out"
+        outputs = commit_split(str(folder), str(out_dir), [
+            {"output_name": "Issue 1", "rel_paths": ["img.png", os.path.join("sub", "img.png")]},
+        ])
+        with zipfile.ZipFile(outputs[0]["path"]) as zf:
+            names = sorted(zf.namelist())
+        # Mirrors combine_cbz: the first keeps its name, later duplicates get b, c, ...
+        assert names == ["img.png", "imgb.png"]
+
+    def test_collision_suffix(self, tmp_path):
+        from cbz_ops.split import commit_split
+        folder = tmp_path / "extracted"
+        folder.mkdir()
+        (folder / "Series 003 - 0001.png").write_bytes(_png_bytes())
+        out_dir = tmp_path / "Series"
+        out_dir.mkdir()
+        (out_dir / "Series 003.cbz").write_bytes(b"existing")
+
+        outputs = commit_split(str(folder), str(out_dir), [
+            {"output_name": "Series 003", "rel_paths": ["Series 003 - 0001.png"]},
+        ])
+        assert outputs[0]["name"] == "Series 003 (1).cbz"

--- a/tests/routes/test_files_routes.py
+++ b/tests/routes/test_files_routes.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import types
+import zipfile
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -692,6 +693,117 @@ class TestCombineCbz:
         data = resp.get_json()
         assert data["success"] is True
         assert data["total_images"] == 4
+
+
+def _make_multi_issue_cbz(path, issues, series="Cult of Dracula"):
+    """issues: dict issue_str -> page_count. Pages named '<series> <issue> - NNNN.png'."""
+    import io
+    import zipfile
+    from PIL import Image
+    with zipfile.ZipFile(str(path), "w") as zf:
+        for issue, pages in issues.items():
+            for p in range(1, pages + 1):
+                buf = io.BytesIO()
+                Image.new("RGB", (50, 75), color=(100, 100, 200)).save(buf, format="PNG")
+                zf.writestr(f"{series} {issue} - {p:04d}.png", buf.getvalue())
+    return str(path)
+
+
+class TestSplitCbz:
+
+    def test_inspect_missing_file_path(self, client):
+        resp = client.get("/api/split-cbz/inspect")
+        assert resp.status_code == 400
+
+    @patch("routes.files.is_valid_library_path", return_value=True)
+    def test_inspect_non_cbz(self, mock_valid, client, tmp_path):
+        f = tmp_path / "x.zip"
+        f.write_bytes(b"fake")
+        resp = client.get(f"/api/split-cbz/inspect?file_path={f}")
+        assert resp.status_code == 400
+
+    @patch("routes.files.is_valid_library_path", return_value=False)
+    def test_inspect_access_denied(self, mock_valid, client, tmp_path):
+        f = tmp_path / "a.cbz"
+        f.write_bytes(b"fake")
+        resp = client.get(f"/api/split-cbz/inspect?file_path={f}")
+        assert resp.status_code == 403
+
+    @patch("routes.files.is_valid_library_path", return_value=True)
+    def test_inspect_groups(self, mock_valid, client, tmp_path):
+        cbz = _make_multi_issue_cbz(tmp_path / "collection.cbz", {"003": 2, "004": 3})
+        resp = client.get(f"/api/split-cbz/inspect?file_path={cbz}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert len(data["groups"]) == 2
+        assert [len(g["pages"]) for g in data["groups"]] == [2, 3]
+        assert data["groups"][0]["pages"][0]["img_data"].startswith("data:image/jpeg;base64,")
+
+    @patch("routes.files.add_file_index_entry")
+    @patch("routes.files.is_valid_library_path", return_value=True)
+    def test_commit_creates_issue_files(self, mock_valid, mock_index, client, tmp_path):
+        cbz = _make_multi_issue_cbz(tmp_path / "collection.cbz", {"003": 2, "004": 1})
+        inspect = client.get(f"/api/split-cbz/inspect?file_path={cbz}").get_json()
+
+        groups = [{"output_name": g["suggested_name"],
+                   "rel_paths": [p["rel_path"] for p in g["pages"]]}
+                  for g in inspect["groups"]]
+        resp = client.post("/api/split-cbz/commit", json={
+            "folder_name": inspect["folder_name"],
+            "root_folder": inspect["root_folder"],
+            "original_file_path": inspect["original_file_path"],
+            "output_folder_name": "Cult of Dracula",
+            "groups": groups,
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["count"] == 2
+
+        out_dir = tmp_path / "Cult of Dracula"
+        cbz_files = sorted(out_dir.glob("*.cbz"))
+        assert len(cbz_files) == 2
+        for f in cbz_files:
+            with zipfile.ZipFile(str(f)) as zf:
+                names = zf.namelist()
+            assert not any(n.lower().endswith("comicinfo.xml") for n in names)
+        assert mock_index.called
+        assert os.path.isfile(cbz)  # original preserved
+
+    @patch("routes.files.add_file_index_entry")
+    @patch("routes.files.is_valid_library_path", return_value=True)
+    def test_commit_collision_suffix(self, mock_valid, mock_index, client, tmp_path):
+        cbz = _make_multi_issue_cbz(tmp_path / "collection.cbz", {"003": 1})
+        inspect = client.get(f"/api/split-cbz/inspect?file_path={cbz}").get_json()
+        out_dir = tmp_path / "Cult of Dracula"
+        out_dir.mkdir()
+        (out_dir / "Cult of Dracula 003.cbz").write_bytes(b"existing")
+
+        groups = [{"output_name": "Cult of Dracula 003",
+                   "rel_paths": [p["rel_path"] for p in inspect["groups"][0]["pages"]]}]
+        resp = client.post("/api/split-cbz/commit", json={
+            "folder_name": inspect["folder_name"],
+            "root_folder": inspect["root_folder"],
+            "original_file_path": inspect["original_file_path"],
+            "output_folder_name": "Cult of Dracula",
+            "groups": groups,
+        })
+        data = resp.get_json()
+        assert data["output_files"][0]["name"] == "Cult of Dracula 003 (1).cbz"
+
+    @patch("routes.files.is_valid_library_path", return_value=True)
+    def test_commit_traversal_rejected(self, mock_valid, client, tmp_path):
+        cbz = tmp_path / "collection.cbz"
+        cbz.write_bytes(b"fake")
+        resp = client.post("/api/split-cbz/commit", json={
+            "folder_name": str(tmp_path),
+            "original_file_path": str(cbz),
+            "output_folder_name": "Evil",
+            "groups": [{"output_name": "x", "rel_paths": ["../evil.png"]}],
+        })
+        assert resp.status_code == 400
+        assert not (tmp_path / "Evil").exists()
 
 
 class TestCrop:


### PR DESCRIPTION
## Context

Users sometimes have a single large CBZ that actually collects several issues (e.g. a 314 MB "Cult of Dracula" file holding issues 1–6). Inside, the page images follow a recognizable pattern:

```
Cult of Dracula 003 - 0001.jpg   ← series, issue 003, page 0001
Cult of Dracula 004 - 0001.jpg
```

There was no way to break such a file into proper single-issue CBZs. This PR adds a **"Split File"** action to the File Manager's per-file dropdown (next to "Edit File", CBZ-only).

## What it does

1. Unpacks the CBZ **non-destructively** (the original is opened read-only and extracted to a pid-unique temp folder — no `.cbz`→`.zip` rename).
2. **Auto-detects issue boundaries** from the internal page filenames and renders an editable, grouped page grid.
3. The user adjusts boundaries (**New issue here** / **Merge into previous**) and renames each issue.
4. Writes one **image-only** CBZ per issue into a **new series subfolder** next to the source. The original is kept.

## Changes

| File | Change |
|------|--------|
| `cbz_ops/split.py` | New. `parse_issue_key`, `detect_groups`, `extract_for_split` (non-destructive), `get_split_modal` (thumbnails + grouping), `commit_split` (writes via `open_zip_for_write`). |
| `routes/files.py` | New `GET /api/split-cbz/inspect` + `POST /api/split-cbz/commit` on `files_bp`, mirroring `combine_cbz`'s security gate, collision handling, and `add_file_index_entry`. |
| `templates/partials/modal_cbz_split.html` | New fullscreen modal. |
| `static/js/clu-cbz-split.js` | Client-side group model, boundary add/merge, commit. |
| `static/js/files.js` | Dropdown item + `openSplitModal` / `saveSplitCBZ`. |
| `templates/files.html` | Wired the include + script tag. |
| `tests/mocked/test_split.py`, `tests/routes/test_files_routes.py` | `cbz_ops` unit tests + `TestSplitCbz` route tests. |

## Design notes

- **Original kept untouched:** non-destructive extract means there's nothing to restore on failure, and concurrent splits of the same file don't collide (temp dir is `.tmp_split_<pid>_<hash>`).
- **No ComicInfo** written; outputs are pure image CBZs (metadata can be scraped per issue afterward).
- Page-name parser handles decimal issues (`003.1`), spacing variants, all-unmatched (single group / manual mode), and leading unmatched pages (absorbed into the first issue).
- Duplicate page basenames within an issue are suffixed `b, c, …`, matching the existing `combine_cbz` convention.

## Testing

- New `cbz_ops` unit tests + route tests exercise the inspect→commit flow end-to-end with real zip/PIL images.
- Full suite: **828 passed**; the only failures are the 13 known env-only `test_pdf.py` failures (missing `pdf2image` locally). Both new JS files pass `node --check`.

Future enhancement (not in this PR): the inverse — building a CBZ from a folder of loose issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)