### PR TITLE
Handle letter-suffixed issue numbers (e.g. 013A) in metadata matching

### DIFF
--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -139,6 +139,8 @@ def extract_issue_number(filename: str) -> Optional[str]:
     - "Amazing Spider-Man 001.cbz" -> "1"
     - "Batman #42.cbz" -> "42"
     - "X-Men v2 012.cbz" -> "12"
+    - "Gen 13 013A.cbz" -> "13A"  (letter-suffixed variant, stored literally
+      by providers like ComicVine)
 
     Args:
         filename: Comic filename
@@ -154,14 +156,24 @@ def extract_issue_number(filename: str) -> Optional[str]:
     # e.g. "Spider-Man 2099 001 (1992)" -> "Spider-Man 2099 001"
     name_clean = re.sub(r'\s*\([^)]*\)', '', name).strip()
 
+    # Issue-number suffix: an optional decimal/alpha point-suffix (".1",
+    # ".BEY") and/or an optional directly-attached letter suffix ("A" in
+    # "13A", "AU" in "1AU" — variant designations providers store literally).
+    # The negative lookahead keeps ordinal endings ("5th", "100th", "1st")
+    # from being mistaken for a letter suffix.
+    _SUFFIX = (
+        r'(?:\.\w+)?'
+        r'(?:(?![sS][tT]\b|[nN][dD]\b|[rR][dD]\b|[tT][hH]\b)[A-Za-z]{1,3})?'
+    )
+
     # Try various patterns (ordered by specificity)
     # Uses lookbehind (?<=\s) instead of \s+ so finditer can find all matches
     patterns = [
-        r'\b[Ii]ssue\s+(\d+(?:\.\w+)?)',              # Issue 080, Issue 700.1, Issue 080.BEY
-        r'#(\d+(?:\.\w+)?)',                            # #42 or #42.1 or #42.BEY
-        r'(?<=\s)(\d{3,}(?:\.\w+)?)(?:\s|$)',           # Space + 3+ digits (001, 078.BEY, 050.LR)
-        r'(?<=\s)(\d{1,2}(?:\.\w+)?)(?:\s|$)',          # Space + 1-2 digits
-        r'[-_](\d+(?:\.\w+)?)(?:\s|$)',                 # Dash/underscore + digits
+        rf'\b[Ii]ssue\s+(\d+{_SUFFIX})',        # Issue 080, Issue 700.1, Issue 013A
+        rf'#(\d+{_SUFFIX})',                      # #42 or #42.1 or #42.BEY or #13A
+        rf'(?<=\s)(\d{{3,}}{_SUFFIX})(?:\s|$)',   # Space + 3+ digits (001, 078.BEY, 013A)
+        rf'(?<=\s)(\d{{1,2}}{_SUFFIX})(?:\s|$)',  # Space + 1-2 digits
+        rf'[-_](\d+{_SUFFIX})(?:\s|$)',           # Dash/underscore + digits
     ]
 
     for pattern in patterns:
@@ -178,15 +190,30 @@ def extract_issue_number(filename: str) -> Optional[str]:
             if not match:
                 continue
 
-        # Remove leading zeros but preserve decimal/suffix parts
-        num_str = match.group(1)
-        if '.' in num_str:
-            parts = num_str.split('.', 1)
-            return str(int(parts[0])) + '.' + parts[1]
-        else:
-            return str(int(num_str))
+        return _normalize_issue_number(match.group(1))
 
     return None
+
+
+def _normalize_issue_number(num_str: str) -> str:
+    """Strip leading zeros from the integer part while preserving a decimal/
+    alpha point-suffix ('.1', '.BEY') or a directly-attached letter suffix
+    ('A' in '013A'). e.g. '013A' -> '13A', '080.BEY' -> '80.BEY', '001' -> '1'.
+    """
+    # Peel off an optional dot-suffix first ('80.BEY' -> '80' + '.BEY').
+    if '.' in num_str:
+        int_part, dot_suffix = num_str.split('.', 1)
+        dot_suffix = '.' + dot_suffix
+    else:
+        int_part, dot_suffix = num_str, ''
+
+    # Then a directly-attached letter suffix ('13A' -> '13' + 'A').
+    letter_suffix = ''
+    m = re.match(r'(\d+)([A-Za-z]+)$', int_part)
+    if m:
+        int_part, letter_suffix = m.group(1), m.group(2)
+
+    return str(int(int_part)) + letter_suffix + dot_suffix
 
 
 class BaseProvider(ABC):

--- a/tests/unit/test_provider_base.py
+++ b/tests/unit/test_provider_base.py
@@ -160,6 +160,14 @@ class TestExtractIssueNumber:
         ("Batman 42 (2020).cbz", "42"),
         # Decimal issues
         ("Batman 050.LR.cbz", "50.LR"),
+        # Letter-suffixed variant issues (providers store these literally)
+        ("Gen 13 013A.cbz", "13A"),
+        ("Gen 13 013B (1995).cbz", "13B"),
+        ("Avengers #001AU.cbz", "1AU"),
+        ("X-Force Issue 013A.cbz", "13A"),
+        ("Comic-013A.cbz", "13A"),
+        # An explicit #N still wins over an ordinal token in the title
+        ("Batman 100th Anniversary Special #5.cbz", "5"),
     ])
     def test_extraction(self, filename, expected):
         assert extract_issue_number(filename) == expected
@@ -167,6 +175,12 @@ class TestExtractIssueNumber:
     def test_no_match_returns_none(self):
         assert extract_issue_number("just-a-name.cbz") is None
 
+    def test_ordinal_not_treated_as_letter_suffix(self):
+        # "100th" must not parse as issue "100th"; with no real issue number
+        # the extractor returns None rather than a bogus ordinal.
+        assert extract_issue_number("Batman 100th Issue.cbz") is None
+
     def test_strips_leading_zeros(self):
         assert extract_issue_number("Comic 001.cbz") == "1"
         assert extract_issue_number("Comic 010.cbz") == "10"
+        assert extract_issue_number("Comic 013A.cbz") == "13A"


### PR DESCRIPTION
## Problem

Comic files whose issue number has a letter directly attached (e.g. `Gen 13 013A.cbz`) failed metadata matching:

```
INFO - Processing Gen 13 013A.cbz (issue/vol #13)
INFO - Searching for issue #13 in volume 5667 (year: None)
INFO - No issues found for volume 5667, issue #13
WARNING - No metadata found for Gen 13 013A.cbz
```

`Gen 13 013A` exists on ComicVine — stored as issue **13A** — but the lookup searched **#13** and found nothing.

## Root cause

`extract_issue_number` in `models/providers/base.py` is the single extractor both metadata paths funnel through (the `routes/metadata.py` batch flow via `comicvine.extract_issue_number`, and the `core/bulk_metadata.py` bulk orchestrator via `models.providers`). Its patterns only captured digits plus an optional **dotted** suffix (`080.BEY`), never a letter attached directly to the digits.

For `013A` the 3-digit pattern failed on the trailing `A`, then the 1–2 digit fallback grabbed the **`13` from the title "Gen 13"** — producing `#13`.

## Fix

- Add a shared `_SUFFIX` fragment to each pattern capturing an optional directly-attached letter suffix (`13A`, `1AU`), with a negative lookahead so ordinals (`5th`, `100th`, `1st`) are not mistaken for a suffix.
- Add `_normalize_issue_number()` to zero-strip only the integer part while preserving dotted (`080.BEY → 80.BEY`) and letter (`013A → 13A`) suffixes. The old code called `int("013A")`, which would raise.

Both metadata paths share this extractor, so both are fixed.

### Known limitation (out of scope)
An **unpadded** collision like `Gen 13 13A.cbz` still grabs the title's `13` via the 1–2 digit first-match heuristic. The reported zero-padded `013A` case is fully fixed.

## Tests

Added parametrized cases (`013A`, `013B`, `001AU`, `Issue 013A`, `Comic-013A`) plus an ordinal-guard test (`Batman 100th Issue.cbz → None`) in `tests/unit/test_provider_base.py`. Related suites pass — 367/367 (provider base, rename, metadata routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
