### PR TITLE
Add multi-user support (RBAC, per-user data isolation, library access)

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ from routes.opds import opds_bp
 from models import gcd
 from models import metron
 from core.config import config, load_flask_config, write_config, load_config
+from core.auth import enforce_path_access
 from cbz_ops.edit import (
     get_edit_modal,
     save_cbz,
@@ -92,6 +93,8 @@ from core.database import (
     update_last_rebuild,
     clear_stats_cache,
     clear_stats_cache_keys,
+    clear_stats_cache_prefix,
+    current_user_id,
     mark_issue_read,
     get_issues_read,
     get_recent_read_issues,
@@ -176,6 +179,25 @@ load_config()
 
 # Initialize Database
 init_db()
+
+# Multi-user: ensure a Store Owner account exists (implicit-owner mode for
+# single-user installs; seeded from CLU_USERNAME/CLU_PASSWORD when present).
+from core.database import seed_owner_if_needed
+
+seed_owner_if_needed()
+
+# Upgrade the provisional per-process secret key (set in load_flask_config
+# before the DB existed) to a stable, persisted one so browser sessions survive
+# restarts. An explicit SECRET_KEY env var always wins.
+if not os.environ.get("SECRET_KEY"):
+    import secrets as _secrets
+    from core.database import get_user_preference as _get_pref, set_user_preference as _set_pref
+
+    _stable_secret = _get_pref("secret_key", default=None)
+    if not _stable_secret:
+        _stable_secret = _secrets.token_hex(32)
+        _set_pref("secret_key", _stable_secret, category="security")
+    app.secret_key = _stable_secret
 
 # Check database integrity on startup and surface any corruption loudly. The
 # result is stored in app_state (read by /api/database/stats and the Database
@@ -1910,6 +1932,13 @@ def run_komga_sync():
             "Config → Komga Reading Sync → Library Path Mapping."
         )
 
+    # Komga is a single shared account per instance; its read/progress data
+    # belongs to the Store Owner. Attribute writes explicitly so they land on
+    # the owner regardless of who (or what scheduler thread) triggered the sync.
+    from core.database import get_owner_user
+    _owner = get_owner_user()
+    owner_id = _owner["id"] if _owner else 1
+
     read_count = 0
     progress_count = 0
     skip_count = 0
@@ -1968,6 +1997,7 @@ def run_komga_sync():
                 issue_path=clu_path,
                 read_at=info["read_date"],
                 page_count=info["page_count"],
+                user_id=owner_id,
             )
             mark_komga_book_synced(book_id, info["url"], clu_path, "read")
             read_count += 1
@@ -1989,7 +2019,7 @@ def run_komga_sync():
             # No is_komga_book_synced guard here, unlike phase 1: "read" is
             # terminal but progress moves, and komga_sync_log records only that
             # a book synced, never at what page. Compare the position itself.
-            existing = get_reading_position(clu_path)
+            existing = get_reading_position(clu_path, user_id=owner_id)
             if existing and existing.get("page_number") == info["current_page"]:
                 progress_skip_count += 1
                 continue
@@ -1998,6 +2028,7 @@ def run_komga_sync():
                 comic_path=clu_path,
                 page_number=info["current_page"],
                 total_pages=info["page_count"],
+                user_id=owner_id,
             )
             mark_komga_book_synced(book_id, info["url"], clu_path, "progress")
             progress_count += 1
@@ -2006,8 +2037,8 @@ def run_komga_sync():
 
     update_komga_last_sync(read_count, progress_count)
 
-    # Clear stats caches so new data shows up
-    clear_stats_cache_keys(["library_stats", "reading_history", "reading_heatmap"])
+    # Clear the owner's stats caches so the newly-synced data shows up.
+    clear_stats_cache_prefix(f"u{owner_id}:")
 
     unlogged = (no_match_count + ambiguous_count) - logged_unmatched
     if unlogged > 0:
@@ -4867,6 +4898,10 @@ def read_comic_page(comic_path, page_num):
     if not comic_path.startswith("/"):
         comic_path = "/" + comic_path
 
+    denied = enforce_path_access(comic_path)
+    if denied:
+        return denied
+
     if not os.path.exists(comic_path):
         app_logger.error(f"Comic file not found: {comic_path}")
         return send_file("static/images/error.svg", mimetype="image/svg+xml")
@@ -4977,6 +5012,10 @@ def read_comic_page_info(comic_path, page_num):
     if not comic_path.startswith("/"):
         comic_path = "/" + comic_path
 
+    denied = enforce_path_access(comic_path)
+    if denied:
+        return denied
+
     if not os.path.exists(comic_path):
         return jsonify({"success": False, "error": "File not found"}), 404
 
@@ -5049,6 +5088,10 @@ def read_comic_info(comic_path):
     # Add leading slash if missing (for absolute paths on Unix systems)
     if not comic_path.startswith("/"):
         comic_path = "/" + comic_path
+
+    denied = enforce_path_access(comic_path)
+    if denied:
+        return denied
 
     if not os.path.exists(comic_path):
         return jsonify({"error": "Comic file not found"}), 404
@@ -5135,7 +5178,7 @@ def api_mark_comic_read():
             characters=characters,
             publisher=publisher,
         )
-        clear_stats_cache_keys(["library_stats", "reading_history", "reading_heatmap"])
+        clear_stats_cache_prefix(f"u{current_user_id()}:")  # per-user reading caches
         app_logger.info(
             f"Marked comic as read: {comic_path}"
             + (f" at {read_at}" if read_at else "")
@@ -5250,7 +5293,7 @@ def api_backfill_reading_metadata():
         conn.close()
 
         # Clear stats cache
-        clear_stats_cache_keys(["library_stats", "reading_history"])
+        clear_stats_cache_prefix(f"u{current_user_id()}:")  # per-user reading caches
 
         app_logger.info(
             f"Backfill complete: {updated_count} updated, {skipped_count} skipped"
@@ -5529,6 +5572,10 @@ def get_thumbnail():
     file_path = request.args.get("path")
     if not file_path:
         return jsonify({"error": "Missing path"}), 400
+
+    denied = enforce_path_access(file_path)
+    if denied:
+        return denied
 
     # Calculate cache path
     cache_dir = config.get("SETTINGS", "CACHE_DIR", fallback="/cache")
@@ -6128,6 +6175,11 @@ def download_file():
         or normalized_path.startswith(os.path.normpath(get_target_dir_live()))
     ):
         return jsonify({"error": "Access denied"}), 403
+
+    # Per-user: deny files outside the user's granted libraries.
+    denied = enforce_path_access(file_path)
+    if denied:
+        return denied
 
     try:
         from helpers import serve_comic_file
@@ -7068,6 +7120,27 @@ def save_recommendations_config():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+@app.route("/users")
+def users_page():
+    """Store Owner user-management page (owner-gated by the central RBAC policy)."""
+    return render_template("users.html", current_page="/users")
+
+
+@app.route("/setup-owner")
+def setup_owner_page():
+    """First-run screen to set the Store Owner's credentials.
+
+    Only meaningful while the owner is a needs_setup placeholder; otherwise it
+    redirects home.
+    """
+    from core.database import get_owner_user
+
+    owner = get_owner_user()
+    if not owner or not owner.get("needs_setup"):
+        return redirect(url_for("index"))
+    return render_template("setup_owner.html", current_page="/setup-owner")
+
+
 @app.route("/config", methods=["GET", "POST"])
 def config_page():
     if request.method == "POST":
@@ -7800,8 +7873,18 @@ signal.signal(signal.SIGINT, lambda signum, frame: shutdown_server())
 
 @app.route("/api/operations")
 def active_operations():
-    ops = app_state.get_active_operations()
-    notifications = app_state.get_and_clear_notifications()
+    # Scope progress/toasts to the viewer (owners see everything). No-op in
+    # implicit-owner mode, where viewer resolves to the owner.
+    from flask import g
+    from core.auth import is_login_required
+    user = getattr(g, "current_user", None)
+    if not is_login_required() or (user and user.get("role") == "owner"):
+        ops = app_state.get_active_operations()
+        notifications = app_state.get_and_clear_notifications()
+    else:
+        viewer_id = user["id"] if user else None
+        ops = app_state.get_active_operations(viewer_id=viewer_id)
+        notifications = app_state.get_and_clear_notifications(viewer_id=viewer_id)
     return jsonify({"operations": ops, "notifications": notifications})
 
 

--- a/core/app_state.py
+++ b/core/app_state.py
@@ -23,12 +23,36 @@ COMPLETED_TTL = 15  # seconds before completed ops are purged
 STALE_TIMEOUT = 300  # seconds with no update before a running op is marked stale/error
 
 
-def register_operation(op_type, label, total=0, op_id=None):
+def _resolve_uid(user_id):
+    """Best-effort id of the user this op/notification belongs to.
+
+    An explicit ``user_id`` wins; otherwise resolve the request's current user
+    (or the Store Owner in a background thread). Kept resilient so the registry
+    never raises just because identity can't be determined.
+    """
+    if user_id is not None:
+        return user_id
+    try:
+        from core.database import current_user_id
+        return current_user_id()
+    except Exception:
+        return None
+
+
+def _visible(op_or_note, viewer_id, is_owner):
+    """Whether a viewer may see an op/notification (owner sees all)."""
+    if is_owner or viewer_id is None:
+        return True
+    return op_or_note.get("user_id") == viewer_id
+
+
+def register_operation(op_type, label, total=0, op_id=None, user_id=None):
     """Register a new long-running operation. Returns the operation ID.
 
     Pass ``op_id`` to use a caller-chosen identifier (e.g. a client-generated
     token for synchronous endpoints that want polled progress). Defaults to a
-    fresh uuid when omitted.
+    fresh uuid when omitted. The op is attributed to ``user_id`` (or the current
+    request user / owner) so progress doesn't leak across accounts.
     """
     if op_id is None:
         op_id = uuid.uuid4().hex
@@ -45,6 +69,7 @@ def register_operation(op_type, label, total=0, op_id=None):
             "started_at": now,
             "updated_at": now,
             "completed_at": None,
+            "user_id": _resolve_uid(user_id),
         }
     return op_id
 
@@ -76,8 +101,12 @@ def complete_operation(op_id, error=False):
             op["current"] = op["total"]
 
 
-def get_active_operations():
-    """Return all operations, auto-pruning completed/stale ops."""
+def get_active_operations(viewer_id=None, is_owner=False):
+    """Return operations visible to the viewer, auto-pruning completed/stale ops.
+
+    With no viewer (``viewer_id=None``) or for an owner, every op is returned
+    (backward-compatible default). A non-owner viewer sees only their own ops.
+    """
     now = time.time()
     with _operations_lock:
         # Mark stale running ops as error (generator abandoned / connection lost)
@@ -96,7 +125,7 @@ def get_active_operations():
         ]
         for oid in expired:
             del _operations[oid]
-        return list(_operations.values())
+        return [op for op in _operations.values() if _visible(op, viewer_id, is_owner)]
 
 
 # ── Background Notifications ──
@@ -105,24 +134,37 @@ _notifications_lock = threading.Lock()
 NOTIFICATION_TTL = 300  # seconds before notifications expire
 
 
-def add_notification(message, level="warning"):
-    """Add a notification for the UI to display (e.g., partial extraction warnings)."""
+def add_notification(message, level="warning", user_id=None):
+    """Add a notification for the UI to display (e.g., partial extraction warnings).
+
+    Attributed to ``user_id`` (or the current request user / owner) so toasts
+    don't surface on another account's screen.
+    """
     with _notifications_lock:
         _notifications.append({
             "message": message,
             "level": level,
             "created_at": time.time(),
+            "user_id": _resolve_uid(user_id),
         })
 
 
-def get_and_clear_notifications():
-    """Return pending notifications and clear them. Also prunes expired ones."""
+def get_and_clear_notifications(viewer_id=None, is_owner=False):
+    """Return the viewer's pending notifications and clear (only) those.
+
+    With no viewer or for an owner, all notifications are returned and cleared
+    (backward-compatible default). A non-owner viewer sees and clears only their
+    own; others' notifications are retained. Expired ones are always pruned.
+    """
     now = time.time()
     with _notifications_lock:
-        # Prune expired
-        active = [n for n in _notifications if (now - n["created_at"]) < NOTIFICATION_TTL]
+        fresh = [n for n in _notifications if (now - n["created_at"]) < NOTIFICATION_TTL]
+        mine = [n for n in fresh if _visible(n, viewer_id, is_owner)]
+        # Retain fresh notifications that belong to other users.
+        retained = [n for n in fresh if not _visible(n, viewer_id, is_owner)]
         _notifications.clear()
-        return active
+        _notifications.extend(retained)
+        return mine
 
 
 # ── Database Integrity State ──

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,0 +1,328 @@
+"""
+Multi-user identity & role-based access control (RBAC).
+
+This module owns the notion of "who is the current user" and "may they do
+this". It is deliberately additive: when no real user accounts have been
+created the app runs in *implicit-owner* mode — every request is treated as
+the Store Owner and no login is required — so existing single-user installs
+behave exactly as before.
+
+Role hierarchy (ascending privilege):
+
+    reader  — read/view comics, personal reading data
+    clerk   — reader + file ops, metadata/scrape, downloads, pull list
+    owner   — clerk + app settings, user management, library grants
+
+Identity is resolved once per request into ``flask.g.current_user`` (a plain
+dict from the ``users`` table, or None). The browser path is wired from
+``routes/auth.py``; the ``/api/v1`` token path sets ``g.current_user`` from its
+own bearer-token ``before_request`` hook.
+"""
+import functools
+import os
+
+from flask import g, request, redirect, url_for, jsonify, flash
+
+from core.database import (
+    count_users,
+    get_owner_user,
+    get_user_by_id,
+    user_has_library,
+)
+
+# Ascending privilege. Unknown roles sort to 0 (deny everything).
+ROLE_LEVELS = {"reader": 1, "clerk": 2, "owner": 3}
+
+
+def role_at_least(user, minimum):
+    """True if ``user`` holds at least the ``minimum`` role."""
+    if not user:
+        return False
+    return ROLE_LEVELS.get(user.get("role"), 0) >= ROLE_LEVELS.get(minimum, 99)
+
+
+def get_owner():
+    """Return the Store Owner account (the implicit-mode identity)."""
+    return get_owner_user()
+
+
+def is_login_required():
+    """Whether the app should force login.
+
+    True when more than one account exists, or when the legacy
+    ``CLU_USERNAME``/``CLU_PASSWORD`` env gate is configured. Otherwise the app
+    stays login-free and everyone is the owner (backward-compat guarantee).
+    """
+    if os.environ.get("CLU_USERNAME") and os.environ.get("CLU_PASSWORD"):
+        return True
+    return count_users() > 1
+
+
+def resolve_current_user():
+    """Resolve the effective user for this request without touching ``g``.
+
+    Session-authenticated user if present; otherwise the implicit owner when
+    login is not required; otherwise None (anonymous / must log in).
+    """
+    from flask import session
+
+    uid = session.get("user_id")
+    if uid:
+        user = get_user_by_id(uid)
+        if user and user.get("is_active"):
+            return user
+    if not is_login_required():
+        return get_owner()
+    return None
+
+
+def load_current_user():
+    """Populate ``g.current_user`` for the request. Idempotent."""
+    if getattr(g, "current_user", None) is None:
+        g.current_user = resolve_current_user()
+    return g.current_user
+
+
+def current_user():
+    """Return the request's current user, resolving lazily if needed."""
+    user = getattr(g, "current_user", None)
+    if user is None:
+        user = load_current_user()
+    return user
+
+
+def _wants_json():
+    """True when the caller expects a JSON error rather than an HTML redirect."""
+    return request.path.startswith("/api/") or request.path.startswith("/opds")
+
+
+def _deny(status=403):
+    if _wants_json():
+        return jsonify({"error": "forbidden" if status == 403 else "unauthorized"}), status
+    if status == 401:
+        return redirect(url_for("auth.login", next=request.path))
+    flash("You don't have permission to do that.")
+    # index is the app-level landing route; fall back to root if unavailable.
+    try:
+        return redirect(url_for("index"))
+    except Exception:
+        return redirect("/")
+
+
+def require_role(minimum):
+    """Decorator: require the current user to hold at least ``minimum`` role.
+
+    Emits JSON 403 for API/OPDS routes, redirect/flash for HTML routes. In
+    implicit-owner mode the owner satisfies every role.
+    """
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            if not is_login_required():
+                return fn(*args, **kwargs)  # implicit-owner mode: unrestricted
+            user = current_user()
+            if user is None:
+                return _deny(401)
+            if not role_at_least(user, minimum):
+                return _deny(403)
+            return fn(*args, **kwargs)
+        return wrapped
+    return decorator
+
+
+def user_can_access_path(user, path):
+    """True if ``user`` may access the library containing ``path``.
+
+    Owners bypass all library scoping. Non-owners need an explicit grant for
+    the library the path resolves to. A path outside every configured library
+    is denied for non-owners.
+    """
+    if not user:
+        return False
+    if user.get("role") == "owner":
+        return True
+    if not path:
+        return False
+    from helpers.library import get_library_for_path
+
+    library = get_library_for_path(path)
+    if not library:
+        return False
+    return user_has_library(user["id"], library["id"])
+
+
+# ---------------------------------------------------------------------------
+# Centralized route policy (role required per request)
+#
+# Enforcement is applied ONLY when login is required (multi-user mode). In
+# implicit-owner mode the gate is skipped entirely, so single-user installs are
+# unaffected. Owners always satisfy every rule.
+#
+# The policy leans on a safe default: any *mutating* request (POST/PUT/DELETE/
+# PATCH) that isn't otherwise classified requires Clerk, while reads default to
+# Reader. That means most file/metadata/download mutations are covered without
+# enumeration; we only enumerate the Owner surface, the few GET-sensitive Clerk
+# areas, and the personal-data writes a Reader must be allowed to perform.
+# ---------------------------------------------------------------------------
+
+_MUTATING_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
+
+# Owner-only regardless of method (settings, system, DB, user/token admin).
+_OWNER_PREFIXES = (
+    "/api/admin",
+    "/config",
+    "/api/config/",
+    "/api/database",
+    "/api/komga",
+    "/api/save-",              # schedule save endpoints
+    "/schedules",
+    "/gcd-import",
+    "/restart",
+    "/api/rebuild-file-index",
+    "/api/providers",          # provider credentials (secrets)
+    "/users",                  # user-management page
+    "/setup-owner",            # first-run owner setup page
+)
+
+# GET is Reader (browsing), but creating/editing/deleting requires Owner.
+_OWNER_MUTATION_PREFIXES = (
+    "/api/libraries",
+    "/api/publishers",
+)
+
+# Personal-data writes a Reader may perform on their own data. Trailing slashes
+# keep these from swallowing unrelated paths (e.g. "/api/reading-lists").
+_READER_WRITE_PREFIXES = (
+    "/api/read/",              # /api/read/<path>/page/<n>
+    "/api/reading-position",
+    "/api/reading-stats",
+    "/api/favorites",          # favorites_bp
+    "/api/to-read",
+    "/to-read",
+    "/api/continue-reading",
+    "/api/on-the-stack",
+)
+
+# Clerk-level areas where even GET is a Clerk feature (not just Reader viewing).
+_CLERK_PREFIXES = (
+    "/api/getcomics",
+    "/api/download-clients",
+    "/api/indexers",
+    "/api/usenet",
+    "/api/pull-list",
+    "/api/bulk-metadata",
+    "/api/source-wall",
+    "/api/weekly-packs",
+)
+
+
+def required_role_for_request():
+    """Return the minimum role required for the current request's path+method."""
+    path = request.path
+    mutating = request.method in _MUTATING_METHODS
+
+    if path.startswith(_OWNER_PREFIXES):
+        return "owner"
+    if mutating and path.startswith(_OWNER_MUTATION_PREFIXES):
+        return "owner"
+    if path.startswith(_READER_WRITE_PREFIXES):
+        return "reader"
+    if path.startswith(_CLERK_PREFIXES):
+        return "clerk"
+    if mutating:
+        return "clerk"
+    return "reader"
+
+
+def check_request_permitted(user):
+    """Return a deny response if ``user`` lacks the role required for this
+    request, else None. Caller is responsible for only invoking this in
+    multi-user mode."""
+    required = required_role_for_request()
+    if not role_at_least(user, required):
+        return _deny(403 if user else 401)
+    return None
+
+
+def accessible_library_ids(user):
+    """Return the set of library ids ``user`` may access.
+
+    Owners (and, defensively, a missing user in implicit-owner mode) get every
+    enabled library; other users get exactly their granted set.
+    """
+    from core.database import get_libraries, get_user_library_ids
+
+    if not user or user.get("role") == "owner":
+        return {lib["id"] for lib in get_libraries(enabled_only=True)}
+    return get_user_library_ids(user["id"])
+
+
+def filter_paths_for_user(user, items, key=None):
+    """Filter a list of paths (or dicts) to those the user may access.
+
+    ``key`` names the dict field holding the path when ``items`` are dicts;
+    when None, ``items`` are treated as plain path strings. No-op (returns the
+    input) in implicit-owner mode so single-user installs are unaffected.
+    """
+    if not is_login_required():
+        return items
+    if user and user.get("role") == "owner":
+        return items
+
+    from helpers.library import get_library_for_path
+
+    allowed = accessible_library_ids(user)
+
+    def _ok(path):
+        if not path:
+            return False
+        lib = get_library_for_path(path)
+        return bool(lib) and lib["id"] in allowed
+
+    if key is None:
+        return [p for p in items if _ok(p)]
+    return [it for it in items if _ok(it.get(key))]
+
+
+def enforce_path_access(path):
+    """Return a deny response if the current user may not access the library
+    containing ``path``, else None. No-op in implicit-owner mode.
+
+    Call this inline in file-serve / reader / browse routes *after* the path has
+    been normalised to an absolute filesystem path.
+    """
+    if not is_login_required():
+        return None
+    user = current_user()
+    if user is None:
+        return _deny(401)
+    if not user_can_access_path(user, path):
+        return _deny(403)
+    return None
+
+
+def require_library_access(path_arg="path"):
+    """Decorator: require the current user to have access to the library that
+    contains the request's target path.
+
+    The path is read (in order) from the view kwargs, query string, then form
+    body, under the name ``path_arg``.
+    """
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            if not is_login_required():
+                return fn(*args, **kwargs)  # implicit-owner mode: unrestricted
+            user = current_user()
+            if user is None:
+                return _deny(401)
+            target = (
+                kwargs.get(path_arg)
+                or request.args.get(path_arg)
+                or request.form.get(path_arg)
+            )
+            if not user_can_access_path(user, target):
+                return _deny(403)
+            return fn(*args, **kwargs)
+        return wrapped
+    return decorator

--- a/core/database.py
+++ b/core/database.py
@@ -121,6 +121,40 @@ def _migrate_db_to_config_dir():
         raise
 
 
+def _rebuild_add_user_scope(c, table, new_table_sql, new_cols, index_sqls):
+    """Rebuild a path-keyed table to add per-user scoping (one-time, idempotent).
+
+    SQLite can't alter a column's UNIQUE constraint in place, so we create a new
+    table (``{table}__new``) with a ``user_id`` column and a composite UNIQUE on
+    ``(user_id, path)``, copy every existing row assigning it to the Store Owner
+    (``user_id = 1``), then swap it into place. No-op once ``user_id`` exists.
+
+    Args:
+        c: open cursor (inside init_db's transaction)
+        table: table to migrate
+        new_table_sql: CREATE statement for ``{table}__new`` (composite UNIQUE)
+        new_cols: column names present in the new table
+        index_sqls: index statements to (re)create on the swapped-in table
+    """
+    old_cols = [r[1] for r in c.execute(f"PRAGMA table_info({table})").fetchall()]
+    if not old_cols or "user_id" in old_cols:
+        return  # table absent or already migrated
+
+    app_logger.info(f"Migrating {table}: adding per-user scope (user_id)")
+    c.execute(new_table_sql)
+    # Copy only columns common to both schemas (excludes user_id, set to owner).
+    common = [col for col in old_cols if col in new_cols and col != "user_id"]
+    collist = ", ".join(common)
+    c.execute(
+        f"INSERT INTO {table}__new ({collist}, user_id) "
+        f"SELECT {collist}, 1 FROM {table}"
+    )
+    c.execute(f"DROP TABLE {table}")
+    c.execute(f"ALTER TABLE {table}__new RENAME TO {table}")
+    for isql in index_sqls:
+        c.execute(isql)
+
+
 def init_db():
     """Initialize the SQLite database and create tables if they don't exist."""
     _migrate_db_to_config_dir()
@@ -520,6 +554,14 @@ def init_db():
         if "description" not in columns:
             app_logger.info("Migrating reading_lists table: adding description column")
             c.execute("ALTER TABLE reading_lists ADD COLUMN description TEXT DEFAULT NULL")
+        if "user_id" not in columns:
+            app_logger.info("Migrating reading_lists table: adding user_id column")
+            # Existing lists belong to the Store Owner (user_id=1). Entries
+            # inherit scope through their reading_list_id FK.
+            c.execute("ALTER TABLE reading_lists ADD COLUMN user_id INTEGER DEFAULT 1")
+            c.execute(
+                "CREATE INDEX IF NOT EXISTS idx_reading_lists_user ON reading_lists(user_id)"
+            )
 
         # Create reading_list_entries table
         c.execute("""
@@ -1130,6 +1172,189 @@ def init_db():
                 app_logger.info("Removed TIMEZONE from config.ini")
         except Exception as e:
             app_logger.debug(f"TIMEZONE migration skipped or already done: {e}")
+
+        # ---------------------------------------------------------------------
+        # Multi-user support (RBAC + per-user data isolation)
+        #
+        # Roles are a plain TEXT column with a CHECK constraint (reader < clerk
+        # < owner) rather than a separate roles table — three fixed roles are
+        # cleaner as an ordered map in Python. See core/auth.py.
+        # ---------------------------------------------------------------------
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                username      TEXT NOT NULL UNIQUE COLLATE NOCASE,
+                password_hash TEXT,
+                role          TEXT NOT NULL DEFAULT 'reader'
+                                 CHECK (role IN ('reader', 'clerk', 'owner')),
+                display_name  TEXT,
+                email         TEXT,
+                is_active     INTEGER DEFAULT 1,
+                needs_setup   INTEGER DEFAULT 0,
+                created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_login_at TIMESTAMP
+            )
+        """)
+
+        # Per-user library access grants. Absence of a row = no access for
+        # non-owners; owners bypass this table entirely (see core/auth.py).
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS library_permissions (
+                user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                library_id INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+                PRIMARY KEY (user_id, library_id)
+            )
+        """)
+
+        # Per-user long-lived bearer tokens for the /api/v1 client. Only the
+        # sha256 hash of the token is stored, never the plaintext.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS api_tokens (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                token_hash   TEXT NOT NULL UNIQUE,
+                name         TEXT,
+                created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_used_at TIMESTAMP
+            )
+        """)
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id)"
+        )
+
+        # publishers is a SHARED metadata table, so a per-user "favorite" flag
+        # can't live on it — this join table carries the per-user state instead.
+        # No FK to users (matches the other personal-data tables): favorites are
+        # written in implicit-owner mode where user_id=1 may pre-date the seeded
+        # owner row, so a FK would spuriously fail.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS user_favorite_publishers (
+                user_id      INTEGER NOT NULL,
+                publisher_id INTEGER NOT NULL,
+                PRIMARY KEY (user_id, publisher_id)
+            )
+        """)
+        # Rebuild an earlier feature-branch schema that declared a FK to users.
+        try:
+            if c.execute("PRAGMA foreign_key_list(user_favorite_publishers)").fetchall():
+                c.execute(
+                    "CREATE TABLE user_favorite_publishers__new "
+                    "(user_id INTEGER NOT NULL, publisher_id INTEGER NOT NULL, "
+                    "PRIMARY KEY (user_id, publisher_id))"
+                )
+                c.execute(
+                    "INSERT OR IGNORE INTO user_favorite_publishers__new "
+                    "SELECT user_id, publisher_id FROM user_favorite_publishers"
+                )
+                c.execute("DROP TABLE user_favorite_publishers")
+                c.execute(
+                    "ALTER TABLE user_favorite_publishers__new "
+                    "RENAME TO user_favorite_publishers"
+                )
+        except sqlite3.OperationalError:
+            pass
+
+        # One-time backfill: existing shared publisher favorites (publishers.favorite=1)
+        # become the Store Owner's per-user favorites. Guarded so it runs once.
+        c.execute("SELECT value FROM user_preferences WHERE key = 'pub_favorites_migrated'")
+        if not c.fetchone():
+            try:
+                c.execute(
+                    "INSERT OR IGNORE INTO user_favorite_publishers (user_id, publisher_id) "
+                    "SELECT 1, id FROM publishers WHERE favorite = 1"
+                )
+                c.execute(
+                    "INSERT OR REPLACE INTO user_preferences (key, value, category, updated_at) "
+                    "VALUES ('pub_favorites_migrated', 'true', 'migration', CURRENT_TIMESTAMP)"
+                )
+                app_logger.info("Migrated shared publisher favorites to the Store Owner")
+            except sqlite3.OperationalError:
+                pass  # publishers table may not exist yet on a brand-new DB
+
+        # Per-user scoping for reading data (one-time table rebuilds). Existing
+        # rows are attributed to the Store Owner (user_id=1). No FK to users is
+        # added on these high-churn tables to avoid ordering/lock constraints.
+        _rebuild_add_user_scope(
+            c, "issues_read",
+            """
+            CREATE TABLE issues_read__new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL DEFAULT 1,
+                issue_path TEXT NOT NULL,
+                read_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                page_count INTEGER DEFAULT 0,
+                time_spent INTEGER DEFAULT 0,
+                writer TEXT DEFAULT '',
+                penciller TEXT DEFAULT '',
+                characters TEXT DEFAULT '',
+                publisher TEXT DEFAULT '',
+                hide INTEGER DEFAULT 0,
+                UNIQUE(user_id, issue_path)
+            )
+            """,
+            {"id", "user_id", "issue_path", "read_at", "page_count", "time_spent",
+             "writer", "penciller", "characters", "publisher", "hide"},
+            [
+                "CREATE INDEX IF NOT EXISTS idx_issues_read_path ON issues_read(issue_path)",
+                "CREATE INDEX IF NOT EXISTS idx_issues_read_user ON issues_read(user_id)",
+            ],
+        )
+        _rebuild_add_user_scope(
+            c, "reading_positions",
+            """
+            CREATE TABLE reading_positions__new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL DEFAULT 1,
+                comic_path TEXT NOT NULL,
+                page_number INTEGER NOT NULL,
+                total_pages INTEGER,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                time_spent INTEGER DEFAULT 0,
+                UNIQUE(user_id, comic_path)
+            )
+            """,
+            {"id", "user_id", "comic_path", "page_number", "total_pages",
+             "updated_at", "time_spent"},
+            [
+                "CREATE INDEX IF NOT EXISTS idx_reading_positions_path ON reading_positions(comic_path)",
+                "CREATE INDEX IF NOT EXISTS idx_reading_positions_user ON reading_positions(user_id)",
+            ],
+        )
+        _rebuild_add_user_scope(
+            c, "favorite_series",
+            """
+            CREATE TABLE favorite_series__new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL DEFAULT 1,
+                series_path TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(user_id, series_path)
+            )
+            """,
+            {"id", "user_id", "series_path", "created_at"},
+            [
+                "CREATE INDEX IF NOT EXISTS idx_favorite_series_path ON favorite_series(series_path)",
+                "CREATE INDEX IF NOT EXISTS idx_favorite_series_user ON favorite_series(user_id)",
+            ],
+        )
+        _rebuild_add_user_scope(
+            c, "to_read",
+            """
+            CREATE TABLE to_read__new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL DEFAULT 1,
+                path TEXT NOT NULL,
+                type TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(user_id, path)
+            )
+            """,
+            {"id", "user_id", "path", "type", "created_at"},
+            [
+                "CREATE INDEX IF NOT EXISTS idx_to_read_path ON to_read(path)",
+                "CREATE INDEX IF NOT EXISTS idx_to_read_user ON to_read(user_id)",
+            ],
+        )
 
         # Bulk metadata processing tables (used by routes/bulk_metadata.py)
         # Job header — one row per "Fetch Metadata" run.
@@ -4296,14 +4521,14 @@ def clear_browse_cache():
 # =============================================================================
 
 
-def set_publisher_favorite(publisher_path, favorite=True):
+def set_publisher_favorite(publisher_path, favorite=True, user_id=None):
     """
-    Set or unset a publisher as favorite by path.
-    If the publisher doesn't exist, creates it with just the path.
+    Set or unset a publisher as a favorite of the current (or given) user.
 
-    Args:
-        publisher_path: Full path to the publisher folder
-        favorite: True to favorite, False to unfavorite
+    Favorites live in the per-user ``user_favorite_publishers`` join table (the
+    ``publishers`` table is shared metadata). If the publisher row doesn't exist
+    yet and we're favoriting, a local-only publisher row is created so the join
+    has something to reference.
 
     Returns:
         True if successful, False otherwise
@@ -4313,44 +4538,49 @@ def set_publisher_favorite(publisher_path, favorite=True):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        favorite_val = 1 if favorite else 0
 
-        # Check if publisher exists by path
+        # Resolve the publisher id for this path.
         c.execute("SELECT id FROM publishers WHERE path = ?", (publisher_path,))
         existing = c.fetchone()
-
         if existing:
-            # Update existing publisher
-            c.execute(
-                "UPDATE publishers SET favorite = ? WHERE path = ?",
-                (favorite_val, publisher_path),
-            )
-        else:
-            # Create new publisher with just path (no Metron ID)
-            # Use negative autoincrement for local-only publishers
+            pub_id = existing[0]
+        elif favorite:
+            # Create a local-only publisher (negative id) to reference.
             c.execute("SELECT MIN(id) FROM publishers")
             min_id = c.fetchone()[0]
-            new_id = (min_id - 1) if min_id and min_id < 0 else -1
-
-            # Extract name from path (last folder name)
+            pub_id = (min_id - 1) if min_id and min_id < 0 else -1
             import os
 
             name = os.path.basename(publisher_path.rstrip("/\\")) or publisher_path
-
             c.execute(
-                """
-                INSERT INTO publishers (id, name, path, favorite, created_at)
-                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
-            """,
-                (new_id, name, publisher_path, favorite_val),
+                "INSERT INTO publishers (id, name, path, created_at) "
+                "VALUES (?, ?, ?, CURRENT_TIMESTAMP)",
+                (pub_id, name, publisher_path),
+            )
+        else:
+            # Unfavoriting a path with no publisher row: nothing to do.
+            conn.close()
+            return True
+
+        if favorite:
+            c.execute(
+                "INSERT OR IGNORE INTO user_favorite_publishers (user_id, publisher_id) "
+                "VALUES (?, ?)",
+                (uid, pub_id),
+            )
+        else:
+            c.execute(
+                "DELETE FROM user_favorite_publishers WHERE user_id = ? AND publisher_id = ?",
+                (uid, pub_id),
             )
 
         conn.commit()
         conn.close()
 
         action = "Added" if favorite else "Removed"
-        app_logger.info(f"{action} favorite publisher: {publisher_path}")
+        app_logger.info(f"{action} favorite publisher: {publisher_path} (user {uid})")
         return True
 
     except Exception as e:
@@ -4358,37 +4588,19 @@ def set_publisher_favorite(publisher_path, favorite=True):
         return False
 
 
-def add_favorite_publisher(publisher_path):
+def add_favorite_publisher(publisher_path, user_id=None):
+    """Add a publisher to the current (or given) user's favorites."""
+    return set_publisher_favorite(publisher_path, favorite=True, user_id=user_id)
+
+
+def remove_favorite_publisher(publisher_path, user_id=None):
+    """Remove a publisher from the current (or given) user's favorites."""
+    return set_publisher_favorite(publisher_path, favorite=False, user_id=user_id)
+
+
+def get_favorite_publishers(user_id=None):
     """
-    Add a publisher to favorites.
-    Wrapper for set_publisher_favorite for backwards compatibility.
-
-    Args:
-        publisher_path: Full path to the publisher folder
-
-    Returns:
-        True if successful, False otherwise
-    """
-    return set_publisher_favorite(publisher_path, favorite=True)
-
-
-def remove_favorite_publisher(publisher_path):
-    """
-    Remove a publisher from favorites.
-    Wrapper for set_publisher_favorite for backwards compatibility.
-
-    Args:
-        publisher_path: Full path to the publisher folder
-
-    Returns:
-        True if successful, False otherwise
-    """
-    return set_publisher_favorite(publisher_path, favorite=False)
-
-
-def get_favorite_publishers():
-    """
-    Get all favorite publishers.
+    Get the current (or given) user's favorite publishers.
 
     Returns:
         List of dicts with publisher_path, name, and created_at, or empty list on error
@@ -4398,13 +4610,15 @@ def get_favorite_publishers():
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute("""
-            SELECT id, name, path as publisher_path, created_at
-            FROM publishers
-            WHERE favorite = 1 AND path IS NOT NULL
-            ORDER BY path
-        """)
+            SELECT p.id, p.name, p.path as publisher_path, p.created_at
+            FROM user_favorite_publishers ufp
+            JOIN publishers p ON p.id = ufp.publisher_id
+            WHERE ufp.user_id = ? AND p.path IS NOT NULL
+            ORDER BY p.path
+        """, (uid,))
         rows = c.fetchall()
         conn.close()
 
@@ -4415,7 +4629,7 @@ def get_favorite_publishers():
         return []
 
 
-def get_favorite_publishers_paginated(offset=0, limit=50):
+def get_favorite_publishers_paginated(offset=0, limit=50, user_id=None):
     """
     Paginated sibling of get_favorite_publishers — returns (rows, total).
     """
@@ -4424,21 +4638,26 @@ def get_favorite_publishers_paginated(offset=0, limit=50):
         if not conn:
             return [], 0
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
-            "SELECT COUNT(*) FROM publishers WHERE favorite = 1 AND path IS NOT NULL"
+            "SELECT COUNT(*) FROM user_favorite_publishers ufp "
+            "JOIN publishers p ON p.id = ufp.publisher_id "
+            "WHERE ufp.user_id = ? AND p.path IS NOT NULL",
+            (uid,),
         )
         total = c.fetchone()[0] or 0
 
         c.execute(
             """
-            SELECT id, name, path as publisher_path, created_at
-            FROM publishers
-            WHERE favorite = 1 AND path IS NOT NULL
-            ORDER BY path
+            SELECT p.id, p.name, p.path as publisher_path, p.created_at
+            FROM user_favorite_publishers ufp
+            JOIN publishers p ON p.id = ufp.publisher_id
+            WHERE ufp.user_id = ? AND p.path IS NOT NULL
+            ORDER BY p.path
             LIMIT ? OFFSET ?
             """,
-            (limit, offset),
+            (uid, limit, offset),
         )
         rows = [dict(r) for r in c.fetchall()]
         conn.close()
@@ -4449,9 +4668,9 @@ def get_favorite_publishers_paginated(offset=0, limit=50):
         return [], 0
 
 
-def is_favorite_publisher(publisher_path):
+def is_favorite_publisher(publisher_path, user_id=None):
     """
-    Check if a publisher is favorited.
+    Check if a publisher is favorited by the current (or given) user.
 
     Args:
         publisher_path: Full path to the publisher folder
@@ -4464,12 +4683,21 @@ def is_favorite_publisher(publisher_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT favorite FROM publishers WHERE path = ?", (publisher_path,))
+        c.execute(
+            """
+            SELECT 1
+            FROM user_favorite_publishers ufp
+            JOIN publishers p ON p.id = ufp.publisher_id
+            WHERE p.path = ? AND ufp.user_id = ?
+            """,
+            (publisher_path, uid),
+        )
         result = c.fetchone()
         conn.close()
 
-        return result is not None and result[0] == 1
+        return result is not None
 
     except Exception as e:
         app_logger.error(f"Failed to check favorite publisher '{publisher_path}': {e}")
@@ -4491,10 +4719,19 @@ def get_publisher_by_path(publisher_path):
         if not conn:
             return None
 
+        uid = _resolve_user_id(None)
         c = conn.cursor()
         c.execute(
-            "SELECT id, name, path, favorite, created_at FROM publishers WHERE path = ?",
-            (publisher_path,),
+            """
+            SELECT p.id, p.name, p.path,
+                   CASE WHEN ufp.publisher_id IS NOT NULL THEN 1 ELSE 0 END AS favorite,
+                   p.created_at
+            FROM publishers p
+            LEFT JOIN user_favorite_publishers ufp
+                   ON ufp.publisher_id = p.id AND ufp.user_id = ?
+            WHERE p.path = ?
+            """,
+            (uid, publisher_path),
         )
         row = c.fetchone()
         conn.close()
@@ -4590,9 +4827,9 @@ def save_publisher_path(publisher_path, name=None, publisher_id=None):
 # =============================================================================
 
 
-def add_favorite_series(series_path):
+def add_favorite_series(series_path, user_id=None):
     """
-    Add a series to favorites.
+    Add a series to the current (or given) user's favorites.
 
     Args:
         series_path: Full path to the series folder
@@ -4605,13 +4842,14 @@ def add_favorite_series(series_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
             """
-            INSERT OR IGNORE INTO favorite_series (series_path)
-            VALUES (?)
+            INSERT OR IGNORE INTO favorite_series (user_id, series_path)
+            VALUES (?, ?)
         """,
-            (series_path,),
+            (uid, series_path),
         )
 
         conn.commit()
@@ -4625,9 +4863,9 @@ def add_favorite_series(series_path):
         return False
 
 
-def remove_favorite_series(series_path):
+def remove_favorite_series(series_path, user_id=None):
     """
-    Remove a series from favorites.
+    Remove a series from the current (or given) user's favorites.
 
     Args:
         series_path: Full path to the series folder
@@ -4640,8 +4878,12 @@ def remove_favorite_series(series_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("DELETE FROM favorite_series WHERE series_path = ?", (series_path,))
+        c.execute(
+            "DELETE FROM favorite_series WHERE series_path = ? AND user_id = ?",
+            (series_path, uid),
+        )
 
         conn.commit()
         conn.close()
@@ -4654,9 +4896,9 @@ def remove_favorite_series(series_path):
         return False
 
 
-def get_favorite_series():
+def get_favorite_series(user_id=None):
     """
-    Get all favorite series.
+    Get all favorite series for the current (or given) user.
 
     Returns:
         List of dicts with series_path and created_at, or empty list on error
@@ -4666,9 +4908,12 @@ def get_favorite_series():
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
-            "SELECT series_path, created_at FROM favorite_series ORDER BY series_path"
+            "SELECT series_path, created_at FROM favorite_series "
+            "WHERE user_id = ? ORDER BY series_path",
+            (uid,),
         )
         rows = c.fetchall()
         conn.close()
@@ -4680,9 +4925,9 @@ def get_favorite_series():
         return []
 
 
-def is_favorite_series(series_path):
+def is_favorite_series(series_path, user_id=None):
     """
-    Check if a series is favorited.
+    Check if a series is favorited by the current (or given) user.
 
     Args:
         series_path: Full path to the series folder
@@ -4695,8 +4940,12 @@ def is_favorite_series(series_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT 1 FROM favorite_series WHERE series_path = ?", (series_path,))
+        c.execute(
+            "SELECT 1 FROM favorite_series WHERE series_path = ? AND user_id = ?",
+            (series_path, uid),
+        )
         result = c.fetchone()
         conn.close()
 
@@ -4721,6 +4970,7 @@ def mark_issue_read(
     penciller="",
     characters="",
     publisher="",
+    user_id=None,
 ):
     """
     Mark an issue as read.
@@ -4744,16 +4994,18 @@ def mark_issue_read(
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
 
         if read_at:
             c.execute(
                 """
                 INSERT OR REPLACE INTO issues_read
-                (issue_path, read_at, page_count, time_spent, writer, penciller, characters, publisher)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (user_id, issue_path, read_at, page_count, time_spent, writer, penciller, characters, publisher)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
+                    uid,
                     issue_path,
                     read_at,
                     page_count,
@@ -4768,10 +5020,11 @@ def mark_issue_read(
             c.execute(
                 """
                 INSERT OR REPLACE INTO issues_read
-                (issue_path, read_at, page_count, time_spent, writer, penciller, characters, publisher)
-                VALUES (?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
+                (user_id, issue_path, read_at, page_count, time_spent, writer, penciller, characters, publisher)
+                VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
             """,
                 (
+                    uid,
                     issue_path,
                     page_count,
                     time_spent,
@@ -4793,7 +5046,7 @@ def mark_issue_read(
         return False
 
 
-def unmark_issue_read(issue_path):
+def unmark_issue_read(issue_path, user_id=None):
     """
     Remove read status from an issue.
 
@@ -4808,8 +5061,12 @@ def unmark_issue_read(issue_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("DELETE FROM issues_read WHERE issue_path = ?", (issue_path,))
+        c.execute(
+            "DELETE FROM issues_read WHERE issue_path = ? AND user_id = ?",
+            (issue_path, uid),
+        )
 
         conn.commit()
         conn.close()
@@ -4822,7 +5079,7 @@ def unmark_issue_read(issue_path):
         return False
 
 
-def hide_issue_from_history(issue_path):
+def hide_issue_from_history(issue_path, user_id=None):
     """
     Hide a read issue from timeline and wrapped views while keeping it for stats.
 
@@ -4837,8 +5094,12 @@ def hide_issue_from_history(issue_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("UPDATE issues_read SET hide = 1 WHERE issue_path = ?", (issue_path,))
+        c.execute(
+            "UPDATE issues_read SET hide = 1 WHERE issue_path = ? AND user_id = ?",
+            (issue_path, uid),
+        )
 
         conn.commit()
         conn.close()
@@ -4851,7 +5112,7 @@ def hide_issue_from_history(issue_path):
         return False
 
 
-def unhide_issue_from_history(issue_path):
+def unhide_issue_from_history(issue_path, user_id=None):
     """
     Unhide a read issue, restoring it to timeline and wrapped views.
 
@@ -4866,8 +5127,12 @@ def unhide_issue_from_history(issue_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("UPDATE issues_read SET hide = 0 WHERE issue_path = ?", (issue_path,))
+        c.execute(
+            "UPDATE issues_read SET hide = 0 WHERE issue_path = ? AND user_id = ?",
+            (issue_path, uid),
+        )
 
         conn.commit()
         conn.close()
@@ -4880,9 +5145,9 @@ def unhide_issue_from_history(issue_path):
         return False
 
 
-def get_issues_read():
+def get_issues_read(user_id=None):
     """
-    Get all read issues.
+    Get all read issues for the current (or given) user.
 
     Returns:
         List of dicts with issue_path and read_at, or empty list on error
@@ -4892,9 +5157,12 @@ def get_issues_read():
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
-            "SELECT issue_path, read_at, page_count, time_spent FROM issues_read ORDER BY read_at DESC"
+            "SELECT issue_path, read_at, page_count, time_spent FROM issues_read "
+            "WHERE user_id = ? ORDER BY read_at DESC",
+            (uid,),
         )
         rows = c.fetchall()
         conn.close()
@@ -4906,9 +5174,9 @@ def get_issues_read():
         return []
 
 
-def get_reading_totals():
+def get_reading_totals(user_id=None):
     """
-    Get total pages read and total time spent.
+    Get total pages read and total time spent for the current (or given) user.
 
     Returns:
         Dict with 'total_pages' and 'total_time' (in seconds)
@@ -4918,8 +5186,12 @@ def get_reading_totals():
         if not conn:
             return {"total_pages": 0, "total_time": 0}
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT SUM(page_count), SUM(time_spent) FROM issues_read")
+        c.execute(
+            "SELECT SUM(page_count), SUM(time_spent) FROM issues_read WHERE user_id = ?",
+            (uid,),
+        )
         row = c.fetchone()
         conn.close()
 
@@ -4933,9 +5205,9 @@ def get_reading_totals():
         return {"total_pages": 0, "total_time": 0}
 
 
-def get_reading_stats_by_year(year=None):
+def get_reading_stats_by_year(year=None, user_id=None):
     """
-    Get reading statistics, optionally filtered by year.
+    Get reading statistics for the current (or given) user, optionally by year.
 
     Args:
         year: Year to filter by (e.g., 2024), or None for all time
@@ -4948,6 +5220,7 @@ def get_reading_stats_by_year(year=None):
         if not conn:
             return {"total_read": 0, "total_pages": 0, "total_time": 0}
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
 
         if year:
@@ -4956,14 +5229,16 @@ def get_reading_stats_by_year(year=None):
                 """
                 SELECT COUNT(*), COALESCE(SUM(page_count), 0), COALESCE(SUM(time_spent), 0)
                 FROM issues_read
-                WHERE strftime('%Y', read_at) = ?
+                WHERE user_id = ? AND strftime('%Y', read_at) = ?
             """,
-                (str(year),),
+                (uid, str(year)),
             )
         else:
             # All time
             c.execute(
-                "SELECT COUNT(*), COALESCE(SUM(page_count), 0), COALESCE(SUM(time_spent), 0) FROM issues_read"
+                "SELECT COUNT(*), COALESCE(SUM(page_count), 0), COALESCE(SUM(time_spent), 0) "
+                "FROM issues_read WHERE user_id = ?",
+                (uid,),
             )
 
         row = c.fetchone()
@@ -4980,7 +5255,7 @@ def get_reading_stats_by_year(year=None):
         return {"total_read": 0, "total_pages": 0, "total_time": 0}
 
 
-def get_reading_trends(field_name, year=None, limit=10):
+def get_reading_trends(field_name, year=None, limit=10, user_id=None):
     """
     Get top values for a metadata field (writer, penciller, characters, publisher).
     Splits comma-separated values and counts each occurrence.
@@ -5004,18 +5279,20 @@ def get_reading_trends(field_name, year=None, limit=10):
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
 
         # Query all non-empty values for the field
         # field_name is validated against valid_fields above
         base = (
             "SELECT " + field_name + " FROM issues_read"
-            " WHERE " + field_name + " != '' AND " + field_name + " IS NOT NULL"
+            " WHERE user_id = ?"
+            " AND " + field_name + " != '' AND " + field_name + " IS NOT NULL"
         )
         if year:
-            c.execute(base + " AND strftime('%Y', read_at) = ?", (str(year),))
+            c.execute(base + " AND strftime('%Y', read_at) = ?", (uid, str(year)))
         else:
-            c.execute(base)
+            c.execute(base, (uid,))
 
         rows = c.fetchall()
         conn.close()
@@ -6106,9 +6383,9 @@ def series_representative_path(series, publisher=None):
         return None
 
 
-def is_issue_read(issue_path):
+def is_issue_read(issue_path, user_id=None):
     """
-    Check if an issue has been read.
+    Check if an issue has been read by the current (or given) user.
 
     Args:
         issue_path: Full path to the issue file
@@ -6121,8 +6398,12 @@ def is_issue_read(issue_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT 1 FROM issues_read WHERE issue_path = ?", (issue_path,))
+        c.execute(
+            "SELECT 1 FROM issues_read WHERE issue_path = ? AND user_id = ?",
+            (issue_path, uid),
+        )
         result = c.fetchone()
         conn.close()
 
@@ -6133,9 +6414,9 @@ def is_issue_read(issue_path):
         return False
 
 
-def get_issue_read_date(issue_path):
+def get_issue_read_date(issue_path, user_id=None):
     """
-    Get the date an issue was read.
+    Get the date an issue was read by the current (or given) user.
 
     Args:
         issue_path: Full path to the issue file
@@ -6148,8 +6429,12 @@ def get_issue_read_date(issue_path):
         if not conn:
             return None
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT read_at FROM issues_read WHERE issue_path = ?", (issue_path,))
+        c.execute(
+            "SELECT read_at FROM issues_read WHERE issue_path = ? AND user_id = ?",
+            (issue_path, uid),
+        )
         result = c.fetchone()
         conn.close()
 
@@ -6165,9 +6450,9 @@ def get_issue_read_date(issue_path):
 # =============================================================================
 
 
-def add_to_read(path, item_type="file"):
+def add_to_read(path, item_type="file", user_id=None):
     """
-    Add an item to the 'to read' list.
+    Add an item to the current (or given) user's 'to read' list.
 
     Args:
         path: Full path to the file or folder
@@ -6181,13 +6466,14 @@ def add_to_read(path, item_type="file"):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
             """
-            INSERT OR IGNORE INTO to_read (path, type)
-            VALUES (?, ?)
+            INSERT OR IGNORE INTO to_read (user_id, path, type)
+            VALUES (?, ?, ?)
         """,
-            (path, item_type),
+            (uid, path, item_type),
         )
 
         conn.commit()
@@ -6201,9 +6487,9 @@ def add_to_read(path, item_type="file"):
         return False
 
 
-def remove_to_read(path):
+def remove_to_read(path, user_id=None):
     """
-    Remove an item from the 'to read' list.
+    Remove an item from the current (or given) user's 'to read' list.
 
     Args:
         path: Full path to the file or folder
@@ -6216,8 +6502,11 @@ def remove_to_read(path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("DELETE FROM to_read WHERE path = ?", (path,))
+        c.execute(
+            "DELETE FROM to_read WHERE path = ? AND user_id = ?", (path, uid)
+        )
 
         conn.commit()
         conn.close()
@@ -6252,9 +6541,9 @@ def compute_display_name(path):
     return name
 
 
-def get_to_read_items(limit=None):
+def get_to_read_items(limit=None, user_id=None):
     """
-    Get all 'to read' items.
+    Get all 'to read' items for the current (or given) user.
 
     Args:
         limit: Optional limit on number of items returned
@@ -6267,15 +6556,19 @@ def get_to_read_items(limit=None):
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         if limit:
             c.execute(
-                "SELECT path, type, created_at FROM to_read ORDER BY created_at DESC LIMIT ?",
-                (limit,),
+                "SELECT path, type, created_at FROM to_read WHERE user_id = ? "
+                "ORDER BY created_at DESC LIMIT ?",
+                (uid, limit),
             )
         else:
             c.execute(
-                "SELECT path, type, created_at FROM to_read ORDER BY created_at DESC"
+                "SELECT path, type, created_at FROM to_read WHERE user_id = ? "
+                "ORDER BY created_at DESC",
+                (uid,),
             )
 
         results = []
@@ -6294,7 +6587,7 @@ def get_to_read_items(limit=None):
         return []
 
 
-def get_to_read_items_paginated(offset=0, limit=50):
+def get_to_read_items_paginated(offset=0, limit=50, user_id=None):
     """
     Paginated sibling of get_to_read_items — returns (rows, total).
     """
@@ -6303,17 +6596,19 @@ def get_to_read_items_paginated(offset=0, limit=50):
         if not conn:
             return [], 0
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT COUNT(*) FROM to_read")
+        c.execute("SELECT COUNT(*) FROM to_read WHERE user_id = ?", (uid,))
         total = c.fetchone()[0] or 0
 
         c.execute(
             """
             SELECT path, type, created_at FROM to_read
+            WHERE user_id = ?
             ORDER BY created_at DESC
             LIMIT ? OFFSET ?
             """,
-            (limit, offset),
+            (uid, limit, offset),
         )
         rows = []
         for row in c.fetchall():
@@ -6329,9 +6624,9 @@ def get_to_read_items_paginated(offset=0, limit=50):
         return [], 0
 
 
-def is_to_read(path):
+def is_to_read(path, user_id=None):
     """
-    Check if an item is in the 'to read' list.
+    Check if an item is in the current (or given) user's 'to read' list.
 
     Args:
         path: Full path to the file or folder
@@ -6344,8 +6639,11 @@ def is_to_read(path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("SELECT 1 FROM to_read WHERE path = ?", (path,))
+        c.execute(
+            "SELECT 1 FROM to_read WHERE path = ? AND user_id = ?", (path, uid)
+        )
         result = c.fetchone()
         conn.close()
 
@@ -6491,6 +6789,29 @@ def clear_stats_cache_keys(keys):
         return False
 
 
+def clear_stats_cache_prefix(prefix):
+    """Delete all stats_cache rows whose key starts with ``prefix``.
+
+    Used to invalidate a single user's namespaced reading caches (keys shaped
+    ``u{uid}:...``) after they mark/unmark/hide an issue.
+    """
+    if not prefix:
+        return False
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return False
+        c = conn.cursor()
+        c.execute("DELETE FROM stats_cache WHERE key LIKE ? ESCAPE '\\'",
+                  (prefix.replace("%", "\\%").replace("_", "\\_") + "%",))
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to clear stats cache prefix '{prefix}': {e}")
+        return False
+
+
 # =============================================================================
 # User Preferences (key-value store for user settings)
 # =============================================================================
@@ -6625,13 +6946,529 @@ def set_api_browse_mode(mode):
 
 
 # =============================================================================
+# Users, roles & per-user API tokens (multi-user support)
+# =============================================================================
+
+
+def _hash_token(token):
+    """Return the sha256 hex digest used to store/look up an API token.
+
+    We never persist the plaintext token; only this digest lands in the
+    api_tokens table, so a DB leak can't be replayed against the API.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_user(username, password=None, role="reader", display_name=None,
+                email=None, needs_setup=0):
+    """Insert a user and return the new user's id (or None on failure).
+
+    ``password`` is hashed with werkzeug when provided; pass None to create a
+    passwordless placeholder (e.g. the first-run owner awaiting setup).
+    """
+    from werkzeug.security import generate_password_hash
+
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        pw_hash = generate_password_hash(password) if password else None
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT INTO users (username, password_hash, role, display_name,
+                               email, needs_setup)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (username, pw_hash, role, display_name, email, 1 if needs_setup else 0),
+        )
+        conn.commit()
+        return c.lastrowid
+    except sqlite3.IntegrityError as e:
+        app_logger.warning(f"create_user('{username}') failed: {e}")
+        return None
+    except Exception as e:
+        app_logger.error(f"create_user('{username}') error: {e}")
+        return None
+    finally:
+        conn.close()
+
+
+def get_user_by_id(user_id):
+    """Return a user row as a dict, or None if not found."""
+    if user_id is None:
+        return None
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        c = conn.cursor()
+        c.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+        row = c.fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_user_by_username(username):
+    """Return a user row as a dict (case-insensitive), or None."""
+    if not username:
+        return None
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        c = conn.cursor()
+        c.execute("SELECT * FROM users WHERE username = ? COLLATE NOCASE", (username,))
+        row = c.fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def count_users():
+    """Return the total number of user accounts.
+
+    Always returns a non-negative int — 0 when the users table doesn't exist
+    yet, the DB is unavailable/corrupt, or the count can't be determined. This
+    runs on every request (via the auth gate), so it must never raise.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return 0
+    try:
+        c = conn.cursor()
+        c.execute("SELECT COUNT(*) FROM users")
+        row = c.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except Exception:
+        return 0  # table missing, DB corrupt, or unexpected shape
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def get_owner_user():
+    """Return the Store Owner account (lowest-id 'owner' role), or None.
+
+    Used as the implicit identity when login is not required — the app runs
+    as the owner so single-user installs behave exactly as before.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        c = conn.cursor()
+        c.execute(
+            "SELECT * FROM users WHERE role = 'owner' ORDER BY id LIMIT 1"
+        )
+        row = c.fetchone()
+        return dict(row) if row else None
+    except Exception:
+        return None  # table missing or DB unavailable/corrupt
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _resolve_user_id(user_id):
+    """Return the user id that owns this request's personal data.
+
+    - An explicit ``user_id`` always wins.
+    - Otherwise, inside a request, use ``g.current_user`` (set by the auth gate,
+      or by the /api/v1 token hook).
+    - Outside a request (background jobs, CLI) or before any user exists, fall
+      back to the Store Owner, then to 1. This keeps single-user installs and
+      pre-multi-user callers writing/reading the owner's data transparently.
+    """
+    if user_id is not None:
+        return user_id
+    try:
+        from flask import g, has_request_context
+
+        if has_request_context():
+            user = getattr(g, "current_user", None)
+            if user:
+                return user["id"]
+    except Exception:
+        pass
+    owner = get_owner_user()
+    return owner["id"] if owner else 1
+
+
+def current_user_id():
+    """Public: the user id owning this request's personal data (see
+    _resolve_user_id). Safe to call from models/ and background code."""
+    return _resolve_user_id(None)
+
+
+def verify_password(username, password):
+    """Return the user dict if the credentials are valid and the account is
+    active, else None. Constant-time via werkzeug's check_password_hash."""
+    from werkzeug.security import check_password_hash
+
+    user = get_user_by_username(username)
+    if not user or not user.get("is_active"):
+        return None
+    if not user.get("password_hash"):
+        return None  # placeholder/needs-setup account can't log in yet
+    if check_password_hash(user["password_hash"], password):
+        return user
+    return None
+
+
+def set_user_password(user_id, password):
+    """Hash and store a new password, clearing the needs_setup flag."""
+    from werkzeug.security import generate_password_hash
+
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        c.execute(
+            "UPDATE users SET password_hash = ?, needs_setup = 0 WHERE id = ?",
+            (generate_password_hash(password), user_id),
+        )
+        conn.commit()
+        return c.rowcount > 0
+    finally:
+        conn.close()
+
+
+def update_last_login(user_id):
+    """Stamp last_login_at = now for the given user."""
+    conn = get_db_connection()
+    if not conn:
+        return
+    try:
+        c = conn.cursor()
+        c.execute(
+            "UPDATE users SET last_login_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (user_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def create_api_token(user_id, name=None):
+    """Generate a per-user bearer token, store only its hash, and return the
+    plaintext token (shown to the user exactly once)."""
+    import secrets
+
+    token = secrets.token_urlsafe(32)
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        c = conn.cursor()
+        c.execute(
+            "INSERT INTO api_tokens (user_id, token_hash, name) VALUES (?, ?, ?)",
+            (user_id, _hash_token(token), name),
+        )
+        conn.commit()
+        return token
+    finally:
+        conn.close()
+
+
+def get_user_by_token_hash(token_hash):
+    """Resolve an API token hash to its owning (active) user dict, or None.
+
+    Also stamps last_used_at on the token for audit/last-seen.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT u.*
+            FROM api_tokens t
+            JOIN users u ON u.id = t.user_id
+            WHERE t.token_hash = ? AND u.is_active = 1
+            """,
+            (token_hash,),
+        )
+        row = c.fetchone()
+        if not row:
+            return None
+        c.execute(
+            "UPDATE api_tokens SET last_used_at = CURRENT_TIMESTAMP WHERE token_hash = ?",
+            (token_hash,),
+        )
+        conn.commit()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def has_api_tokens():
+    """True if any per-user API token exists (used to decide API-enabled)."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        c.execute("SELECT 1 FROM api_tokens LIMIT 1")
+        return c.fetchone() is not None
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        conn.close()
+
+
+def list_api_tokens(user_id):
+    """Return a user's tokens (metadata only — never the plaintext or hash)."""
+    conn = get_db_connection()
+    if not conn:
+        return []
+    try:
+        c = conn.cursor()
+        c.execute(
+            "SELECT id, name, created_at, last_used_at FROM api_tokens "
+            "WHERE user_id = ? ORDER BY created_at DESC",
+            (user_id,),
+        )
+        return [dict(r) for r in c.fetchall()]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
+def delete_api_token(token_id, user_id=None):
+    """Delete a token by id, optionally constrained to a user. Returns True if
+    a row was removed."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        if user_id is None:
+            c.execute("DELETE FROM api_tokens WHERE id = ?", (token_id,))
+        else:
+            c.execute(
+                "DELETE FROM api_tokens WHERE id = ? AND user_id = ?",
+                (token_id, user_id),
+            )
+        conn.commit()
+        return c.rowcount > 0
+    finally:
+        conn.close()
+
+
+def get_user_library_ids(user_id):
+    """Return the set of library ids a user has been granted access to."""
+    conn = get_db_connection()
+    if not conn:
+        return set()
+    try:
+        c = conn.cursor()
+        c.execute(
+            "SELECT library_id FROM library_permissions WHERE user_id = ?",
+            (user_id,),
+        )
+        return {r[0] for r in c.fetchall()}
+    finally:
+        conn.close()
+
+
+def user_has_library(user_id, library_id):
+    """True if the user has an explicit grant for this library."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        c.execute(
+            "SELECT 1 FROM library_permissions WHERE user_id = ? AND library_id = ?",
+            (user_id, library_id),
+        )
+        return c.fetchone() is not None
+    finally:
+        conn.close()
+
+
+def set_user_libraries(user_id, library_ids):
+    """Replace a user's library grants with the given iterable of library ids."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        c.execute("DELETE FROM library_permissions WHERE user_id = ?", (user_id,))
+        c.executemany(
+            "INSERT OR IGNORE INTO library_permissions (user_id, library_id) VALUES (?, ?)",
+            [(user_id, int(lib_id)) for lib_id in library_ids],
+        )
+        conn.commit()
+        return True
+    finally:
+        conn.close()
+
+
+_USER_PUBLIC_COLUMNS = (
+    "id, username, role, display_name, email, is_active, needs_setup, "
+    "created_at, last_login_at"
+)
+
+
+def list_users():
+    """Return all users as dicts (never includes password_hash)."""
+    conn = get_db_connection()
+    if not conn:
+        return []
+    try:
+        c = conn.cursor()
+        c.execute(f"SELECT {_USER_PUBLIC_COLUMNS} FROM users ORDER BY id")
+        return [dict(r) for r in c.fetchall()]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
+def count_owners():
+    """Number of active Store Owner accounts (guards last-owner removal)."""
+    conn = get_db_connection()
+    if not conn:
+        return 0
+    try:
+        c = conn.cursor()
+        c.execute("SELECT COUNT(*) FROM users WHERE role = 'owner' AND is_active = 1")
+        return c.fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        conn.close()
+
+
+def update_user(user_id, role=None, display_name=None, email=None,
+                is_active=None, username=None):
+    """Patch a user's fields. Only non-None args are applied. Returns True if a
+    row was updated (False on no-op or a username-uniqueness collision)."""
+    fields, values = [], []
+    if username is not None:
+        fields.append("username = ?")
+        values.append(username)
+    if role is not None:
+        fields.append("role = ?")
+        values.append(role)
+    if display_name is not None:
+        fields.append("display_name = ?")
+        values.append(display_name)
+    if email is not None:
+        fields.append("email = ?")
+        values.append(email)
+    if is_active is not None:
+        fields.append("is_active = ?")
+        values.append(1 if is_active else 0)
+    if not fields:
+        return False
+
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        values.append(user_id)
+        c = conn.cursor()
+        c.execute(f"UPDATE users SET {', '.join(fields)} WHERE id = ?", values)
+        conn.commit()
+        return c.rowcount > 0
+    except sqlite3.IntegrityError as e:
+        app_logger.warning(f"update_user({user_id}) failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def delete_user(user_id):
+    """Delete a user (cascades to library_permissions / api_tokens). Returns
+    True if a row was removed."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        c.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        conn.commit()
+        return c.rowcount > 0
+    finally:
+        conn.close()
+
+
+def seed_owner_if_needed():
+    """Ensure a Store Owner account exists (idempotent; runs at startup).
+
+    - If any users already exist, do nothing.
+    - Else if CLU_USERNAME/CLU_PASSWORD are set, migrate them into a hashed
+      owner account.
+    - Else create a passwordless placeholder owner (needs_setup=1) so
+      user_id=1 exists for data backfill; the first-run setup screen will set
+      real credentials.
+
+    Finally, migrate any existing global api_token into the owner's api_tokens
+    row so the current mobile client keeps working.
+    """
+    if count_users() > 0:
+        return
+
+    username = os.environ.get("CLU_USERNAME", "").strip()
+    password = os.environ.get("CLU_PASSWORD", "")
+
+    if username and password:
+        owner_id = create_user(username, password=password, role="owner")
+        app_logger.info(
+            f"Seeded Store Owner '{username}' from CLU_USERNAME/CLU_PASSWORD env vars"
+        )
+    else:
+        owner_id = create_user(
+            "owner", password=None, role="owner",
+            display_name="Store Owner", needs_setup=1,
+        )
+        app_logger.info(
+            "Seeded placeholder Store Owner (needs_setup); first-run setup will "
+            "set credentials"
+        )
+
+    if not owner_id:
+        app_logger.error("seed_owner_if_needed: failed to create owner account")
+        return
+
+    # Migrate the legacy global API token so the existing client keeps working.
+    legacy_token = get_api_token()
+    if legacy_token:
+        conn = get_db_connection()
+        if conn:
+            try:
+                c = conn.cursor()
+                c.execute(
+                    "INSERT OR IGNORE INTO api_tokens (user_id, token_hash, name) "
+                    "VALUES (?, ?, ?)",
+                    (owner_id, _hash_token(legacy_token), "Migrated global token"),
+                )
+                conn.commit()
+                app_logger.info("Migrated global API token to the Store Owner account")
+            finally:
+                conn.close()
+
+
+# =============================================================================
 # Reading Positions (bookmark reading progress in comics)
 # =============================================================================
 
 
-def save_reading_position(comic_path, page_number, total_pages=None, time_spent=0):
+def save_reading_position(comic_path, page_number, total_pages=None, time_spent=0,
+                          user_id=None):
     """
-    Save or update reading position for a comic.
+    Save or update reading position for a comic (per user).
 
     Args:
         comic_path: Full path to the comic file
@@ -6647,13 +7484,14 @@ def save_reading_position(comic_path, page_number, total_pages=None, time_spent=
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
             """
-            INSERT OR REPLACE INTO reading_positions (comic_path, page_number, total_pages, updated_at, time_spent)
-            VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)
+            INSERT OR REPLACE INTO reading_positions (user_id, comic_path, page_number, total_pages, updated_at, time_spent)
+            VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
         """,
-            (comic_path, page_number, total_pages, time_spent),
+            (uid, comic_path, page_number, total_pages, time_spent),
         )
 
         conn.commit()
@@ -6667,9 +7505,9 @@ def save_reading_position(comic_path, page_number, total_pages=None, time_spent=
         return False
 
 
-def get_reading_position(comic_path):
+def get_reading_position(comic_path, user_id=None):
     """
-    Get saved reading position for a comic.
+    Get saved reading position for a comic (per user).
 
     Args:
         comic_path: Full path to the comic file
@@ -6682,14 +7520,15 @@ def get_reading_position(comic_path):
         if not conn:
             return None
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
             """
             SELECT page_number, total_pages, updated_at, time_spent
             FROM reading_positions
-            WHERE comic_path = ?
+            WHERE comic_path = ? AND user_id = ?
         """,
-            (comic_path,),
+            (comic_path, uid),
         )
 
         row = c.fetchone()
@@ -6709,9 +7548,9 @@ def get_reading_position(comic_path):
         return None
 
 
-def delete_reading_position(comic_path):
+def delete_reading_position(comic_path, user_id=None):
     """
-    Remove saved reading position for a comic.
+    Remove saved reading position for a comic (per user).
 
     Args:
         comic_path: Full path to the comic file
@@ -6724,8 +7563,12 @@ def delete_reading_position(comic_path):
         if not conn:
             return False
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
-        c.execute("DELETE FROM reading_positions WHERE comic_path = ?", (comic_path,))
+        c.execute(
+            "DELETE FROM reading_positions WHERE comic_path = ? AND user_id = ?",
+            (comic_path, uid),
+        )
 
         conn.commit()
         conn.close()
@@ -6738,9 +7581,9 @@ def delete_reading_position(comic_path):
         return False
 
 
-def get_all_reading_positions():
+def get_all_reading_positions(user_id=None):
     """
-    Get all saved reading positions.
+    Get all saved reading positions for the current (or given) user.
 
     Returns:
         List of dicts with comic_path, page_number, total_pages, updated_at
@@ -6750,12 +7593,14 @@ def get_all_reading_positions():
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute("""
             SELECT comic_path, page_number, total_pages, updated_at
             FROM reading_positions
+            WHERE user_id = ?
             ORDER BY updated_at DESC
-        """)
+        """, (uid,))
 
         rows = c.fetchall()
         conn.close()
@@ -6767,9 +7612,10 @@ def get_all_reading_positions():
         return []
 
 
-def get_reading_positions_since(unix_ts):
+def get_reading_positions_since(unix_ts, user_id=None):
     """
-    Get reading positions whose updated_at is at or after a given unix timestamp.
+    Get reading positions whose updated_at is at or after a given unix timestamp,
+    for the current (or given) user.
 
     Args:
         unix_ts: Unix epoch seconds (int). Pass 0 to get all rows.
@@ -6783,16 +7629,18 @@ def get_reading_positions_since(unix_ts):
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
             """
             SELECT comic_path, page_number, total_pages, time_spent, updated_at,
                    CAST(strftime('%s', updated_at) AS INTEGER) AS updated_at_unix
             FROM reading_positions
-            WHERE CAST(strftime('%s', updated_at) AS INTEGER) >= ?
+            WHERE user_id = ?
+              AND CAST(strftime('%s', updated_at) AS INTEGER) >= ?
             ORDER BY updated_at ASC
             """,
-            (int(unix_ts),),
+            (uid, int(unix_ts)),
         )
 
         rows = c.fetchall()
@@ -6805,10 +7653,11 @@ def get_reading_positions_since(unix_ts):
         return []
 
 
-def get_reading_positions_since_paginated(unix_ts, offset=0, limit=50):
+def get_reading_positions_since_paginated(unix_ts, offset=0, limit=50, user_id=None):
     """
     Paginated variant of get_reading_positions_since: returns
-    (rows, total_count_across_all_pages) for the same WHERE clause.
+    (rows, total_count_across_all_pages) for the same WHERE clause, scoped to
+    the current (or given) user.
 
     Used by /api/v1/progress/since so a long-offline client can sync without
     pulling every row in one response.
@@ -6818,14 +7667,16 @@ def get_reading_positions_since_paginated(unix_ts, offset=0, limit=50):
         if not conn:
             return [], 0
         try:
+            uid = _resolve_user_id(user_id)
             c = conn.cursor()
             ts_int = int(unix_ts)
             c.execute(
                 """
                 SELECT COUNT(*) AS n FROM reading_positions
-                WHERE CAST(strftime('%s', updated_at) AS INTEGER) >= ?
+                WHERE user_id = ?
+                  AND CAST(strftime('%s', updated_at) AS INTEGER) >= ?
                 """,
-                (ts_int,),
+                (uid, ts_int),
             )
             total = c.fetchone()["n"]
 
@@ -6834,11 +7685,12 @@ def get_reading_positions_since_paginated(unix_ts, offset=0, limit=50):
                 SELECT comic_path, page_number, total_pages, time_spent, updated_at,
                        CAST(strftime('%s', updated_at) AS INTEGER) AS updated_at_unix
                 FROM reading_positions
-                WHERE CAST(strftime('%s', updated_at) AS INTEGER) >= ?
+                WHERE user_id = ?
+                  AND CAST(strftime('%s', updated_at) AS INTEGER) >= ?
                 ORDER BY updated_at ASC
                 LIMIT ? OFFSET ?
                 """,
-                (ts_int, int(limit), int(offset)),
+                (uid, ts_int, int(limit), int(offset)),
             )
             rows = [dict(r) for r in c.fetchall()]
             return rows, total
@@ -6851,9 +7703,10 @@ def get_reading_positions_since_paginated(unix_ts, offset=0, limit=50):
         return [], 0
 
 
-def get_continue_reading_items(limit=10):
+def get_continue_reading_items(limit=10, user_id=None):
     """
-    Get comics with saved reading positions that are in-progress (not completed).
+    Get comics with saved reading positions that are in-progress (not completed),
+    for the current (or given) user.
 
     Args:
         limit: Maximum number of items to return (default 10)
@@ -6867,6 +7720,7 @@ def get_continue_reading_items(limit=10):
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
         c.execute(
             """
@@ -6877,14 +7731,15 @@ def get_continue_reading_items(limit=10):
                    rp.updated_at
             FROM reading_positions rp
             LEFT JOIN file_index fi ON rp.comic_path = fi.path
-            WHERE rp.page_number > 0
+            WHERE rp.user_id = ?
+              AND rp.page_number > 0
               AND rp.total_pages IS NOT NULL
               AND rp.total_pages > 0
               AND rp.page_number < rp.total_pages - 1
             ORDER BY rp.updated_at DESC
             LIMIT ?
         """,
-            (limit,),
+            (uid, limit),
         )
 
         rows = c.fetchall()
@@ -6914,9 +7769,10 @@ def get_continue_reading_items(limit=10):
         return []
 
 
-def get_on_the_stack_items(limit=10):
+def get_on_the_stack_items(limit=10, user_id=None):
     """
-    Get the next unread issue for each subscribed series.
+    Get the next unread issue for each subscribed series, for the current
+    (or given) user's read history.
 
     For each Metron-mapped series where:
     - series_subscription is enabled (or NULL + status='Ongoing')
@@ -6930,7 +7786,9 @@ def get_on_the_stack_items(limit=10):
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
+        # user_id lives in the LEFT JOIN condition so unread issues still appear.
         c.execute("""
             SELECT
                 s.id as series_id,
@@ -6946,7 +7804,7 @@ def get_on_the_stack_items(limit=10):
             FROM series s
             JOIN collection_status cs ON s.id = cs.series_id
             JOIN issues i ON cs.issue_id = i.id
-            LEFT JOIN issues_read ir ON cs.file_path = ir.issue_path
+            LEFT JOIN issues_read ir ON cs.file_path = ir.issue_path AND ir.user_id = ?
             WHERE s.mapped_path IS NOT NULL
               AND cs.found = 1
               AND (
@@ -6954,7 +7812,7 @@ def get_on_the_stack_items(limit=10):
                 OR (s.series_subscription IS NULL AND s.status = 'Ongoing')
               )
             ORDER BY s.id, CAST(cs.issue_number AS REAL)
-        """)
+        """, (uid,))
 
         rows = c.fetchall()
         conn.close()
@@ -7191,9 +8049,9 @@ def get_pull_list_collection_counts(today):
 #########################
 
 
-def create_reading_list(name, source=None, source_hash=None):
+def create_reading_list(name, source=None, source_hash=None, user_id=None):
     """
-    Create a new reading list.
+    Create a new reading list owned by the current (or given) user.
 
     Args:
         name: Name of the reading list
@@ -7204,11 +8062,12 @@ def create_reading_list(name, source=None, source_hash=None):
         ID of the new reading list, or None on error
     """
     try:
+        uid = _resolve_user_id(user_id)
         conn = get_db_connection()
         c = conn.cursor()
         c.execute(
-            "INSERT INTO reading_lists (name, source, source_hash, last_synced) VALUES (?, ?, ?, ?)",
-            (name, source, source_hash, datetime.now() if source_hash else None),
+            "INSERT INTO reading_lists (name, source, source_hash, last_synced, user_id) VALUES (?, ?, ?, ?, ?)",
+            (name, source, source_hash, datetime.now() if source_hash else None, uid),
         )
         list_id = c.lastrowid
         conn.commit()
@@ -7264,19 +8123,21 @@ def add_reading_list_entry(list_id, data):
         return None
 
 
-def get_reading_lists():
+def get_reading_lists(user_id=None):
     """
-    Get all reading lists.
+    Get the current (or given) user's reading lists.
 
     Returns:
         List of dictionaries containing reading list info
     """
     try:
+        uid = _resolve_user_id(user_id)
         conn = get_db_connection()
         conn.row_factory = sqlite3.Row
         c = conn.cursor()
 
-        # Get lists with entry counts and read counts
+        # Get lists with entry counts and read counts. read_count is scoped to
+        # the same user so one user's progress doesn't inflate another's list.
         c.execute("""
             SELECT rl.*,
                    COUNT(DISTINCT rle.id) as entry_count,
@@ -7284,9 +8145,11 @@ def get_reading_lists():
             FROM reading_lists rl
             LEFT JOIN reading_list_entries rle ON rl.id = rle.reading_list_id
             LEFT JOIN issues_read ir ON COALESCE(rle.manual_override_path, rle.matched_file_path) = ir.issue_path
+                                    AND ir.user_id = ?
+            WHERE rl.user_id = ?
             GROUP BY rl.id
             ORDER BY rl.created_at DESC
-        """)
+        """, (uid, uid))
 
         lists = [dict(row) for row in c.fetchall()]
 
@@ -7739,9 +8602,10 @@ def get_all_reading_list_tags():
         return []
 
 
-def get_recent_read_issues(limit=None):
+def get_recent_read_issues(limit=None, user_id=None):
     """
-    Get the most recently read issues for recommendation context.
+    Get the most recently read issues for recommendation context, for the
+    current (or given) user.
 
     Args:
         limit: Maximum number of issues to return (None = no limit)
@@ -7754,6 +8618,7 @@ def get_recent_read_issues(limit=None):
         if not conn:
             return []
 
+        uid = _resolve_user_id(user_id)
         c = conn.cursor()
 
         # We need to extract series info. For now, we'll return the path and let the consumer process it,
@@ -7763,17 +8628,19 @@ def get_recent_read_issues(limit=None):
                 """
                 SELECT issue_path, read_at
                 FROM issues_read
+                WHERE user_id = ?
                 ORDER BY read_at DESC
                 LIMIT ?
             """,
-                (limit,),
+                (uid, limit),
             )
         else:
             c.execute("""
                 SELECT issue_path, read_at
                 FROM issues_read
+                WHERE user_id = ?
                 ORDER BY read_at DESC
-            """)
+            """, (uid,))
 
         rows = c.fetchall()
         conn.close()
@@ -7957,10 +8824,19 @@ def get_publisher(publisher_id):
         if not conn:
             return None
 
+        uid = _resolve_user_id(None)
         c = conn.cursor()
         c.execute(
-            "SELECT id, name, path, favorite, logo, brand_keywords, created_at FROM publishers WHERE id = ?",
-            (publisher_id,),
+            """
+            SELECT p.id, p.name, p.path,
+                   CASE WHEN ufp.publisher_id IS NOT NULL THEN 1 ELSE 0 END AS favorite,
+                   p.logo, p.brand_keywords, p.created_at
+            FROM publishers p
+            LEFT JOIN user_favorite_publishers ufp
+                   ON ufp.publisher_id = p.id AND ufp.user_id = ?
+            WHERE p.id = ?
+            """,
+            (uid, publisher_id),
         )
         row = c.fetchone()
         conn.close()
@@ -7984,12 +8860,17 @@ def get_all_publishers():
         if not conn:
             return []
 
+        uid = _resolve_user_id(None)
         c = conn.cursor()
         c.execute("""
-            SELECT id, name, path, favorite, logo, brand_keywords, created_at
-            FROM publishers
-            ORDER BY name
-        """)
+            SELECT p.id, p.name, p.path,
+                   CASE WHEN ufp.publisher_id IS NOT NULL THEN 1 ELSE 0 END AS favorite,
+                   p.logo, p.brand_keywords, p.created_at
+            FROM publishers p
+            LEFT JOIN user_favorite_publishers ufp
+                   ON ufp.publisher_id = p.id AND ufp.user_id = ?
+            ORDER BY p.name
+        """, (uid,))
         rows = c.fetchall()
         conn.close()
 

--- a/models/stats.py
+++ b/models/stats.py
@@ -1,58 +1,58 @@
 import sqlite3
 import os
 import re
-from core.database import get_db_connection, get_db_path, get_cached_stats, save_cached_stats, get_user_preference
+from core.database import get_db_connection, get_db_path, get_cached_stats, save_cached_stats, get_user_preference, current_user_id
 from core.app_logging import app_logger
 
 def get_library_stats():
     """
     Get high-level statistics about the library.
-    """
-    # Check cache first
-    cached = get_cached_stats('library_stats')
-    if cached:
-        return cached
 
+    The library-wide counts (files, size, directories) are cached globally; the
+    per-user counts (read / to-read) are computed fresh for the current user so
+    they can't leak across accounts.
+    """
+    uid = current_user_id()
+
+    stats = get_cached_stats('library_stats')  # global, file-only fields
     try:
         conn = get_db_connection()
         if not conn:
-            return None
+            return stats
 
         c = conn.cursor()
 
-        stats = {}
+        if not stats:
+            stats = {}
+            # Total files and size
+            c.execute("SELECT COUNT(*), SUM(size) FROM file_index WHERE type = 'file'")
+            row = c.fetchone()
+            stats['total_files'] = row[0] or 0
+            stats['total_size'] = row[1] or 0
 
-        # Total files and size
-        c.execute("SELECT COUNT(*), SUM(size) FROM file_index WHERE type = 'file'")
-        row = c.fetchone()
-        stats['total_files'] = row[0] or 0
-        stats['total_size'] = row[1] or 0
+            # Total directories
+            c.execute("SELECT COUNT(*) FROM file_index WHERE type = 'directory'")
+            stats['total_directories'] = c.fetchone()[0] or 0
 
-        # Total directories
-        c.execute("SELECT COUNT(*) FROM file_index WHERE type = 'directory'")
-        stats['total_directories'] = c.fetchone()[0] or 0
+            # Root folders (publishers - top-level directories under /data)
+            c.execute("SELECT COUNT(*) FROM file_index WHERE type = 'directory' AND parent = '/data'")
+            stats['root_folders'] = c.fetchone()[0] or 0
 
-        # Root folders (publishers - top-level directories under /data)
-        c.execute("SELECT COUNT(*) FROM file_index WHERE type = 'directory' AND parent = '/data'")
-        stats['root_folders'] = c.fetchone()[0] or 0
+            # Cache only the library-wide fields (no per-user data).
+            save_cached_stats('library_stats', stats)
 
-        # Total read issues
-        c.execute("SELECT COUNT(*) FROM issues_read")
+        # Per-user counts — always fresh, never cached under the shared key.
+        c.execute("SELECT COUNT(*) FROM issues_read WHERE user_id = ?", (uid,))
         stats['total_read'] = c.fetchone()[0] or 0
 
-        # Total to-read
-        c.execute("SELECT COUNT(*) FROM to_read")
+        c.execute("SELECT COUNT(*) FROM to_read WHERE user_id = ?", (uid,))
         stats['total_to_read'] = c.fetchone()[0] or 0
 
         conn.close()
-
-        # Save to cache
-        save_cached_stats('library_stats', stats)
-
         return stats
     except Exception as e:
         app_logger.error(f"Error getting library stats: {e}")
-        return None
+        return stats
 
 def get_file_type_distribution():
     """
@@ -171,8 +171,9 @@ def get_reading_history_stats():
     if not re.match(r'^[+-]\d+(\.\d+)? hours$', offset_str):
         offset_str = '+0 hours'
 
-    # Check cache first (include timezone in cache key)
-    cache_key = f'reading_history_{tz_offset}'
+    # Check cache first (include user + timezone in cache key)
+    uid = current_user_id()
+    cache_key = f'u{uid}:reading_history_{tz_offset}'
     cached = get_cached_stats(cache_key)
     if cached:
         return cached
@@ -189,9 +190,11 @@ def get_reading_history_stats():
         c.execute(  # nosec B608 - offset_str is regex-validated
             "SELECT strftime('%m-%d-%Y', datetime(read_at, '" + offset_str + "')) as date, COUNT(*) as count"
             " FROM issues_read"
+            " WHERE user_id = ?"
             " GROUP BY date"
             " ORDER BY datetime(read_at, '" + offset_str + "') DESC"
-            " LIMIT 90"
+            " LIMIT 90",
+            (uid,),
         )
 
         rows = c.fetchall()
@@ -325,7 +328,9 @@ def get_reading_heatmap_data():
     Get reading counts grouped by year and month for heatmap display.
     Returns dict: { "2024": [jan_count, feb_count, ..., dec_count], ... }
     """
-    cached = get_cached_stats('reading_heatmap')
+    uid = current_user_id()
+    cache_key = f'u{uid}:reading_heatmap'
+    cached = get_cached_stats(cache_key)
     if cached:
         return cached
 
@@ -342,9 +347,10 @@ def get_reading_heatmap_data():
                    strftime('%m', read_at) as month,
                    COUNT(*) as count
             FROM issues_read
+            WHERE user_id = ?
             GROUP BY year, month
             ORDER BY year, month
-        """)
+        """, (uid,))
 
         rows = c.fetchall()
         conn.close()
@@ -368,7 +374,7 @@ def get_reading_heatmap_data():
                 if str(y) not in heatmap:
                     heatmap[str(y)] = [0] * 12
 
-        save_cached_stats('reading_heatmap', heatmap)
+        save_cached_stats(cache_key, heatmap)
         return heatmap
 
     except Exception as e:

--- a/models/timeline.py
+++ b/models/timeline.py
@@ -1,10 +1,10 @@
 import sqlite3
 import os
-from core.database import get_db_connection, get_user_preference
+from core.database import get_db_connection, get_user_preference, current_user_id
 from core.app_logging import app_logger
 from datetime import datetime, timedelta
 
-def get_reading_timeline(limit=100, offset=0, year=None, month=None):
+def get_reading_timeline(limit=100, offset=0, year=None, month=None, user_id=None):
     """
     Get reading history with full metadata for the timeline view.
     Groups results by date. Optionally filters by year and/or month.
@@ -39,9 +39,11 @@ def get_reading_timeline(limit=100, offset=0, year=None, month=None):
 
         c = conn.cursor()
 
-        # Build WHERE clauses for optional year/month filtering
-        where_clauses = ["r.hide = 0"]
-        params = []
+        # Build WHERE clauses. user_id first so it applies to every derived query
+        # (detailed list, totals, top-publisher, series, streak).
+        uid = current_user_id() if user_id is None else user_id
+        where_clauses = ["r.user_id = ?", "r.hide = 0"]
+        params = [uid]
         if year is not None:
             where_clauses.append("strftime('%Y', r.read_at) = ?")
             params.append(str(year))

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -10,17 +10,35 @@ and the token managed here is the very thing it authenticates against.
 from flask import Blueprint, Response, jsonify, request
 
 from core.app_logging import app_logger
+from core.auth import require_role
 from core.database import (
+    count_owners,
+    create_api_token,
+    create_user,
+    delete_api_token,
+    delete_user,
+    list_api_tokens,
     get_api_browse_mode,
     get_api_token,
+    get_libraries,
+    get_owner_user,
+    get_user_by_id,
+    get_user_by_username,
+    get_user_library_ids,
+    list_users,
     rotate_api_token,
     set_api_browse_mode,
+    set_user_libraries,
+    set_user_password,
+    update_user,
 )
 from core.debug_package import build_debug_package
 from core.version import __version__
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/api/admin")
+
+VALID_ROLES = ("reader", "clerk", "owner")
 
 
 @admin_bp.route("/api-token", methods=["GET"])
@@ -62,6 +80,206 @@ def put_browse_mode():
             "error": "mode must be 'metadata' or 'filesystem'",
         }), 400
     return jsonify({"success": True, "mode": get_api_browse_mode()})
+
+
+# ---------------------------------------------------------------------------
+# User management (Store Owner only)
+# ---------------------------------------------------------------------------
+
+
+def _user_payload(user):
+    """Attach the user's granted library ids to a public user dict."""
+    user = dict(user)
+    user["library_ids"] = sorted(get_user_library_ids(user["id"]))
+    return user
+
+
+@admin_bp.route("/setup-owner", methods=["POST"])
+@require_role("owner")
+def setup_owner_route():
+    """First-run: set real credentials on the placeholder Store Owner.
+
+    Reachable in implicit-owner mode (require_role short-circuits when login
+    isn't required) so a fresh install can bootstrap its owner before any login
+    is enforced.
+    """
+    owner = get_owner_user()
+    if not owner:
+        return jsonify({"success": False, "error": "no owner account"}), 404
+    if not owner.get("needs_setup"):
+        return jsonify({"success": False, "error": "owner already configured"}), 409
+
+    body = request.get_json(silent=True) or {}
+    username = (body.get("username") or "").strip()
+    password = body.get("password") or ""
+    if not password:
+        return jsonify({"success": False, "error": "password is required"}), 400
+
+    if username and username.lower() != owner["username"].lower():
+        if not update_user(owner["id"], username=username):
+            return jsonify({
+                "success": False,
+                "error": "username unavailable",
+            }), 409
+    set_user_password(owner["id"], password)  # also clears needs_setup
+    return jsonify({"success": True, "user": _user_payload(get_user_by_id(owner["id"]))})
+
+
+@admin_bp.route("/users", methods=["GET"])
+@require_role("owner")
+def list_users_route():
+    """List all accounts (no password hashes) with their library grants."""
+    users = [_user_payload(u) for u in list_users()]
+    libraries = get_libraries()
+    return jsonify({"success": True, "users": users, "libraries": libraries})
+
+
+@admin_bp.route("/users", methods=["POST"])
+@require_role("owner")
+def create_user_route():
+    """Create a Reader/Clerk/Owner account."""
+    body = request.get_json(silent=True) or {}
+    username = (body.get("username") or "").strip()
+    password = body.get("password") or ""
+    role = (body.get("role") or "reader").lower()
+    display_name = body.get("display_name")
+    email = body.get("email")
+    library_ids = body.get("library_ids") or []
+
+    if not username:
+        return jsonify({"success": False, "error": "username is required"}), 400
+    if not password:
+        return jsonify({"success": False, "error": "password is required"}), 400
+    if role not in VALID_ROLES:
+        return jsonify({"success": False, "error": "invalid role"}), 400
+
+    user_id = create_user(username, password=password, role=role,
+                          display_name=display_name, email=email)
+    if not user_id:
+        return jsonify({
+            "success": False,
+            "error": "could not create user (username may already exist)",
+        }), 409
+
+    if library_ids:
+        set_user_libraries(user_id, library_ids)
+
+    return jsonify({"success": True, "user": _user_payload(get_user_by_id(user_id))}), 201
+
+
+@admin_bp.route("/users/<int:user_id>", methods=["PUT"])
+@require_role("owner")
+def update_user_route(user_id):
+    """Update role/status/profile/password/library grants for an account.
+
+    Guards the last active Store Owner from being demoted or deactivated.
+    """
+    target = get_user_by_id(user_id)
+    if not target:
+        return jsonify({"success": False, "error": "user not found"}), 404
+
+    body = request.get_json(silent=True) or {}
+    role = body.get("role")
+    is_active = body.get("is_active")
+    display_name = body.get("display_name")
+    email = body.get("email")
+    password = body.get("password")
+    library_ids = body.get("library_ids")
+
+    if role is not None and role.lower() not in VALID_ROLES:
+        return jsonify({"success": False, "error": "invalid role"}), 400
+
+    # Resolve a username change (only when it actually differs), guarding
+    # against collisions with another account.
+    new_username = None
+    raw_username = (body.get("username") or "").strip()
+    if raw_username and raw_username.lower() != target["username"].lower():
+        clash = get_user_by_username(raw_username)
+        if clash and clash["id"] != user_id:
+            return jsonify({
+                "success": False,
+                "error": "username already exists",
+            }), 409
+        new_username = raw_username
+
+    # Protect the last active owner from losing owner access.
+    demoting = target["role"] == "owner" and role is not None and role != "owner"
+    deactivating = target["role"] == "owner" and is_active is False
+    if (demoting or deactivating) and count_owners() <= 1:
+        return jsonify({
+            "success": False,
+            "error": "cannot remove the last Store Owner",
+        }), 400
+
+    update_user(
+        user_id,
+        username=new_username,
+        role=role.lower() if role is not None else None,
+        display_name=display_name,
+        email=email,
+        is_active=is_active,
+    )
+    if password:
+        set_user_password(user_id, password)
+    if library_ids is not None:
+        set_user_libraries(user_id, library_ids)
+
+    return jsonify({"success": True, "user": _user_payload(get_user_by_id(user_id))})
+
+
+@admin_bp.route("/users/<int:user_id>", methods=["DELETE"])
+@require_role("owner")
+def delete_user_route(user_id):
+    """Delete an account. The last active Store Owner cannot be deleted."""
+    target = get_user_by_id(user_id)
+    if not target:
+        return jsonify({"success": False, "error": "user not found"}), 404
+    if target["role"] == "owner" and count_owners() <= 1:
+        return jsonify({
+            "success": False,
+            "error": "cannot delete the last Store Owner",
+        }), 400
+
+    delete_user(user_id)
+    return jsonify({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Per-user API tokens (Store Owner only)
+# ---------------------------------------------------------------------------
+
+
+@admin_bp.route("/users/<int:user_id>/tokens", methods=["GET"])
+@require_role("owner")
+def list_user_tokens_route(user_id):
+    """List a user's API tokens (metadata only — never the plaintext/hash)."""
+    if not get_user_by_id(user_id):
+        return jsonify({"success": False, "error": "user not found"}), 404
+    return jsonify({"success": True, "tokens": list_api_tokens(user_id)})
+
+
+@admin_bp.route("/users/<int:user_id>/tokens", methods=["POST"])
+@require_role("owner")
+def create_user_token_route(user_id):
+    """Issue a new API token for a user. The plaintext token is returned exactly
+    once; only its hash is stored."""
+    if not get_user_by_id(user_id):
+        return jsonify({"success": False, "error": "user not found"}), 404
+    body = request.get_json(silent=True) or {}
+    name = (body.get("name") or "").strip() or None
+    token = create_api_token(user_id, name=name)
+    if not token:
+        return jsonify({"success": False, "error": "could not create token"}), 500
+    return jsonify({"success": True, "token": token, "name": name}), 201
+
+
+@admin_bp.route("/tokens/<int:token_id>", methods=["DELETE"])
+@require_role("owner")
+def delete_token_route(token_id):
+    """Revoke (delete) an API token by id."""
+    if not delete_api_token(token_id):
+        return jsonify({"success": False, "error": "token not found"}), 404
+    return jsonify({"success": True})
 
 
 @admin_bp.route("/debug-package", methods=["GET"])

--- a/routes/api_v1.py
+++ b/routes/api_v1.py
@@ -2,9 +2,11 @@
 v1 JSON API for the offline mobile/desktop client.
 
 All endpoints are mounted under /api/v1/ and require a long-lived bearer
-token. The token is generated server-side and stored in user_preferences
-(key='api_token'). When no token has been generated, the entire blueprint
-returns 503 so it cannot be probed.
+token. Tokens are per-user (api_tokens table, stored hashed) and resolve the
+request to that user via g.current_user, so reading progress / favorites /
+library scope are per-account. A legacy single global token (user_preferences
+key='api_token') still works and maps to the Store Owner. When no token exists
+at all, the entire blueprint returns 503 so it cannot be probed.
 
 Identity contract:
 - Browse / cover / download endpoints accept file_index.id (integer).
@@ -27,6 +29,7 @@ from core.database import (
     get_api_browse_mode,
     get_api_token,
     get_db_connection,
+    has_api_tokens,
     get_favorite_publishers_paginated,
     get_reading_position,
     get_reading_positions_since_paginated,
@@ -48,15 +51,35 @@ api_v1_bp = Blueprint("api_v1", __name__, url_prefix="/api/v1")
 # ---------------------------------------------------------------------------
 
 
+def _api_enabled(legacy_token):
+    """The token API is enabled once any per-user token OR a legacy global
+    token exists. Otherwise the whole blueprint returns 503 (probe protection)."""
+    return bool(legacy_token) or has_api_tokens()
+
+
 @api_v1_bp.before_request
 def _require_api_token():
-    token = get_api_token()
-    if not token:
+    """Authenticate the bearer token and bind the request to its user.
+
+    A per-user token (api_tokens) resolves to its owning user via
+    get_user_by_token_hash; the legacy single global token still works and maps
+    to the Store Owner. On success ``g.current_user`` is set so every downstream
+    data call (progress, favorites, browse) scopes to that user.
+    """
+    from flask import g
+    from core.database import (
+        _hash_token, get_owner_user, get_user_by_token_hash, has_api_tokens,
+    )
+
+    legacy_token = get_api_token()
+
+    if not _api_enabled(legacy_token):
         return jsonify({
             "error": "api_disabled",
             "message": (
-                "API token is not set. Generate one with: "
-                "python -m flask --app app rotate-api-token"
+                "No API tokens exist. Create one for a user in Settings → Users, "
+                "or generate a global token with: python -m flask --app app "
+                "rotate-api-token"
             ),
         }), 503
 
@@ -65,10 +88,19 @@ def _require_api_token():
         return jsonify({"error": "unauthorized"}), 401
 
     presented = auth_header[len("Bearer "):].strip()
-    if not hmac.compare_digest(presented, token):
-        return jsonify({"error": "unauthorized"}), 401
 
-    return None
+    # Per-user token → its user.
+    user = get_user_by_token_hash(_hash_token(presented))
+    if user:
+        g.current_user = user
+        return None
+
+    # Legacy global token → Store Owner (constant-time compare).
+    if legacy_token and hmac.compare_digest(presented, legacy_token):
+        g.current_user = get_owner_user()
+        return None
+
+    return jsonify({"error": "unauthorized"}), 401
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +130,28 @@ def _file_row_by_id(file_id):
         return dict(row) if row else None
     finally:
         conn.close()
+
+
+def _authorized_file_row(file_id):
+    """Fetch a file_index row by id, but only if the token's user may access
+    the library it lives in.
+
+    Owner and legacy-global-token requests (``g.current_user`` is the owner or
+    None) see everything; a per-user reader/clerk token is scoped to its granted
+    libraries. Returns None (→ 404) when forbidden, so file existence isn't
+    leaked across libraries.
+    """
+    row = _file_row_by_id(file_id)
+    if not row:
+        return None
+    from flask import g
+    from core.auth import user_can_access_path
+
+    user = getattr(g, "current_user", None)
+    if user and user.get("role") in ("reader", "clerk"):
+        if not user_can_access_path(user, row["path"]):
+            return None
+    return row
 
 
 def _paginate_args():
@@ -616,7 +670,7 @@ def list_recent():
 
 @api_v1_bp.route("/issue/<int:file_id>", methods=["GET"])
 def get_issue(file_id):
-    row = _file_row_by_id(file_id)
+    row = _authorized_file_row(file_id)
     if not row:
         return jsonify({"error": "not_found"}), 404
 
@@ -651,7 +705,7 @@ def get_issue(file_id):
 
 @api_v1_bp.route("/issue/<int:file_id>/cover", methods=["GET"])
 def get_issue_cover(file_id):
-    row = _file_row_by_id(file_id)
+    row = _authorized_file_row(file_id)
     if not row:
         return jsonify({"error": "not_found"}), 404
     file_path = row["path"]
@@ -700,7 +754,7 @@ def get_issue_cover(file_id):
 
 @api_v1_bp.route("/issue/<int:file_id>/download", methods=["GET"])
 def download_issue(file_id):
-    row = _file_row_by_id(file_id)
+    row = _authorized_file_row(file_id)
     if not row:
         return jsonify({"error": "not_found"}), 404
     return serve_comic_file(

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,18 +1,21 @@
 """
-Optional environment-variable login gate.
+Browser login gate + per-request identity resolution.
 
-When CLU_USERNAME *and* CLU_PASSWORD are both set the app requires
-browser-based authentication.  When either is absent the app behaves
-exactly as before (no login required).
+Authentication is *opt-in*: while only the implicit Store Owner exists (and no
+CLU_USERNAME/CLU_PASSWORD env gate is configured) the app requires no login and
+runs as the owner, exactly as the single-user app did. Login/RBAC activate once
+a second account exists or the env gate is set (see core.auth.is_login_required).
 
-OPDS and static routes are always exempt so comic-reader apps and
-assets continue to work without a browser session.
+Credentials are validated against the ``users`` table (werkzeug-hashed
+passwords); the legacy CLU_USERNAME/CLU_PASSWORD are migrated into a hashed
+owner account at startup, so they continue to work through this same path.
+
+OPDS, static, and /api/v1 routes are exempt from the browser gate (OPDS and the
+token API carry their own identity).
 """
-import hmac
-
 from flask import (
     Blueprint,
-    current_app,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -20,15 +23,14 @@ from flask import (
     url_for,
 )
 
+from core.auth import (
+    check_request_permitted,
+    is_login_required,
+    load_current_user,
+)
+from core.database import update_last_login, verify_password
+
 auth_bp = Blueprint("auth", __name__)
-
-
-def _auth_enabled():
-    """Return True when both CLU_USERNAME and CLU_PASSWORD are configured."""
-    return bool(
-        current_app.config.get("CLU_USERNAME")
-        and current_app.config.get("CLU_PASSWORD")
-    )
 
 
 _EXEMPT_PREFIXES = ("/login", "/logout", "/static/", "/opds", "/api/insights", "/api/v1/")
@@ -36,22 +38,34 @@ _EXEMPT_PREFIXES = ("/login", "/logout", "/static/", "/opds", "/api/insights", "
 
 @auth_bp.before_app_request
 def require_login():
-    """Redirect unauthenticated users to /login when auth is enabled."""
-    if not _auth_enabled():
-        return None
+    """Resolve the current user for every request and gate browser access.
 
+    Always populates ``g.current_user`` (to the owner in implicit-owner mode).
+    Redirects to /login only when login is required and no user is
+    authenticated.
+    """
     if any(request.path.startswith(p) for p in _EXEMPT_PREFIXES):
         return None
 
-    if session.get("authenticated"):
+    user = load_current_user()
+
+    if not is_login_required():
+        # Implicit-owner mode: no login, no RBAC — single-user behaviour.
         return None
 
-    return redirect(url_for("auth.login", next=request.path))
+    if user is None:
+        # API namespaces get a JSON 401; browser routes redirect to login.
+        if request.path.startswith(("/api/", "/opds")):
+            return jsonify({"error": "unauthorized"}), 401
+        return redirect(url_for("auth.login", next=request.path))
+
+    # Multi-user mode: enforce role-based access for the resolved user.
+    return check_request_permitted(user)
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
 def login():
-    if not _auth_enabled():
+    if not is_login_required():
         return redirect(url_for("index"))
 
     error = None
@@ -59,13 +73,11 @@ def login():
         username = request.form.get("username", "")
         password = request.form.get("password", "")
 
-        expected_user = current_app.config["CLU_USERNAME"]
-        expected_pass = current_app.config["CLU_PASSWORD"]
-
-        if hmac.compare_digest(username, expected_user) and hmac.compare_digest(
-            password, expected_pass
-        ):
-            session["authenticated"] = True
+        user = verify_password(username, password)
+        if user:
+            session["user_id"] = user["id"]
+            session["authenticated"] = True  # legacy flag, kept for compatibility
+            update_last_login(user["id"])
             next_url = request.args.get("next") or url_for("index")
             return redirect(next_url)
 

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -23,6 +23,7 @@ from PIL import Image
 from core.app_logging import app_logger
 from core.config import config
 from helpers.library import get_library_roots, get_default_library, is_valid_library_path
+from core.auth import enforce_path_access, filter_paths_for_user, current_user
 from core.database import (
     get_directory_children, get_path_counts_batch, get_recent_files,
     invalidate_browse_cache, add_file_index_entry, delete_file_index_entry,
@@ -306,6 +307,10 @@ def api_browse():
     path = request.args.get('path')
     if not path:
         path = DATA_DIR
+
+    denied = enforce_path_access(path)
+    if denied:
+        return denied
 
     try:
         app_logger.info(f"/api/browse request for path: {path}")
@@ -677,6 +682,10 @@ def api_browse_recursive():
         return jsonify({"error": "Invalid path"}), 400
     if not os.path.isdir(abs_path):
         return jsonify({"error": "Invalid path"}), 400
+
+    denied = enforce_path_access(path)
+    if denied:
+        return denied
 
     try:
         offset = max(0, int(request.args.get('offset', 0)))
@@ -1057,6 +1066,9 @@ def list_recent_files():
 
         recent_files = get_recent_files(limit=limit)
 
+        # Per-user: drop files in libraries the user hasn't been granted.
+        recent_files = filter_paths_for_user(current_user(), recent_files, key='file_path')
+
         date_range = None
         if recent_files:
             oldest_date = recent_files[-1]['added_at']
@@ -1093,6 +1105,9 @@ def search_files():
 
     try:
         results = search_file_index(query, limit=100)
+
+        # Per-user: drop hits in libraries the user hasn't been granted.
+        results = filter_paths_for_user(current_user(), results, key='path')
 
         return jsonify({
             "success": True,
@@ -1136,6 +1151,10 @@ def cbz_preview():
 
     if not file_path or not os.path.exists(file_path):
         return jsonify({"error": "Invalid file path"}), 400
+
+    denied = enforce_path_access(file_path)
+    if denied:
+        return denied
 
     if not file_path.lower().endswith(('.cbz', '.zip')):
         return jsonify({"error": "File is not a CBZ"}), 400

--- a/routes/favorites.py
+++ b/routes/favorites.py
@@ -16,9 +16,15 @@ from core.database import (
     get_issues_read, is_issue_read, get_issue_read_date,
     hide_issue_from_history,
     add_to_read, remove_to_read, get_to_read_items, is_to_read,
-    clear_stats_cache_keys
+    clear_stats_cache_keys, clear_stats_cache_prefix, current_user_id
 )
 from core.app_logging import app_logger
+
+
+def _invalidate_reading_caches():
+    """Invalidate the current user's per-user reading caches after a read-state
+    change (their namespaced reading_history / reading_heatmap entries)."""
+    clear_stats_cache_prefix(f"u{current_user_id()}:")
 
 favorites_bp = Blueprint('favorites', __name__, url_prefix='/api/favorites')
 
@@ -149,7 +155,7 @@ def mark_read():
     try:
         success = mark_issue_read(path)
         if success:
-            clear_stats_cache_keys(['library_stats', 'reading_history'])  # Only invalidate reading-related cache
+            _invalidate_reading_caches()
             return jsonify({"success": True})
         else:
             return jsonify({"success": False, "error": "Failed to mark issue as read"}), 500
@@ -170,7 +176,7 @@ def unmark_read():
     try:
         success = unmark_issue_read(path)
         if success:
-            clear_stats_cache_keys(['library_stats', 'reading_history'])  # Only invalidate reading-related cache
+            _invalidate_reading_caches()
             return jsonify({"success": True})
         else:
             return jsonify({"success": False, "error": "Failed to unmark issue as read"}), 500
@@ -191,7 +197,7 @@ def hide_from_history():
     try:
         success = hide_issue_from_history(path)
         if success:
-            clear_stats_cache_keys(['library_stats', 'reading_history'])
+            _invalidate_reading_caches()
             return jsonify({"success": True})
         else:
             return jsonify({"success": False, "error": "Failed to hide issue from history"}), 500

--- a/routes/opds.py
+++ b/routes/opds.py
@@ -16,6 +16,41 @@ from urllib.parse import quote
 opds_bp = Blueprint('opds', __name__, url_prefix='/opds')
 
 
+def _opds_unauthorized():
+    """401 with a Basic-Auth challenge OPDS readers understand."""
+    return Response(
+        "Authentication required", status=401,
+        headers={"WWW-Authenticate": 'Basic realm="CLU OPDS"'},
+    )
+
+
+@opds_bp.before_request
+def _opds_auth():
+    """Identify the OPDS client so feeds scope to their account.
+
+    In implicit-owner mode (single-user) no auth is required and the request
+    runs as the owner — unchanged behaviour. Once real accounts exist, OPDS
+    requires HTTP Basic Auth validated against the users table.
+    """
+    from flask import g
+    from core.auth import is_login_required
+    from core.database import get_owner_user, update_last_login, verify_password
+
+    if not is_login_required():
+        g.current_user = get_owner_user()
+        return None
+
+    auth = request.authorization
+    if not auth or not auth.username:
+        return _opds_unauthorized()
+    user = verify_password(auth.username, auth.password or "")
+    if not user:
+        return _opds_unauthorized()
+    g.current_user = user
+    update_last_login(user["id"])
+    return None
+
+
 def get_library_roots():
     """Get list of all enabled library root paths."""
     libraries = get_libraries(enabled_only=True)
@@ -161,10 +196,16 @@ def browse():
 
     # If no path specified, show all libraries at root level
     if not current_path:
+        from flask import g
+        from core.auth import is_login_required, accessible_library_ids
+
         entries = []
         libraries = get_libraries(enabled_only=True)
+        allowed = accessible_library_ids(g.current_user) if is_login_required() else None
 
         for lib in libraries:
+            if allowed is not None and lib['id'] not in allowed:
+                continue  # library not granted to this user
             if os.path.exists(lib['path']):
                 thumb_path = check_folder_thumbnail(lib['path'])
                 thumbnail_url = None
@@ -194,6 +235,12 @@ def browse():
 
     # Security check - ensure path is within any configured library
     if not is_valid_library_path(current_path):
+        return Response("Access denied", status=403)
+
+    # Per-user: deny paths outside the user's granted libraries.
+    from flask import g
+    from core.auth import is_login_required, user_can_access_path
+    if is_login_required() and not user_can_access_path(getattr(g, 'current_user', None), current_path):
         return Response("Access denied", status=403)
 
     if not os.path.exists(current_path):

--- a/routes/series.py
+++ b/routes/series.py
@@ -1634,12 +1634,18 @@ def api_wanted_status():
 
 @series_bp.route("/api/libraries", methods=["GET"])
 def api_get_libraries():
-    """Get all configured libraries."""
+    """Get the configured libraries the current user may access."""
     from core.database import get_libraries
+    from core.auth import accessible_library_ids, current_user, is_login_required
 
     try:
         include_disabled = request.args.get("all", "").lower() == "true"
         libraries = get_libraries(enabled_only=not include_disabled)
+        # Non-owners only see libraries they've been granted (no-op in
+        # implicit-owner mode / for owners).
+        if is_login_required():
+            allowed = accessible_library_ids(current_user())
+            libraries = [lib for lib in libraries if lib["id"] in allowed]
         return jsonify({"success": True, "libraries": libraries})
     except Exception as e:
         app_logger.error(f"Error getting libraries: {e}")

--- a/templates/header.html
+++ b/templates/header.html
@@ -187,6 +187,14 @@
                 <i class="bi bi-clock-history me-2"></i>Metadata History
               </a>
             </li>
+            {% if g.get('current_user') and g.current_user.role == 'owner' %}
+            <li>
+              <a href="/users"
+                class="dropdown-item {% if current_page == '/users' %}active{% endif %}">
+                <i class="bi bi-people me-2"></i>Users
+              </a>
+            </li>
+            {% endif %}
             {% if session.get('authenticated') %}
             <li><hr class="dropdown-divider"></li>
             <li>

--- a/templates/setup_owner.html
+++ b/templates/setup_owner.html
@@ -1,0 +1,58 @@
+{% extends 'base.html' %}
+
+{% block title %}CLU: Owner Setup{% endblock %}
+
+{% block content %}
+<div class="container py-5" style="max-width: 480px;">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h3 class="card-title mb-1"><i class="bi bi-shield-lock me-2"></i>Store Owner Setup</h3>
+      <p class="text-muted">
+        Set the credentials for your Store Owner account. You'll use these to log
+        in once you add more users.
+      </p>
+      <div id="alert-area"></div>
+      <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input type="text" class="form-control" id="s-username" value="owner" autocomplete="username">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" class="form-control" id="s-password" autocomplete="new-password">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Confirm password</label>
+        <input type="password" class="form-control" id="s-confirm" autocomplete="new-password">
+      </div>
+      <button class="btn btn-primary w-100" onclick="submitSetup()">Save &amp; Continue</button>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+function alertMsg(msg, type = "danger") {
+  document.getElementById("alert-area").innerHTML =
+    `<div class="alert alert-${type}" role="alert">${msg}</div>`;
+}
+
+async function submitSetup() {
+  const username = document.getElementById("s-username").value.trim();
+  const password = document.getElementById("s-password").value;
+  const confirm = document.getElementById("s-confirm").value;
+  if (!password) { alertMsg("Password is required."); return; }
+  if (password !== confirm) { alertMsg("Passwords do not match."); return; }
+
+  const resp = await fetch("/api/admin/setup-owner", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok || !data.success) { alertMsg(data.error || "Setup failed."); return; }
+  window.location.href = "/users";
+}
+</script>
+{% endblock %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,294 @@
+{% extends 'base.html' %}
+
+{% block title %}CLU: Users{% endblock %}
+
+{% block content %}
+<div class="container py-4" id="users-app">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0"><i class="bi bi-people me-2"></i>Users</h2>
+    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#userModal"
+            onclick="openCreate()">
+      <i class="bi bi-person-plus me-1"></i>Add User
+    </button>
+  </div>
+
+  <div id="alert-area"></div>
+
+  <div class="table-responsive">
+    <table class="table table-hover align-middle">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Display name</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>Libraries</th>
+          <th class="text-end">Actions</th>
+        </tr>
+      </thead>
+      <tbody id="users-tbody">
+        <tr><td colspan="6" class="text-center text-muted">Loading…</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p class="text-muted small">
+    Roles: <strong>Reader</strong> views comics and their own reading data ·
+    <strong>Clerk</strong> adds file management, metadata &amp; downloads ·
+    <strong>Store Owner</strong> has full administrative control.
+    Readers and Clerks only see the libraries granted to them.
+  </p>
+</div>
+
+<!-- Create / edit modal -->
+<div class="modal fade" id="userModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="userModalTitle">Add User</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" id="f-id">
+        <div class="mb-3">
+          <label class="form-label">Username</label>
+          <input type="text" class="form-control" id="f-username" autocomplete="off">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Display name <span class="text-muted">(optional)</span></label>
+          <input type="text" class="form-control" id="f-display">
+        </div>
+        <div class="mb-3">
+          <label class="form-label" id="pw-label">Password</label>
+          <input type="password" class="form-control" id="f-password" autocomplete="new-password">
+          <div class="form-text" id="pw-help"></div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Role</label>
+          <select class="form-select" id="f-role">
+            <option value="reader">Reader</option>
+            <option value="clerk">Clerk</option>
+            <option value="owner">Store Owner</option>
+          </select>
+        </div>
+        <div class="mb-3 form-check" id="active-wrap">
+          <input type="checkbox" class="form-check-input" id="f-active" checked>
+          <label class="form-check-label" for="f-active">Active</label>
+        </div>
+        <div class="mb-2">
+          <label class="form-label d-block">Library access</label>
+          <div id="lib-checks" class="border rounded p-2" style="max-height:180px;overflow:auto">
+            <span class="text-muted small">No libraries configured.</span>
+          </div>
+          <div class="form-text">Owners always have access to every library.</div>
+        </div>
+
+        <div class="mb-2" id="tokens-section" style="display:none">
+          <label class="form-label d-block">API tokens
+            <span class="text-muted small">(mobile / OPDS)</span></label>
+          <div id="tokens-list" class="border rounded p-2 small" style="max-height:150px;overflow:auto">
+            <span class="text-muted">No tokens.</span>
+          </div>
+          <div class="input-group input-group-sm mt-2">
+            <input type="text" class="form-control" id="token-name" placeholder="Token name (e.g. Phone)">
+            <button class="btn btn-outline-primary" type="button" onclick="createToken()">Create token</button>
+          </div>
+          <div id="new-token" class="alert alert-success py-2 px-2 mt-2 mb-0 small d-none">
+            <strong>Copy this token now — it won't be shown again:</strong>
+            <code id="new-token-value" class="d-block text-break"></code>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="save-btn" onclick="saveUser()">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+let LIBRARIES = [];
+
+const ROLE_LABEL = { reader: "Reader", clerk: "Clerk", owner: "Store Owner" };
+const ROLE_BADGE = { reader: "bg-secondary", clerk: "bg-info text-dark", owner: "bg-warning text-dark" };
+
+function alertMsg(msg, type = "danger") {
+  document.getElementById("alert-area").innerHTML =
+    `<div class="alert alert-${type} alert-dismissible fade show" role="alert">${msg}
+     <button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
+}
+
+function esc(s) {
+  return (s ?? "").toString().replace(/[&<>"']/g, c =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+async function loadUsers() {
+  const resp = await fetch("/api/admin/users");
+  if (!resp.ok) { alertMsg("Failed to load users."); return; }
+  const data = await resp.json();
+  LIBRARIES = data.libraries || [];
+  const rows = (data.users || []).map(u => {
+    const libs = u.role === "owner"
+      ? "<span class='text-muted small'>All</span>"
+      : (u.library_ids.length
+          ? u.library_ids.map(id => {
+              const lib = LIBRARIES.find(l => l.id === id);
+              return `<span class="badge bg-light text-dark border me-1">${esc(lib ? lib.name : id)}</span>`;
+            }).join("")
+          : "<span class='text-muted small'>None</span>");
+    const status = u.is_active
+      ? "<span class='badge bg-success'>Active</span>"
+      : "<span class='badge bg-secondary'>Disabled</span>";
+    const setup = u.needs_setup
+      ? " <span class='badge bg-danger'>Needs setup</span>" : "";
+    return `<tr>
+      <td>${esc(u.username)}${setup}</td>
+      <td>${esc(u.display_name || "")}</td>
+      <td><span class="badge ${ROLE_BADGE[u.role]}">${ROLE_LABEL[u.role]}</span></td>
+      <td>${status}</td>
+      <td>${libs}</td>
+      <td class="text-end">
+        <button class="btn btn-sm btn-outline-secondary" onclick='openEdit(${JSON.stringify(u)})'>
+          <i class="bi bi-pencil"></i></button>
+        <button class="btn btn-sm btn-outline-danger" onclick="deleteUser(${u.id}, '${esc(u.username)}')">
+          <i class="bi bi-trash"></i></button>
+      </td></tr>`;
+  }).join("");
+  document.getElementById("users-tbody").innerHTML =
+    rows || "<tr><td colspan='6' class='text-center text-muted'>No users.</td></tr>";
+}
+
+function renderLibChecks(selected = []) {
+  const box = document.getElementById("lib-checks");
+  if (!LIBRARIES.length) { box.innerHTML = "<span class='text-muted small'>No libraries configured.</span>"; return; }
+  box.innerHTML = LIBRARIES.map(l => `
+    <div class="form-check">
+      <input class="form-check-input lib-check" type="checkbox" value="${l.id}"
+             id="lib-${l.id}" ${selected.includes(l.id) ? "checked" : ""}>
+      <label class="form-check-label" for="lib-${l.id}">${esc(l.name)}</label>
+    </div>`).join("");
+}
+
+function openCreate() {
+  document.getElementById("userModalTitle").textContent = "Add User";
+  document.getElementById("f-id").value = "";
+  document.getElementById("f-username").value = "";
+  document.getElementById("f-username").disabled = false;
+  document.getElementById("f-display").value = "";
+  document.getElementById("f-password").value = "";
+  document.getElementById("pw-label").textContent = "Password";
+  document.getElementById("pw-help").textContent = "";
+  document.getElementById("f-role").value = "reader";
+  document.getElementById("f-active").checked = true;
+  document.getElementById("active-wrap").style.display = "none";
+  document.getElementById("tokens-section").style.display = "none";
+  renderLibChecks([]);
+}
+
+function openEdit(u) {
+  document.getElementById("userModalTitle").textContent = "Edit User";
+  document.getElementById("f-id").value = u.id;
+  document.getElementById("f-username").value = u.username;
+  document.getElementById("f-username").disabled = false;
+  document.getElementById("f-display").value = u.display_name || "";
+  document.getElementById("f-password").value = "";
+  document.getElementById("pw-label").textContent = "Reset password";
+  document.getElementById("pw-help").textContent = "Leave blank to keep the current password.";
+  document.getElementById("f-role").value = u.role;
+  document.getElementById("f-active").checked = !!u.is_active;
+  document.getElementById("active-wrap").style.display = "block";
+  renderLibChecks(u.library_ids || []);
+  document.getElementById("tokens-section").style.display = "block";
+  document.getElementById("new-token").classList.add("d-none");
+  document.getElementById("token-name").value = "";
+  loadTokens(u.id);
+  new bootstrap.Modal(document.getElementById("userModal")).show();
+}
+
+async function loadTokens(userId) {
+  const box = document.getElementById("tokens-list");
+  box.dataset.userId = userId;
+  const resp = await fetch(`/api/admin/users/${userId}/tokens`);
+  const data = await resp.json().catch(() => ({}));
+  const tokens = (data && data.tokens) || [];
+  if (!tokens.length) { box.innerHTML = "<span class='text-muted'>No tokens.</span>"; return; }
+  box.innerHTML = tokens.map(t => `
+    <div class="d-flex justify-content-between align-items-center py-1">
+      <span>${esc(t.name || "(unnamed)")}
+        <span class="text-muted">· ${t.last_used_at ? "last used " + esc(t.last_used_at) : "never used"}</span>
+      </span>
+      <button class="btn btn-sm btn-outline-danger py-0" onclick="revokeToken(${t.id})">Revoke</button>
+    </div>`).join("");
+}
+
+async function createToken() {
+  const userId = document.getElementById("tokens-list").dataset.userId;
+  const name = document.getElementById("token-name").value.trim();
+  const resp = await fetch(`/api/admin/users/${userId}/tokens`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok || !data.success) { alertMsg(data.error || "Failed to create token."); return; }
+  document.getElementById("new-token-value").textContent = data.token;
+  document.getElementById("new-token").classList.remove("d-none");
+  document.getElementById("token-name").value = "";
+  loadTokens(userId);
+}
+
+async function revokeToken(tokenId) {
+  if (!confirm("Revoke this token? Any client using it will lose access.")) return;
+  const resp = await fetch(`/api/admin/tokens/${tokenId}`, { method: "DELETE" });
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok || !data.success) { alertMsg(data.error || "Failed to revoke token."); return; }
+  loadTokens(document.getElementById("tokens-list").dataset.userId);
+}
+
+function selectedLibs() {
+  return Array.from(document.querySelectorAll(".lib-check:checked")).map(c => parseInt(c.value, 10));
+}
+
+async function saveUser() {
+  const id = document.getElementById("f-id").value;
+  const payload = {
+    username: document.getElementById("f-username").value.trim(),
+    display_name: document.getElementById("f-display").value.trim(),
+    role: document.getElementById("f-role").value,
+    library_ids: selectedLibs(),
+  };
+  const pw = document.getElementById("f-password").value;
+  if (pw) payload.password = pw;
+
+  let url = "/api/admin/users", method = "POST";
+  if (id) {
+    url = `/api/admin/users/${id}`; method = "PUT";
+    payload.is_active = document.getElementById("f-active").checked;
+  }
+  const resp = await fetch(url, {
+    method, headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+  });
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok || !data.success) {
+    alertMsg(data.error || "Save failed."); return;
+  }
+  bootstrap.Modal.getInstance(document.getElementById("userModal")).hide();
+  alertMsg("Saved.", "success");
+  loadUsers();
+}
+
+async function deleteUser(id, name) {
+  if (!confirm(`Delete user "${name}"? This cannot be undone.`)) return;
+  const resp = await fetch(`/api/admin/users/${id}`, { method: "DELETE" });
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok || !data.success) { alertMsg(data.error || "Delete failed."); return; }
+  alertMsg("User deleted.", "success");
+  loadUsers();
+}
+
+document.addEventListener("DOMContentLoaded", loadUsers);
+</script>
+{% endblock %}

--- a/tests/integration/test_favorites_insights_scope.py
+++ b/tests/integration/test_favorites_insights_scope.py
@@ -1,0 +1,142 @@
+"""
+PR4: per-user scoping of favorites, insights, and reading lists.
+
+Verifies two users keep independent favorite series/publishers, insights
+(library stats read counts, reading history, heatmap, timeline, wrapped), and
+reading lists.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import models.stats as stats
+import models.timeline as timeline
+import wrapped
+from core.database import (
+    add_favorite_series,
+    create_reading_list,
+    get_favorite_publishers,
+    get_favorite_series,
+    get_reading_lists,
+    is_favorite_publisher,
+    is_favorite_series,
+    mark_issue_read,
+    remove_favorite_series,
+    set_publisher_favorite,
+)
+
+get_library_stats = stats.get_library_stats
+
+A, B = 1, 2
+
+
+# ---------------------------------------------------------------------------
+# Favorite series
+# ---------------------------------------------------------------------------
+class TestFavoriteSeriesIsolation:
+    def test_independent(self, db_connection):
+        add_favorite_series("/data/DC/Batman", user_id=A)
+        assert is_favorite_series("/data/DC/Batman", user_id=A) is True
+        assert is_favorite_series("/data/DC/Batman", user_id=B) is False
+        assert [f["series_path"] for f in get_favorite_series(user_id=A)] == ["/data/DC/Batman"]
+        assert get_favorite_series(user_id=B) == []
+
+    def test_remove_scoped(self, db_connection):
+        add_favorite_series("/data/X", user_id=A)
+        add_favorite_series("/data/X", user_id=B)
+        remove_favorite_series("/data/X", user_id=A)
+        assert is_favorite_series("/data/X", user_id=A) is False
+        assert is_favorite_series("/data/X", user_id=B) is True
+
+
+# ---------------------------------------------------------------------------
+# Favorite publishers (per-user join table)
+# ---------------------------------------------------------------------------
+class TestFavoritePublisherIsolation:
+    def test_independent(self, db_connection):
+        set_publisher_favorite("/data/DC", favorite=True, user_id=A)
+        assert is_favorite_publisher("/data/DC", user_id=A) is True
+        assert is_favorite_publisher("/data/DC", user_id=B) is False
+        assert [p["publisher_path"] for p in get_favorite_publishers(user_id=A)] == ["/data/DC"]
+        assert get_favorite_publishers(user_id=B) == []
+
+    def test_unfavorite_scoped(self, db_connection):
+        set_publisher_favorite("/data/Marvel", favorite=True, user_id=A)
+        set_publisher_favorite("/data/Marvel", favorite=True, user_id=B)
+        set_publisher_favorite("/data/Marvel", favorite=False, user_id=A)
+        assert is_favorite_publisher("/data/Marvel", user_id=A) is False
+        assert is_favorite_publisher("/data/Marvel", user_id=B) is True
+
+
+# ---------------------------------------------------------------------------
+# Insights: library stats, reading history, heatmap (models/stats.py)
+# ---------------------------------------------------------------------------
+class TestInsightsIsolation:
+    def _seed(self):
+        mark_issue_read("/data/a.cbz", read_at="2024-06-01T10:00:00",
+                        page_count=20, user_id=A)
+        mark_issue_read("/data/b.cbz", read_at="2024-06-02T10:00:00",
+                        page_count=10, user_id=A)
+        mark_issue_read("/data/c.cbz", read_at="2024-07-01T10:00:00",
+                        page_count=5, user_id=B)
+
+    def test_library_stats_read_count_per_user(self, db_connection):
+        self._seed()
+        with patch.object(stats, "current_user_id", return_value=A):
+            assert get_library_stats()["total_read"] == 2
+        with patch.object(stats, "current_user_id", return_value=B):
+            assert get_library_stats()["total_read"] == 1
+
+    def test_reading_history_per_user(self, db_connection):
+        self._seed()
+        with patch.object(stats, "current_user_id", return_value=A):
+            total_a = sum(d["count"] for d in stats.get_reading_history_stats())
+        with patch.object(stats, "current_user_id", return_value=B):
+            total_b = sum(d["count"] for d in stats.get_reading_history_stats())
+        assert total_a == 2
+        assert total_b == 1
+
+    def test_heatmap_per_user(self, db_connection):
+        self._seed()
+        with patch.object(stats, "current_user_id", return_value=A):
+            hm_a = stats.get_reading_heatmap_data()
+        with patch.object(stats, "current_user_id", return_value=B):
+            hm_b = stats.get_reading_heatmap_data()
+        # A read 2 in June 2024; B read 1 in July 2024.
+        assert hm_a["2024"][5] == 2 and hm_a["2024"][6] == 0
+        assert hm_b["2024"][6] == 1 and hm_b["2024"][5] == 0
+
+
+# ---------------------------------------------------------------------------
+# Timeline + wrapped
+# ---------------------------------------------------------------------------
+class TestTimelineWrappedIsolation:
+    def _seed(self):
+        mark_issue_read("/data/a.cbz", read_at="2024-06-01T10:00:00", user_id=A)
+        mark_issue_read("/data/b.cbz", read_at="2024-06-02T10:00:00", user_id=A)
+        mark_issue_read("/data/c.cbz", read_at="2024-06-03T10:00:00", user_id=B)
+
+    def test_timeline_total_read_per_user(self, db_connection):
+        self._seed()
+        assert timeline.get_reading_timeline(user_id=A)["stats"]["total_read"] == 2
+        assert timeline.get_reading_timeline(user_id=B)["stats"]["total_read"] == 1
+
+    def test_wrapped_yearly_total_per_user(self, db_connection):
+        self._seed()
+        with patch.object(wrapped, "current_user_id", return_value=A):
+            assert wrapped.get_yearly_total_read(2024) == 2
+        with patch.object(wrapped, "current_user_id", return_value=B):
+            assert wrapped.get_yearly_total_read(2024) == 1
+
+
+# ---------------------------------------------------------------------------
+# Reading lists
+# ---------------------------------------------------------------------------
+class TestReadingListIsolation:
+    def test_lists_are_per_user(self, db_connection):
+        create_reading_list("A's List", user_id=A)
+        create_reading_list("B's List", user_id=B)
+        names_a = {rl["name"] for rl in get_reading_lists(user_id=A)}
+        names_b = {rl["name"] for rl in get_reading_lists(user_id=B)}
+        assert names_a == {"A's List"}
+        assert names_b == {"B's List"}

--- a/tests/integration/test_reading_scope.py
+++ b/tests/integration/test_reading_scope.py
@@ -1,0 +1,183 @@
+"""
+PR3: per-user scoping of reading data (issues_read, reading_positions, to_read).
+
+Verifies two users keep independent read history, progress, and to-read queues,
+that the composite (user_id, path) uniqueness prevents cross-user clobbering,
+and that the one-time table rebuild backfills existing rows to the owner.
+"""
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from core.database import (
+    add_to_read,
+    get_continue_reading_items,
+    get_issues_read,
+    get_reading_position,
+    get_reading_totals,
+    get_to_read_items,
+    init_db,
+    is_issue_read,
+    is_to_read,
+    mark_issue_read,
+    remove_to_read,
+    save_reading_position,
+    unmark_issue_read,
+)
+
+A, B = 1, 2  # two distinct user ids
+
+
+# ---------------------------------------------------------------------------
+# issues_read
+# ---------------------------------------------------------------------------
+class TestReadHistoryIsolation:
+    def test_read_status_is_per_user(self, db_connection):
+        path = "/data/x/Book 001.cbz"
+        mark_issue_read(path, page_count=20, user_id=A)
+        assert is_issue_read(path, user_id=A) is True
+        assert is_issue_read(path, user_id=B) is False
+
+        mark_issue_read(path, page_count=20, user_id=B)
+        assert is_issue_read(path, user_id=B) is True
+
+    def test_unmark_does_not_affect_other_user(self, db_connection):
+        path = "/data/x/Book 002.cbz"
+        mark_issue_read(path, user_id=A)
+        mark_issue_read(path, user_id=B)
+        unmark_issue_read(path, user_id=A)
+        assert is_issue_read(path, user_id=A) is False
+        assert is_issue_read(path, user_id=B) is True  # B's row survives
+
+    def test_get_issues_read_scoped(self, db_connection):
+        mark_issue_read("/data/a.cbz", user_id=A)
+        mark_issue_read("/data/b.cbz", user_id=B)
+        assert [i["issue_path"] for i in get_issues_read(user_id=A)] == ["/data/a.cbz"]
+        assert [i["issue_path"] for i in get_issues_read(user_id=B)] == ["/data/b.cbz"]
+
+    def test_reading_totals_scoped(self, db_connection):
+        mark_issue_read("/data/a.cbz", page_count=10, time_spent=100, user_id=A)
+        mark_issue_read("/data/b.cbz", page_count=5, time_spent=50, user_id=B)
+        assert get_reading_totals(user_id=A)["total_pages"] == 10
+        assert get_reading_totals(user_id=B)["total_pages"] == 5
+
+    def test_same_path_two_users_coexist(self, db_connection):
+        path = "/data/shared.cbz"
+        mark_issue_read(path, page_count=1, user_id=A)
+        mark_issue_read(path, page_count=2, user_id=B)
+        rows = db_connection.execute(
+            "SELECT user_id, page_count FROM issues_read WHERE issue_path = ? ORDER BY user_id",
+            (path,),
+        ).fetchall()
+        assert [(r[0], r[1]) for r in rows] == [(A, 1), (B, 2)]
+
+
+# ---------------------------------------------------------------------------
+# reading_positions
+# ---------------------------------------------------------------------------
+class TestReadingPositionIsolation:
+    def test_positions_are_per_user(self, db_connection):
+        path = "/data/c.cbz"
+        save_reading_position(path, 5, 20, user_id=A)
+        save_reading_position(path, 15, 20, user_id=B)
+        assert get_reading_position(path, user_id=A)["page_number"] == 5
+        assert get_reading_position(path, user_id=B)["page_number"] == 15
+
+    def test_continue_reading_scoped(self, db_connection):
+        save_reading_position("/data/c.cbz", 5, 20, user_id=A)
+        assert len(get_continue_reading_items(user_id=A)) == 1
+        assert len(get_continue_reading_items(user_id=B)) == 0
+
+
+# ---------------------------------------------------------------------------
+# to_read
+# ---------------------------------------------------------------------------
+class TestToReadIsolation:
+    def test_to_read_is_per_user(self, db_connection):
+        path = "/data/d.cbz"
+        add_to_read(path, user_id=A)
+        assert is_to_read(path, user_id=A) is True
+        assert is_to_read(path, user_id=B) is False
+        assert len(get_to_read_items(user_id=A)) == 1
+        assert len(get_to_read_items(user_id=B)) == 0
+
+    def test_remove_scoped(self, db_connection):
+        path = "/data/e.cbz"
+        add_to_read(path, user_id=A)
+        add_to_read(path, user_id=B)
+        remove_to_read(path, user_id=A)
+        assert is_to_read(path, user_id=A) is False
+        assert is_to_read(path, user_id=B) is True
+
+
+# ---------------------------------------------------------------------------
+# One-time migration / backfill from a pre-multi-user schema
+# ---------------------------------------------------------------------------
+class TestMigrationBackfill:
+    def _build_legacy_db(self, db_path):
+        """Create a pre-migration issues_read/reading_positions/to_read schema
+        (path-keyed, no user_id) with a couple of rows."""
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE issues_read (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "issue_path TEXT NOT NULL UNIQUE, read_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "page_count INTEGER DEFAULT 0, time_spent INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO issues_read (issue_path, page_count) VALUES ('/old/read.cbz', 12)"
+        )
+        conn.execute(
+            "CREATE TABLE reading_positions (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "comic_path TEXT NOT NULL UNIQUE, page_number INTEGER NOT NULL, "
+            "total_pages INTEGER, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+        )
+        conn.execute(
+            "INSERT INTO reading_positions (comic_path, page_number, total_pages) "
+            "VALUES ('/old/pos.cbz', 3, 22)"
+        )
+        conn.execute(
+            "CREATE TABLE to_read (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "path TEXT NOT NULL UNIQUE, type TEXT NOT NULL, "
+            "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+        )
+        conn.execute("INSERT INTO to_read (path, type) VALUES ('/old/want.cbz', 'file')")
+        conn.commit()
+        conn.close()
+
+    def test_backfill_assigns_existing_rows_to_owner(self, db_path):
+        self._build_legacy_db(db_path)
+        with patch("core.database.get_db_path", return_value=db_path):
+            assert init_db() is True
+
+            conn = sqlite3.connect(db_path)
+            try:
+                # user_id column now exists on all three tables.
+                for table, path_col, path_val in [
+                    ("issues_read", "issue_path", "/old/read.cbz"),
+                    ("reading_positions", "comic_path", "/old/pos.cbz"),
+                    ("to_read", "path", "/old/want.cbz"),
+                ]:
+                    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+                    assert "user_id" in cols, f"{table} missing user_id"
+                    row = conn.execute(
+                        f"SELECT user_id FROM {table} WHERE {path_col} = ?", (path_val,)
+                    ).fetchone()
+                    assert row is not None and row[0] == 1, f"{table} not backfilled to owner"
+            finally:
+                conn.close()
+
+    def test_migration_is_idempotent(self, db_path):
+        self._build_legacy_db(db_path)
+        with patch("core.database.get_db_path", return_value=db_path):
+            assert init_db() is True
+            assert init_db() is True  # second run must not error or duplicate
+
+            conn = sqlite3.connect(db_path)
+            try:
+                n = conn.execute(
+                    "SELECT COUNT(*) FROM issues_read WHERE issue_path = '/old/read.cbz'"
+                ).fetchone()[0]
+                assert n == 1
+            finally:
+                conn.close()

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -1,0 +1,226 @@
+"""
+Integration tests for the multi-user data layer (PR1):
+user CRUD, password hashing, roles, per-user API tokens, library grants,
+and the owner-seeding / backfill startup routine.
+"""
+import pytest
+
+from core.auth import ROLE_LEVELS, role_at_least
+from core.database import (
+    _hash_token,
+    count_users,
+    create_api_token,
+    create_user,
+    get_api_token,
+    get_owner_user,
+    get_user_by_id,
+    get_user_by_token_hash,
+    get_user_by_username,
+    get_user_library_ids,
+    seed_owner_if_needed,
+    set_user_libraries,
+    set_user_password,
+    user_has_library,
+    verify_password,
+)
+from tests.factories.db_factories import create_library
+
+
+# ---------------------------------------------------------------------------
+# User CRUD & password hashing
+# ---------------------------------------------------------------------------
+class TestUserCrud:
+    def test_create_and_fetch_user(self, db_connection):
+        uid = create_user("alice", password="pw", role="clerk",
+                          display_name="Alice", email="a@x.com")
+        assert uid
+        user = get_user_by_id(uid)
+        assert user["username"] == "alice"
+        assert user["role"] == "clerk"
+        assert user["display_name"] == "Alice"
+        # Password must be hashed, never stored plaintext.
+        assert user["password_hash"] and user["password_hash"] != "pw"
+
+    def test_username_is_unique_case_insensitive(self, db_connection):
+        assert create_user("Bob", password="pw")
+        assert create_user("bob", password="pw2") is None  # UNIQUE COLLATE NOCASE
+
+    def test_get_user_by_username_case_insensitive(self, db_connection):
+        create_user("Carol", password="pw")
+        assert get_user_by_username("carol")["username"] == "Carol"
+
+    def test_invalid_role_rejected(self, db_connection):
+        assert create_user("dave", password="pw", role="superadmin") is None
+
+    def test_count_users(self, db_connection):
+        assert count_users() == 0
+        create_user("u1", password="pw")
+        create_user("u2", password="pw")
+        assert count_users() == 2
+
+
+# ---------------------------------------------------------------------------
+# Password verification
+# ---------------------------------------------------------------------------
+class TestPasswordVerification:
+    def test_correct_password(self, db_connection):
+        create_user("eve", password="s3cret", role="reader")
+        user = verify_password("eve", "s3cret")
+        assert user and user["username"] == "eve"
+
+    def test_wrong_password(self, db_connection):
+        create_user("frank", password="s3cret")
+        assert verify_password("frank", "nope") is None
+
+    def test_unknown_user(self, db_connection):
+        assert verify_password("ghost", "whatever") is None
+
+    def test_inactive_user_cannot_authenticate(self, db_connection):
+        uid = create_user("grace", password="pw")
+        conn = db_connection
+        conn.execute("UPDATE users SET is_active = 0 WHERE id = ?", (uid,))
+        conn.commit()
+        assert verify_password("grace", "pw") is None
+
+    def test_placeholder_without_password_cannot_authenticate(self, db_connection):
+        create_user("owner", password=None, role="owner", needs_setup=1)
+        assert verify_password("owner", "") is None
+
+    def test_set_user_password_enables_login_and_clears_needs_setup(self, db_connection):
+        uid = create_user("owner", password=None, role="owner", needs_setup=1)
+        assert set_user_password(uid, "newpw")
+        assert verify_password("owner", "newpw")
+        assert get_user_by_id(uid)["needs_setup"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Role hierarchy
+# ---------------------------------------------------------------------------
+class TestRoleHierarchy:
+    def test_levels_ordered(self):
+        assert ROLE_LEVELS["reader"] < ROLE_LEVELS["clerk"] < ROLE_LEVELS["owner"]
+
+    @pytest.mark.parametrize("role,minimum,expected", [
+        ("owner", "reader", True),
+        ("owner", "clerk", True),
+        ("owner", "owner", True),
+        ("clerk", "reader", True),
+        ("clerk", "clerk", True),
+        ("clerk", "owner", False),
+        ("reader", "reader", True),
+        ("reader", "clerk", False),
+    ])
+    def test_role_at_least(self, role, minimum, expected):
+        assert role_at_least({"role": role}, minimum) is expected
+
+    def test_none_user_never_satisfies(self):
+        assert role_at_least(None, "reader") is False
+
+
+# ---------------------------------------------------------------------------
+# Per-user API tokens
+# ---------------------------------------------------------------------------
+class TestApiTokens:
+    def test_create_token_resolves_to_user(self, db_connection):
+        uid = create_user("holly", password="pw", role="reader")
+        token = create_api_token(uid, name="phone")
+        assert token
+        user = get_user_by_token_hash(_hash_token(token))
+        assert user and user["id"] == uid
+
+    def test_token_stored_hashed_not_plaintext(self, db_connection):
+        uid = create_user("ivan", password="pw")
+        token = create_api_token(uid)
+        row = db_connection.execute(
+            "SELECT token_hash FROM api_tokens WHERE user_id = ?", (uid,)
+        ).fetchone()
+        assert row["token_hash"] == _hash_token(token)
+        assert row["token_hash"] != token
+
+    def test_unknown_token_returns_none(self, db_connection):
+        assert get_user_by_token_hash(_hash_token("bogus")) is None
+
+    def test_token_for_inactive_user_rejected(self, db_connection):
+        uid = create_user("jane", password="pw")
+        token = create_api_token(uid)
+        db_connection.execute("UPDATE users SET is_active = 0 WHERE id = ?", (uid,))
+        db_connection.commit()
+        assert get_user_by_token_hash(_hash_token(token)) is None
+
+
+# ---------------------------------------------------------------------------
+# Library grants
+# ---------------------------------------------------------------------------
+class TestLibraryGrants:
+    def test_grant_and_check(self, db_connection):
+        uid = create_user("ken", password="pw", role="reader")
+        lib_a = create_library(name="A", path="/data/a")
+        lib_b = create_library(name="B", path="/data/b")
+
+        set_user_libraries(uid, [lib_a])
+        assert user_has_library(uid, lib_a) is True
+        assert user_has_library(uid, lib_b) is False
+        assert get_user_library_ids(uid) == {lib_a}
+
+    def test_set_libraries_replaces_prior_grants(self, db_connection):
+        uid = create_user("leo", password="pw")
+        lib_a = create_library(name="A", path="/data/a")
+        lib_b = create_library(name="B", path="/data/b")
+        set_user_libraries(uid, [lib_a])
+        set_user_libraries(uid, [lib_b])
+        assert get_user_library_ids(uid) == {lib_b}
+
+    def test_new_user_has_no_libraries_by_default(self, db_connection):
+        uid = create_user("mia", password="pw")
+        assert get_user_library_ids(uid) == set()
+
+
+# ---------------------------------------------------------------------------
+# Owner seeding / backfill
+# ---------------------------------------------------------------------------
+class TestSeedOwner:
+    def test_seed_creates_placeholder_owner_without_env(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()
+        owner = get_owner_user()
+        assert owner and owner["role"] == "owner"
+        assert owner["needs_setup"] == 1
+        assert owner["password_hash"] is None
+
+    def test_seed_from_env_creates_hashed_owner(self, db_connection, monkeypatch):
+        monkeypatch.setenv("CLU_USERNAME", "boss")
+        monkeypatch.setenv("CLU_PASSWORD", "hunter2")
+        seed_owner_if_needed()
+        owner = get_owner_user()
+        assert owner["username"] == "boss"
+        assert owner["needs_setup"] == 0
+        assert verify_password("boss", "hunter2")
+
+    def test_seed_is_idempotent(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()
+        seed_owner_if_needed()
+        assert count_users() == 1
+
+    def test_seed_skips_when_users_exist(self, db_connection, monkeypatch):
+        create_user("existing", password="pw", role="reader")
+        monkeypatch.setenv("CLU_USERNAME", "boss")
+        monkeypatch.setenv("CLU_PASSWORD", "hunter2")
+        seed_owner_if_needed()
+        assert count_users() == 1
+        assert get_owner_user() is None  # no owner was seeded
+
+    def test_legacy_global_token_migrated_to_owner(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        from core.database import set_user_preference
+        set_user_preference("api_token", "legacy-token-123", category="security")
+        assert get_api_token() == "legacy-token-123"
+
+        seed_owner_if_needed()
+        owner = get_owner_user()
+        # The old global token now resolves to the owner via api_tokens.
+        user = get_user_by_token_hash(_hash_token("legacy-token-123"))
+        assert user and user["id"] == owner["id"]

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -1,11 +1,18 @@
 """
 Routes: /login, /logout and the before_app_request auth gate.
+
+Auth is now opt-in and DB-user based (see routes/auth.py + core/auth.py):
+- Implicit-owner mode: no accounts + no env gate → no login required.
+- Login required once >1 account exists (or the CLU_USERNAME/CLU_PASSWORD env
+  gate is set), validated against the users table.
 """
 import pytest
 
+from core.database import create_user, seed_owner_if_needed
 
-class TestAuthDisabled:
-    """When CLU_USERNAME / CLU_PASSWORD are not set, auth is off."""
+
+class TestImplicitOwnerMode:
+    """With no real accounts and no env gate, the app requires no login."""
 
     def test_pages_accessible_without_login(self, client):
         r = client.get("/")
@@ -17,16 +24,16 @@ class TestAuthDisabled:
         assert r.headers["Location"].endswith("/")
 
 
-class TestAuthEnabled:
-    """When CLU_USERNAME and CLU_PASSWORD are set, auth is required."""
+class TestLoginRequiredMultiUser:
+    """More than one account exists → browser login is enforced."""
 
     @pytest.fixture(autouse=True)
-    def _enable_auth(self, app):
-        app.config["CLU_USERNAME"] = "admin"
-        app.config["CLU_PASSWORD"] = "secret"
+    def _two_users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
         yield
-        app.config["CLU_USERNAME"] = ""
-        app.config["CLU_PASSWORD"] = ""
 
     def test_unauthenticated_redirects_to_login(self, client):
         r = client.get("/")
@@ -36,63 +43,74 @@ class TestAuthEnabled:
     def test_login_page_renders(self, client):
         r = client.get("/login")
         assert r.status_code == 200
-        body = r.get_data(as_text=True)
-        assert "Sign In" in body
+        assert "Sign In" in r.get_data(as_text=True)
 
     def test_correct_credentials_authenticate(self, client):
         r = client.post(
             "/login",
-            data={"username": "admin", "password": "secret"},
+            data={"username": "reader", "password": "readerpass"},
             follow_redirects=False,
         )
         assert r.status_code == 302
-        # After login, index should be accessible
-        r2 = client.get("/")
-        assert r2.status_code == 200
+        assert client.get("/").status_code == 200
 
     def test_wrong_credentials_show_error(self, client):
-        r = client.post(
-            "/login",
-            data={"username": "admin", "password": "wrong"},
-        )
+        r = client.post("/login", data={"username": "reader", "password": "wrong"})
         assert r.status_code == 200
-        body = r.get_data(as_text=True)
-        assert "Invalid" in body
+        assert "Invalid" in r.get_data(as_text=True)
 
     def test_next_param_redirect(self, client):
         r = client.post(
             "/login?next=/config",
-            data={"username": "admin", "password": "secret"},
+            data={"username": "owner", "password": "ownerpass"},
             follow_redirects=False,
         )
         assert r.status_code == 302
         assert r.headers["Location"].endswith("/config")
 
     def test_logout_clears_session(self, client):
-        # Login first
-        client.post(
-            "/login",
-            data={"username": "admin", "password": "secret"},
-        )
-        # Verify authenticated
-        r = client.get("/")
-        assert r.status_code == 200
+        client.post("/login", data={"username": "owner", "password": "ownerpass"})
+        assert client.get("/").status_code == 200
 
-        # Logout
         r = client.get("/logout")
         assert r.status_code == 302
         assert "/login" in r.headers["Location"]
 
-        # Should be redirected again
+        # Session cleared → gated again.
         r = client.get("/")
         assert r.status_code == 302
         assert "/login" in r.headers["Location"]
 
     def test_opds_exempt_from_auth(self, client):
         r = client.get("/opds")
-        # OPDS may return 200 or its own status, but NOT a redirect to /login
         assert "/login" not in r.headers.get("Location", "")
 
     def test_static_exempt_from_auth(self, client):
         r = client.get("/static/images/clu.png")
         assert r.status_code != 302 or "/login" not in r.headers.get("Location", "")
+
+
+class TestEnvGateBackwardCompat:
+    """The legacy CLU_USERNAME/CLU_PASSWORD env gate still forces login, now
+    routed through a seeded owner account."""
+
+    @pytest.fixture(autouse=True)
+    def _env_gate(self, db_connection, monkeypatch):
+        monkeypatch.setenv("CLU_USERNAME", "admin")
+        monkeypatch.setenv("CLU_PASSWORD", "secret")
+        seed_owner_if_needed()  # migrate env creds into a hashed owner account
+        yield
+
+    def test_unauthenticated_redirects_to_login(self, client):
+        r = client.get("/")
+        assert r.status_code == 302
+        assert "/login" in r.headers["Location"]
+
+    def test_env_credentials_authenticate(self, client):
+        r = client.post(
+            "/login",
+            data={"username": "admin", "password": "secret"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        assert client.get("/").status_code == 200

--- a/tests/routes/test_favorites_routes.py
+++ b/tests/routes/test_favorites_routes.py
@@ -94,7 +94,7 @@ class TestIssuesReadEndpoints:
         resp = client.get("/api/favorites/issues/check")
         assert resp.status_code == 400
 
-    @patch("routes.favorites.clear_stats_cache_keys")
+    @patch("routes.favorites._invalidate_reading_caches")
     @patch("routes.favorites.mark_issue_read", return_value=True)
     def test_mark_read(self, mock_mark, mock_cache, client):
         resp = client.post("/api/favorites/issues",
@@ -107,7 +107,7 @@ class TestIssuesReadEndpoints:
         resp = client.post("/api/favorites/issues", json={})
         assert resp.status_code == 400
 
-    @patch("routes.favorites.clear_stats_cache_keys")
+    @patch("routes.favorites._invalidate_reading_caches")
     @patch("routes.favorites.unmark_issue_read", return_value=True)
     def test_unmark_read(self, mock_unmark, mock_cache, client):
         resp = client.delete("/api/favorites/issues",
@@ -118,7 +118,7 @@ class TestIssuesReadEndpoints:
 
 class TestHideFromHistoryEndpoint:
 
-    @patch("routes.favorites.clear_stats_cache_keys")
+    @patch("routes.favorites._invalidate_reading_caches")
     @patch("routes.favorites.hide_issue_from_history", return_value=True)
     def test_hide_success(self, mock_hide, mock_cache, client):
         resp = client.post("/api/favorites/issues/hide",

--- a/tests/routes/test_library_access.py
+++ b/tests/routes/test_library_access.py
@@ -1,0 +1,118 @@
+"""
+PR5: library-level access enforcement.
+
+A Reader granted only Library A cannot see or open files in Library B — via
+browse, file-serve, thumbnails, search, or the library list. Owners bypass all
+library scoping, and implicit-owner mode (single-user) enforces nothing.
+"""
+import pytest
+
+from core.database import create_user, get_user_by_username, set_user_libraries
+from tests.factories.db_factories import create_library
+
+
+def _login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+A_FILE = "/data/LibA/Batman_001.cbz"
+B_FILE = "/data/LibB/Spider-Man_001.cbz"
+
+
+class TestLibraryAccessMultiUser:
+    @pytest.fixture(autouse=True)
+    def _setup(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        self.lib_a = create_library(name="Library A", path="/data/LibA")
+        self.lib_b = create_library(name="Library B", path="/data/LibB")
+        # Reader is granted only Library A.
+        set_user_libraries(get_user_by_username("reader")["id"], [self.lib_a])
+        yield
+
+    # --- Browse -----------------------------------------------------------
+    def test_reader_can_browse_granted_library(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get("/api/browse?path=/data/LibA").status_code != 403
+
+    def test_reader_denied_browse_ungranted_library(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get("/api/browse?path=/data/LibB").status_code == 403
+
+    def test_owner_can_browse_any_library(self, client):
+        _login(client, "owner", "ownerpass")
+        assert client.get("/api/browse?path=/data/LibB").status_code != 403
+
+    # --- File-access gate (the helper behind the reader/thumbnail/download
+    #     routes; those app.py routes are stubbed in the blueprint test app,
+    #     so we assert the shared gate directly). --------------------------
+    def test_path_gate_grants_and_denies(self):
+        from core.auth import user_can_access_path
+
+        reader = get_user_by_username("reader")
+        owner = get_user_by_username("owner")
+        assert user_can_access_path(reader, A_FILE) is True    # granted library
+        assert user_can_access_path(reader, B_FILE) is False   # ungranted library
+        assert user_can_access_path(owner, B_FILE) is True     # owner bypass
+        assert user_can_access_path(reader, "/tmp/outside.cbz") is False
+
+    def test_accessible_ids_scoped(self):
+        from core.auth import accessible_library_ids
+
+        reader = get_user_by_username("reader")
+        owner = get_user_by_username("owner")
+        assert accessible_library_ids(reader) == {self.lib_a}
+        assert accessible_library_ids(owner) == {self.lib_a, self.lib_b}
+
+    # --- Search (blueprint route — end to end) ---------------------------
+    def test_search_filtered_for_reader(self, client, db_connection):
+        from tests.factories.db_factories import create_file_index_entry
+        create_file_index_entry(name="Batman_001.cbz", path=A_FILE, parent="/data/LibA")
+        create_file_index_entry(name="Batman_002.cbz",
+                                path="/data/LibB/Batman_002.cbz", parent="/data/LibB")
+        _login(client, "reader", "readerpass")
+        results = client.get("/search-files?query=Batman").get_json()["results"]
+        paths = {r["path"] for r in results}
+        assert A_FILE in paths
+        assert "/data/LibB/Batman_002.cbz" not in paths
+
+    # --- Listings ---------------------------------------------------------
+    def test_library_list_filtered_for_reader(self, client):
+        _login(client, "reader", "readerpass")
+        libs = client.get("/api/libraries").get_json()["libraries"]
+        names = {lib["name"] for lib in libs}
+        assert names == {"Library A"}
+
+    def test_library_list_full_for_owner(self, client):
+        _login(client, "owner", "ownerpass")
+        libs = client.get("/api/libraries").get_json()["libraries"]
+        names = {lib["name"] for lib in libs}
+        assert names == {"Library A", "Library B"}
+
+
+class TestLibraryAccessImplicitOwner:
+    """With no real accounts, enforcement is a no-op (single-user install)."""
+
+    @pytest.fixture(autouse=True)
+    def _libs(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_library(name="Library A", path="/data/LibA")
+        create_library(name="Library B", path="/data/LibB")
+        yield
+
+    def test_browse_any_library_allowed(self, client):
+        assert client.get("/api/browse?path=/data/LibB").status_code != 403
+
+    def test_filter_is_noop_in_implicit_mode(self):
+        # No login required → no filtering, even for a non-owner-shaped user.
+        from core.auth import filter_paths_for_user
+
+        items = [{"path": A_FILE}, {"path": B_FILE}]
+        assert filter_paths_for_user(None, items, key="path") == items
+
+    def test_library_list_unfiltered(self, client):
+        libs = client.get("/api/libraries").get_json()["libraries"]
+        assert len(libs) == 2

--- a/tests/routes/test_multiuser_api_opds.py
+++ b/tests/routes/test_multiuser_api_opds.py
@@ -1,0 +1,128 @@
+"""
+PR6: per-user API tokens (/api/v1) and OPDS Basic-Auth identity.
+"""
+import base64
+
+import pytest
+
+from core.database import (
+    add_to_read,
+    create_api_token,
+    create_user,
+    get_user_by_username,
+    set_user_libraries,
+)
+from tests.factories.db_factories import create_library
+
+
+def _bearer(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _basic(username, password):
+    creds = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {creds}"}
+
+
+# ---------------------------------------------------------------------------
+# /api/v1 per-user tokens
+# ---------------------------------------------------------------------------
+class TestApiV1PerUserTokens:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("alice", password="pw", role="reader")
+        create_user("bob", password="pw", role="reader")
+        self.alice = get_user_by_username("alice")["id"]
+        self.bob = get_user_by_username("bob")["id"]
+        self.token_a = create_api_token(self.alice, name="phone")
+        self.token_b = create_api_token(self.bob, name="tablet")
+        yield
+
+    def test_unknown_token_401(self, client):
+        r = client.get("/api/v1/auth/ping", headers=_bearer("nope"))
+        assert r.status_code == 401
+
+    def test_valid_token_200(self, client):
+        r = client.get("/api/v1/auth/ping", headers=_bearer(self.token_a))
+        assert r.status_code == 200
+
+    def test_progress_is_per_token_user(self, client):
+        client.put("/api/v1/progress", json={"path": "/data/x.cbz", "page_number": 5,
+                                             "total_pages": 20}, headers=_bearer(self.token_a))
+        client.put("/api/v1/progress", json={"path": "/data/x.cbz", "page_number": 15,
+                                             "total_pages": 20}, headers=_bearer(self.token_b))
+
+        ra = client.get("/api/v1/progress?path=/data/x.cbz", headers=_bearer(self.token_a))
+        rb = client.get("/api/v1/progress?path=/data/x.cbz", headers=_bearer(self.token_b))
+        assert ra.get_json()["page_number"] == 5
+        assert rb.get_json()["page_number"] == 15
+
+    def test_token_library_scope(self, client, db_connection):
+        from tests.factories.db_factories import create_file_index_entry
+
+        lib_a = create_library(name="A", path="/data/LibA")
+        create_library(name="B", path="/data/LibB")
+        set_user_libraries(self.alice, [lib_a])  # alice: only Library A
+
+        create_file_index_entry(name="b.cbz", path="/data/LibB/b.cbz", parent="/data/LibB")
+        fid = db_connection.execute(
+            "SELECT id FROM file_index WHERE path = ?", ("/data/LibB/b.cbz",)
+        ).fetchone()[0]
+
+        # Alice (granted only A) can't see a file in B → 404.
+        r = client.get(f"/api/v1/issue/{fid}", headers=_bearer(self.token_a))
+        assert r.status_code == 404
+
+
+class TestApiV1Disabled:
+    def test_503_when_no_tokens(self, db_connection, client):
+        # No users, no tokens, no legacy global token → API disabled.
+        r = client.get("/api/v1/auth/ping")
+        assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# OPDS identity
+# ---------------------------------------------------------------------------
+class TestOpdsImplicitOwner:
+    def test_no_auth_required(self, db_connection, client, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        assert client.get("/opds/").status_code == 200
+
+
+class TestOpdsMultiUser:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        yield
+
+    def test_requires_auth(self, client):
+        r = client.get("/opds/")
+        assert r.status_code == 401
+        assert "Basic" in r.headers.get("WWW-Authenticate", "")
+
+    def test_wrong_credentials(self, client):
+        assert client.get("/opds/", headers=_basic("reader", "nope")).status_code == 401
+
+    def test_valid_credentials(self, client):
+        assert client.get("/opds/", headers=_basic("reader", "readerpass")).status_code == 200
+
+    def test_to_read_is_per_user(self, client):
+        reader_id = get_user_by_username("reader")["id"]
+        owner_id = get_user_by_username("owner")["id"]
+        add_to_read("/data/reader-book.cbz", user_id=reader_id)
+        add_to_read("/data/owner-book.cbz", user_id=owner_id)
+
+        reader_feed = client.get("/opds/to-read",
+                                 headers=_basic("reader", "readerpass")).get_data(as_text=True)
+        owner_feed = client.get("/opds/to-read",
+                                headers=_basic("owner", "ownerpass")).get_data(as_text=True)
+        assert "reader-book.cbz" in reader_feed
+        assert "reader-book.cbz" not in owner_feed
+        assert "owner-book.cbz" in owner_feed

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -1,0 +1,276 @@
+"""
+PR2: RBAC enforcement + admin user management.
+
+Covers the centralized route policy (required_role_for_request), the per-role
+403 matrix through the real before_app_request gate, the /api/admin/users CRUD
+surface, and first-run owner setup.
+"""
+import pytest
+
+from core.auth import required_role_for_request
+from core.database import (
+    create_user,
+    get_owner_user,
+    get_user_by_username,
+    seed_owner_if_needed,
+    verify_password,
+)
+
+
+def _login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+# ---------------------------------------------------------------------------
+# Policy classification (unit-level, via a request context)
+# ---------------------------------------------------------------------------
+class TestRolePolicy:
+    @pytest.mark.parametrize("method,path,expected", [
+        ("GET", "/", "reader"),
+        ("GET", "/collection", "reader"),
+        ("GET", "/api/libraries", "reader"),          # browsing libraries
+        ("POST", "/api/favorites/toggle", "reader"),  # personal data write
+        ("GET", "/api/continue-reading", "reader"),
+        ("POST", "/rename", "clerk"),                 # default: mutation → clerk
+        ("DELETE", "/api/delete-file", "clerk"),
+        ("GET", "/api/getcomics/search", "clerk"),    # clerk-only read area
+        ("POST", "/api/bulk-metadata/start", "clerk"),
+        ("GET", "/config", "owner"),
+        ("POST", "/api/config/file-processing", "owner"),
+        ("GET", "/api/database/stats", "owner"),
+        ("GET", "/api/admin/users", "owner"),
+        ("POST", "/api/libraries", "owner"),          # library CRUD → owner
+        ("DELETE", "/api/publishers/10", "owner"),
+        ("GET", "/users", "owner"),
+    ])
+    def test_required_role(self, app, method, path, expected):
+        with app.test_request_context(path, method=method):
+            assert required_role_for_request() == expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end 403 matrix through the auth gate
+# ---------------------------------------------------------------------------
+class TestRbacMatrix:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("clerk", password="clerkpass", role="clerk")
+        create_user("reader", password="readerpass", role="reader")
+        yield
+
+    # Reader
+    def test_reader_can_browse(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get("/").status_code == 200
+
+    def test_reader_denied_owner_page(self, client):
+        _login(client, "reader", "readerpass")
+        # HTML owner page → redirect home with a flash (not a 403 body).
+        assert client.get("/config").status_code == 302
+
+    def test_reader_denied_admin_api(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get("/api/admin/users").status_code == 403
+
+    def test_reader_denied_clerk_mutation(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.delete("/api/delete-file").status_code == 403
+
+    # Clerk
+    def test_clerk_can_browse(self, client):
+        _login(client, "clerk", "clerkpass")
+        assert client.get("/").status_code == 200
+
+    def test_clerk_allowed_clerk_mutation(self, client):
+        _login(client, "clerk", "clerkpass")
+        # Allowed by RBAC → reaches the handler (which may 400/500), never 403.
+        assert client.delete("/api/delete-file").status_code != 403
+
+    def test_clerk_denied_owner_api(self, client):
+        _login(client, "clerk", "clerkpass")
+        assert client.get("/api/admin/users").status_code == 403
+
+    def test_clerk_denied_config(self, client):
+        _login(client, "clerk", "clerkpass")
+        assert client.get("/config").status_code == 302
+
+    # Owner
+    def test_owner_allowed_admin_api(self, client):
+        _login(client, "owner", "ownerpass")
+        assert client.get("/api/admin/users").status_code == 200
+
+    def test_owner_allowed_config(self, client):
+        _login(client, "owner", "ownerpass")
+        assert client.get("/config").status_code == 200
+
+    def test_unauthenticated_redirected(self, client):
+        r = client.get("/api/admin/users")
+        # JSON namespace → 401, not an HTML redirect.
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Admin user-management API
+# ---------------------------------------------------------------------------
+class TestAdminUserApi:
+    @pytest.fixture(autouse=True)
+    def _owner_and_login(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("second", password="secondpass", role="reader")
+        yield
+
+    def test_list_users(self, client):
+        _login(client, "owner", "ownerpass")
+        data = client.get("/api/admin/users").get_json()
+        assert data["success"] is True
+        assert {u["username"] for u in data["users"]} == {"owner", "second"}
+        assert "libraries" in data
+
+    def test_create_user_with_library_grant(self, client, db_connection):
+        from tests.factories.db_factories import create_library
+        lib = create_library(name="A", path="/data/a")
+        _login(client, "owner", "ownerpass")
+        resp = client.post("/api/admin/users", json={
+            "username": "newclerk", "password": "pw", "role": "clerk",
+            "library_ids": [lib],
+        })
+        assert resp.status_code == 201
+        user = resp.get_json()["user"]
+        assert user["role"] == "clerk"
+        assert user["library_ids"] == [lib]
+
+    def test_create_duplicate_username_conflicts(self, client):
+        _login(client, "owner", "ownerpass")
+        resp = client.post("/api/admin/users", json={
+            "username": "owner", "password": "pw", "role": "reader",
+        })
+        assert resp.status_code == 409
+
+    def test_create_requires_password(self, client):
+        _login(client, "owner", "ownerpass")
+        resp = client.post("/api/admin/users", json={"username": "x", "role": "reader"})
+        assert resp.status_code == 400
+
+    def test_update_role_and_password(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("second")["id"]
+        resp = client.put(f"/api/admin/users/{uid}", json={
+            "role": "clerk", "password": "changed",
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["user"]["role"] == "clerk"
+        assert verify_password("second", "changed")
+
+    def test_update_username(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("second")["id"]
+        resp = client.put(f"/api/admin/users/{uid}", json={"username": "renamed"})
+        assert resp.status_code == 200
+        assert resp.get_json()["user"]["username"] == "renamed"
+        assert get_user_by_username("renamed")["id"] == uid
+        assert get_user_by_username("second") is None
+
+    def test_update_username_conflict(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("second")["id"]
+        # "owner" already exists → renaming "second" to it must 409 and not change.
+        resp = client.put(f"/api/admin/users/{uid}", json={"username": "owner"})
+        assert resp.status_code == 409
+        assert get_user_by_username("second")["id"] == uid
+
+    def test_delete_user(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("second")["id"]
+        assert client.delete(f"/api/admin/users/{uid}").status_code == 200
+        assert get_user_by_username("second") is None
+
+    def test_cannot_delete_last_owner(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("owner")["id"]
+        resp = client.delete(f"/api/admin/users/{uid}")
+        assert resp.status_code == 400
+        assert get_user_by_username("owner") is not None
+
+    def test_cannot_demote_last_owner(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("owner")["id"]
+        resp = client.put(f"/api/admin/users/{uid}", json={"role": "reader"})
+        assert resp.status_code == 400
+        assert get_user_by_username("owner")["role"] == "owner"
+
+    def test_reader_forbidden_from_admin(self, client):
+        _login(client, "second", "secondpass")  # reader
+        assert client.get("/api/admin/users").status_code == 403
+        assert client.post("/api/admin/users", json={
+            "username": "z", "password": "pw",
+        }).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Reading data resolves to the logged-in user (request-context scoping)
+# ---------------------------------------------------------------------------
+class TestReadingDataScopedByRequest:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("alice", password="alicepass", role="reader")
+        create_user("bob", password="bobpass", role="reader")
+        yield
+
+    def test_mark_read_scopes_to_logged_in_user(self, app):
+        from core.database import is_issue_read
+
+        alice = app.test_client()
+        _login(alice, "alice", "alicepass")
+        bob = app.test_client()
+        _login(bob, "bob", "bobpass")
+
+        assert alice.post("/api/favorites/issues",
+                          json={"path": "/data/alice.cbz"}).status_code == 200
+        assert bob.post("/api/favorites/issues",
+                        json={"path": "/data/bob.cbz"}).status_code == 200
+
+        aid = get_user_by_username("alice")["id"]
+        bid = get_user_by_username("bob")["id"]
+        # Each user's read history contains only their own issue.
+        assert is_issue_read("/data/alice.cbz", user_id=aid) is True
+        assert is_issue_read("/data/alice.cbz", user_id=bid) is False
+        assert is_issue_read("/data/bob.cbz", user_id=bid) is True
+        assert is_issue_read("/data/bob.cbz", user_id=aid) is False
+
+
+# ---------------------------------------------------------------------------
+# First-run owner setup (implicit-owner mode)
+# ---------------------------------------------------------------------------
+class TestSetupOwner:
+    def test_setup_placeholder_owner(self, client, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()  # creates a needs_setup placeholder owner
+        assert get_owner_user()["needs_setup"] == 1
+
+        # Reachable without login in implicit-owner mode.
+        resp = client.post("/api/admin/setup-owner", json={
+            "username": "boss", "password": "hunter2",
+        })
+        assert resp.status_code == 200
+        owner = get_owner_user()
+        assert owner["username"] == "boss"
+        assert owner["needs_setup"] == 0
+        assert verify_password("boss", "hunter2")
+
+    def test_setup_rejected_once_configured(self, client, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="pw", role="owner")  # already configured
+        resp = client.post("/api/admin/setup-owner", json={
+            "username": "x", "password": "y",
+        })
+        assert resp.status_code == 409

--- a/tests/unit/test_app_state_scoping.py
+++ b/tests/unit/test_app_state_scoping.py
@@ -1,0 +1,72 @@
+"""
+PR7: per-user scoping of the in-memory operations registry and notifications
+(core/app_state.py). A user sees only their own progress/toasts; owners (and
+the backward-compatible no-viewer default) see everything.
+"""
+import pytest
+
+import core.app_state as app_state
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    with app_state._operations_lock:
+        app_state._operations.clear()
+    with app_state._notifications_lock:
+        app_state._notifications.clear()
+    yield
+    with app_state._operations_lock:
+        app_state._operations.clear()
+    with app_state._notifications_lock:
+        app_state._notifications.clear()
+
+
+A, B = 101, 102
+
+
+class TestOperationScoping:
+    def test_operation_stamped_with_user(self):
+        op_id = app_state.register_operation("scan", "A scan", user_id=A)
+        op = next(o for o in app_state.get_active_operations() if o["id"] == op_id)
+        assert op["user_id"] == A
+
+    def test_viewer_sees_only_own_ops(self):
+        a = app_state.register_operation("scan", "A scan", user_id=A)
+        b = app_state.register_operation("scan", "B scan", user_id=B)
+        assert {o["id"] for o in app_state.get_active_operations(viewer_id=A)} == {a}
+        assert {o["id"] for o in app_state.get_active_operations(viewer_id=B)} == {b}
+
+    def test_owner_sees_all_ops(self):
+        app_state.register_operation("scan", "A scan", user_id=A)
+        app_state.register_operation("scan", "B scan", user_id=B)
+        assert len(app_state.get_active_operations(is_owner=True)) == 2
+
+    def test_no_viewer_returns_all(self):
+        app_state.register_operation("scan", "A scan", user_id=A)
+        app_state.register_operation("scan", "B scan", user_id=B)
+        # Backward-compatible default (implicit-owner mode / existing callers).
+        assert len(app_state.get_active_operations()) == 2
+
+
+class TestNotificationScoping:
+    def test_viewer_gets_and_clears_only_own(self):
+        app_state.add_notification("for A", user_id=A)
+        app_state.add_notification("for B", user_id=B)
+
+        mine = app_state.get_and_clear_notifications(viewer_id=A)
+        assert [n["message"] for n in mine] == ["for A"]
+
+        # B's notification is retained, not cleared by A's fetch.
+        remaining = app_state.get_and_clear_notifications(viewer_id=B)
+        assert [n["message"] for n in remaining] == ["for B"]
+
+    def test_owner_gets_all(self):
+        app_state.add_notification("for A", user_id=A)
+        app_state.add_notification("for B", user_id=B)
+        got = app_state.get_and_clear_notifications(is_owner=True)
+        assert {n["message"] for n in got} == {"for A", "for B"}
+
+    def test_no_viewer_returns_all(self):
+        app_state.add_notification("x", user_id=A)
+        app_state.add_notification("y", user_id=B)
+        assert len(app_state.get_and_clear_notifications()) == 2

--- a/wrapped.py
+++ b/wrapped.py
@@ -11,7 +11,7 @@ import sqlite3
 import hashlib
 from datetime import datetime
 from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageOps, ImageChops, ImageEnhance
-from core.database import get_db_connection
+from core.database import get_db_connection, current_user_id
 from core.app_logging import app_logger
 from core.config import config
 import math
@@ -137,8 +137,9 @@ def create_gradient(width: int, height: int, color1: str, color2: str, vertical:
 
 def get_years_with_reading_data() -> list:
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT DISTINCT strftime('%Y', read_at) as year FROM issues_read WHERE read_at IS NOT NULL AND hide = 0 ORDER BY year DESC")
+        cursor = conn.execute("SELECT DISTINCT strftime('%Y', read_at) as year FROM issues_read WHERE user_id = ? AND read_at IS NOT NULL AND hide = 0 ORDER BY year DESC", (uid,))
         years = [int(row[0]) for row in cursor.fetchall() if row[0]]
         conn.close()
         return years
@@ -147,8 +148,9 @@ def get_years_with_reading_data() -> list:
 
 def get_yearly_total_read(year: int) -> int:
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT COUNT(*) FROM issues_read WHERE strftime('%Y', read_at) = ? AND hide = 0", (str(year),))
+        cursor = conn.execute("SELECT COUNT(*) FROM issues_read WHERE user_id = ? AND strftime('%Y', read_at) = ? AND hide = 0", (uid, str(year)))
         result = cursor.fetchone()[0]
         conn.close()
         return result or 0
@@ -159,8 +161,9 @@ def get_most_read_series(year: int, limit: int = 1) -> list:
     import re
     from collections import Counter
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT issue_path FROM issues_read WHERE strftime('%Y', read_at) = ? AND hide = 0", (str(year),))
+        cursor = conn.execute("SELECT issue_path FROM issues_read WHERE user_id = ? AND strftime('%Y', read_at) = ? AND hide = 0", (uid, str(year)))
         rows = cursor.fetchall()
         conn.close()
         series_counter = Counter()
@@ -180,8 +183,9 @@ def get_most_read_series(year: int, limit: int = 1) -> list:
 
 def get_busiest_day(year: int) -> dict:
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT date(read_at) as read_date, COUNT(*) as count FROM issues_read WHERE strftime('%Y', read_at) = ? AND hide = 0 GROUP BY read_date ORDER BY count DESC LIMIT 1", (str(year),))
+        cursor = conn.execute("SELECT date(read_at) as read_date, COUNT(*) as count FROM issues_read WHERE user_id = ? AND strftime('%Y', read_at) = ? AND hide = 0 GROUP BY read_date ORDER BY count DESC LIMIT 1", (uid, str(year)))
         row = cursor.fetchone()
         conn.close()
         if row and row[0]:
@@ -193,8 +197,9 @@ def get_busiest_day(year: int) -> dict:
 
 def get_busiest_month(year: int) -> dict:
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT strftime('%m', read_at) as month_num, COUNT(*) as count FROM issues_read WHERE strftime('%Y', read_at) = ? AND hide = 0 GROUP BY month_num ORDER BY count DESC LIMIT 1", (str(year),))
+        cursor = conn.execute("SELECT strftime('%m', read_at) as month_num, COUNT(*) as count FROM issues_read WHERE user_id = ? AND strftime('%Y', read_at) = ? AND hide = 0 GROUP BY month_num ORDER BY count DESC LIMIT 1", (uid, str(year)))
         row = cursor.fetchone()
         conn.close()
         if row and row[0]:
@@ -209,8 +214,9 @@ def get_top_series_with_thumbnails(year: int, limit: int = 6) -> list:
     import re
     from collections import Counter
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT issue_path FROM issues_read WHERE strftime('%Y', read_at) = ? AND hide = 0 ORDER BY issue_path", (str(year),))
+        cursor = conn.execute("SELECT issue_path FROM issues_read WHERE user_id = ? AND strftime('%Y', read_at) = ? AND hide = 0 ORDER BY issue_path", (uid, str(year)))
         rows = cursor.fetchall()
         conn.close()
         series_counter = Counter()
@@ -235,8 +241,9 @@ def get_top_series_with_thumbnails(year: int, limit: int = 6) -> list:
 
 def get_read_issues(year: int) -> list:
     try:
+        uid = current_user_id()
         conn = get_db_connection()
-        cursor = conn.execute("SELECT issue_path FROM issues_read WHERE strftime('%Y', read_at) = ? AND hide = 0 ORDER BY read_at ASC", (str(year),))
+        cursor = conn.execute("SELECT issue_path FROM issues_read WHERE user_id = ? AND strftime('%Y', read_at) = ? AND hide = 0 ORDER BY read_at ASC", (uid, str(year)))
         rows = cursor.fetchall()
         conn.close()
         return [row[0] for row in rows]
@@ -753,25 +760,26 @@ def get_monthly_stats(year: int, month: int) -> dict:
     month_str = str(month).zfill(2)
     year_str = str(year)
     try:
+        uid = current_user_id()
         conn = get_db_connection()
         c = conn.cursor()
 
         # Total issues read
         c.execute("""SELECT COUNT(*) FROM issues_read
-                     WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
-                  (year_str, month_str))
+                     WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
+                  (uid, year_str, month_str))
         total_read = c.fetchone()[0] or 0
 
         # Total pages
         c.execute("""SELECT COALESCE(SUM(page_count), 0) FROM issues_read
-                     WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
-                  (year_str, month_str))
+                     WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
+                  (uid, year_str, month_str))
         total_pages = c.fetchone()[0] or 0
 
         # Total series (count distinct series by parent path)
         c.execute("""SELECT issue_path FROM issues_read
-                     WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
-                  (year_str, month_str))
+                     WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
+                  (uid, year_str, month_str))
         rows = c.fetchall()
         series_set = set()
         for row in rows:
@@ -782,18 +790,18 @@ def get_monthly_stats(year: int, month: int) -> dict:
 
         # Top publisher
         c.execute("""SELECT publisher, COUNT(*) as cnt FROM issues_read
-                     WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ?
+                     WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ?
                      AND publisher != '' AND publisher IS NOT NULL AND hide = 0
                      GROUP BY publisher ORDER BY cnt DESC LIMIT 1""",
-                  (year_str, month_str))
+                  (uid, year_str, month_str))
         row = c.fetchone()
         top_publisher = row[0] if row else 'Unknown'
 
         # Busiest day
         c.execute("""SELECT date(read_at) as read_date, COUNT(*) as cnt FROM issues_read
-                     WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
+                     WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
                      GROUP BY read_date ORDER BY cnt DESC LIMIT 1""",
-                  (year_str, month_str))
+                  (uid, year_str, month_str))
         row = c.fetchone()
         if row and row[0]:
             date_obj = datetime.strptime(row[0], '%Y-%m-%d')
@@ -824,11 +832,12 @@ def get_monthly_most_read_series(year: int, month: int, limit: int = 1) -> list:
     month_str = str(month).zfill(2)
     year_str = str(year)
     try:
+        uid = current_user_id()
         conn = get_db_connection()
         cursor = conn.execute(
             """SELECT issue_path FROM issues_read
-               WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
-            (year_str, month_str))
+               WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0""",
+            (uid, year_str, month_str))
         rows = cursor.fetchall()
         conn.close()
         series_counter = Counter()
@@ -854,12 +863,13 @@ def get_monthly_top_series_with_thumbnails(year: int, month: int, limit: int = 9
     month_str = str(month).zfill(2)
     year_str = str(year)
     try:
+        uid = current_user_id()
         conn = get_db_connection()
         cursor = conn.execute(
             """SELECT issue_path FROM issues_read
-               WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
+               WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
                ORDER BY issue_path""",
-            (year_str, month_str))
+            (uid, year_str, month_str))
         rows = cursor.fetchall()
         conn.close()
         series_counter = Counter()
@@ -891,12 +901,13 @@ def get_monthly_series_issue_paths(year: int, month: int, series_path: str, limi
     month_str = str(month).zfill(2)
     year_str = str(year)
     try:
+        uid = current_user_id()
         conn = get_db_connection()
         cursor = conn.execute(
             """SELECT issue_path FROM issues_read
-               WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
+               WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
                ORDER BY read_at ASC""",
-            (year_str, month_str))
+            (uid, year_str, month_str))
         rows = cursor.fetchall()
         conn.close()
         results = []
@@ -919,12 +930,13 @@ def get_monthly_read_issues(year: int, month: int) -> list:
     month_str = str(month).zfill(2)
     year_str = str(year)
     try:
+        uid = current_user_id()
         conn = get_db_connection()
         cursor = conn.execute(
             """SELECT issue_path FROM issues_read
-               WHERE strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
+               WHERE user_id = ? AND strftime('%Y', read_at) = ? AND strftime('%m', read_at) = ? AND hide = 0
                ORDER BY read_at ASC""",
-            (year_str, month_str))
+            (uid, year_str, month_str))
         rows = cursor.fetchall()
         conn.close()
         return [row[0] for row in rows]


### PR DESCRIPTION
## Overview

Implements **multi-user support** — role-based access control (RBAC) plus per-user data isolation — targeting the `feature/multi-user` line. Delivered as seven incremental phases, each independently green.

**Backward-compatible by design:** all enforcement is skipped in *implicit-owner mode* (no real accounts configured), so existing single-user installs keep working with no login and full access. RBAC/scoping activate once the Store Owner creates additional accounts (or the legacy `CLU_USERNAME`/`CLU_PASSWORD` env gate is set).

## Roles

- **Reader** — view comics + their own reading data
- **Clerk** — Reader + file ops, metadata/scrape, downloads, pull list
- **Store Owner** — full admin: settings, user management, library grants

## Phases

| Phase | Summary |
|-------|---------|
| **PR1** | Users/roles/auth core: `users`, `library_permissions`, `api_tokens`, `user_favorite_publishers` tables; werkzeug password hashing; `core/auth.py` role hierarchy; implicit-owner mode; owner bootstrap (env creds or first-run screen); persistent `SECRET_KEY`. |
| **PR2** | RBAC enforcement: centralized route policy + `@require_role`/`@require_library_access`; `/api/admin/users` CRUD + user-management UI; last-owner protection. |
| **PR3** | Per-user reading data: `user_id` + composite uniqueness on `issues_read`, `reading_positions`, `to_read` via one-time table rebuild backfilling to owner; `_resolve_user_id` resolver. |
| **PR4** | Per-user favorites/insights/reading lists: `favorite_series` rebuild; favorite publishers → `user_favorite_publishers` join; `user_id` filters in `stats.py`/`timeline.py`/`wrapped.py` + per-user stats-cache namespacing; per-user `reading_lists`. |
| **PR5** | Library-level access enforcement: `accessible_library_ids` / `filter_paths_for_user` / `enforce_path_access` guard file-serve, reader, thumbnail, download, browse routes and filter search/recent/library listings. |
| **PR6** | Per-user API tokens + OPDS identity: `/api/v1` resolves bearer tokens to users (legacy global token → owner); reader/clerk tokens library-scoped; per-user token management; OPDS HTTP Basic Auth. |
| **PR7** | Per-user operations/notifications (`core/app_state.py`); explicit owner-attribution for Komga sync. |

## Tests

- `tests/routes` + `tests/integration`: **1075 passed**
- `tests/unit` + `tests/mocked`: **1556 passed, 6 skipped**

New suites: `test_users`, `test_rbac`, `test_reading_scope`, `test_favorites_insights_scope`, `test_library_access`, `test_multiuser_api_opds`, `test_app_state_scoping`.

## Deferred (documented, standalone follow-ups)

1. **Per-user `user_preferences`** (personal theme / dashboard order) — held back for import-order reasons; low value, not a privacy leak.
2. **Full per-user Komga config** (each user links their own Komga server) — feature-sized; no data-leak today since the shared account already syncs to the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
