### PR TITLE
Make Scan Library resilient to a single bad sidecar (#436)

### DIFF
--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -189,13 +189,22 @@ def _resolve_identity(folder, api, cv_api_key=None):
     return _candidate(None, "sidecar", "Sidecar has no Metron or ComicVine ID")
 
 
+def _walk_onerror(err):
+    """os.walk error handler: log and skip an unreadable subtree, never raise.
+
+    Without this, an OSError raised while walking (a permissions/IO problem on
+    one directory) aborts the entire scan.
+    """
+    app_logger.warning(f"automap: skipping unreadable path during scan: {err}")
+
+
 def _find_candidate_folders(roots):
     """Return every folder under the library roots that holds a sidecar file."""
     folders = []
     for root in roots:
         if not root or not os.path.isdir(root):
             continue
-        for dirpath, dirnames, filenames in os.walk(root):
+        for dirpath, dirnames, filenames in os.walk(root, onerror=_walk_onerror):
             # Don't descend into hidden dirs (.git, .@__thumb, etc.)
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             if SIDECAR_NAMES.intersection(f.lower() for f in filenames):
@@ -215,7 +224,11 @@ def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
         progress_cb: Optional callable(current, total, folder_or_None).
 
     Returns:
-        dict with keys ``auto``, ``review``, ``skipped``, ``total_candidates``.
+        dict with keys ``auto``, ``review``, ``skipped``, ``errors``,
+        ``total_candidates``. Each candidate folder is resolved independently:
+        one folder that raises (e.g. an unreadable/corrupt sidecar or a transient
+        API error) is collected into ``errors`` and the scan continues, so a
+        single bad sidecar can never discard the whole run's work.
     """
     from core.database import get_all_mapped_series
 
@@ -235,41 +248,61 @@ def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
     auto = []
     review = []
     skipped = []
+    errors = []
     seen_ids = {}  # metron_id -> normalised folder that first claimed it
 
     for index, folder in enumerate(candidates):
         if progress_cb:
             progress_cb(index, total, folder)
 
-        nfolder = _norm(folder)
-        if nfolder in mapped_paths:
-            continue  # already tracked -- leave it alone
+        # Resolve each folder independently: a corrupt sidecar or a transient API
+        # error here must never abort the whole scan and discard every success.
+        try:
+            nfolder = _norm(folder)
+            if nfolder in mapped_paths:
+                continue  # already tracked -- leave it alone
 
-        ident = _resolve_identity(folder, api, cv_api_key=cv_api_key)
-        if ident is None:
-            continue
-        ident["comic_count"] = _count_comics(folder)
+            ident = _resolve_identity(folder, api, cv_api_key=cv_api_key)
+            if ident is None:
+                # Every candidate folder was flagged because it holds a sidecar
+                # file, so resolving to nothing means that sidecar (typically a
+                # series.json) is present but unreadable/corrupt -- report it
+                # rather than dropping it silently (issue #436).
+                errors.append({
+                    "folder": folder,
+                    "series_name": _series_name_from_folder(folder),
+                    "reason": "Sidecar present but could not be read or parsed",
+                })
+                continue
+            ident["comic_count"] = _count_comics(folder)
 
-        mid = ident["metron_id"]
-        if not mid:
-            skipped.append(ident)
-            continue
+            mid = ident["metron_id"]
+            if not mid:
+                skipped.append(ident)
+                continue
 
-        existing = mapped_ids.get(mid)
-        if existing and existing != nfolder:
-            ident["reason"] = f"Series already mapped to {existing}"
-            ident["conflict_with"] = existing
-            review.append(ident)
-            continue
+            existing = mapped_ids.get(mid)
+            if existing and existing != nfolder:
+                ident["reason"] = f"Series already mapped to {existing}"
+                ident["conflict_with"] = existing
+                review.append(ident)
+                continue
 
-        if mid in seen_ids and seen_ids[mid] != nfolder:
-            ident["reason"] = f"Same series also found in {seen_ids[mid]}"
-            ident["conflict_with"] = seen_ids[mid]
-            review.append(ident)
-            continue
+            if mid in seen_ids and seen_ids[mid] != nfolder:
+                ident["reason"] = f"Same series also found in {seen_ids[mid]}"
+                ident["conflict_with"] = seen_ids[mid]
+                review.append(ident)
+                continue
 
-        seen_ids[mid] = nfolder
-        auto.append(ident)
+            seen_ids[mid] = nfolder
+            auto.append(ident)
+        except Exception as e:
+            app_logger.warning(f"automap: failed to scan folder {folder}: {e}")
+            errors.append({
+                "folder": folder,
+                "series_name": _series_name_from_folder(folder),
+                "reason": f"Could not read/resolve sidecar: {e}",
+            })
 
     if progress_cb:
         progress_cb(total, total, None)
@@ -278,6 +311,7 @@ def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
         "auto": auto,
         "review": review,
         "skipped": skipped,
+        "errors": errors,
         "total_candidates": total,
     }
 
@@ -823,6 +857,7 @@ def _run_scan_job_inner(op_id, app):
             "applied_failed": applied["failed"],
             "review": scan["review"],
             "skipped": scan["skipped"],
+            "errors": scan["errors"],
             "total_candidates": scan["total_candidates"],
         }
         with _jobs_lock:
@@ -834,20 +869,27 @@ def _run_scan_job_inner(op_id, app):
                     current=job.get("total", 0),
                     finished_at=time.time(),
                 )
-
-        # Result is already stored (UI can render), so this runs as a background
-        # tail. First heal any series left with a volume-folder fallback name
-        # (e.g. "v2017") from an earlier scan that hit the API rate limit, then
-        # sync + match every mapped series that isn't matched yet, so the Pull
-        # List / Wanted lists reflect owned vs missing without opening each one.
-        repair_volume_named_series(api)
-        match_unmatched_mapped_series(api)
     except Exception as e:
         app_logger.error(f"automap: scan job {op_id} failed: {e}")
         with _jobs_lock:
             job = _jobs.get(op_id)
             if job:
                 job.update(status="error", error=str(e), finished_at=time.time())
+        return
+
+    # The scan result is already stored and marked ``done`` above, so this runs
+    # as a best-effort background tail OUTSIDE the try -- a failure here (e.g. a
+    # Metron/ComicVine rate-limit) must never flip an already-successful job to
+    # ``error`` and make the UI discard mappings that were applied. First heal any
+    # series left with a volume-folder fallback name (e.g. "v2017") from an
+    # earlier scan that hit the API rate limit, then sync + match every mapped
+    # series that isn't matched yet, so the Pull List / Wanted lists reflect
+    # owned vs missing without opening each one.
+    try:
+        repair_volume_named_series(api)
+        match_unmatched_mapped_series(api)
+    except Exception as e:
+        app_logger.error(f"automap: scan job {op_id} post-scan tail failed: {e}")
 
 
 def start_scan_job(app):

--- a/models/series_json.py
+++ b/models/series_json.py
@@ -170,7 +170,10 @@ def read_series_json(folder_path):
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
+    except Exception as e:
+        # Best-effort read: degrade to None on ANY failure (malformed JSON, an
+        # OSError, or a UnicodeDecodeError from a sidecar not saved as UTF-8) so a
+        # single unreadable series.json never aborts a whole library scan.
         app_logger.warning(f"Failed to parse existing {path}: {e}")
         return None
 

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -339,6 +339,16 @@
                         </button>
                         <div class="collapse" id="automapSkippedList"></div>
                     </div>
+
+                    <div id="automapErrorsWrap" class="d-none mt-3">
+                        <h6 class="fw-bold text-danger mb-1">
+                            <i class="bi bi-exclamation-triangle me-1"></i>Errored
+                        </h6>
+                        <p class="text-muted small mb-2">These folders had a sidecar we couldn't
+                            read or resolve (e.g. a corrupt <code>series.json</code>). The rest of
+                            the scan completed — fix or remove these and re-scan.</p>
+                        <div id="automapErrorsList"></div>
+                    </div>
                 </div>
 
                 <div id="automapError" class="alert alert-danger d-none"></div>
@@ -373,6 +383,7 @@
             document.getElementById('automapError').classList.add('d-none');
             document.getElementById('automapReviewWrap').classList.add('d-none');
             document.getElementById('automapSkippedWrap').classList.add('d-none');
+            document.getElementById('automapErrorsWrap').classList.add('d-none');
             document.getElementById('automapReload').classList.add('d-none');
             document.getElementById('automapBar').style.width = '0%';
             document.getElementById('automapDetail').textContent = 'Starting…';
@@ -430,13 +441,31 @@
             const applied = result.applied || 0;
             const reviewN = (result.review || []).length;
             const skippedN = (result.skipped || []).length;
+            const errorN = (result.errors || []).length;
             document.getElementById('automapSummary').innerHTML =
                 `<strong>Mapped ${applied}</strong> series automatically from `
                 + `${result.total_candidates || 0} folder(s) with sidecar files. `
                 + (reviewN ? `${reviewN} need review. ` : '')
                 + (skippedN ? `${skippedN} skipped. ` : '')
+                + (errorN ? `${errorN} errored. ` : '')
                 + `<div class="small text-muted mt-2"><i class="bi bi-hourglass-split me-1"></i>`
                 + `Matching your files to issues in the background — reload in a moment to see owned/missing counts.</div>`;
+
+            // Errored folders — a sidecar we couldn't read/resolve. The rest of
+            // the scan still completed, so these are reported, not fatal.
+            const errors = result.errors || [];
+            const errWrap = document.getElementById('automapErrorsWrap');
+            if (errors.length) {
+                document.getElementById('automapErrorsList').innerHTML =
+                    '<ul class="list-group list-group-flush small">' + errors.map(it => `
+                        <li class="list-group-item px-0 bg-transparent">
+                            <span class="text-danger">${esc(it.folder)}</span>
+                            — ${esc(it.reason)}
+                        </li>`).join('') + '</ul>';
+                errWrap.classList.remove('d-none');
+            } else {
+                errWrap.classList.add('d-none');
+            }
 
             // Review table
             reviewItems = result.review || [];

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -170,6 +170,49 @@ class TestScan:
         assert not result["auto"]
         assert len(result["skipped"]) == 1
 
+    def test_one_bad_folder_does_not_abort_scan(self, tmp_path):
+        # A folder that raises while resolving must be collected into `errors`,
+        # and every other folder must still be classified (issue #436: one bad
+        # sidecar previously discarded the whole scan).
+        good = _make_folder(tmp_path, "Batman",
+                            series_json={"name": "Batman", "metron_id": 555})
+        bad = _make_folder(tmp_path, "Broken",
+                           series_json={"name": "Broken", "metron_id": 999})
+        real_resolve = library_automap._resolve_identity
+
+        def flaky_resolve(folder, api, cv_api_key=None):
+            if library_automap._norm(folder) == library_automap._norm(bad):
+                raise ValueError("corrupt sidecar")
+            return real_resolve(folder, api, cv_api_key=cv_api_key)
+
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], [])
+        with p_roots, p_map, \
+             patch.object(library_automap, "_resolve_identity", side_effect=flaky_resolve):
+            result = library_automap.scan_library_for_automap(api=None)
+
+        assert [it["metron_id"] for it in result["auto"]] == [555]
+        assert len(result["errors"]) == 1
+        assert library_automap._norm(result["errors"][0]["folder"]) == library_automap._norm(bad)
+        assert "corrupt sidecar" in result["errors"][0]["reason"]
+
+    def test_bad_encoding_series_json_is_not_fatal(self, tmp_path):
+        # End-to-end: a series.json with invalid UTF-8 bytes (the concrete crash
+        # from issue #436) resolves to no id -> skipped, never raising, and the
+        # good folder is still auto-mapped.
+        good = _make_folder(tmp_path, "Batman",
+                            series_json={"name": "Batman", "metron_id": 555})
+        bad = os.path.join(str(tmp_path), "Broken")
+        os.makedirs(bad, exist_ok=True)
+        with open(os.path.join(bad, "series.json"), "wb") as f:
+            f.write(b'{"metadata": {"name": "\xff\xfe", "metron_id": 7}}')
+        p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], [])
+        with p_roots, p_map:
+            result = library_automap.scan_library_for_automap(api=None)
+        assert [it["metron_id"] for it in result["auto"]] == [555]
+        # The unreadable sidecar is reported (not silently dropped, not fatal).
+        assert len(result["errors"]) == 1
+        assert library_automap._norm(result["errors"][0]["folder"]) == library_automap._norm(bad)
+
 
 class TestApply:
     def test_applies_and_saves_mapping(self, tmp_path):
@@ -686,3 +729,60 @@ class TestRepairVolumeNamedSeries:
         assert saved["id"] == cv_series_id
         # ComicVine offset id must not be stamped into series.json as a Metron id.
         write.assert_not_called()
+
+
+class TestScanJobResilience:
+    """_run_scan_job_inner: a successful scan must stay `done` (issue #436)."""
+
+    def _seed_job(self, op_id):
+        library_automap._jobs[op_id] = {
+            "id": op_id, "status": "running", "current": 0, "total": 2,
+            "detail": "", "result": None, "error": None,
+        }
+
+    def test_tail_failure_keeps_job_done(self):
+        op_id = "test-tail-fail"
+        self._seed_job(op_id)
+        scan_result = {
+            "auto": [], "review": [], "skipped": [],
+            "errors": [{"folder": "/data/Bad", "reason": "boom"}],
+            "total_candidates": 2,
+        }
+        try:
+            with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+                 patch.object(library_automap.comicvine, "get_cv_api_key", return_value=None), \
+                 patch.object(library_automap, "scan_library_for_automap",
+                              return_value=scan_result), \
+                 patch.object(library_automap, "apply_automap",
+                              return_value={"applied": 1, "failed": [], "applied_ids": [1]}), \
+                 patch.object(library_automap, "repair_volume_named_series",
+                              side_effect=RuntimeError("rate limited")) as repair, \
+                 patch.object(library_automap, "match_unmatched_mapped_series",
+                              side_effect=RuntimeError("rate limited")):
+                library_automap._run_scan_job_inner(op_id, app=MagicMock())
+            job = library_automap._jobs[op_id]
+            assert job["status"] == "done"          # NOT flipped to error by the tail
+            assert job["error"] is None
+            assert job["result"]["applied"] == 1
+            # errors from the scan are surfaced in the job result for the UI.
+            assert job["result"]["errors"] == scan_result["errors"]
+            repair.assert_called_once()             # tail actually ran (and raised)
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_scan_failure_marks_job_error(self):
+        # A genuine failure in the scan phase (before the result is stored) still
+        # marks the job error, so real problems aren't hidden.
+        op_id = "test-scan-fail"
+        self._seed_job(op_id)
+        try:
+            with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+                 patch.object(library_automap.comicvine, "get_cv_api_key", return_value=None), \
+                 patch.object(library_automap, "scan_library_for_automap",
+                              side_effect=RuntimeError("walk blew up")):
+                library_automap._run_scan_job_inner(op_id, app=MagicMock())
+            job = library_automap._jobs[op_id]
+            assert job["status"] == "error"
+            assert "walk blew up" in job["error"]
+        finally:
+            library_automap._jobs.pop(op_id, None)

--- a/tests/routes/test_pull_list_automap.py
+++ b/tests/routes/test_pull_list_automap.py
@@ -32,13 +32,30 @@ class TestScanStatusRoute:
     def test_done_job_returns_result(self, client):
         job = {
             "status": "done", "current": 10, "total": 10, "detail": "",
-            "result": {"applied": 4, "review": [], "skipped": [], "total_candidates": 4},
+            "result": {"applied": 4, "review": [], "skipped": [], "errors": [],
+                       "total_candidates": 4},
         }
         with patch("models.library_automap.get_scan_job", return_value=job):
             resp = client.get("/api/pull-list/scan/status?op_id=x")
         data = resp.get_json()
         assert data["status"] == "done"
         assert data["result"]["applied"] == 4
+
+    def test_done_job_passes_through_errors(self, client):
+        # Errored folders (issue #436) ride along in the done result so the UI
+        # can report them without failing the whole scan.
+        job = {
+            "status": "done", "current": 4, "total": 4, "detail": "",
+            "result": {
+                "applied": 3, "review": [], "skipped": [], "total_candidates": 4,
+                "errors": [{"folder": "/data/Broken", "reason": "corrupt sidecar"}],
+            },
+        }
+        with patch("models.library_automap.get_scan_job", return_value=job):
+            resp = client.get("/api/pull-list/scan/status?op_id=x")
+        data = resp.get_json()
+        assert data["status"] == "done"
+        assert data["result"]["errors"][0]["folder"] == "/data/Broken"
 
     def test_error_job_returns_error(self, client):
         job = {"status": "error", "current": 0, "total": 0, "detail": "", "error": "boom"}

--- a/tests/unit/test_series_json.py
+++ b/tests/unit/test_series_json.py
@@ -386,3 +386,11 @@ class TestReadSeriesJson:
         from models.series_json import read_series_json
         (tmp_path / "series.json").write_text("{{not json", encoding="utf-8")
         assert read_series_json(str(tmp_path)) is None
+
+    def test_returns_none_on_bad_encoding(self, tmp_path):
+        # A sidecar not saved as UTF-8 raises UnicodeDecodeError on read; it must
+        # degrade to None (not raise), so a single bad file can't abort a scan.
+        from models.series_json import read_series_json
+        # 0xFF is an invalid UTF-8 start byte.
+        (tmp_path / "series.json").write_bytes(b'{"metadata": {"name": "\xff\xfe"}}')
+        assert read_series_json(str(tmp_path)) is None


### PR DESCRIPTION
## Problem

Fixes #436. Clicking **Scan Library** on the Pull List starts a background job that walks the library, resolves `series.json` / `cvinfo` sidecars, and auto-maps them. On a large library (~4,000 series) the whole scan could fail and **discard every successfully-scanned series** when a single folder hit an error.

Two independent defects converged on this:

1. **Scan-phase abort (data loss).** `scan_library_for_automap` looped over sidecar folders with **no per-folder error handling**. A corrupt `series.json` (e.g. invalid UTF‑8 bytes — a `UnicodeDecodeError` that `read_series_json` did *not* catch) or a transient Metron/ComicVine error propagated out and marked the whole job `error`. Because persistence (`apply_automap`) runs only *after* the full scan completes, **nothing was saved**.
2. **Post-`done` tail flipped success → error.** The background tail (`repair_volume_named_series` + `match_unmatched_mapped_series`) ran *inside the same `try`* after the job was already marked `done`. Both re-raise on failure, so a rate-limit/DB error there overwrote the successful `done` result with `status="error"`, and the UI discarded mappings that had actually been applied. This race against the 1s poll matches the intermittent nature of the report.

## Changes

- **`models/library_automap.py`**
  - Wrap the per-folder scan loop in `try/except` — failures are collected into a new `errors` list and the scan always finishes. An unreadable-but-present sidecar (resolves to `None`) is now **reported** rather than silently dropped.
  - Add `onerror=` to `os.walk` so an unreadable subtree is logged and skipped, not fatal.
  - Move the repair/match tail **outside** the main `try` (with its own guarded `try/except`) so a `done` result is final. Add `errors` to the job result.
- **`models/series_json.py`** — broaden `read_series_json` to degrade to `None` on any read failure (including bad encodings), keeping the existing warning log.
- **`templates/pull_list.html`** — the scan modal now shows an **Errored** section (folder + reason) and counts errors in the summary.

Scope is intentionally **error-collection resilience only** — `apply_automap` already persists each success independently, so this fully resolves the reported data loss without an incremental/batch-persistence refactor.

## Tests

- `tests/mocked/test_library_automap.py` — one bad folder no longer aborts the scan; bad-encoding `series.json` end-to-end; job stays `done` when the tail raises; a genuine scan-phase failure still marks `error`.
- `tests/unit/test_series_json.py` — `read_series_json` returns `None` (no raise) on invalid UTF‑8.
- `tests/routes/test_pull_list_automap.py` — `/scan/status` passes `errors` through in a `done` result.

Full suite: **2469 passed** (only the pre-existing local `pdf2image` env failures remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
