### PR TITLE
Fix GetComics alias auto-creation + 11 issues from PR #248 review

### DIFF
--- a/app.py
+++ b/app.py
@@ -986,420 +986,427 @@ def scheduled_getcomics_download(dry_run=False):
 
             # Find wanted issues with store_date <= today (already released)
             for issue in issues:
-                issue_num = str(issue.get("number", ""))
-                status = issue_status.get(issue_num, {})
-                store_date = issue.get("store_date")
-
-                # Skip if already found in collection
-                if status.get("found"):
-                    continue
-
-                # Skip if manually marked as owned or skipped
-                if issue_num in manual_status:
-                    continue
-
-                # Skip if this issue is covered by a downloaded range pack.
-                # Guard the int() conversion: "0"/"00"/"" strip to '' (int('')
-                # raises) and non-numeric issue numbers (e.g. "1.MU") also fail —
-                # in those cases issue_number_to_int returns None and we skip the
-                # numeric range check rather than aborting the whole run.
-                issue_int = issue_number_to_int(issue_num)
-                series_ranges = downloaded_ranges.get(series_name, [])
-                skip_for_range = False
-                if issue_int is not None:
-                    for r_start, r_end in series_ranges:
-                        if r_start <= issue_int <= r_end:
-                            skip_for_range = True
-                            app_logger.debug(f"Skipping {series_name} #{issue_num} — covered by downloaded range #{r_start}-{r_end}")
-                            break
-                if skip_for_range:
-                    continue
-
-                # Only process issues with store_date <= today (already released)
-                if not store_date or store_date > today:
-                    continue
-
-                # Search GetComics for this issue
-                search_count += 1
-
-                # Get year from store_date or series (used in query and scoring)
-                issue_year = int(store_date[:4]) if store_date else series_year
-
-                # Get variant search preferences
-                search_variants_str = config.get("SETTINGS", "VARIANT_TYPES", fallback="")
-                search_variants = [v.strip().lower() for v in search_variants_str.split(",") if v.strip()]
-
-                # Build searchable context for logging
-                ctx_parts = [f"{series_name} #{issue_num}"]
-                if series_volume:
-                    ctx_parts.insert(1, f"Vol {series_volume}")
-                if issue_year:
-                    ctx_parts.append(str(issue_year))
-                search_context = "[" + ", ".join(ctx_parts) + "]"
-
-                # Search GetComics
-                # Before searching, proactively refresh the scrape index for
-                # the upcoming issue so it's ready when the download runs.
-                # Use cover_date (publication date) for proactive refresh —
-                # it gives weeks of lead time vs store_date (2-3 days before release).
                 try:
-                    from datetime import datetime, timedelta
-                    from models.getcomics import update_scrape_index
-                    cover_date = issue.get("cover_date")
-                    if cover_date:
-                        try:
-                            cover_dt = datetime.strptime(cover_date[:10], "%Y-%m-%d")
-                            days_ahead = (cover_dt.date() - datetime.now().date()).days
-                            # If issue cover date is within next 30 days, proactively refresh
-                            if 0 <= days_ahead <= 30:
-                                update_scrape_index(
-                                    series_name,
-                                    force_refresh=False,
-                                    max_workers=3,
-                                    rate_limit=0.5,
-                                    refresh_for_issue=issue_num,
-                                )
-                        except Exception:
-                            pass
-                except Exception:
-                    pass  # Proactive refresh is best-effort
+                    issue_num = str(issue.get("number", ""))
+                    status = issue_status.get(issue_num, {})
+                    store_date = issue.get("store_date")
 
-                # Usenet first: try indexers before GetComics; on a hit, submit
-                # to the client and skip GetComics for this issue.
-                if usenet_on and usenet_first:
-                    u = usenet_mod.try_download_for_issue(
-                        series_name, issue_num,
-                        issue_year=issue_year,
-                        series_volume=series_volume,
-                        series_year=series_year,
-                        publisher_name=publisher_name,
-                        search_variants=search_variants,
-                        series_aliases=series_aliases,
-                        dry_run=bool(dry_run),
-                    )
-                    if dry_run and u.get("status") == "match_found":
-                        simulation_results.append({
-                            "series": series_name,
-                            "issue": issue_num,
-                            "issue_year": issue_year,
-                            "series_volume": series_volume,
-                            "search_context": search_context,
-                            "source": "usenet",
-                            "best_accept": u.get("chosen"),
-                            "best_fallback": None,
-                            "all_results": u.get("all_results", []),
-                            "status": "match_found",
-                        })
+                    # Skip if already found in collection
+                    if status.get("found"):
                         continue
-                    if not dry_run and u.get("submitted"):
-                        download_count += 1
-                        app_logger.info(
-                            f"Submitted Usenet download for {series_name} #{issue_num}: "
-                            f"{u['chosen']['filename']} {search_context}"
+
+                    # Skip if manually marked as owned or skipped
+                    if issue_num in manual_status:
+                        continue
+
+                    # Skip if this issue is covered by a downloaded range pack.
+                    # Guard the int() conversion: "0"/"00"/"" strip to '' (int('')
+                    # raises) and non-numeric issue numbers (e.g. "1.MU") also fail —
+                    # in those cases issue_number_to_int returns None and we skip the
+                    # numeric range check rather than aborting the whole run.
+                    issue_int = issue_number_to_int(issue_num)
+                    series_ranges = downloaded_ranges.get(series_name, [])
+                    skip_for_range = False
+                    if issue_int is not None:
+                        for r_start, r_end in series_ranges:
+                            if r_start <= issue_int <= r_end:
+                                skip_for_range = True
+                                app_logger.debug(f"Skipping {series_name} #{issue_num} — covered by downloaded range #{r_start}-{r_end}")
+                                break
+                    if skip_for_range:
+                        continue
+
+                    # Only process issues with store_date <= today (already released)
+                    if not store_date or store_date > today:
+                        continue
+
+                    # Search GetComics for this issue
+                    search_count += 1
+
+                    # Get year from store_date or series (used in query and scoring)
+                    issue_year = int(store_date[:4]) if store_date else series_year
+
+                    # Get variant search preferences
+                    search_variants_str = config.get("SETTINGS", "VARIANT_TYPES", fallback="")
+                    search_variants = [v.strip().lower() for v in search_variants_str.split(",") if v.strip()]
+
+                    # Build searchable context for logging
+                    ctx_parts = [f"{series_name} #{issue_num}"]
+                    if series_volume:
+                        ctx_parts.insert(1, f"Vol {series_volume}")
+                    if issue_year:
+                        ctx_parts.append(str(issue_year))
+                    search_context = "[" + ", ".join(ctx_parts) + "]"
+
+                    # Search GetComics
+                    # Before searching, proactively refresh the scrape index for
+                    # the upcoming issue so it's ready when the download runs.
+                    # Use cover_date (publication date) for proactive refresh —
+                    # it gives weeks of lead time vs store_date (2-3 days before release).
+                    try:
+                        from datetime import datetime, timedelta
+                        from models.getcomics import update_scrape_index
+                        cover_date = issue.get("cover_date")
+                        if cover_date:
+                            try:
+                                cover_dt = datetime.strptime(cover_date[:10], "%Y-%m-%d")
+                                days_ahead = (cover_dt.date() - datetime.now().date()).days
+                                # If issue cover date is within next 30 days, proactively refresh
+                                if 0 <= days_ahead <= 30:
+                                    update_scrape_index(
+                                        series_name,
+                                        force_refresh=False,
+                                        max_workers=3,
+                                        rate_limit=0.5,
+                                        refresh_for_issue=issue_num,
+                                    )
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass  # Proactive refresh is best-effort
+
+                    # Usenet first: try indexers before GetComics; on a hit, submit
+                    # to the client and skip GetComics for this issue.
+                    if usenet_on and usenet_first:
+                        u = usenet_mod.try_download_for_issue(
+                            series_name, issue_num,
+                            issue_year=issue_year,
+                            series_volume=series_volume,
+                            series_year=series_year,
+                            publisher_name=publisher_name,
+                            search_variants=search_variants,
+                            series_aliases=series_aliases,
+                            dry_run=bool(dry_run),
                         )
-                        continue
-
-                # Track queue count so we can tell whether GetComics queued
-                # anything for this issue (used by the Usenet fallback below).
-                gc_count_before = download_count
-
-                results = search_getcomics_for_issue(
-                    series_name=series_name,
-                    issue_num=issue_num,
-                    issue_year=issue_year,
-                    series_volume=series_volume,
-                    series_year=series_year,  # Pass volume_year to help find correct series edition
-                    search_variants=search_variants,
-                    series_aliases=series_aliases,
-                )
-
-                if not results:
-                    if dry_run:
-                        simulation_results.append({
-                            "series": series_name,
-                            "issue": issue_num,
-                            "issue_year": issue_year,
-                            "series_volume": series_volume,
-                            "search_context": search_context,
-                            "search_params": {
-                                "series_name": series_name,
-                                "issue_num": issue_num,
+                        if dry_run and u.get("status") == "match_found":
+                            simulation_results.append({
+                                "series": series_name,
+                                "issue": issue_num,
                                 "issue_year": issue_year,
                                 "series_volume": series_volume,
-                                "series_year": series_year,
-                                "search_variants": search_variants,
-                            },
-                            "best_accept": None,
-                            "best_fallback": None,
-                            "all_results": [],
-                            "status": "no_results",
-                        })
-                    continue
+                                "search_context": search_context,
+                                "source": "usenet",
+                                "best_accept": u.get("chosen"),
+                                "best_fallback": None,
+                                "all_results": u.get("all_results", []),
+                                "status": "match_found",
+                            })
+                            continue
+                        if not dry_run and u.get("submitted"):
+                            download_count += 1
+                            app_logger.info(
+                                f"Submitted Usenet download for {series_name} #{issue_num}: "
+                                f"{u['chosen']['filename']} {search_context}"
+                            )
+                            continue
 
-                # Score results and find best match.
-                # Two-tier: ACCEPT (direct match) beats FALLBACK (range pack).
-                best_accept = None   # (result, score) for best ACCEPT
-                best_fallback = None   # (result, score) for best FALLBACK
-                single_found = False
-                scored_results = []
+                    # Track queue count so we can tell whether GetComics queued
+                    # anything for this issue (used by the Usenet fallback below).
+                    gc_count_before = download_count
 
-                for result in results:
-                    # When searching with variants, accept those variants without penalty
-                    score, is_range, series_match = score_getcomics_result(
-                        result["title"], series_name, issue_num, issue_year,
-                        accept_variants=search_variants,
+                    results = search_getcomics_for_issue(
+                        series_name=series_name,
+                        issue_num=issue_num,
+                        issue_year=issue_year,
                         series_volume=series_volume,
-                        volume_year=series_year,
-                        publisher_name=publisher_name,
+                        series_year=series_year,  # Pass volume_year to help find correct series edition
+                        search_variants=search_variants,
                         series_aliases=series_aliases,
                     )
-                    decision = accept_result(
-                        score, is_range, series_match,
-                        single_issue_found=single_found,
-                    )
-                    scored_results.append({
-                        "title": result.get("title", ""),
-                        "link": result.get("link", ""),
-                        "download_url": result.get("download_url", ""),
-                        "score": score,
-                        "decision": decision,
-                        "range_contains_target": is_range,
-                        "series_match": series_match,
-                    })
-                    if decision == "ACCEPT":
-                        if best_accept is None or score > best_accept[1]:
-                            best_accept = (result, score)
-                        single_found = True
-                    elif decision == "FALLBACK" and best_fallback is None:
-                        best_fallback = (result, score)
 
-                # Refine with year when multiple ACCEPT matches are ambiguous.
-                # Example: "Lobo 2" returns multiple Lobo volumes; "Lobo 2 2026"
-                # uniquely identifies the Lobo (2026) #2 issue on GetComics.
-                accept_count = sum(1 for s in scored_results if s["decision"] == "ACCEPT")
-                refine_year = issue_year or series_year
-                if accept_count > 1 and refine_year:
-                    refined_query = f"{series_name} {issue_num} {refine_year}"
-                    app_logger.info(
-                        f"Multiple ACCEPT matches ({accept_count}) for {series_name} #{issue_num} "
-                        f"— refining with year: {refined_query} {search_context}"
-                    )
-                    try:
-                        refined_raw = search_getcomics(refined_query, max_pages=1) or []
-                    except Exception as e:
-                        app_logger.debug(f"Year-refined search failed: {e}")
-                        refined_raw = []
-                    refined_best_accept = None
-                    seen_links = {s["link"] for s in scored_results}
-                    refined_single_found = False
-                    for r in refined_raw:
-                        r_score, r_is_range, r_series_match = score_getcomics_result(
-                            r["title"], series_name, issue_num, issue_year,
+                    if not results:
+                        if dry_run:
+                            simulation_results.append({
+                                "series": series_name,
+                                "issue": issue_num,
+                                "issue_year": issue_year,
+                                "series_volume": series_volume,
+                                "search_context": search_context,
+                                "search_params": {
+                                    "series_name": series_name,
+                                    "issue_num": issue_num,
+                                    "issue_year": issue_year,
+                                    "series_volume": series_volume,
+                                    "series_year": series_year,
+                                    "search_variants": search_variants,
+                                },
+                                "best_accept": None,
+                                "best_fallback": None,
+                                "all_results": [],
+                                "status": "no_results",
+                            })
+                        continue
+
+                    # Score results and find best match.
+                    # Two-tier: ACCEPT (direct match) beats FALLBACK (range pack).
+                    best_accept = None   # (result, score) for best ACCEPT
+                    best_fallback = None   # (result, score) for best FALLBACK
+                    single_found = False
+                    scored_results = []
+
+                    for result in results:
+                        # When searching with variants, accept those variants without penalty
+                        score, is_range, series_match = score_getcomics_result(
+                            result["title"], series_name, issue_num, issue_year,
                             accept_variants=search_variants,
                             series_volume=series_volume,
                             volume_year=series_year,
                             publisher_name=publisher_name,
                             series_aliases=series_aliases,
                         )
-                        r_decision = accept_result(
-                            r_score, r_is_range, r_series_match,
-                            single_issue_found=refined_single_found,
+                        decision = accept_result(
+                            score, is_range, series_match,
+                            single_issue_found=single_found,
                         )
-                        if r.get("link") not in seen_links:
-                            scored_results.append({
-                                "title": r.get("title", ""),
-                                "link": r.get("link", ""),
-                                "download_url": r.get("download_url", ""),
-                                "score": r_score,
-                                "decision": r_decision,
-                                "range_contains_target": r_is_range,
-                                "series_match": r_series_match,
-                                "refined": True,
+                        scored_results.append({
+                            "title": result.get("title", ""),
+                            "link": result.get("link", ""),
+                            "download_url": result.get("download_url", ""),
+                            "score": score,
+                            "decision": decision,
+                            "range_contains_target": is_range,
+                            "series_match": series_match,
+                        })
+                        if decision == "ACCEPT":
+                            if best_accept is None or score > best_accept[1]:
+                                best_accept = (result, score)
+                            single_found = True
+                        elif decision == "FALLBACK" and best_fallback is None:
+                            best_fallback = (result, score)
+
+                    # Refine with year when multiple ACCEPT matches are ambiguous.
+                    # Example: "Lobo 2" returns multiple Lobo volumes; "Lobo 2 2026"
+                    # uniquely identifies the Lobo (2026) #2 issue on GetComics.
+                    accept_count = sum(1 for s in scored_results if s["decision"] == "ACCEPT")
+                    refine_year = issue_year or series_year
+                    if accept_count > 1 and refine_year:
+                        refined_query = f"{series_name} {issue_num} {refine_year}"
+                        app_logger.info(
+                            f"Multiple ACCEPT matches ({accept_count}) for {series_name} #{issue_num} "
+                            f"— refining with year: {refined_query} {search_context}"
+                        )
+                        try:
+                            refined_raw = search_getcomics(refined_query, max_pages=1) or []
+                        except Exception as e:
+                            app_logger.debug(f"Year-refined search failed: {e}")
+                            refined_raw = []
+                        refined_best_accept = None
+                        seen_links = {s["link"] for s in scored_results}
+                        refined_single_found = False
+                        for r in refined_raw:
+                            r_score, r_is_range, r_series_match = score_getcomics_result(
+                                r["title"], series_name, issue_num, issue_year,
+                                accept_variants=search_variants,
+                                series_volume=series_volume,
+                                volume_year=series_year,
+                                publisher_name=publisher_name,
+                                series_aliases=series_aliases,
+                            )
+                            r_decision = accept_result(
+                                r_score, r_is_range, r_series_match,
+                                single_issue_found=refined_single_found,
+                            )
+                            if r.get("link") not in seen_links:
+                                scored_results.append({
+                                    "title": r.get("title", ""),
+                                    "link": r.get("link", ""),
+                                    "download_url": r.get("download_url", ""),
+                                    "score": r_score,
+                                    "decision": r_decision,
+                                    "range_contains_target": r_is_range,
+                                    "series_match": r_series_match,
+                                    "refined": True,
+                                })
+                            if r_decision == "ACCEPT":
+                                if refined_best_accept is None or r_score > refined_best_accept[1]:
+                                    refined_best_accept = (r, r_score)
+                                refined_single_found = True
+                        if refined_best_accept:
+                            app_logger.info(
+                                f"Refined match chosen (score={refined_best_accept[1]}): "
+                                f"{refined_best_accept[0]['title']} {search_context}"
+                            )
+                            best_accept = refined_best_accept
+                        else:
+                            app_logger.info(
+                                f"Refinement did not improve match — keeping original best ACCEPT {search_context}"
+                            )
+
+                    chosen = best_accept or best_fallback
+                    if chosen:
+                        best_result, best_score = chosen
+                        tier = "direct match" if best_accept else "range fallback"
+                        app_logger.info(
+                            f"Found match for {series_name} #{issue_num} ({tier}, score={best_score}): {best_result['title']} {search_context}"
+                        )
+
+                        # Get download links
+                        links = get_download_links(best_result["link"])
+
+                        # Use config-driven provider priority
+                        priority_str = config.get(
+                            "SETTINGS",
+                            "DOWNLOAD_PROVIDER_PRIORITY",
+                            fallback="pixeldrain,download_now,mega",
+                        )
+                        (primary_provider, download_url), fallback_urls = select_download_url(
+                            links, priority_str
+                        )
+
+                        if dry_run:
+                            if best_accept:
+                                best_accept_data = {
+                                    "result": {
+                                        "title": best_result.get("title", ""),
+                                        "link": best_result.get("link", ""),
+                                        "download_url": download_url,
+                                    },
+                                    "score": best_score,
+                                    "tier": "direct match",
+                                }
+                            else:
+                                best_accept_data = None
+                            best_fallback_data = None
+                            if best_fallback:
+                                best_fallback_data = {
+                                    "result": {
+                                        "title": best_fallback[0].get("title", ""),
+                                        "link": best_fallback[0].get("link", ""),
+                                        "download_url": None,
+                                    },
+                                    "score": best_fallback[1],
+                                    "tier": "range fallback",
+                                }
+                            simulation_results.append({
+                                "series": series_name,
+                                "issue": issue_num,
+                                "issue_year": issue_year,
+                                "series_volume": series_volume,
+                                "search_context": search_context,
+                                "search_params": {
+                                    "series_name": series_name,
+                                    "issue_num": issue_num,
+                                    "issue_year": issue_year,
+                                    "series_volume": series_volume,
+                                    "series_year": series_year,
+                                    "search_variants": search_variants,
+                                },
+                                "best_accept": best_accept_data,
+                                "best_fallback": best_fallback_data,
+                                "all_results": scored_results,
+                                "status": "match_found",
                             })
-                        if r_decision == "ACCEPT":
-                            if refined_best_accept is None or r_score > refined_best_accept[1]:
-                                refined_best_accept = (r, r_score)
-                            refined_single_found = True
-                    if refined_best_accept:
-                        app_logger.info(
-                            f"Refined match chosen (score={refined_best_accept[1]}): "
-                            f"{refined_best_accept[0]['title']} {search_context}"
-                        )
-                        best_accept = refined_best_accept
-                    else:
-                        app_logger.info(
-                            f"Refinement did not improve match — keeping original best ACCEPT {search_context}"
-                        )
+                        elif download_url:
+                            # Queue the download (matching manual download structure)
+                            # Use result title for range packs so filename reflects actual content
+                            if tier == "range fallback":
+                                raw_title = best_result.get("title", f"{series_name} {issue_num}")
+                            else:
+                                raw_title = f"{series_name} {issue_num}"
+                            filename = raw_title.replace("/", "-").replace("\\", "-").replace("#", "").strip() + ".cbz"
+                            download_id = str(uuid.uuid4())
 
-                chosen = best_accept or best_fallback
-                if chosen:
-                    best_result, best_score = chosen
-                    tier = "direct match" if best_accept else "range fallback"
-                    app_logger.info(
-                        f"Found match for {series_name} #{issue_num} ({tier}, score={best_score}): {best_result['title']} {search_context}"
-                    )
-
-                    # Get download links
-                    links = get_download_links(best_result["link"])
-
-                    # Use config-driven provider priority
-                    priority_str = config.get(
-                        "SETTINGS",
-                        "DOWNLOAD_PROVIDER_PRIORITY",
-                        fallback="pixeldrain,download_now,mega",
-                    )
-                    (primary_provider, download_url), fallback_urls = select_download_url(
-                        links, priority_str
-                    )
-
-                    if dry_run:
-                        if best_accept:
-                            best_accept_data = {
-                                "result": {
-                                    "title": best_result.get("title", ""),
-                                    "link": best_result.get("link", ""),
-                                    "download_url": download_url,
-                                },
-                                "score": best_score,
-                                "tier": "direct match",
+                            # Set up progress tracking (same structure as manual download)
+                            download_progress[download_id] = {
+                                "url": download_url,
+                                "progress": 0,
+                                "bytes_total": 0,
+                                "bytes_downloaded": 0,
+                                "status": "queued",
+                                "filename": filename,
+                                "error": None,
+                                "provider": PROVIDER_LABELS.get(primary_provider),
                             }
+
+                            # Queue task (same structure as manual download)
+                            task = {
+                                "download_id": download_id,
+                                "url": download_url,
+                                "dest_filename": filename,
+                                "internal": True,
+                                "fallback_urls": fallback_urls,
+                                # The provider priority already chose this link, so pass the
+                                # key through rather than letting api.py re-derive it from the
+                                # resolved URL — getcomics wraps every provider's button in an
+                                # indistinguishable /dls/ redirector.
+                                "provider": primary_provider,
+                                # Surfaced as the manual-download link if every mirror is
+                                # Cloudflare-protected — the post page lets the browser
+                                # establish the session/referrer the mirrors require.
+                                "page_url": best_result["link"],
+                            }
+                            download_queue.put(task)
+
+                            # Record range pack to skip subsequent issues in the same range
+                            if tier == "range fallback":
+                                import re
+                                title = best_result.get("title", "")
+                                range_match = re.search(r'#(\d+)\s*[-–]\s*(\d+)', title)
+                                if range_match:
+                                    r_start = int(range_match.group(1))
+                                    r_end = int(range_match.group(2))
+                                    if series_name not in downloaded_ranges:
+                                        downloaded_ranges[series_name] = []
+                                    downloaded_ranges[series_name].append((r_start, r_end))
+                                    app_logger.info(f"Recorded range #{r_start}-{r_end} for {series_name} to skip subsequent issues")
+
+                            download_count += 1
+                            app_logger.info(f"Queued download for {series_name} #{issue_num}: {filename} {search_context}")
                         else:
-                            best_accept_data = None
-                        best_fallback_data = None
-                        if best_fallback:
-                            best_fallback_data = {
-                                "result": {
-                                    "title": best_fallback[0].get("title", ""),
-                                    "link": best_fallback[0].get("link", ""),
-                                    "download_url": None,
-                                },
-                                "score": best_fallback[1],
-                                "tier": "range fallback",
-                            }
-                        simulation_results.append({
-                            "series": series_name,
-                            "issue": issue_num,
-                            "issue_year": issue_year,
-                            "series_volume": series_volume,
-                            "search_context": search_context,
-                            "search_params": {
-                                "series_name": series_name,
-                                "issue_num": issue_num,
+                            app_logger.warning(
+                                f"No download link found for: {best_result['title']} {search_context}"
+                            )
+                    else:
+                        app_logger.debug(
+                            f"No good match found for {series_name} #{issue_num} {search_context}"
+                        )
+                        if dry_run:
+                            best_score_val = scored_results[0]["score"] if scored_results else 0
+                            simulation_results.append({
+                                "series": series_name,
+                                "issue": issue_num,
                                 "issue_year": issue_year,
                                 "series_volume": series_volume,
-                                "series_year": series_year,
-                                "search_variants": search_variants,
-                            },
-                            "best_accept": best_accept_data,
-                            "best_fallback": best_fallback_data,
-                            "all_results": scored_results,
-                            "status": "match_found",
-                        })
-                    elif download_url:
-                        # Queue the download (matching manual download structure)
-                        # Use result title for range packs so filename reflects actual content
-                        if tier == "range fallback":
-                            raw_title = best_result.get("title", f"{series_name} {issue_num}")
-                        else:
-                            raw_title = f"{series_name} {issue_num}"
-                        filename = raw_title.replace("/", "-").replace("\\", "-").replace("#", "").strip() + ".cbz"
-                        download_id = str(uuid.uuid4())
+                                "search_context": search_context,
+                                "search_params": {
+                                    "series_name": series_name,
+                                    "issue_num": issue_num,
+                                    "issue_year": issue_year,
+                                    "series_volume": series_volume,
+                                    "series_year": series_year,
+                                    "search_variants": search_variants,
+                                },
+                                "best_accept": None,
+                                "best_fallback": None,
+                                "all_results": scored_results,
+                                "status": "no_match",
+                            })
 
-                        # Set up progress tracking (same structure as manual download)
-                        download_progress[download_id] = {
-                            "url": download_url,
-                            "progress": 0,
-                            "bytes_total": 0,
-                            "bytes_downloaded": 0,
-                            "status": "queued",
-                            "filename": filename,
-                            "error": None,
-                            "provider": PROVIDER_LABELS.get(primary_provider),
-                        }
-
-                        # Queue task (same structure as manual download)
-                        task = {
-                            "download_id": download_id,
-                            "url": download_url,
-                            "dest_filename": filename,
-                            "internal": True,
-                            "fallback_urls": fallback_urls,
-                            # The provider priority already chose this link, so pass the
-                            # key through rather than letting api.py re-derive it from the
-                            # resolved URL — getcomics wraps every provider's button in an
-                            # indistinguishable /dls/ redirector.
-                            "provider": primary_provider,
-                            # Surfaced as the manual-download link if every mirror is
-                            # Cloudflare-protected — the post page lets the browser
-                            # establish the session/referrer the mirrors require.
-                            "page_url": best_result["link"],
-                        }
-                        download_queue.put(task)
-
-                        # Record range pack to skip subsequent issues in the same range
-                        if tier == "range fallback":
-                            import re
-                            title = best_result.get("title", "")
-                            range_match = re.search(r'#(\d+)\s*[-–]\s*(\d+)', title)
-                            if range_match:
-                                r_start = int(range_match.group(1))
-                                r_end = int(range_match.group(2))
-                                if series_name not in downloaded_ranges:
-                                    downloaded_ranges[series_name] = []
-                                downloaded_ranges[series_name].append((r_start, r_end))
-                                app_logger.info(f"Recorded range #{r_start}-{r_end} for {series_name} to skip subsequent issues")
-
-                        download_count += 1
-                        app_logger.info(f"Queued download for {series_name} #{issue_num}: {filename} {search_context}")
-                    else:
-                        app_logger.warning(
-                            f"No download link found for: {best_result['title']} {search_context}"
+                    # Usenet fallback: GetComics queued nothing for this issue, so
+                    # try the indexers before moving on to the next issue.
+                    if (usenet_on and not usenet_first and not dry_run
+                            and download_count == gc_count_before):
+                        u = usenet_mod.try_download_for_issue(
+                            series_name, issue_num,
+                            issue_year=issue_year,
+                            series_volume=series_volume,
+                            series_year=series_year,
+                            publisher_name=publisher_name,
+                            search_variants=search_variants,
+                            series_aliases=series_aliases,
                         )
-                else:
-                    app_logger.debug(
-                        f"No good match found for {series_name} #{issue_num} {search_context}"
+                        if u.get("submitted"):
+                            download_count += 1
+                            app_logger.info(
+                                f"Submitted Usenet fallback for {series_name} #{issue_num}: "
+                                f"{u['chosen']['filename']} {search_context}"
+                            )
+                except Exception as issue_err:
+                    app_logger.error(
+                        f"GetComics auto-download: skipping {series_name} "
+                        f"#{issue.get('number')} after error: {issue_err}"
                     )
-                    if dry_run:
-                        best_score_val = scored_results[0]["score"] if scored_results else 0
-                        simulation_results.append({
-                            "series": series_name,
-                            "issue": issue_num,
-                            "issue_year": issue_year,
-                            "series_volume": series_volume,
-                            "search_context": search_context,
-                            "search_params": {
-                                "series_name": series_name,
-                                "issue_num": issue_num,
-                                "issue_year": issue_year,
-                                "series_volume": series_volume,
-                                "series_year": series_year,
-                                "search_variants": search_variants,
-                            },
-                            "best_accept": None,
-                            "best_fallback": None,
-                            "all_results": scored_results,
-                            "status": "no_match",
-                        })
-
-                # Usenet fallback: GetComics queued nothing for this issue, so
-                # try the indexers before moving on to the next issue.
-                if (usenet_on and not usenet_first and not dry_run
-                        and download_count == gc_count_before):
-                    u = usenet_mod.try_download_for_issue(
-                        series_name, issue_num,
-                        issue_year=issue_year,
-                        series_volume=series_volume,
-                        series_year=series_year,
-                        publisher_name=publisher_name,
-                        search_variants=search_variants,
-                        series_aliases=series_aliases,
-                    )
-                    if u.get("submitted"):
-                        download_count += 1
-                        app_logger.info(
-                            f"Submitted Usenet fallback for {series_name} #{issue_num}: "
-                            f"{u['chosen']['filename']} {search_context}"
-                        )
+                    continue
 
         # Update last run timestamp
         update_last_getcomics_run()

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -1165,7 +1165,10 @@ def parse_result_title(title: str) -> ComicTitle:
     format_variants = get_format_variants()
     for variant in format_variants:
         variant_escaped = re.escape(variant)
-        pattern = rf'\+?\s*{variant_escaped}(?:s)?\b'
+        # Leading (?<![a-zA-Z]) guard so short tokens like "os"/"omb" don't match
+        # mid-word (e.g. "Chaos", "Cosmos", "Bomb Queen") and wrongly flag a format
+        # variant, which would penalize and reject a legitimate issue.
+        pattern = rf'\+?\s*(?<![a-zA-Z]){variant_escaped}(?:s)?\b'
         variant_match = re.search(pattern, title, re.IGNORECASE)
         if variant_match:
             parsed_format_variants.append(variant)
@@ -1175,7 +1178,6 @@ def parse_result_title(title: str) -> ComicTitle:
     arc_match = re.search(r'[-–—]\s*(.+?)\s*(?:#|$)', title)
     if arc_match:
         potential_arc = arc_match.group(1).strip()
-        arc_start = arc_match.start()
         pub_type_end_pattern = r'^(\d{4}\s+)?(' + '|'.join(get_publication_types()) + r')$'
         prefix_match = re.search(r'([^#\d]+)\s*[-–—]\s*.+$', title)
         if prefix_match:
@@ -1200,8 +1202,14 @@ def parse_result_title(title: str) -> ComicTitle:
             if (len(prefix) > 2 and not re.match(pub_type_end_pattern, prefix, re.IGNORECASE)
                     and not has_volume_before_dash and not prefix_is_compound_hyphen):
                 parsed_is_arc = True
-                parsed_arc_name = potential_arc
-                matched_patterns.append((arc_start, len(title)))
+                # Remove the arc from the REAL separator position (arc_pos_in_full),
+                # not the first dash — otherwise a hyphenated series name
+                # (Spider-Man, X-Men) is sliced at its internal hyphen
+                # ("Spider-Man - Blue" -> name "Spider", arc "Man - Blue"). Derive
+                # the arc name from the text after the real separator too.
+                arc_tail = title[arc_pos_in_full:].lstrip(' \t-–—')
+                parsed_arc_name = arc_tail.split('#')[0].strip() or potential_arc
+                matched_patterns.append((arc_pos_in_full, len(title)))
 
     # Publication types (annual, quarterly)
     pub_type_pattern = r'\b(' + '|'.join(get_publication_types()) + r')\b'
@@ -1237,10 +1245,16 @@ def parse_result_title(title: str) -> ComicTitle:
     normalized_for_series = title_for_analysis.replace('&', '+').replace('/', '+').replace(' + ', '+')
     normalized_for_series = normalized_for_series.replace('\u2013', '+').replace('\u2014', '+')
     series_separators = normalized_for_series.count('+')
-    if series_separators >= 1:
-        if not re.search(r'#\d+\s*\+\s*\d+', title_for_analysis):
+    # Not multi-series if this is an arc (a dash-separated subtitle, not a
+    # crossover) — otherwise en/em-dash arcs like "X-Men – Inferno" get flagged.
+    if series_separators >= 1 and not parsed_is_arc:
+        # Check the range guard against normalized_for_series (where en/em-dashes
+        # were converted to '+'), not the raw title — otherwise a same-series
+        # en-dash range pack like "Batman #1 – 12" is misflagged as multi-series
+        # and silently excluded from results.
+        if not re.search(r'#\d+\s*\+\s*\d+', normalized_for_series):
             fmt_pattern = r'\+\s*(' + '|'.join(re.escape(v) for v in format_variants) + r')s?\b'
-            if not re.search(fmt_pattern, title_for_analysis, re.IGNORECASE):
+            if not re.search(fmt_pattern, normalized_for_series, re.IGNORECASE):
                 parsed_is_multi_series = True
 
     # Construct series name by removing all matched patterns
@@ -1563,7 +1577,8 @@ def score_getcomics_result(
         -30  Collected edition keyword (omnibus, TPB, hardcover, etc.)
         -40  Confirmed issue mismatch (#N present but points to wrong number)
         -40  Volume mismatch (both search and result have explicit volumes but they differ)
-        -20  Format pack mismatch (searching for regular issue, result is TPB/omnibus/oneshot pack)
+        -50  Format pack mismatch (searching for regular issue, result is a TPB/omnibus/
+             oneshot pack); -10 instead when the result is an issue *range* pack
         -10  Format pack partial (searching for format, result pack contains format but not standalone)
 
     Sub-series handling:
@@ -2967,6 +2982,24 @@ def _ensure_urls_table():
         migrated = _migrate_from_old_tables(conn)
         logger.info(f"Migrated {migrated} entries from old tables to getcomics_urls")
 
+    # Migration: make `url` UNIQUE so `INSERT OR REPLACE INTO getcomics_urls`
+    # actually replaces instead of appending a duplicate row. Older builds had
+    # no unique index on `url` (and the spurious one on full_url was removed
+    # above), so every re-scrape accumulated duplicates. De-dupe first (keep the
+    # newest row per url — matches the go-forward replace semantics), then add
+    # the unique index. Gated on the index's absence so it runs at most once.
+    try:
+        idx_names = {r[1] for r in conn.execute("PRAGMA index_list(getcomics_urls)").fetchall()}
+        if 'idx_urls_url' not in idx_names:
+            conn.execute("""
+                DELETE FROM getcomics_urls
+                WHERE id NOT IN (SELECT MAX(id) FROM getcomics_urls GROUP BY url)
+            """)
+            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_urls_url ON getcomics_urls(url)")
+            logger.info("Added UNIQUE index on getcomics_urls(url); de-duplicated existing rows")
+    except Exception as e:
+        logger.debug(f"getcomics_urls url-unique migration skipped: {e}")
+
     conn.commit()
     conn.close()
 
@@ -3118,6 +3151,34 @@ def purge_invalid_aliases() -> int:
     return cleaned
 
 
+def clear_scrape_generated_aliases() -> int:
+    """Remove all scrape-generated search aliases from getcomics_urls.
+
+    The scrape indexer used to auto-derive a search alias from each page title,
+    which frequently produced wrong/junk aliases (a different title on the page,
+    or "Name (Year) :" fragments) that broke GetComics matching. Auto-alias
+    derivation has been removed; this one-time cleanup wipes what it left behind.
+
+    Only the getcomics_urls.search_aliases CSV is cleared. User-defined aliases
+    live in getcomics_series_aliases (the scrape never writes there) and are left
+    intact — get_series_aliases() falls back to that table, so they keep working.
+
+    Idempotent — a second run finds nothing to clear and returns 0. Returns the
+    number of rows cleared.
+    """
+    from core.database import get_db_connection
+    conn = get_db_connection()
+    try:
+        cleared = conn.execute(
+            "UPDATE getcomics_urls SET search_aliases = NULL "
+            "WHERE search_aliases IS NOT NULL AND search_aliases != ''"
+        ).rowcount
+        conn.commit()
+    finally:
+        conn.close()
+    return cleared
+
+
 def _ensure_alias_table():
     """Create the getcomics_series_aliases table if it doesn't exist."""
     from core.database import get_db_connection
@@ -3150,6 +3211,14 @@ def _ensure_alias_table():
                 set_user_preference("getcomics_aliases_purged_v1", "1", category="getcomics")
                 if n:
                     logger.info(f"Purged {n} invalid GetComics alias(es) from the database")
+            # One-time removal of scrape-generated aliases now that the indexer no
+            # longer auto-derives them. User aliases in getcomics_series_aliases are
+            # untouched and still surface via get_series_aliases()'s fallback.
+            if not get_user_preference("getcomics_scrape_aliases_cleared_v1"):
+                n = clear_scrape_generated_aliases()
+                set_user_preference("getcomics_scrape_aliases_cleared_v1", "1", category="getcomics")
+                if n:
+                    logger.info(f"Cleared scrape-generated GetComics aliases from {n} row(s)")
         except Exception as e:
             logger.debug(f"GetComics alias purge skipped: {e}")
 
@@ -3256,7 +3325,7 @@ def add_series_alias(alias: str, canonical: str) -> bool:
         # Also sync to getcomics_urls.search_aliases so both alias systems stay in sync
         norm_canonical = _normalize_alias(canonical)
         existing_row = conn.execute(
-            "SELECT search_aliases FROM getcomics_urls WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '\u2013', ' ')) = ? LIMIT 1",
+            "SELECT search_aliases FROM getcomics_urls WHERE series_norm_norm = ? LIMIT 1",
             (norm_canonical,)
         ).fetchone()
         existing_aliases = existing_row[0] if existing_row else ""
@@ -3269,7 +3338,7 @@ def add_series_alias(alias: str, canonical: str) -> bool:
         conn.execute("""
             UPDATE getcomics_urls
             SET search_aliases = ?
-            WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '\u2013', ' ')) = ?
+            WHERE series_norm_norm = ?
         """, (new_aliases, norm_canonical))
 
         conn.commit()
@@ -3315,7 +3384,7 @@ def delete_series_alias(alias: str) -> bool:
     if deleted and canonical_row:
         norm_canonical = _normalize_alias(canonical_row[0])
         existing_row = conn.execute(
-            "SELECT search_aliases FROM getcomics_urls WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '\u2013', ' ')) = ? LIMIT 1",
+            "SELECT search_aliases FROM getcomics_urls WHERE series_norm_norm = ? LIMIT 1",
             (norm_canonical,)
         ).fetchone()
         if existing_row and existing_row[0]:
@@ -3326,7 +3395,7 @@ def delete_series_alias(alias: str) -> bool:
                 conn.execute("""
                     UPDATE getcomics_urls
                     SET search_aliases = ?
-                    WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '\u2013', ' ')) = ?
+                    WHERE series_norm_norm = ?
                 """, (new_aliases, norm_canonical))
 
     conn.commit()
@@ -3431,11 +3500,14 @@ def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", la
         return slug[:50]
 
     scraper = cloudscraper.create_scraper()
-    # Load stored Last-Modified for conditional fetch (skip if page unchanged)
+    # Load stored Last-Modified for conditional fetch (skip if page unchanged).
+    # Close this connection immediately — the writes below open their own; leaving
+    # it open leaked one connection per URL scraped under the threaded indexer.
     stored_lastmod = conn.execute(
         "SELECT url_last_modified FROM getcomics_urls WHERE full_url = ? LIMIT 1",
         (url,)
     ).fetchone()
+    conn.close()
     headers = {}
     if stored_lastmod and stored_lastmod[0]:
         headers["If-Modified-Since"] = stored_lastmod[0]
@@ -3485,19 +3557,13 @@ def _scrape_url_to_index(url: str, url_slug: str = "", series_norm: str = "", la
                     title_text = title_text.split("GetComics")[0].strip().rstrip("-").rstrip()
 
             parsed = parse_result_title(title_text)
-            # Use the passed-in series_norm as canonical (preserves CLU's naming),
-            # but when the page title normalizes to something different, record that
-            # as a search_alias so searches for either name find this scrape.
-            # E.g. CLU searches "The Punisher" but page title normalized to "Punisher" —
-            # both stored_series="The Punisher" and aliases="Punisher" get stored.
-            entry_aliases = search_aliases
+            # The scrape indexer does NOT derive search aliases from page titles.
+            # Auto-generated aliases were frequently wrong (a different title on the
+            # page, or "Name (Year) :" junk) and broke GetComics matching. Search
+            # aliases are user-defined only and live in getcomics_series_aliases.
+            entry_aliases = search_aliases  # always "" from callers; kept for signature stability
             if parsed.name:
-                page_norm = normalize_series_name(parsed.name)[0]
-                stored_series = series_norm if series_norm else page_norm
-                if page_norm and page_norm != stored_series:
-                    existing = entry_aliases or ""
-                    if page_norm not in existing:
-                        entry_aliases = f"{existing},{page_norm}" if existing else page_norm
+                stored_series = series_norm if series_norm else normalize_series_name(parsed.name)[0]
             elif series_norm:
                 stored_series = series_norm
             else:
@@ -3817,6 +3883,7 @@ def update_scrape_index(
             url_lower = url.lower()
             if f"-{refresh_for_issue}-" in url_lower or url_lower.endswith(f"-{refresh_for_issue}/"):
                 # This URL is for the upcoming issue — make sure it's fresh
+                idx_at = idx_info["indexed_at"] if idx_info else None
                 if idx_info and idx_at:
                     try:
                         from datetime import datetime, timedelta
@@ -4023,7 +4090,7 @@ def update_series_aliases(series_name: str, aliases: str) -> int:
     updated = conn.execute("""
         UPDATE getcomics_urls
         SET search_aliases = ?
-        WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '\u2013', ' ')) = ?
+        WHERE series_norm_norm = ?
     """, (normalized_aliases, norm_series_lower)).rowcount
 
     # Sync to getcomics_series_aliases so resolve_series_alias() works
@@ -4078,7 +4145,7 @@ def get_series_aliases(series_name: str) -> str:
     try:
         row = conn.execute("""
             SELECT search_aliases FROM getcomics_urls
-            WHERE LOWER(REPLACE(REPLACE(series_norm, '-', ' '), '–', ' ')) = ?
+            WHERE series_norm_norm = ?
               AND search_aliases IS NOT NULL AND search_aliases != ''
             LIMIT 1
         """, (norm_series_lower,)).fetchone()

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -181,6 +181,16 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
     # If target_series_id is set, filter to just that series
     if target_series_id:
         mapped_series = [s for s in mapped_series if s["id"] == target_series_id]
+
+    # Bound the work: `limit` is the endpoint's safety cap on how many series to
+    # simulate. Without it, a no-target run does a live GetComics search + page
+    # scrape for every wanted issue of every mapped series, synchronously in the
+    # request thread (multi-minute hangs). Count only series we actually simulate.
+    from core.download_utils import issue_number_to_int
+    simulated_series = 0
+    # Ranges the simulation would download, keyed by series name — used to skip
+    # subsequent issues a range pack covers, mirroring scheduled_getcomics_download.
+    downloaded_ranges = {}
     for series in mapped_series:
         sid = series["id"]
         series_name = series.get("name", "")
@@ -205,6 +215,13 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
         if not issues:
             continue
 
+        # Stop once we've simulated `limit` eligible series (unless a specific
+        # series was requested, in which case we always show all its issues).
+        if not target_series_id:
+            if simulated_series >= limit:
+                break
+            simulated_series += 1
+
         issue_objs = [IssueObj(i) for i in issues]
         series_obj = SeriesObj(series)
         issue_status = match_issues_to_collection(mapped_path, issue_objs, series_obj)
@@ -220,6 +237,15 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
             if issue_num in manual_status:
                 continue
             if not store_date or store_date > today:
+                continue
+
+            # Skip issues covered by a range pack the simulation would download,
+            # so the preview matches the real auto-download (which grabs the range
+            # once and skips the rest) instead of re-searching every issue.
+            issue_int = issue_number_to_int(issue_num)
+            if issue_int is not None and any(
+                rs <= issue_int <= re_ for rs, re_ in downloaded_ranges.get(series_name, [])
+            ):
                 continue
 
             issue_year = int(store_date[:4]) if store_date else series_year
@@ -312,6 +338,15 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
             if chosen:
                 best_result, best_score = chosen
                 tier = "direct match" if best_accept else "range fallback"
+                # Record a range pack the sim would download so later issues it
+                # covers are skipped (mirrors scheduled_getcomics_download).
+                if tier == "range fallback":
+                    import re
+                    rmatch = re.search(r'#(\d+)\s*[-–]\s*(\d+)', best_result.get("title", ""))
+                    if rmatch:
+                        downloaded_ranges.setdefault(series_name, []).append(
+                            (int(rmatch.group(1)), int(rmatch.group(2)))
+                        )
                 # Use cached links from scrape_and_score_candidate if available,
                 # otherwise fall back to re-scraping (for live search results)
                 if best_result.get("links"):

--- a/scrape_sitemap.py
+++ b/scrape_sitemap.py
@@ -47,7 +47,7 @@ def _scrape_url_for_index(url: str, url_slug: str = "", series_norm: str = "",
     import re
     from bs4 import BeautifulSoup
     from core.database import get_db_connection
-    from models.getcomics import parse_result_title, normalize_series_name, is_valid_series_name
+    from models.getcomics import parse_result_title, is_valid_series_name
 
     def _slugify(text: str) -> str:
         """Create URL-safe slug from title text for use as entry identifier."""
@@ -99,14 +99,10 @@ def _scrape_url_for_index(url: str, url_slug: str = "", series_norm: str = "",
             return
 
         parsed = parse_result_title(title_text)
+        # The scrape does NOT derive search aliases from page titles — auto aliases
+        # were often wrong and broke matching. Aliases are user-defined only.
         stored_series = series_norm
         entry_aliases = ''
-        if parsed.name:
-            page_norm = normalize_series_name(parsed.name)[0]
-            if page_norm and page_norm != stored_series:
-                entry_aliases = page_norm
-        elif series_norm:
-            stored_series = series_norm
 
         now_ts = datetime.now().isoformat()
         conn = get_db_connection()

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -715,6 +715,42 @@ class TestParseAndStoreRejectsJunk:
         assert not any("AI Girlfriend" in (t or "") for t in titles)
 
 
+class TestScrapeDoesNotCreateAliases:
+    """The scrape indexer must never auto-derive a search alias from a page title."""
+
+    # Page title normalizes to "Punisher", canonical is "The Punisher" — the old
+    # behavior stored "Punisher" as a search alias. It must now store nothing.
+    LISTING_HTML = """\
+<html><body>
+<div class="post-content"><h5><a href="https://getcomics.org/p">Punisher #4 (2026)</a></h5></div>
+</body></html>
+"""
+
+    def test_page_title_does_not_become_alias(self, db_connection):
+        from unittest.mock import MagicMock, patch
+        from models.getcomics import _scrape_url_to_index, _ensure_urls_table
+        from core.database import get_db_connection
+
+        _ensure_urls_table()
+
+        resp = MagicMock(status_code=200, text=self.LISTING_HTML)
+        resp.headers = {}
+        fake_scraper = MagicMock()
+        fake_scraper.get.return_value = resp
+
+        with patch("models.getcomics.cloudscraper.create_scraper", return_value=fake_scraper):
+            _scrape_url_to_index("https://getcomics.org/listing", series_norm="The Punisher")
+
+        conn = get_db_connection()
+        rows = conn.execute("SELECT title, search_aliases FROM getcomics_urls").fetchall()
+        conn.close()
+
+        # The page was indexed...
+        assert any("Punisher" in (r[0] or "") for r in rows)
+        # ...but no search alias was derived from it.
+        assert all(not (r[1] or "") for r in rows)
+
+
 class TestGetSeriesAliasesFilters:
     """Junk already stored in the DB must be filtered out on read."""
 
@@ -723,15 +759,21 @@ class TestGetSeriesAliasesFilters:
             get_series_aliases, get_series_alias_list,
             _ensure_urls_table,
         )
-        from core.database import get_db_connection
+        from core.database import get_db_connection, set_user_preference
+
+        # This test exercises CSV read-time emoji filtering, not the one-time
+        # scrape-alias clear — mark that migration done so it doesn't wipe the
+        # CSV row we seed below.
+        set_user_preference("getcomics_scrape_aliases_cleared_v1", "1", category="getcomics")
 
         _ensure_urls_table()
         conn = get_db_connection()
+        # series_norm_norm is the indexed lookup key production always populates.
         conn.execute(
-            "INSERT INTO getcomics_urls (url, full_url, series_norm, search_aliases, title) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO getcomics_urls (url, full_url, series_norm, series_norm_norm, search_aliases, title) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             ("https://getcomics.org/dd", "https://getcomics.org/dd",
-             "Daredevil", f"Punisher,{_JUNK}", "Daredevil #4"),
+             "Daredevil", "daredevil", f"Punisher,{_JUNK}", "Daredevil #4"),
         )
         conn.commit()
         conn.close()
@@ -786,6 +828,56 @@ class TestPurgeInvalidAliases:
 
         # Idempotent: a second run finds nothing to clean.
         assert purge_invalid_aliases() == 0
+
+
+class TestClearScrapeGeneratedAliases:
+    """The one-time clear wipes scrape CSV aliases but preserves user aliases."""
+
+    def test_clears_csv_preserves_user_aliases_and_is_idempotent(self, db_connection):
+        from models.getcomics import (
+            clear_scrape_generated_aliases, get_series_aliases,
+            _ensure_urls_table, _ensure_alias_table,
+        )
+        from core.database import get_db_connection
+
+        _ensure_urls_table()
+        _ensure_alias_table()
+        conn = get_db_connection()
+        # User-defined alias lives in getcomics_series_aliases (the durable store).
+        conn.execute(
+            "INSERT INTO getcomics_series_aliases (alias, alias_norm, canonical, canonical_norm) "
+            "VALUES (?, ?, ?, ?)",
+            ("Punisher", "punisher", "Daredevil", "daredevil"),
+        )
+        # Scrape-index row with a stray (auto-derived + junk) alias CSV.
+        conn.execute(
+            "INSERT INTO getcomics_urls (url, full_url, series_norm, search_aliases, title) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("https://getcomics.org/dd", "https://getcomics.org/dd",
+             "Daredevil", "Punisher,daredevil (2026) :", "Daredevil #4"),
+        )
+        conn.commit()
+        conn.close()
+
+        cleared = clear_scrape_generated_aliases()
+        assert cleared == 1
+
+        conn = get_db_connection()
+        csv = conn.execute(
+            "SELECT search_aliases FROM getcomics_urls WHERE series_norm = 'Daredevil'"
+        ).fetchone()[0]
+        user_rows = [r[0] for r in conn.execute(
+            "SELECT alias FROM getcomics_series_aliases").fetchall()]
+        conn.close()
+
+        # CSV wiped; user alias table untouched.
+        assert csv is None
+        assert user_rows == ["Punisher"]
+        # User alias still surfaces via get_series_aliases()'s fallback.
+        assert get_series_aliases("Daredevil") == "Punisher"
+
+        # Idempotent: a second run clears nothing.
+        assert clear_scrape_generated_aliases() == 0
 
 
 # ===================================================================

--- a/tests/mocked/test_pr248_review_fixes.py
+++ b/tests/mocked/test_pr248_review_fixes.py
@@ -1,0 +1,135 @@
+"""Regression tests for the PR #248 review fixes.
+
+Covers defects found reviewing commit e96e49b:
+  1. Format-variant regex matched mid-word ("os"/"omb") → valid issues rejected.
+  2. getcomics_urls had no UNIQUE(url) → INSERT OR REPLACE appended duplicates.
+  4. update_scrape_index raised NameError (idx_at) on the proactive-refresh path.
+
+Fix 3 (per-issue error isolation in app.scheduled_getcomics_download) is a
+structural try/except wrap around the loop body; it can't be exercised here
+because importing the real app.py pulls in optional deps not installed in the
+test env (the repo's route tests use a mock app module for the same reason).
+"""
+
+from datetime import datetime
+
+
+# ── Fix 1: format-variant word boundary ─────────────────────────────────────
+class TestFormatVariantWordBoundary:
+    def test_midword_variants_not_flagged(self):
+        from models.getcomics import parse_result_title
+        for title in ["Chaos War #1", "Cosmos #3", "Bomb Queen #5",
+                      "Kudos #1", "Los Angeles #1"]:
+            assert parse_result_title(title).format_variants == [], title
+
+    def test_standalone_variant_still_flagged(self):
+        # A genuinely standalone "OS" token must still be detected — the boundary
+        # guard only blocks mid-word matches, not real trailing format tokens.
+        from models.getcomics import parse_result_title
+        assert "os" in [v.lower() for v in parse_result_title("Justice League OS #1").format_variants]
+
+    def test_midword_variant_series_now_accepts(self):
+        # "Chaos War" scored -5 (REJECT) before the fix because "os" matched
+        # mid-word and applied the format-mismatch penalty. It must now ACCEPT.
+        from models.getcomics import score_getcomics_result
+        score, _is_range, match = score_getcomics_result("Chaos War #1", "Chaos War", "1", None)
+        assert match is True
+        assert score >= 40, f"expected ACCEPT, got {score}"
+
+
+# ── Fix 2: UNIQUE(url) so INSERT OR REPLACE dedups ──────────────────────────
+class TestGetcomicsUrlUnique:
+    def test_insert_or_replace_replaces_not_appends(self, db_connection):
+        from models.getcomics import _ensure_urls_table
+        from core.database import get_db_connection
+        _ensure_urls_table()
+        conn = get_db_connection()
+        for title in ("First", "Second"):
+            conn.execute(
+                "INSERT OR REPLACE INTO getcomics_urls (url, full_url, series_norm, title) "
+                "VALUES (?, ?, ?, ?)",
+                ("https://getcomics.org/x", "https://getcomics.org/x", "X", title),
+            )
+        conn.commit()
+        rows = conn.execute(
+            "SELECT title FROM getcomics_urls WHERE url = ?", ("https://getcomics.org/x",)
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "Second"
+
+    def test_dedup_migration_collapses_existing_duplicates(self, db_connection):
+        from models.getcomics import _ensure_urls_table
+        from core.database import get_db_connection
+        _ensure_urls_table()
+        # Simulate a legacy DB: drop the unique index and insert duplicate rows.
+        conn = get_db_connection()
+        conn.execute("DROP INDEX IF EXISTS idx_urls_url")
+        for t in ("old", "new"):
+            conn.execute(
+                "INSERT INTO getcomics_urls (url, full_url, series_norm, title) VALUES (?,?,?,?)",
+                ("https://getcomics.org/dup", "https://getcomics.org/dup", "Dup", t),
+            )
+        conn.commit()
+        conn.close()
+
+        # Re-running the ensure/migration de-dupes (keeps newest) + re-adds index.
+        _ensure_urls_table()
+        conn = get_db_connection()
+        rows = conn.execute(
+            "SELECT title FROM getcomics_urls WHERE url = ?", ("https://getcomics.org/dup",)
+        ).fetchall()
+        idx = {r[1] for r in conn.execute("PRAGMA index_list(getcomics_urls)").fetchall()}
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "new"
+        assert "idx_urls_url" in idx
+
+
+# ── Fix 9: alias lookups use the indexed, em-dash-aware normalized column ────
+class TestAliasLookupNormalizedColumn:
+    def test_em_dash_series_alias_is_found(self, db_connection):
+        from models.getcomics import (
+            get_series_aliases, _normalize_alias, _ensure_urls_table,
+        )
+        from core.database import get_db_connection, set_user_preference
+
+        set_user_preference("getcomics_scrape_aliases_cleared_v1", "1", category="getcomics")
+        _ensure_urls_table()
+        name = "Nightwing—Rebirth"  # em-dash — the old 2-dash WHERE missed this
+        conn = get_db_connection()
+        conn.execute(
+            "INSERT INTO getcomics_urls "
+            "(url, full_url, series_norm, series_norm_norm, search_aliases, title) "
+            "VALUES (?,?,?,?,?,?)",
+            ("http://x/nw", "http://x/nw", name, _normalize_alias(name), "Nightwing", "t"),
+        )
+        conn.commit()
+        conn.close()
+
+        assert get_series_aliases(name) == "Nightwing"
+
+
+# ── Fix 4: proactive-refresh branch no longer NameErrors ────────────────────
+class TestUpdateScrapeIndexProactiveRefresh:
+    def test_proactive_refresh_reaches_branch_without_nameerror(self, db_connection):
+        from models.getcomics import _ensure_urls_table, update_scrape_index
+        from core.database import get_db_connection
+
+        _ensure_urls_table()
+        url = "https://getcomics.org/download/test-series-50-2024/"
+        conn = get_db_connection()
+        conn.execute(
+            "INSERT OR REPLACE INTO getcomics_urls "
+            "(url, full_url, series_norm, series_norm_norm, title, scrape_status, lastmod, indexed_at) "
+            "VALUES (?,?,?,?,?,?,?,?)",
+            (url, url, "Test Series", "test series", "Test Series #50",
+             "success", "", datetime.now().isoformat()),
+        )
+        conn.commit()
+        conn.close()
+
+        # Reaches the proactive-refresh branch (issue 50 already indexed & fresh).
+        # Before the fix this raised NameError: idx_at. Now it returns 0 with no
+        # network work because nothing is stale.
+        assert update_scrape_index("Test Series", refresh_for_issue="50") == 0

--- a/tests/routes/test_downloads_simulation.py
+++ b/tests/routes/test_downloads_simulation.py
@@ -1,0 +1,70 @@
+"""Tests for the GetComics wanted-issue simulation (PR #248 review fixes 5 & 8).
+
+Fix 5: the simulation must honor `limit` and bound the live search work, rather
+       than searching every issue of every series synchronously.
+Fix 8: the simulation must skip issues covered by a range pack it would download,
+       mirroring the real scheduled_getcomics_download.
+"""
+
+from unittest.mock import patch
+
+
+def _series(i):
+    return {"id": i, "name": f"S{i}", "mapped_path": f"/data/S{i}",
+            "monitored": 1, "volume": 1, "volume_year": 2020,
+            "year_began": 2020, "publisher_name": "DC"}
+
+
+def test_simulation_bounds_series_to_limit():
+    import routes.downloads as dl
+
+    series = [_series(i) for i in range(5)]
+    issues = [{"number": "1", "store_date": "2000-01-01"}]
+
+    searched = []
+
+    def fake_search(**kw):
+        searched.append(kw["series_name"])
+        return []
+
+    with patch("routes.downloads.get_all_mapped_series", return_value=series), \
+         patch("routes.downloads.get_issues_for_series", return_value=issues), \
+         patch("routes.downloads.get_manual_status_for_series", return_value={}), \
+         patch("routes.downloads.get_series_alias_list", return_value=[]), \
+         patch("routes.downloads.match_issues_to_collection", return_value={}), \
+         patch("routes.downloads.search_getcomics_for_issue", side_effect=fake_search), \
+         patch("models.usenet.usenet_enabled_and_configured", return_value=False):
+        dl._run_wanted_simulation(limit=2, target_series_id=None, target_series_name=None)
+
+    # Only 2 of the 5 mapped series were simulated (live searches bounded).
+    assert len(set(searched)) == 2
+
+
+def test_simulation_skips_issues_covered_by_range():
+    import routes.downloads as dl
+
+    series = [_series(1)]
+    issues = [{"number": n, "store_date": "2000-01-01"} for n in ("1", "2", "3")]
+
+    searched = []
+
+    def fake_search(**kw):
+        searched.append(kw["issue_num"])
+        return [{"title": "S1 #1-3", "link": "http://x/1", "download_url": ""}]
+
+    with patch("routes.downloads.get_all_mapped_series", return_value=series), \
+         patch("routes.downloads.get_issues_for_series", return_value=issues), \
+         patch("routes.downloads.get_manual_status_for_series", return_value={}), \
+         patch("routes.downloads.get_series_alias_list", return_value=[]), \
+         patch("routes.downloads.match_issues_to_collection", return_value={}), \
+         patch("routes.downloads.search_getcomics_for_issue", side_effect=fake_search), \
+         patch("routes.downloads.score_getcomics_result", return_value=(39, True, True)), \
+         patch("routes.downloads.accept_result", return_value="FALLBACK"), \
+         patch("routes.downloads.get_download_links", return_value={}), \
+         patch("routes.downloads.select_download_url", return_value=(("pixeldrain", None), [])), \
+         patch("models.usenet.usenet_enabled_and_configured", return_value=False):
+        dl._run_wanted_simulation(limit=10, target_series_id=None, target_series_name=None)
+
+    # Issue 1 resolves to a range pack (#1-3); issues 2 and 3 are covered by it
+    # and must not be searched again.
+    assert searched == ["1"]


### PR DESCRIPTION
## Summary

Two related pieces of GetComics hardening, bundled because they touch the same subsystem:

1. **Search aliases are now user-defined only.** The scrape indexer used to derive a "search alias" from every scraped page title. That produced wrong/junk aliases you never added — e.g. `Absolute Batman (2026) :` — which then broke GetComics matching so issues weren't found. The scrape no longer creates aliases, and a one-time migration clears the ones it already stored. Aliases you add by hand (stored in `getcomics_series_aliases`) are untouched and still work.

2. **11 issues found reviewing PR #248** (`e96e49b`, the large "GetComics scoring / scrape-index / auto-download" commit).

## Fixes

| # | Fix |
|---|-----|
| 1 | Format-variant regex matched **mid-word** — `os`/`omb` inside "Chaos War", "Cosmos", "Bomb Queen", "Kudos", "Los Angeles" — so those series scored **−5 (REJECT)** on a perfect match. Added a leading word-boundary guard. |
| 2 | `getcomics_urls` had **no `UNIQUE(url)`**, so `INSERT OR REPLACE` appended a new row every re-scrape instead of replacing. Added a de-dupe + `CREATE UNIQUE INDEX idx_urls_url` migration. |
| 3 | The scheduled auto-download loop had **no per-issue error isolation** — one bad issue aborted the whole batch and skipped the last-run timestamp. Wrapped the per-issue body in try/except…continue. |
| 4 | `NameError: idx_at` on `update_scrape_index`'s proactive upcoming-issue refresh path (the feature silently never ran). |
| 5 | The "simulate wanted" run **ignored its `limit`** and searched+scraped every issue of every series synchronously → multi-minute request hang. Now bounded to `limit` series. |
| 6 | **Connection leak** in `_scrape_url_to_index` — the outer DB connection was opened for one read and never closed (one leaked SQLite connection per URL scraped). |
| 7 | En/em-dash issue ranges & arcs (`Batman #1 – 12`, `X-Men – Inferno`) were wrongly flagged `is_multi_series` and silently excluded. |
| 8 | *(partial)* The simulator now **skips issues covered by a range pack** it would download, matching the real path. Still open: the dead `dry_run` code in `scheduled_getcomics_download` and year-refinement parity — deferred as follow-ups (see below). |
| 9 | Alias lookup/sync queries now use the indexed `series_norm_norm` column (were doing a full-table `LOWER(REPLACE(...))` scan and mis-handling em-dashes). |
| 10 | Arc parsing no longer truncates **hyphenated** series names (`Spider-Man - Blue` → name was "Spider", now "Spider Man"). |
| 11 | Reconciled the docstring: the format-pack penalty is **−50** (−10 for range packs), not −20. |

## What you'll see

**Config → Database tab ("Current Database"):**
- On the **first app start after this merge**, a one-time migration removes duplicate scrape rows. Expect the **`getcomics_urls` row count** (and the **Total rows** figure) to **drop** — potentially by a lot if the index had been re-scraped many times. This is the duplicate cleanup from fix #2, not data loss.
- A one-time pass also blanks the auto-created `search_aliases` values (fix for the alias issue). This clears a column, not rows, so table row counts don't change from it.
- The startup log will show lines like `Added UNIQUE index on getcomics_urls(url); de-duplicated existing rows` and `Cleared scrape-generated GetComics aliases from N row(s)`.

**Series page → "GetComics Search Aliases":**
- Auto-created and malformed aliases (e.g. `Absolute Batman (2026) :`) **disappear**. The list now shows only aliases you added yourself, and stays that way — the scrape won't repopulate it.

**Auto-download & "simulate":**
- Series whose names contain `os`/`omb` (Chaos War, Cosmos, Bomb Queen, …) now match and download instead of being silently rejected (#1).
- The **simulate** action returns promptly (bounded to `limit` series) and no longer lists every issue a single range pack already covers (#5, #8).

## Follow-ups intentionally left open
- **#8 dead code:** `scheduled_getcomics_download(dry_run=True)` is never called. Removing it means editing ~10 sites in the untested critical download path; deferred until there's a way to exercise the scheduler so it isn't a blind edit.
- **#8 year-refinement:** the simulator still lacks the real path's "re-search with year when >1 ACCEPT" step; replicating it would add duplication rather than remove it.

## Testing
- New: `tests/mocked/test_pr248_review_fixes.py`, `tests/routes/test_downloads_simulation.py`.
- Fixes 1, 7, 10 also verified empirically against the real functions.
- **Full suite: 2480 passed, 6 skipped** (POSIX-perms, expected on Windows), 13 deselected (known env-only `test_pdf.py`). No changes to `api.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
