### PR TITLE
Unwrap & Convert Hybrid/Multipart releases in the WATCH folder

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -443,6 +443,9 @@ def _format_issue_month(month_raw):
 # keep all copies in lockstep.
 FILENAME_ILLEGAL_CHARS = '\\/:*?"<>|&$;'
 
+# Extensions eligible for doubled-extension collapse in clean_final_filename.
+_DOUBLE_EXT_COLLAPSE = {".cbz", ".cbr", ".cbt", ".pdf", ".zip", ".rar", ".epub"}
+
 
 _FILENAME_CLEANUP_DEFAULTS = {
     "spaces_enabled": False,
@@ -560,6 +563,14 @@ def clean_final_filename(filename):
         stem, ext = filename[:last_dot], filename[last_dot:]
     else:
         stem, ext = filename, ""
+    # Collapse an accidentally doubled extension (e.g. "Name.cbz.cbz" -> "Name.cbz").
+    # This arises when an issue-number capture (\d{1,4}(?:\.\w+)?) swallows the
+    # extension as a fake decimal suffix and a pattern then re-appends it. Limited
+    # to known comic/archive extensions so dotted titles/suffixes (e.g. "1.MU")
+    # are left untouched.
+    if ext.lower() in _DOUBLE_EXT_COLLAPSE:
+        while stem.lower().endswith(ext.lower()):
+            stem = stem[: -len(ext)]
     stem = apply_filename_cleanup(stem)
     return stem + ext
 

--- a/helpers/unwrap.py
+++ b/helpers/unwrap.py
@@ -1,0 +1,381 @@
+"""Recursive unwrapping of Hybrid/Multipart release folders.
+
+Usenet releases (e.g. BitBook) arrive as a folder of obfuscated, multi-part
+archives rather than a ready comic — a set of ``.zip`` parts that extract to a
+``.RAR`` that extracts to the real PDF/CBR/CBZ. This module reassembles and
+recursively extracts such a folder until the comic file(s) emerge, so the normal
+monitor pipeline can take over.
+
+Nothing here mutates the source folder — extraction happens in an isolated work
+dir under WATCH — so a failed or partial unwrap leaves the originals intact for
+recovery. The monitor (monitor.py) owns the source-side cleanup and hand-off.
+
+Reuses ``extract_rar_with_unar`` (unrar -> 7z -> unar, multi-volume aware) for
+RAR layers; zip layers are extracted with zipfile and a 7z/unar fallback.
+"""
+import os
+import re
+import shutil
+import subprocess
+import uuid
+import zipfile
+from collections import defaultdict, namedtuple
+
+from core.app_logging import app_logger
+from helpers import is_hidden, match_parent_permissions, extract_rar_with_unar
+from helpers.library import is_allowed_path
+
+# Comic containers that end the recursion — hand these back to the pipeline.
+COMIC_EXTS = {".pdf", ".cbr", ".cbz", ".cbt"}
+# Release cruft that is safe to delete once a comic has emerged.
+CRUFT_EXTS = {".nfo", ".diz", ".sfv", ".txt"}
+
+# Archive-part patterns. RAR: plain .rar, part-volumes (.part01.rar) and old-style
+# .r00/.r01 volumes. ZIP: plain .zip and spanned .z01/.z02 volumes. Numeric split
+# volumes (.001/.002) round out the common Usenet packaging styles.
+RAR_PART_RE = re.compile(r"\.part(\d+)\.rar$", re.IGNORECASE)
+RAR_VOL_RE = re.compile(r"\.r\d{2}$", re.IGNORECASE)
+RAR_MAIN_RE = re.compile(r"\.rar$", re.IGNORECASE)
+ZIP_VOL_RE = re.compile(r"\.z\d{2}$", re.IGNORECASE)
+ZIP_MAIN_RE = re.compile(r"\.zip$", re.IGNORECASE)
+SPLIT_RE = re.compile(r"\.(\d{3})$")
+
+# Classification results for a WATCH subfolder.
+MULTIPART_ARCHIVE = "MULTIPART_ARCHIVE"
+NORMAL = "NORMAL"
+
+UnwrapResult = namedtuple(
+    "UnwrapResult", ["comics", "ok", "reason", "partial", "work_dir"]
+)
+
+
+def _is_rar_family(name):
+    return bool(RAR_MAIN_RE.search(name) or RAR_VOL_RE.search(name))
+
+
+def _is_zip_family(name):
+    return bool(ZIP_MAIN_RE.search(name) or ZIP_VOL_RE.search(name))
+
+
+def is_archive_part(name):
+    """True if the filename looks like any archive volume we know how to open."""
+    return bool(
+        _is_rar_family(name) or _is_zip_family(name) or SPLIT_RE.search(name)
+    )
+
+
+def _rar_stem(name):
+    m = RAR_PART_RE.search(name)
+    if m:
+        return name[: m.start()].lower()
+    if RAR_VOL_RE.search(name) or RAR_MAIN_RE.search(name):
+        return name[:-4].lower()
+    return name.lower()
+
+
+def _zip_stem(name):
+    if ZIP_VOL_RE.search(name) or ZIP_MAIN_RE.search(name):
+        return name[:-4].lower()
+    return name.lower()
+
+
+def pick_primary_volume(parts):
+    """Given the volumes of a single archive set, return the one to hand the
+    extractor (which then follows the remaining volumes natively).
+
+    Order of preference: lowest ``.partNN.rar``; the plain ``.rar`` of a
+    ``.rar``+``.rNN`` set; the ``.zip`` of a ``.zip``+``.zNN`` spanned set; the
+    lowest numeric ``.NNN`` split. Falls back to the lexicographically first
+    name so the choice is deterministic for obfuscated same-extension sets.
+    """
+    if not parts:
+        return None
+    names = sorted(parts, key=lambda s: s.lower())
+
+    part_rars = []
+    for n in names:
+        m = RAR_PART_RE.search(n)
+        if m:
+            part_rars.append((int(m.group(1)), n))
+    if part_rars:
+        return min(part_rars)[1]
+
+    plain_rars = [n for n in names if RAR_MAIN_RE.search(n) and not RAR_PART_RE.search(n)]
+    if plain_rars and any(RAR_VOL_RE.search(n) for n in names):
+        return plain_rars[0]
+
+    zips = [n for n in names if ZIP_MAIN_RE.search(n)]
+    if zips and any(ZIP_VOL_RE.search(n) for n in names):
+        return zips[0]
+
+    splits = []
+    for n in names:
+        m = SPLIT_RE.search(n)
+        if m:
+            splits.append((int(m.group(1)), n))
+    if splits:
+        return min(splits)[1]
+
+    if plain_rars:
+        return plain_rars[0]
+    return names[0]
+
+
+def _looks_obfuscated(name):
+    """Heuristic for scene/Usenet obfuscated names (e.g. ``--bbyvt3ga.zip``)."""
+    if name.startswith("--"):
+        return True
+    stem = os.path.splitext(name)[0].lstrip("-_")
+    return bool(re.fullmatch(r"[a-z0-9]{6,}", stem))
+
+
+def classify_release_folder(folder_path):
+    """Classify a WATCH subfolder as ``MULTIPART_ARCHIVE`` or ``NORMAL``.
+
+    Conservative by design (a false positive would try to unwrap a normal
+    folder): fires only when the folder has NO ready comic, has at least one
+    archive part, and shows a multipart signal — several parts, release cruft
+    (.nfo/file_id.diz), or an obfuscated archive name.
+    """
+    try:
+        entries = os.listdir(folder_path)
+    except OSError:
+        return NORMAL
+
+    files = []
+    for e in entries:
+        p = os.path.join(folder_path, e)
+        if os.path.isfile(p) and not is_hidden(p):
+            files.append(e)
+
+    if any(os.path.splitext(f)[1].lower() in COMIC_EXTS for f in files):
+        # A ready comic is present — this is a normal pipeline job, never unwrap.
+        return NORMAL
+
+    archives = [f for f in files if is_archive_part(f)]
+    if not archives:
+        return NORMAL
+
+    cruft = [
+        f for f in files
+        if os.path.splitext(f)[1].lower() in CRUFT_EXTS or f.lower() == "file_id.diz"
+    ]
+
+    if len(archives) >= 2 or cruft or any(_looks_obfuscated(f) for f in archives):
+        return MULTIPART_ARCHIVE
+    return NORMAL
+
+
+def _find_comics(dirpath):
+    """Return full paths of comic files anywhere under ``dirpath`` (sorted)."""
+    found = []
+    for root, dirs, files in os.walk(dirpath):
+        dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
+        for f in files:
+            if is_hidden(os.path.join(root, f)):
+                continue
+            if os.path.splitext(f)[1].lower() in COMIC_EXTS:
+                found.append(os.path.join(root, f))
+    return sorted(found)
+
+
+def _plan_layer_extractions(dirpath):
+    """Return the list of primary-volume paths to extract from one directory.
+
+    RAR/spanned-zip/split sets collapse to a single primary (the extractor
+    follows the rest); independent zips each become their own primary.
+    """
+    try:
+        entries = os.listdir(dirpath)
+    except OSError:
+        return []
+    archives = [
+        e for e in entries
+        if os.path.isfile(os.path.join(dirpath, e))
+        and not is_hidden(os.path.join(dirpath, e))
+        and is_archive_part(e)
+    ]
+
+    primaries = []
+
+    rar_family = [f for f in archives if _is_rar_family(f)]
+    rar_groups = defaultdict(list)
+    for f in rar_family:
+        rar_groups[_rar_stem(f)].append(f)
+    for group in rar_groups.values():
+        primaries.append(os.path.join(dirpath, pick_primary_volume(group)))
+
+    # Zip: skip spanned volumes (.zNN) — their .zip primary drives them. Every
+    # remaining .zip (spanned primary or independent) is extracted.
+    for f in archives:
+        if ZIP_MAIN_RE.search(f) and not ZIP_VOL_RE.search(f):
+            primaries.append(os.path.join(dirpath, f))
+
+    split_groups = defaultdict(list)
+    for f in archives:
+        if SPLIT_RE.search(f):
+            split_groups[f[:-4].lower()].append(f)
+    for group in split_groups.values():
+        primaries.append(os.path.join(dirpath, pick_primary_volume(group)))
+
+    return primaries
+
+
+def _extract_zip(zip_path, out_dir):
+    """Extract a zip into ``out_dir``. Returns (ok, failed_count).
+
+    Standard/independent zips go through zipfile; a spanned or otherwise
+    unreadable zip falls back to 7z then unar (which assemble volume sets).
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            failed = 0
+            for member in zf.namelist():
+                try:
+                    zf.extract(member, out_dir)
+                except Exception as e:
+                    failed += 1
+                    app_logger.warning(f"unwrap: failed to extract {member} from {zip_path}: {e}")
+        return True, failed
+    except zipfile.BadZipFile:
+        pass  # likely a spanned volume — fall back to external tools
+    except Exception as e:
+        app_logger.warning(f"unwrap: zipfile error on {zip_path}: {e}")
+
+    for cmd in (
+        ["7z", "x", f"-o{out_dir}", "-y", zip_path],
+        ["unar", "-f", "-o", out_dir, zip_path],
+    ):
+        try:
+            subprocess.run(cmd, capture_output=True)
+        except FileNotFoundError:
+            continue
+        except Exception as e:
+            app_logger.warning(f"unwrap: {cmd[0]} error on {zip_path}: {e}")
+            continue
+        if os.path.isdir(out_dir) and any(os.listdir(out_dir)):
+            return True, 0
+    return False, 0
+
+
+def _extract_archive(primary_path, out_dir):
+    """Dispatch to the RAR or ZIP extractor. Returns (ok, failed_count)."""
+    name = os.path.basename(primary_path)
+    if _is_rar_family(name):
+        try:
+            return extract_rar_with_unar(primary_path, out_dir)
+        except Exception as e:
+            app_logger.warning(f"unwrap: RAR extraction failed for {primary_path}: {e}")
+            return False, 0
+    return _extract_zip(primary_path, out_dir)
+
+
+def _dir_size(dirpath):
+    total = 0
+    for root, _dirs, files in os.walk(dirpath):
+        for f in files:
+            try:
+                total += os.path.getsize(os.path.join(root, f))
+            except OSError:
+                pass
+    return total
+
+
+def unwrap_release(src_folder, work_root, *, max_depth=8, max_expansion_ratio=200):
+    """Recursively unwrap a multipart release folder.
+
+    Stages the archive parts into an isolated work dir under ``work_root`` and
+    extracts layer by layer (breadth-first) until comic files emerge. The source
+    folder is never modified. The caller is responsible for removing the
+    returned ``work_dir`` once it has moved the comics out.
+
+    Guards against archive bombs via ``max_depth``, a cumulative-size ceiling
+    (``max_expansion_ratio`` * staged size), and a visited-name set.
+
+    Returns an ``UnwrapResult(comics, ok, reason, partial, work_dir)`` where
+    ``comics`` are paths inside ``work_dir``.
+    """
+    try:
+        src_folder = os.path.realpath(src_folder)
+        if not is_allowed_path(src_folder):
+            return UnwrapResult([], False, "path_not_allowed", False, None)
+
+        parts = [
+            os.path.join(src_folder, e)
+            for e in os.listdir(src_folder)
+            if os.path.isfile(os.path.join(src_folder, e))
+            and not is_hidden(os.path.join(src_folder, e))
+            and is_archive_part(e)
+        ]
+        if not parts:
+            return UnwrapResult([], False, "no_archives", False, None)
+
+        os.makedirs(work_root, exist_ok=True)
+        work_dir = os.path.join(
+            work_root, f"{os.path.basename(src_folder)}-{uuid.uuid4().hex[:8]}"
+        )
+        layer0 = os.path.join(work_dir, "L0")
+        os.makedirs(layer0)
+
+        staged_size = 0
+        for p in parts:
+            shutil.copy2(p, os.path.join(layer0, os.path.basename(p)))
+            try:
+                staged_size += os.path.getsize(p)
+            except OSError:
+                pass
+
+        comics = []
+        partial = False
+        total_extracted = 0
+        visited = set()
+        queue = [(layer0, 0)]
+        layer_no = 0
+
+        while queue:
+            cur_dir, depth = queue.pop(0)
+
+            found = _find_comics(cur_dir)
+            if found:
+                comics.extend(found)
+                continue
+
+            if depth >= max_depth:
+                app_logger.warning(
+                    f"unwrap: max depth {max_depth} reached for {src_folder}"
+                )
+                return UnwrapResult(comics, False, "max_depth", partial, work_dir)
+
+            primaries = _plan_layer_extractions(cur_dir)
+            primaries = [p for p in primaries if os.path.basename(p).lower() not in visited]
+            if not primaries:
+                continue
+
+            layer_no += 1
+            out_dir = os.path.join(work_dir, f"L{depth + 1}_{layer_no}")
+            os.makedirs(out_dir, exist_ok=True)
+
+            for primary in primaries:
+                visited.add(os.path.basename(primary).lower())
+                ok, failed = _extract_archive(primary, out_dir)
+                if failed:
+                    partial = True
+
+            total_extracted += _dir_size(out_dir)
+            if staged_size and total_extracted > staged_size * max_expansion_ratio:
+                app_logger.warning(
+                    f"unwrap: expansion ceiling exceeded for {src_folder}"
+                )
+                return UnwrapResult(comics, False, "expansion_limit", partial, work_dir)
+
+            queue.append((out_dir, depth + 1))
+
+        if comics:
+            return UnwrapResult(comics, True, None, partial, work_dir)
+        return UnwrapResult([], False, "no_comics", partial, work_dir)
+
+    except Exception as e:
+        app_logger.error(f"unwrap: unexpected error unwrapping {src_folder}: {e}")
+        wd = locals().get("work_dir")
+        return UnwrapResult([], False, "error", False, wd)

--- a/monitor.py
+++ b/monitor.py
@@ -12,6 +12,7 @@ from cbz_ops.rename import rename_file, clean_directory_name
 from cbz_ops.single_file import convert_to_cbz
 from core.config import config, load_config, get_watch_dir, get_target_dir
 from helpers import is_hidden
+from helpers.unwrap import classify_release_folder, unwrap_release, MULTIPART_ARCHIVE
 from core.app_logging import MONITOR_LOG
 from core.database import init_db
 
@@ -84,6 +85,15 @@ class DownloadCompleteHandler(FileSystemEventHandler):
         self._processing_lock = threading.Lock()
         self._in_flight = set()
 
+        # Release folders currently being unwrapped (multipart/hybrid). Guards
+        # the per-file loop from moving the obfuscated archive parts of a release
+        # while its folder-level unwrap is mid-flight. Same lock as _in_flight.
+        self._in_flight_dirs = set()
+        # Multipart release folders to skip until a timestamp: failed unwraps get
+        # a short retry cooldown; partial ones a long skip. In-memory (cleared on
+        # restart) so a release the user later fixes is eventually retried.
+        self._failed_unwraps = {}
+
 
     def reload_settings(self):
         ###
@@ -128,11 +138,13 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             print(f"Error: {zip_filename} not found in the current directory.")
             return
 
-        # Open and extract the zip file
+        # Extract into the zip's own folder (not the global watch root), so a zip
+        # sitting in a subfolder unpacks beside itself rather than at WATCH root.
+        extract_dir = os.path.dirname(zip_filename) or self.directory
         with zipfile.ZipFile(zip_filename, 'r') as zip_ref:
-            zip_ref.extractall(directory)  # Defaults to current directory
+            zip_ref.extractall(extract_dir)
 
-        monitor_logger.info(f"Successfully extracted {zip_filename} into {os.getcwd()}")
+        monitor_logger.info(f"Successfully extracted {zip_filename} into {extract_dir}")
 
         # Delete the zip file after extraction if it still exists
         if os.path.exists(zip_filename):
@@ -145,6 +157,169 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             monitor_logger.info(f"Zip file {zip_filename} not found during deletion; it may have been already removed.")
 
 
+    def _unwrap_staging_root(self):
+        """Hidden work root under WATCH for multipart extraction scratch space."""
+        return os.path.join(self.directory, ".clu_unwrap")
+
+
+    def _release_parts_stable(self, folder_path):
+        """True once every archive part in the release folder is size-stable, so
+        we don't unwrap while parts are still being written by the download client."""
+        try:
+            from helpers.unwrap import is_archive_part
+            for entry in os.listdir(folder_path):
+                p = os.path.join(folder_path, entry)
+                if os.path.isfile(p) and not is_hidden(p) and is_archive_part(entry):
+                    if not self._is_download_complete(p):
+                        return False
+            return True
+        except OSError:
+            return False
+
+
+    def _cleanup_release_cruft(self, folder_path):
+        """Delete archive parts and release cruft (.nfo/.diz/.sfv/file_id.diz)
+        from a successfully-unwrapped release folder. Staged comics are left."""
+        from helpers.unwrap import is_archive_part, CRUFT_EXTS
+        try:
+            entries = os.listdir(folder_path)
+        except OSError:
+            return
+        for entry in entries:
+            p = os.path.join(folder_path, entry)
+            if not os.path.isfile(p):
+                continue
+            ext = os.path.splitext(entry)[1].lower()
+            if is_archive_part(entry) or ext in CRUFT_EXTS or entry.lower() == "file_id.diz":
+                try:
+                    os.remove(p)
+                    monitor_logger.info(f"Removed release cruft: {p}")
+                except OSError as e:
+                    monitor_logger.error(f"Error removing {p}: {e}")
+
+
+    def _handoff_unwrapped(self, staged_path):
+        """Convert a staged PDF to CBZ if needed, then feed the comic into the
+        normal per-file pipeline (rename, CBR->CBZ, move to TARGET)."""
+        ext = os.path.splitext(staged_path)[1].lower()
+        if ext == ".pdf":
+            monitor_logger.info(f"Converting unwrapped PDF to CBZ: {staged_path}")
+            try:
+                from cbz_ops.pdf import process_pdf_file
+                process_pdf_file(staged_path)  # writes a sibling .cbz, deletes the PDF
+            except Exception as e:
+                monitor_logger.error(f"PDF conversion failed for {staged_path}: {e}")
+                return
+            cbz_path = os.path.splitext(staged_path)[0] + ".cbz"
+            if not os.path.exists(cbz_path):
+                monitor_logger.error(f"PDF conversion produced no CBZ for {staged_path}")
+                return
+            from helpers import match_parent_permissions
+            match_parent_permissions(cbz_path)
+            staged_path = cbz_path
+
+        self._process_file(staged_path)
+
+
+    def _maybe_unwrap_release_folder(self, folder_path):
+        """If ``folder_path`` is a Hybrid/Multipart release, unwrap it recursively
+        and hand the emerged comic(s) to the pipeline. Returns True if the folder
+        was claimed as a multipart release (so the caller prunes it from the
+        per-file walk), False to let normal per-file processing handle it.
+        """
+        if not getattr(self, "auto_unpack", False):
+            return False
+
+        folder_abs = os.path.abspath(folder_path)
+        watch_abs = os.path.abspath(self.directory)
+        # Only operate on real subfolders of WATCH; never the watch root itself.
+        if folder_abs == watch_abs or not folder_abs.startswith(watch_abs + os.sep):
+            return False
+        if is_hidden(folder_abs) or not os.path.isdir(folder_abs):
+            return False
+
+        if classify_release_folder(folder_abs) != MULTIPART_ARCHIVE:
+            return False
+
+        # Cooldown: a folder that recently failed/partially unwrapped is left
+        # pruned (claimed) but not retried until its skip window elapses.
+        skip_until = self._failed_unwraps.get(folder_abs)
+        if skip_until and time.time() < skip_until:
+            monitor_logger.debug(f"Unwrap on cooldown, skipping: {folder_abs}")
+            return True
+
+        # Claim the folder so the sweep and a live event don't unwrap it twice.
+        with self._processing_lock:
+            if folder_abs in self._in_flight_dirs:
+                return True
+            self._in_flight_dirs.add(folder_abs)
+
+        try:
+            if not self._release_parts_stable(folder_abs):
+                monitor_logger.info(f"Release parts still arriving, deferring unwrap: {folder_abs}")
+                return True
+
+            monitor_logger.info(f"Unwrapping multipart release: {folder_abs}")
+            result = unwrap_release(folder_abs, self._unwrap_staging_root())
+
+            try:
+                if not result.comics:
+                    # Nothing emerged — keep the source intact, retry after a cooldown.
+                    cooldown = max(self.reconcile_interval_minutes, 5) * 60
+                    self._failed_unwraps[folder_abs] = time.time() + cooldown
+                    monitor_logger.warning(
+                        f"Unwrap produced no comic ({result.reason}); keeping source: {folder_abs}"
+                    )
+                    return True
+
+                # Stage every emerged comic into the release folder under the
+                # cleaned release name, then process each. Staging all first keeps
+                # the folder non-empty until the last hand-off prunes it.
+                base = clean_directory_name(os.path.basename(folder_abs)) or os.path.basename(folder_abs)
+                staged = []
+                for idx, comic in enumerate(result.comics):
+                    c_ext = os.path.splitext(comic)[1]
+                    name = f"{base}{c_ext}" if len(result.comics) == 1 else f"{base} ({idx + 1}){c_ext}"
+                    dest = get_unique_filepath(os.path.join(folder_abs, name))
+                    try:
+                        shutil.move(comic, dest)
+                        from helpers import match_parent_permissions
+                        match_parent_permissions(dest)
+                        staged.append(dest)
+                    except Exception as e:
+                        monitor_logger.error(f"Failed to stage unwrapped comic {comic}: {e}")
+
+                if not staged:
+                    cooldown = max(self.reconcile_interval_minutes, 5) * 60
+                    self._failed_unwraps[folder_abs] = time.time() + cooldown
+                    return True
+
+                if result.partial:
+                    # Some parts failed to extract: hand off what we got but keep
+                    # the source parts for manual recovery, and don't re-hand-off.
+                    monitor_logger.warning(
+                        f"Partial unwrap for {folder_abs}; keeping source parts for recovery"
+                    )
+                    self._failed_unwraps[folder_abs] = time.time() + 24 * 3600
+                else:
+                    self._cleanup_release_cruft(folder_abs)
+                    self._failed_unwraps.pop(folder_abs, None)
+
+                for s in staged:
+                    self._handoff_unwrapped(s)
+                return True
+            finally:
+                # Always remove the extraction scratch dir.
+                if result.work_dir and os.path.isdir(result.work_dir):
+                    shutil.rmtree(result.work_dir, ignore_errors=True)
+        except Exception as e:
+            monitor_logger.error(f"Error unwrapping release {folder_abs}: {e}")
+            return True
+        finally:
+            with self._processing_lock:
+                self._in_flight_dirs.discard(folder_abs)
+
+
     def on_created(self, event):
         # Refresh settings on every event
         self.reload_settings()
@@ -154,6 +329,8 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             monitor_logger.info(f"File created: {event.src_path}")
         else:
             monitor_logger.info(f"Directory created: {event.src_path}")
+            if self._maybe_unwrap_release_folder(event.src_path):
+                return
             self._scan_directory(event.src_path)
 
 
@@ -173,6 +350,8 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             monitor_logger.info(f"File Moved: {event.dest_path}")
         else:
             monitor_logger.info(f"Directory Moved: {event.dest_path}")
+            if self._maybe_unwrap_release_folder(event.dest_path):
+                return
             self._scan_directory(event.dest_path)
 
 
@@ -197,6 +376,15 @@ class DownloadCompleteHandler(FileSystemEventHandler):
 
         _, extension = os.path.splitext(filepath)
         extension = extension.lower()
+
+        # Skip files that live under a release folder currently being unwrapped —
+        # its archive parts must not be moved/unzipped individually by this loop.
+        key_abs = os.path.abspath(filepath)
+        with self._processing_lock:
+            for d in self._in_flight_dirs:
+                if key_abs == d or key_abs.startswith(d + os.sep):
+                    monitor_logger.debug(f"Skipping file under in-flight unwrap dir: {filepath}")
+                    return
 
         # Check if this is a temporary download file that should be ignored
         if self._is_temporary_download_file(filepath, extension):
@@ -337,6 +525,14 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             for root, dirs, files in os.walk(self.directory):
                 # Skip hidden directories from being traversed.
                 dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
+                # Offer each subfolder to the multipart unwrapper first; prune any
+                # it claims so the per-file loop never sees the obfuscated parts.
+                kept = []
+                for d in dirs:
+                    if self._maybe_unwrap_release_folder(os.path.join(root, d)):
+                        continue
+                    kept.append(d)
+                dirs[:] = kept
                 for file in files:
                     file_path = os.path.join(root, file)
                     if is_hidden(file_path):
@@ -369,6 +565,14 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             # Check if the file is a zip file
             if filepath.lower().endswith('.zip'):
                 if self.auto_unpack:
+                    # If this zip is a part of a multipart/hybrid release, hand the
+                    # whole folder to the unwrapper instead of unzipping the lone
+                    # obfuscated part (closes the race where a part's file event
+                    # fires before the folder-level pre-pass claims it).
+                    parent = os.path.dirname(os.path.abspath(filepath))
+                    if parent != os.path.abspath(self.directory) and \
+                            self._maybe_unwrap_release_folder(parent):
+                        return
                     monitor_logger.info(f"Zip file detected and auto_unpack is enabled. Unzipping: {filepath}")
                     self.unzip_file(filepath)
                     return  # Exit after unzipping

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -171,3 +171,145 @@ def test_reconcile_missing_watch_dir_is_noop(handler):
     h, watch, target = handler
     h.directory = os.path.join(watch, "does-not-exist")
     h.reconcile_directory()  # must not raise
+
+
+# --------------------- multipart / hybrid release unwrapping ---------------------
+
+def _make_release(watch, name):
+    rel = os.path.join(watch, name)
+    os.makedirs(rel)
+    _write(os.path.join(rel, "--bbyvt3ga.zip"))
+    _write(os.path.join(rel, "--bb.nfo"))
+    _write(os.path.join(rel, "file_id.diz"))
+    return rel
+
+
+def test_maybe_unwrap_moves_comic_and_cleans_cruft(handler, tmp_path, monkeypatch):
+    """A multipart release is unwrapped: the emerged comic lands in TARGET under
+    the cleaned release name, and the archive parts + cruft are deleted."""
+    import monitor
+    from helpers.unwrap import UnwrapResult
+    from cbz_ops.rename import clean_directory_name
+
+    h, watch, target = handler
+    h.auto_unpack = True
+    rel = _make_release(watch, "Europe.Comics-Pin.Up.10 (2022)")
+
+    # Fake unwrap: emit a comic sitting in an isolated work dir.
+    work = tmp_path / "work"
+    work.mkdir()
+    comic = work / "obfuscated.cbz"
+    _write(str(comic))
+
+    monkeypatch.setattr(monitor, "classify_release_folder",
+                        lambda p: monitor.MULTIPART_ARCHIVE)
+    monkeypatch.setattr(monitor, "unwrap_release",
+                        lambda folder, root, **k: UnwrapResult([str(comic)], True, None, False, str(work)))
+
+    handled = h._maybe_unwrap_release_folder(rel)
+
+    assert handled is True
+    base = clean_directory_name("Europe.Comics-Pin.Up.10 (2022)")
+    assert os.path.exists(_moved_path(target, base + ".cbz")), "comic should reach TARGET"
+    assert not os.path.exists(os.path.join(rel, "--bbyvt3ga.zip")), "parts deleted"
+    assert not os.path.exists(str(work)), "work dir removed"
+    assert h._in_flight_dirs == set(), "dir claim released"
+
+
+def test_maybe_unwrap_failure_keeps_source(handler, tmp_path, monkeypatch):
+    """When nothing emerges, the source folder is kept and put on cooldown."""
+    import monitor
+    from helpers.unwrap import UnwrapResult
+
+    h, watch, target = handler
+    h.auto_unpack = True
+    rel = _make_release(watch, "Broken.Release")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setattr(monitor, "classify_release_folder",
+                        lambda p: monitor.MULTIPART_ARCHIVE)
+    monkeypatch.setattr(monitor, "unwrap_release",
+                        lambda folder, root, **k: UnwrapResult([], False, "no_comics", False, str(work)))
+
+    handled = h._maybe_unwrap_release_folder(rel)
+
+    assert handled is True
+    assert os.path.exists(os.path.join(rel, "--bbyvt3ga.zip")), "parts kept for recovery"
+    assert os.path.abspath(rel) in h._failed_unwraps, "folder placed on cooldown"
+    assert not os.path.exists(str(work)), "work dir removed even on failure"
+
+
+def test_maybe_unwrap_disabled_when_autounpack_off(handler, monkeypatch):
+    """AUTO_UNPACK off -> multipart folder is not claimed (normal loop handles it)."""
+    import monitor
+    h, watch, target = handler
+    h.auto_unpack = False
+    rel = _make_release(watch, "Some.Release")
+    monkeypatch.setattr(monitor, "classify_release_folder",
+                        lambda p: monitor.MULTIPART_ARCHIVE)
+    assert h._maybe_unwrap_release_folder(rel) is False
+
+
+def test_maybe_unwrap_real_zip_end_to_end(handler, monkeypatch):
+    """End-to-end with real zip extraction (no RAR binary needed): a release of
+    obfuscated zip parts carrying a .cbz is unwrapped, renamed, and moved to
+    TARGET, with the parts cleaned up."""
+    import zipfile
+    import helpers.unwrap as U
+    from cbz_ops.rename import clean_directory_name
+
+    monkeypatch.setattr(U, "is_allowed_path", lambda p: True)  # avoid DB coupling
+
+    h, watch, target = handler
+    h.auto_unpack = True
+    rel = os.path.join(watch, "Pin.Up 10 (2022)")
+    os.makedirs(rel)
+    with zipfile.ZipFile(os.path.join(rel, "--bbyvt3ga.zip"), "w") as z:
+        z.writestr("TheComic.cbz", b"PK\x03\x04fake-comic")
+    _write(os.path.join(rel, "--bb.nfo"))
+    _write(os.path.join(rel, "file_id.diz"))
+
+    handled = h._maybe_unwrap_release_folder(rel)
+
+    assert handled is True
+    base = clean_directory_name("Pin.Up 10 (2022)")
+    assert os.path.exists(_moved_path(target, base + ".cbz")), "unwrapped comic in TARGET"
+    assert not os.path.exists(os.path.join(rel, "--bbyvt3ga.zip")), "part cleaned up"
+
+
+def test_process_file_normal_zip_still_unzips(handler, monkeypatch):
+    """A lone, normally-named zip in a subfolder is NOT treated as multipart —
+    it still goes through the plain auto_unpack unzip path."""
+    h, watch, target = handler
+    h.auto_unpack = True
+    sub = os.path.join(watch, "Batman (2024)")
+    os.makedirs(sub)
+    zpath = os.path.join(sub, "Batman 001 (2024).zip")
+    _write(zpath)
+
+    calls = []
+    monkeypatch.setattr(h, "unzip_file", lambda p: calls.append(p))
+
+    h._process_file(zpath)
+
+    assert calls == [zpath], "normal single zip must still unzip, not route to unwrap"
+
+
+def test_file_under_in_flight_dir_is_skipped(handler, monkeypatch):
+    """A file inside a release folder being unwrapped is not processed by the
+    per-file loop (regression guard for 'parts moved individually')."""
+    h, watch, target = handler
+    rel = os.path.join(watch, "release")
+    os.makedirs(rel)
+    part = os.path.join(rel, "--bbyvt3ga.zip")
+    _write(part)
+
+    called = []
+    monkeypatch.setattr(h, "_process_file", lambda fp: called.append(fp))
+    h._in_flight_dirs.add(os.path.abspath(rel))
+
+    h._handle_file_if_complete(part)
+
+    assert called == [], "file under in-flight unwrap dir must not be processed"
+    assert os.path.exists(part), "part must stay put"

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -302,6 +302,22 @@ class TestCleanFinalFilename:
         from cbz_ops.rename import clean_final_filename
         assert clean_final_filename("") == ""
 
+    def test_collapses_doubled_extension(self):
+        # An issue-number capture can swallow the extension as a fake decimal
+        # suffix and a pattern re-appends it, yielding "Name.cbz.cbz".
+        from cbz_ops.rename import clean_final_filename
+        assert clean_final_filename("Pin-Up 010.cbz.cbz") == "Pin-Up 010.cbz"
+        assert clean_final_filename("Batman.cbr.cbr.cbr") == "Batman.cbr"
+
+    def test_does_not_collapse_single_extension(self):
+        from cbz_ops.rename import clean_final_filename
+        assert clean_final_filename("Pin-Up 010.cbz") == "Pin-Up 010.cbz"
+
+    def test_preserves_dotted_issue_suffix(self):
+        # "1.MU" must not be mistaken for a doubled extension.
+        from cbz_ops.rename import clean_final_filename
+        assert clean_final_filename("Series 1.MU.cbz") == "Series 1.MU.cbz"
+
 
 # ===== clean_parentheses_content =====
 

--- a/tests/unit/test_unwrap.py
+++ b/tests/unit/test_unwrap.py
@@ -1,0 +1,139 @@
+"""Unit tests for helpers/unwrap.py — the recursive Hybrid/Multipart release
+unwrapper.
+
+Covers folder classification (conservative — never fire on a ready comic),
+primary-volume selection for the common packaging styles, the recursive
+zip->rar->comic happy path (RAR layer stubbed since Python can't write RAR),
+and the archive-bomb depth guard.
+"""
+import os
+import zipfile
+
+import pytest
+
+import helpers.unwrap as U
+
+
+def _write(path, content=b"x"):
+    with open(path, "wb") as f:
+        f.write(content)
+
+
+# --------------------------- classify_release_folder ---------------------------
+
+def test_classify_multipart_release(tmp_path):
+    rel = tmp_path / "Europe.Comics-Pin.Up.10 (2022)"
+    rel.mkdir()
+    _write(str(rel / "--bbyvt3ga.zip"))
+    _write(str(rel / "--bbyvt3gb.zip"))
+    _write(str(rel / "--bb.nfo"))
+    _write(str(rel / "file_id.diz"))
+    assert U.classify_release_folder(str(rel)) == U.MULTIPART_ARCHIVE
+
+
+def test_classify_normal_when_comic_present(tmp_path):
+    """A folder with a ready comic is a normal job even if a zip sits alongside."""
+    rel = tmp_path / "folder"
+    rel.mkdir()
+    _write(str(rel / "Series 001 (2024).cbz"))
+    _write(str(rel / "extra.zip"))
+    assert U.classify_release_folder(str(rel)) == U.NORMAL
+
+
+def test_classify_normal_lone_plain_zip(tmp_path):
+    """One non-obfuscated zip with no cruft is not a multipart release."""
+    rel = tmp_path / "folder"
+    rel.mkdir()
+    _write(str(rel / "Batman 001.zip"))
+    assert U.classify_release_folder(str(rel)) == U.NORMAL
+
+
+def test_classify_normal_empty(tmp_path):
+    rel = tmp_path / "folder"
+    rel.mkdir()
+    assert U.classify_release_folder(str(rel)) == U.NORMAL
+
+
+# ---------------------------- pick_primary_volume -----------------------------
+
+@pytest.mark.parametrize("parts,expected", [
+    (["x.part03.rar", "x.part01.rar", "x.part02.rar"], "x.part01.rar"),
+    (["x.r01", "x.rar", "x.r00"], "x.rar"),
+    (["x.z02", "x.zip", "x.z01"], "x.zip"),
+    (["a.003", "a.001", "a.002"], "a.001"),
+    (["--bbyvt3gb.zip", "--bbyvt3ga.zip", "--bbyvt3gc.zip"], "--bbyvt3ga.zip"),
+])
+def test_pick_primary_volume(parts, expected):
+    assert U.pick_primary_volume(parts) == expected
+
+
+def test_pick_primary_volume_empty():
+    assert U.pick_primary_volume([]) is None
+
+
+# ------------------------------ unwrap_release --------------------------------
+
+def test_unwrap_release_zip_to_rar_to_comic(tmp_path, monkeypatch):
+    monkeypatch.setattr(U, "is_allowed_path", lambda p: True)
+
+    # Stand in for the RAR extractor: emit the final comic (Python cannot write
+    # a real RAR, so the RAR layer is simulated).
+    def fake_rar(primary, out_dir):
+        os.makedirs(out_dir, exist_ok=True)
+        _write(os.path.join(out_dir, "TheComic.cbz"), b"PK\x03\x04comic")
+        return True, 0
+    monkeypatch.setattr(U, "extract_rar_with_unar", fake_rar)
+
+    rel = tmp_path / "release"
+    rel.mkdir()
+    # Two independent obfuscated zip parts, each holding one RAR volume.
+    for part, inner in (("--bbyvt3ga.zip", "payload.rar"), ("--bbyvt3gb.zip", "payload.r00")):
+        with zipfile.ZipFile(rel / part, "w") as z:
+            z.writestr(inner, b"rar-volume-bytes")
+    _write(str(rel / "--bb.nfo"), b"nfo")
+
+    result = U.unwrap_release(str(rel), str(tmp_path / "work"))
+
+    assert result.ok
+    assert result.reason is None
+    assert not result.partial
+    assert len(result.comics) == 1
+    assert result.comics[0].lower().endswith("thecomic.cbz")
+    # Source folder is left untouched — unwrap never mutates it.
+    assert (rel / "--bbyvt3ga.zip").exists()
+
+
+def test_unwrap_release_depth_guard(tmp_path, monkeypatch):
+    """A self-nesting archive that never yields a comic aborts at max_depth."""
+    monkeypatch.setattr(U, "is_allowed_path", lambda p: True)
+
+    counter = {"n": 0}
+
+    def fake_extract(primary, out_dir):
+        counter["n"] += 1
+        os.makedirs(out_dir, exist_ok=True)
+        # Unique name each layer so the visited-name guard doesn't short-circuit
+        # before the depth guard is exercised.
+        _write(os.path.join(out_dir, f"nested{counter['n']}.rar"))
+        return True, 0
+    monkeypatch.setattr(U, "_extract_archive", fake_extract)
+
+    rel = tmp_path / "release"
+    rel.mkdir()
+    _write(str(rel / "start.rar"))
+
+    result = U.unwrap_release(str(rel), str(tmp_path / "work"), max_depth=3)
+
+    assert not result.ok
+    assert result.reason == "max_depth"
+    assert result.comics == []
+
+
+def test_unwrap_release_no_archives(tmp_path, monkeypatch):
+    monkeypatch.setattr(U, "is_allowed_path", lambda p: True)
+    rel = tmp_path / "release"
+    rel.mkdir()
+    _write(str(rel / "readme.txt"))
+    result = U.unwrap_release(str(rel), str(tmp_path / "work"))
+    assert not result.ok
+    assert result.reason == "no_archives"


### PR DESCRIPTION
## Context

Now that CLU supports Usenet, download clients drop **Hybrid/Multipart** release folders into the WATCH folder that aren't ready comics. A common style (e.g. BitBook):

```
Europe.Comics-Pin.Up.10.The.Case.Of.Alfred.H.2022.Hybrid.Comic.eBook-BitBook/
  --bb-pin.u.nfo
  --bbyvt3ga.zip   --bbyvt3gb.zip   --bbyvt3gc.zip   --bbyvt3gd.zip
  --file_id.diz
```

The `.zip` parts together extract to a `.RAR`, which extracts to the real PDF/CBR/CBZ. The monitor processes WATCH strictly **per file** and re-feeds extracted files through its own loop, so a multipart release had each obfuscated `.zip` part moved to TARGET as garbage — the nested comic was never reconstructed.

## What this does

Adds a recursive **release-folder-level unwrap** step, hooked in `monitor.py` *before* the per-file loop can touch the parts.

- **`helpers/unwrap.py`** (new)
  - `classify_release_folder` — conservative; never fires when a ready comic is already present.
  - `pick_primary_volume` — handles `.partNN.rar`, `.rar`+`.r00`, `.zip`+`.z01`, and `.NNN` split sets.
  - `unwrap_release` — breadth-first extraction in an isolated hidden work dir under WATCH (**never mutates the source**), reusing `extract_rar_with_unar` for RAR layers and `zipfile` + 7z/unar for zip layers. Guarded against archive bombs via max-depth, a cumulative-size ceiling, and a visited-name set.
- **`monitor.py`**
  - `_maybe_unwrap_release_folder` claims the folder (`_in_flight_dirs`), waits for parts to be size-stable, unwraps, renames the emerged comic to the cleaned release name, converts PDFs to CBZ, then hands off to the existing pipeline (rename → CBR→CBZ → move to TARGET).
  - Deletes parts + cruft on success; keeps the source with a retry cooldown on failure/partial.
  - Guards the per-file loop and the `.zip` `auto_unpack` branch so parts are never processed individually (closes the "parts moved individually" race).
  - Fixes the latent `unzip_file` bug that extracted into the global WATCH root instead of the zip's own folder.

Gated on the existing **`AUTO_UNPACK`** setting — no new config or UI. `api.py` and `models/usenet.py` are untouched, so every WATCH source benefits.

## Doubled-extension fix

This flow surfaced a latent renamer bug: the issue-number capture `\d{1,4}(?:\.\w+)?` can swallow a trailing `.cbz` as a fake decimal suffix when no year separates the issue from the extension, and a rename rule that re-appends the extension then yields `Name.cbz.cbz`. `clean_final_filename` now collapses a doubled comic/archive extension, restricted to known extensions so dotted issue suffixes (`1.MU`) and dotted titles are left untouched.

## Testing

- `helpers/unwrap.py`: classification, primary-volume selection, recursive zip→rar→comic happy path, depth guard.
- `monitor.py`: unwrap+handoff+cleanup, failure keeps source, `AUTO_UNPACK` gating, in-flight-dir guard, normal-zip regression, and a real-zip end-to-end.
- `clean_final_filename`: doubled-extension collapse + false-positive guards.
- Full suite: **2463 passed** (the 13 excluded are the known `pdf2image`-env `test_pdf.py` failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)