### PR TITLE
Fix Reader-role access to folder thumbnails, folder details, and reading history (#446, #447, #448)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -194,6 +194,7 @@ _OWNER_MUTATION_PREFIXES = (
 # keep these from swallowing unrelated paths (e.g. "/api/reading-lists").
 _READER_WRITE_PREFIXES = (
     "/api/read/",              # /api/read/<path>/page/<n>
+    "/api/mark-comic-read",    # records the reader's own read history
     "/api/reading-position",
     "/api/reading-stats",
     "/api/favorites",          # favorites_bp
@@ -201,6 +202,17 @@ _READER_WRITE_PREFIXES = (
     "/to-read",
     "/api/continue-reading",
     "/api/on-the-stack",
+)
+
+# Read-only endpoints that use POST purely to carry a request body (a batch of
+# paths), not to mutate anything. Without an explicit entry these fall through
+# to the "mutation → clerk" default and 403 for Readers, breaking the parts of
+# the collection grid that load lazily via these batch endpoints — folder
+# thumbnails and folder/file counts — which every role must be able to view.
+# Keep this list to genuine reads.
+_READER_READ_POST_PREFIXES = (
+    "/api/browse-thumbnails",  # batch folder-thumbnail lookup
+    "/api/browse-metadata",    # batch folder/file counts
 )
 
 # Clerk-level areas where even GET is a Clerk feature (not just Reader viewing).
@@ -226,6 +238,8 @@ def required_role_for_request():
     if mutating and path.startswith(_OWNER_MUTATION_PREFIXES):
         return "owner"
     if path.startswith(_READER_WRITE_PREFIXES):
+        return "reader"
+    if path.startswith(_READER_READ_POST_PREFIXES):
         return "reader"
     if path.startswith(_CLERK_PREFIXES):
         return "clerk"

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -30,6 +30,9 @@ class TestRolePolicy:
         ("GET", "/collection", "reader"),
         ("GET", "/api/libraries", "reader"),          # browsing libraries
         ("POST", "/api/favorites/toggle", "reader"),  # personal data write
+        ("POST", "/api/mark-comic-read", "reader"),    # reader records own reads
+        ("POST", "/api/browse-thumbnails", "reader"),  # read-only batch (POST body)
+        ("POST", "/api/browse-metadata", "reader"),    # read-only batch (POST body)
         ("GET", "/api/continue-reading", "reader"),
         ("POST", "/rename", "clerk"),                 # default: mutation → clerk
         ("DELETE", "/api/delete-file", "clerk"),
@@ -78,6 +81,26 @@ class TestRbacMatrix:
     def test_reader_denied_clerk_mutation(self, client):
         _login(client, "reader", "readerpass")
         assert client.delete("/api/delete-file").status_code == 403
+
+    def test_reader_can_batch_fetch_folder_thumbnails(self, client):
+        # Regression for #446: folder thumbnails load lazily via this read-only
+        # POST endpoint. RBAC must not treat it as a clerk mutation, or the
+        # thumbnails silently fail to render for non-admin users.
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/browse-thumbnails", json={"paths": ["/data"]})
+        assert resp.status_code != 403
+
+    def test_reader_can_batch_fetch_folder_metadata(self, client):
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/browse-metadata", json={"paths": ["/data"]})
+        assert resp.status_code != 403
+
+    def test_reader_can_mark_comic_read(self, client):
+        # Regression for #448: a Reader must be able to record their own reads,
+        # or "On the Stack" (next-unread-per-series) can never populate for them.
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/mark-comic-read", json={"path": "/data/x.cbz"})
+        assert resp.status_code != 403
 
     # Clerk
     def test_clerk_can_browse(self, client):


### PR DESCRIPTION
## Summary

Follow-up bug fixes for the multi-user work (#445), addressing three Reader-role issues that share a single root cause in `core/auth.py`.

The RBAC policy `required_role_for_request()` uses a safe default — any unlisted `POST/PUT/DELETE/PATCH` is treated as a **clerk-level mutation**. But three endpoints Readers legitimately use are POSTs, so Readers received a `403` and parts of the collection UI silently failed for non-admin users.

| Issue | Symptom (non-admin) | Endpoint | Cause | Fix |
|-------|---------------------|----------|-------|-----|
| #446 | Some `folder.png` thumbnails don't load | `POST /api/browse-thumbnails` | Read-only batch lookup over POST → `clerk` | allowlist as reader |
| #447 | Folder details show "Empty"/blank instead of "N folders \| M files" | `POST /api/browse-metadata` | Read-only batch counts over POST → `clerk` | allowlist as reader |
| #448 | "On the Stack" next-issue never appears | `POST /api/mark-comic-read` | Reader's own read-history write missing from allowlist → `clerk` → reads never recorded → on-the-stack (needs a prior read in-series) stays empty | add to reader-write allowlist |

The same `/api/browse-thumbnails` fix also restores the `#wantToReadSwiper` folder thumbnails on `collection.html`, which use that endpoint.

**Why "some" thumbnails (#446):** thumbnails delivered inline by `GET /api/browse` loaded fine; only the lazily-batched ones (dashboard swipers / pending folders) 403'd.

## Changes

- `core/auth.py`
  - New `_READER_READ_POST_PREFIXES` (`/api/browse-thumbnails`, `/api/browse-metadata`) — genuine reads that use POST only to carry a batch of paths.
  - Added `/api/mark-comic-read` to `_READER_WRITE_PREFIXES`.
  - The default mutation→clerk rule is left intact; only these specific reader-legit paths are exempted.
- `tests/routes/test_rbac.py` — policy-classification cases for all three endpoints + end-to-end Reader (no-403) assertions.

Per-user attribution already flows correctly through `_resolve_user_id` (`g.current_user`), so once a Reader reaches the handler, writes and read-back are scoped to them.

## Verification

- Reproduced against the real app: `/api/browse-thumbnails` returns **403 without** the fix and **200 with** it for a granted Reader; `/api/thumbnail` (file covers) was never role-blocked (normal loading→image flow).
- `pytest tests/routes/test_rbac.py` — 47 passed. Reader-facing suites (auth, library-access, collection, favorites, multiuser API/OPDS, reading-scope) all green.

Closes #446
Closes #447
Closes #448
Closes #450
Closed #451 

🤖 Generated with [Claude Code](https://claude.com/claude-code)