### PR TITLE
Add WebP output option for PDF→CBZ and fix CropBox white padding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ tests/
 1. Comics stored in `/data` (mounted volume)
 2. Downloads go to `/downloads/temp` then processed to `/downloads/processed`
 3. SQLite database in `CACHE_DIR` (default `/cache`)
-4. Config persisted in `/config/config.ini`
+4. Config persisted in `/config/config.ini` - deprecated - all future settings should be stored in `user_preferences` table in the database
 
 ### Frontend
 - Jinja2 templates in `templates/`
@@ -136,6 +136,7 @@ Settings in `core/config.py` define defaults merged with `/config/config.ini`. K
 - `AUTOCONVERT`: Auto CBR-to-CBZ conversion
 - `BOOTSTRAP_THEME`: UI theme name
 - API keys: `COMICVINE_API_KEY`, `PIXELDRAIN_API_KEY`, `METRON_USERNAME/PASSWORD`
+- `config.ini`  is being deprecated - all future settings should be stored in `user_preferences` table in the database
 
 ## File Processing Pipeline
 

--- a/app.py
+++ b/app.py
@@ -6740,6 +6740,15 @@ def save_file_processing_config():
             _issue_pad,
             category="file_processing",
         )
+        # PDF → CBZ page image format: jpeg | webp (allowlist; default jpeg).
+        _pdf_fmt = str(data.get("pdfImageFormat", "jpeg")).strip().lower()
+        if _pdf_fmt not in ("jpeg", "webp"):
+            _pdf_fmt = "jpeg"
+        set_user_preference(
+            "pdf_image_format",
+            _pdf_fmt,
+            category="file_processing",
+        )
         set_user_preference(
             "smart_rename_preview_enabled",
             bool(data.get("smartRenamePreviewEnabled", True)),
@@ -7196,6 +7205,13 @@ def config_page():
         set_user_preference(
             "issue_pad_width", _issue_pad, category="file_processing"
         )
+        # PDF → CBZ page image format: jpeg | webp (allowlist; default jpeg).
+        _pdf_fmt = str(request.form.get("pdfImageFormat", "jpeg")).strip().lower()
+        if _pdf_fmt not in ("jpeg", "webp"):
+            _pdf_fmt = "jpeg"
+        set_user_preference(
+            "pdf_image_format", _pdf_fmt, category="file_processing"
+        )
         config["SETTINGS"]["ENABLE_AUTO_MOVE"] = str(
             request.form.get("enableAutoMove") == "on"
         )
@@ -7289,6 +7305,7 @@ def config_page():
         autoConvert=settings.get("AUTOCONVERT", "False") == "True",
         readSubdirectories=settings.get("READ_SUBDIRECTORIES", "False") == "True",
         convertSubdirectories=settings.get("CONVERT_SUBDIRECTORIES", "False") == "True",
+        pdfImageFormat=str(get_user_preference("pdf_image_format", default="jpeg") or "jpeg"),
         xmlYear=settings.get("XML_YEAR", "False") == "True",
         xmlMarkdown=settings.get("XML_MARKDOWN", "False") == "True",
         xmlList=settings.get("XML_LIST", "False") == "True",

--- a/cbz_ops/pdf.py
+++ b/cbz_ops/pdf.py
@@ -3,6 +3,7 @@ import sys
 import zipfile
 from pdf2image import convert_from_path, pdfinfo_from_path
 from core.app_logging import app_logger
+from core.database import get_user_preference
 from PIL import Image
 from helpers import is_hidden, open_zip_for_write
 import gc
@@ -47,7 +48,17 @@ def process_pdf_file(pdf_path):
     cbz_path = os.path.join(os.path.dirname(pdf_path), f"{pdf_name}.cbz")
     
     app_logger.info(f"Processing: {pdf_path}")
-    
+
+    # Resolve the output image format once per PDF (default JPEG). WebP yields
+    # significantly smaller pages at similar quality; anything unknown falls
+    # back to JPEG so a bad stored value never breaks conversion. Stored in the
+    # user_preferences table (see set_user_preference('pdf_image_format', ...)).
+    image_format = str(
+        get_user_preference("pdf_image_format", default="jpeg") or "jpeg"
+    ).strip().lower()
+    if image_format not in ("jpeg", "webp"):
+        image_format = "jpeg"
+
     try:
         # Get PDF info first
         pdf_info = pdfinfo_from_path(pdf_path)
@@ -65,18 +76,25 @@ def process_pdf_file(pdf_path):
             
             # Convert batch of pages
             pages = convert_from_path(
-                pdf_path, 
-                first_page=batch_start, 
-                last_page=batch_end, 
+                pdf_path,
+                first_page=batch_start,
+                last_page=batch_end,
                 thread_count=1,
                 fmt="jpeg",
-                dpi=300  # Match native DPI of most comic PDFs
+                dpi=300,  # Match native DPI of most comic PDFs
+                use_cropbox=True,  # Render the CropBox, not the MediaBox: many
+                # comic PDFs set a CropBox tighter than the page's MediaBox, and
+                # rendering the MediaBox bakes the surrounding margins in as large
+                # white borders around every page.
             )
             
             # Process each page in the batch
             for i, page in enumerate(pages):
                 page_number = batch_start + i
-                process_single_page(page, page_number, pdf_name, output_folder)
+                process_single_page(
+                    page, page_number, pdf_name, output_folder,
+                    image_format=image_format,
+                )
                 # Explicitly close the page to free memory
                 page.close()
             
@@ -104,19 +122,28 @@ def process_pdf_file(pdf_path):
             cleanup_temp_folder(output_folder)
 
 
-def process_single_page(page, page_number, pdf_name, output_folder):
+def process_single_page(page, page_number, pdf_name, output_folder, image_format="jpeg"):
     """
     Process a single page with memory-efficient operations.
+
+    :param image_format: "jpeg" (default) or "webp" — controls the saved page
+        extension and encoder. WebP is written lossy for a smaller file at
+        comparable quality.
     """
     try:
+        image_format = (image_format or "jpeg").strip().lower()
+        if image_format not in ("jpeg", "webp"):
+            image_format = "jpeg"
+
         width, height = page.size
         total_pixels = width * height
-        
+
         app_logger.info(f"Page {page_number} size: {width}x{height} pixels ({total_pixels}px)")
-        
-        page_filename = f"{pdf_name} page_{page_number}.jpg"
+
+        extension = "webp" if image_format == "webp" else "jpg"
+        page_filename = f"{pdf_name} page_{page_number}.{extension}"
         page_path = os.path.join(output_folder, page_filename)
-        
+
         # Resize image if too large to prevent memory issues
         max_pixels = 50_000_000  # 50MP limit
         if total_pixels > max_pixels:
@@ -126,9 +153,12 @@ def process_single_page(page, page_number, pdf_name, output_folder):
             new_width = int(width * ratio)
             new_height = int(height * ratio)
             page = page.resize((new_width, new_height), Image.LANCZOS)
-        
+
         # Save with optimized settings
-        page.save(page_path, "JPEG", quality=92, optimize=True)
+        if image_format == "webp":
+            page.save(page_path, "WEBP", quality=90, method=6)
+        else:
+            page.save(page_path, "JPEG", quality=92, optimize=True)
         app_logger.info(f"Saved page {page_number} as {page_filename}")
         
     except Exception as e:

--- a/templates/config.html
+++ b/templates/config.html
@@ -318,6 +318,18 @@
                                 </small>
                             </div>
                         </div>
+                        <div class="col-md-6">
+                            <label for="pdfImageFormat" class="form-label">PDF → CBZ Image Format:</label>
+                            <select class="form-select" name="pdfImageFormat" id="pdfImageFormat">
+                                <option value="jpeg" {% if pdfImageFormat == 'jpeg' %}selected{% endif %}>JPEG (default)</option>
+                                <option value="webp" {% if pdfImageFormat == 'webp' %}selected{% endif %}>WebP (smaller files)</option>
+                            </select>
+                            <small class="form-text text-muted">
+                                Image format for pages when converting PDFs to CBZ. WebP is
+                                significantly smaller (~30-50%) at similar quality; JPEG is the
+                                widest-compatibility default.
+                            </small>
+                        </div>
                     </div>
                     <p class="text-muted">Settings related to Directory & File processing features.</p>
                     <div class="row">
@@ -1847,6 +1859,7 @@
             autoCleanupOrphanFiles: document.getElementById('autoCleanupOrphanFiles')?.checked || false,
             cleanupIntervalHours: document.getElementById('cleanupIntervalHours')?.value || '24',
             convertSubdirectories: document.getElementById('convertSubdirectories')?.checked || false,
+            pdfImageFormat: document.getElementById('pdfImageFormat')?.value || 'jpeg',
             skippedFiles: document.getElementById('skippedFiles')?.value || '',
             deletedFiles: document.getElementById('deletedFiles')?.value || '',
             enableCustomRename: document.getElementById('enableCustomRename')?.checked || false,

--- a/tests/mocked/test_pdf.py
+++ b/tests/mocked/test_pdf.py
@@ -46,6 +46,32 @@ class TestProcessSinglePage:
         files = os.listdir(output_folder)
         assert len(files) == 3
 
+    def test_saves_page_as_webp(self, tmp_path):
+        from cbz_ops.pdf import process_single_page
+
+        page = Image.new("RGB", (800, 1200), "white")
+        output_folder = str(tmp_path)
+
+        process_single_page(page, 1, "WebComic", output_folder, image_format="webp")
+
+        saved = os.path.join(output_folder, "WebComic page_1.webp")
+        assert os.path.exists(saved)
+        # A .jpg must NOT have been written when webp is requested.
+        assert not os.path.exists(os.path.join(output_folder, "WebComic page_1.jpg"))
+        with Image.open(saved) as img:
+            assert img.format == "WEBP"
+
+    def test_invalid_format_falls_back_to_jpeg(self, tmp_path):
+        from cbz_ops.pdf import process_single_page
+
+        page = Image.new("RGB", (800, 1200), "white")
+        output_folder = str(tmp_path)
+
+        process_single_page(page, 1, "FallbackComic", output_folder, image_format="gif")
+
+        saved = os.path.join(output_folder, "FallbackComic page_1.jpg")
+        assert os.path.exists(saved)
+
 
 class TestCreateCbzFile:
 
@@ -123,7 +149,37 @@ class TestProcessPdfFile:
 
         mock_info.assert_called_once_with(pdf_path)
         assert mock_convert.call_count >= 1
+        # Render the CropBox, not the MediaBox, so pages with a tight crop box
+        # don't get large white margins baked into every image.
+        assert mock_convert.call_args.kwargs.get("use_cropbox") is True
         mock_create_cbz.assert_called_once()
+
+    @patch("cbz_ops.pdf.get_user_preference", return_value="webp")
+    @patch("cbz_ops.pdf.process_single_page")
+    @patch("cbz_ops.pdf.cleanup_temp_folder")
+    @patch("cbz_ops.pdf.create_cbz_file")
+    @patch("cbz_ops.pdf.convert_from_path")
+    @patch("cbz_ops.pdf.pdfinfo_from_path", return_value={"Pages": 1})
+    def test_threads_webp_format_from_preference(self, mock_info, mock_convert,
+                                                 mock_create_cbz, mock_cleanup,
+                                                 mock_single_page, mock_pref,
+                                                 tmp_path):
+        from cbz_ops.pdf import process_pdf_file
+
+        pdf_path = str(tmp_path / "comic.pdf")
+        with open(pdf_path, "w") as f:
+            f.write("fake pdf")
+
+        page = MagicMock()
+        page.size = (800, 1200)
+        page.close = MagicMock()
+        mock_convert.return_value = [page]
+
+        process_pdf_file(pdf_path)
+
+        mock_pref.assert_called_once_with("pdf_image_format", default="jpeg")
+        assert mock_single_page.call_count >= 1
+        assert mock_single_page.call_args.kwargs.get("image_format") == "webp"
 
     @patch("cbz_ops.pdf.pdfinfo_from_path", side_effect=Exception("corrupt PDF"))
     def test_handles_corrupt_pdf(self, mock_info, tmp_path):


### PR DESCRIPTION
## Summary

- Adds a user-selectable **PDF → CBZ page image format** (JPEG default / WebP) in the File Processing settings. WebP is lossy `quality=90` — roughly 30–50% smaller than JPEG at similar quality.
- Stores the setting in the **`user_preferences` table** (key `pdf_image_format`, category `file_processing`) rather than `config.ini`, per the config.ini deprecation for new settings. `cbz_ops/pdf.py` reads it via `get_user_preference`, so both `monitor.py` and the `python -m cbz_ops.pdf` subprocess path honor it.
- Fixes **large white margins** on converted pages: many comic PDFs (e.g. the example `BBA027.pdf`, MediaBox `612×1008` vs CropBox `504×756`) define a CropBox tighter than the MediaBox, and `pdftoppm` renders the MediaBox by default. Passing `use_cropbox=True` to `convert_from_path` renders the visible CropBox instead.

## Changes

| File | Change |
|------|--------|
| `cbz_ops/pdf.py` | Read `pdf_image_format` from user_preferences; thread `image_format` into `process_single_page` (`.webp` → `WEBP` q90, `.jpg` → `JPEG` q92); add `use_cropbox=True` to `convert_from_path` |
| `app.py` | Save `pdf_image_format` (allowlisted jpeg/webp) in both save paths; render it into the config page |
| `templates/config.html` | JPEG/WebP dropdown + JS gather field |
| `tests/mocked/test_pdf.py` | WebP save, jpeg fallback, preference threading, and `use_cropbox` assertions |
| `CLAUDE.md` | Note config.ini deprecation for new settings |

## Testing

- `python -m py_compile` clean on all modified modules.
- Exercised the real save path with a stubbed `pdf2image`: WebP page **1768 B vs 5909 B** JPEG at identical resolution; invalid format falls back to `.jpg`; `process_pdf_file` calls `get_user_preference('pdf_image_format', default='jpeg')` and threads the result through.

⚠️ **`tests/mocked/test_pdf.py` cannot run in the dev environment** — `pdf2image`/poppler aren't installed there, so the module fails to import and every test in the file errors at collection (documented env-only baseline). The new tests use only PIL/mocks and will pass wherever `pdf2image` is available (CI/Docker). The CropBox padding fix was diagnosed from the PDF's box geometry, not a rendered image — please confirm on a poppler-equipped machine that converted pages fill the frame with no white border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)