### PR TITLE
Honor issue-pad width for 'Series #N (YYYY)' filenames

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -1119,7 +1119,7 @@ def extract_comic_values(filename, width=3):
         series_name = series_issue_year_match.group("series").replace("_", " ").strip()
         series_name = re.sub(r"[#\-\s]+$", "", series_name).strip()
         values["series_name"] = smart_title_case(series_name)
-        values["issue_number"] = _pad_issue_number(series_issue_year_match.group("issue"))
+        values["issue_number"] = _pad_issue_number(series_issue_year_match.group("issue"), width)
         values["year"] = series_issue_year_match.group("year")
         app_logger.info(
             f"Matched series/issue/year pattern: series={values['series_name']}, issue={values['issue_number']}, year={values['year']}"

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -201,6 +201,22 @@ class TestIssuePadWidth:
              patch("cbz_ops.rename.load_issue_pad_width", return_value=4):
             assert get_renamed_filename("Avengers 1.MU (2017).cbz") == "Avengers 0001.MU (2017).cbz"
 
+    @pytest.mark.parametrize("width,expected", [
+        (0, "1"),      # "None" must strip leading zeros, not force-pad to 001
+        (3, "001"),
+        (4, "0001"),
+    ])
+    def test_extract_series_hash_issue_year_honors_width(self, width, expected):
+        # Regression: the "Series #N (YYYY)" branch of extract_comic_values used
+        # to pad to a hardcoded width of 3, ignoring the configured pad width, so
+        # "The Man of Steel #1 (1986)" always came back as issue 001 even when the
+        # user picked "None". Now it must honor the width argument.
+        from cbz_ops.rename import extract_comic_values
+        values = extract_comic_values("The Man of Steel #1 (1986).cbz", width)
+        assert values["issue_number"] == expected
+        assert values["series_name"] == "The Man of Steel"
+        assert values["year"] == "1986"
+
     def test_rule_engine_pad_filter_width(self, tmp_path):
         # The {issue|pad} rule-engine filter honors the configured width.
         from cbz_ops.rename import try_rule_engine


### PR DESCRIPTION
## Problem

With **Issue Number Leading Zeros** set to **None — 44** (`issuePadWidth = none`), renaming `The Man of Steel #1 (1986).cbz` still zero-padded the issue number to `001` instead of stripping it to `1`.

## Root cause

`extract_comic_values()` in `cbz_ops/rename.py` has a branch that matches the `Series #N (YYYY)` filename shape (which this file hits exactly). That branch called `_pad_issue_number(...)` **without passing the configured `width`**, so it fell back to the hardcoded default of `3` and always produced `001`, ignoring the user's selection.

`extract_comic_values` is the shared extraction step for both the custom-rename path (`get_renamed_filename`) and Smart Rename (`_plan_file`), so the wrong width propagated into the final filename regardless of which flow ran.

## Fix

```python
# cbz_ops/rename.py:1122
- values["issue_number"] = _pad_issue_number(series_issue_year_match.group("issue"))
+ values["issue_number"] = _pad_issue_number(series_issue_year_match.group("issue"), width)
```

Now the width is honored: `#1` → `1` (None), `001` (3-digit), `0001` (4-digit), with the series name, year, and any decimal/alpha suffix preserved. This was the only unwidthed `_pad_issue_number` call left in the extraction logic.

## Tests

- Added `test_extract_series_hash_issue_year_honors_width` (parametrized over widths 0/3/4) in `tests/unit/test_rename.py`. Verified it **fails** against the old code and **passes** with the fix.
- Full affected suite green: `tests/unit/test_rename.py`, `tests/unit/test_smart_rename.py`, `tests/integration/test_issue_pad_width_pref.py` — **304 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
