### PR TITLE
Per-user folder-level access permissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ from routes.opds import opds_bp
 from models import gcd
 from models import metron
 from core.config import config, load_flask_config, write_config, load_config
-from core.auth import enforce_path_access
+from core.auth import enforce_path_access, current_user, filter_paths_for_user
 from cbz_ops.edit import (
     get_edit_modal,
     save_cbz,
@@ -4161,6 +4161,8 @@ def api_on_the_stack():
         if limit > 100:
             limit = 100
         items = get_on_the_stack_items(limit=limit)
+        # Folder-scope: hide next-up issues in folders the user can't access.
+        items = filter_paths_for_user(current_user(), items, key='file_path')
         return jsonify({"success": True, "items": items, "total_count": len(items)})
     except Exception as e:
         app_logger.error(f"Error in api_on_the_stack: {e}")

--- a/core/auth.py
+++ b/core/auth.py
@@ -27,7 +27,6 @@ from core.database import (
     count_users,
     get_owner_user,
     get_user_by_id,
-    user_has_library,
 )
 
 # Ascending privilege. Unknown roles sort to 0 (deny everything).
@@ -130,25 +129,116 @@ def require_role(minimum):
     return decorator
 
 
-def user_can_access_path(user, path):
-    """True if ``user`` may access the library containing ``path``.
+# ---------------------------------------------------------------------------
+# Folder-level access
+#
+# Library grants (library_permissions) are the coarse gate; folder grants
+# (user_folder_permissions) refine access WITHIN a granted library. A grant on a
+# folder covers that folder and every descendant (nested inheritance). A granted
+# library with no folder grants shows nothing. A grant equal to the library root
+# = the whole library. Owners and single-user (implicit-owner) installs bypass
+# all of this and get full access.
+#
+# folder_access_level() returns one of:
+#   'full'     — view + read files here (path at/under a grant).
+#   'traverse' — path is an ancestor of a grant: list it so the user can navigate
+#                down, but its direct contents must be filtered (grant siblings
+#                stay hidden). NOT sufficient to serve a file.
+#   'none'     — no access.
+# ---------------------------------------------------------------------------
 
-    Owners bypass all library scoping. Non-owners need an explicit grant for
-    the library the path resolves to. A path outside every configured library
-    is denied for non-owners.
-    """
-    if not user:
-        return False
-    if user.get("role") == "owner":
-        return True
+
+def _load_scope(user):
+    """Fetch a non-owner's scope once so a whole listing can be filtered without
+    per-item DB hits. Returns (libraries, granted_library_ids, grant_paths)."""
+    from core.database import get_libraries, get_user_folder_paths
+
+    libraries = get_libraries(enabled_only=True)
+    granted = accessible_library_ids(user)
+    grants = (
+        [os.path.normpath(g) for g in get_user_folder_paths(user["id"])]
+        if user else []
+    )
+    return libraries, granted, grants
+
+
+def _level_for(path, libraries, granted, grants):
+    """Pure access-level computation against pre-loaded scope (see _load_scope)."""
     if not path:
-        return False
-    from helpers.library import get_library_for_path
+        return "none"
+    norm = os.path.normpath(path)
 
-    library = get_library_for_path(path)
-    if not library:
-        return False
-    return user_has_library(user["id"], library["id"])
+    lib_root = None
+    lib_id = None
+    for lib in libraries:
+        root = os.path.normpath(lib["path"])
+        if norm == root or norm.startswith(root + os.sep):
+            lib_root, lib_id = root, lib["id"]
+            break
+    if lib_root is None or lib_id not in granted:
+        return "none"
+
+    in_lib = [g for g in grants if g == lib_root or g.startswith(lib_root + os.sep)]
+    if not in_lib:
+        return "none"  # granted library, no folder picks -> nothing
+
+    for g in in_lib:
+        if norm == g or norm.startswith(g + os.sep):
+            return "full"
+    for g in in_lib:
+        if g.startswith(norm + os.sep):
+            return "traverse"
+    return "none"
+
+
+def folder_access_level(user, path):
+    """Return 'full' | 'traverse' | 'none' for ``user`` accessing ``path``."""
+    if not is_login_required():
+        return "full"
+    if not user:
+        return "none"
+    if user.get("role") == "owner":
+        return "full"
+    if not path:
+        return "none"
+    libraries, granted, grants = _load_scope(user)
+    return _level_for(path, libraries, granted, grants)
+
+
+def accessible_folder_prefixes(user):
+    """Return the absolute folder prefixes a user may see, or None when
+    unrestricted (owner / implicit-owner mode).
+
+    Used by DB-aggregate readers (the metadata browser) to constrain rows to the
+    user's granted subtrees. A non-owner with granted libraries but no folder
+    picks — and an anonymous user in multi-user mode — returns [] (sees nothing).
+    """
+    if not is_login_required():
+        return None
+    if user and user.get("role") == "owner":
+        return None
+    if not user:
+        return []
+    libraries, granted, grants = _load_scope(user)
+    lib_roots = [(os.path.normpath(l["path"]), l["id"]) for l in libraries]
+    out = []
+    for g in grants:
+        for root, lid in lib_roots:
+            if (g == root or g.startswith(root + os.sep)) and lid in granted:
+                out.append(g)
+                break
+    return out
+
+
+def user_can_access_path(user, path):
+    """True if ``user`` may fully view and read files under ``path``.
+
+    Owners bypass all scoping. Non-owners need the containing library granted AND
+    a folder grant covering the path. This is the strict check used by
+    file-serve, the reader, OPDS and the token API — a 'traverse'-only ancestor
+    directory does NOT satisfy it.
+    """
+    return folder_access_level(user, path) == "full"
 
 
 # ---------------------------------------------------------------------------
@@ -293,46 +383,56 @@ def accessible_library_ids(user):
     return get_user_library_ids(user["id"])
 
 
-def filter_paths_for_user(user, items, key=None):
+def filter_paths_for_user(user, items, key=None, allow_traverse=False):
     """Filter a list of paths (or dicts) to those the user may access.
 
     ``key`` names the dict field holding the path when ``items`` are dicts;
     when None, ``items`` are treated as plain path strings. No-op (returns the
     input) in implicit-owner mode so single-user installs are unaffected.
+
+    ``allow_traverse`` keeps navigable ancestor directories (those on the path to
+    a grant): pass True when filtering a directory listing so the user can walk
+    down to a granted subfolder; keep it False for recent-files / search results,
+    which must be fully accessible.
     """
     if not is_login_required():
         return items
     if user and user.get("role") == "owner":
         return items
+    if not user:
+        return []
 
-    from helpers.library import get_library_for_path
-
-    allowed = accessible_library_ids(user)
+    libraries, granted, grants = _load_scope(user)
+    allowed = ("full", "traverse") if allow_traverse else ("full",)
 
     def _ok(path):
-        if not path:
-            return False
-        lib = get_library_for_path(path)
-        return bool(lib) and lib["id"] in allowed
+        return _level_for(path, libraries, granted, grants) in allowed
 
     if key is None:
         return [p for p in items if _ok(p)]
     return [it for it in items if _ok(it.get(key))]
 
 
-def enforce_path_access(path):
-    """Return a deny response if the current user may not access the library
-    containing ``path``, else None. No-op in implicit-owner mode.
+def enforce_path_access(path, mode="full"):
+    """Return a deny response if the current user may not access ``path``, else
+    None. No-op in implicit-owner mode.
 
-    Call this inline in file-serve / reader / browse routes *after* the path has
-    been normalised to an absolute filesystem path.
+    ``mode='full'`` (default) is the strict check for file-serve / reader routes.
+    ``mode='browse'`` also permits a 'traverse'-only ancestor directory, so a
+    browse/list route can render the directory (its contents must then be run
+    through ``filter_paths_for_user(..., allow_traverse=True)``).
+
+    Call this inline *after* the path has been normalised to an absolute
+    filesystem path.
     """
     if not is_login_required():
         return None
     user = current_user()
     if user is None:
         return _deny(401)
-    if not user_can_access_path(user, path):
+    level = folder_access_level(user, path)
+    allowed = ("full", "traverse") if mode == "browse" else ("full",)
+    if level not in allowed:
         return _deny(403)
     return None
 

--- a/core/database.py
+++ b/core/database.py
@@ -1206,6 +1206,35 @@ def init_db():
             )
         """)
 
+        # Per-user folder-level access grants (refines library_permissions).
+        # A grant on a folder covers that folder and every descendant. A granted
+        # library with NO folder rows shows nothing (folder picks are required);
+        # a grant equal to the library root path = the whole library. Owners
+        # bypass this entirely (see core/auth.py.folder_access_level).
+        #
+        # One-time backfill: the first time this table is created, seed a root
+        # grant for every existing (user, library) so current accounts keep the
+        # "whole library" access they had before folder scoping existed.
+        c.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+            " AND name='user_folder_permissions'"
+        )
+        _ufp_new = c.fetchone() is None
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS user_folder_permissions (
+                user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                folder_path TEXT    NOT NULL,
+                PRIMARY KEY (user_id, folder_path)
+            )
+        """)
+        if _ufp_new:
+            c.execute("""
+                INSERT OR IGNORE INTO user_folder_permissions (user_id, folder_path)
+                SELECT lp.user_id, l.path
+                FROM library_permissions lp
+                JOIN libraries l ON l.id = lp.library_id
+            """)
+
         # Per-user long-lived bearer tokens for the /api/v1 client. Only the
         # sha256 hash of the token is stored, never the plaintext.
         c.execute("""
@@ -3429,6 +3458,7 @@ def get_files_recursive_paged(
     letter=None,
     search=None,
     max_retries=3,
+    allowed_prefixes=None,
 ):
     """
     Return a paged slice of file rows under path_prefix from file_index, plus
@@ -3480,6 +3510,13 @@ def get_files_recursive_paged(
             "OR LOWER(IFNULL(ci_series, '')) LIKE ? ESCAPE '\\')"
         )
         base_params.extend([s_pattern, s_pattern])
+
+    # Per-user folder scope (None = unrestricted, [] = nothing). Folded into the
+    # base WHERE so the page, count, and letters queries stay consistent.
+    prefix_clause, prefix_params = _metadata_prefix_clause(allowed_prefixes)
+    if prefix_clause is not None:
+        base_clauses.append(prefix_clause)
+        base_params.extend(prefix_params)
 
     # Letters query uses base WHERE (no letter filter) so the filter bar
     # always shows all available buckets.
@@ -5750,7 +5787,26 @@ def invalidate_metadata_browser_cache():
         _mb_cache.clear()
 
 
-def _build_metadata_where(filters):
+def _metadata_prefix_clause(allowed_prefixes):
+    """Build a (clause, params) restricting file_index.path to the given absolute
+    folder prefixes (per-user folder scope). Matches the folder itself and any
+    descendant, in both '/' and '\\' separator styles since file_index may hold
+    either. Returns (None, []) when unrestricted; ("1=0", []) to match nothing.
+    """
+    if allowed_prefixes is None:
+        return None, []
+    if not allowed_prefixes:
+        return "1=0", []
+    ors, params = [], []
+    for p in allowed_prefixes:
+        fwd = str(p).replace("\\", "/").rstrip("/")
+        back = fwd.replace("/", "\\")
+        ors.append("(path = ? OR path LIKE ? OR path = ? OR path LIKE ?)")
+        params.extend([fwd, fwd + "/%", back, back + "\\%"])
+    return "(" + " OR ".join(ors) + ")", params
+
+
+def _build_metadata_where(filters, allowed_prefixes=None):
     """
     Build a SQL WHERE clause + params list from a filter dict.
 
@@ -5758,6 +5814,9 @@ def _build_metadata_where(filters):
         publisher, series -> list[str] (scalar IN)
         year_from, year_to -> int/str (inclusive range on ci_year)
         search -> str (case-insensitive LIKE on name/ci_series/ci_title)
+
+    allowed_prefixes: per-user folder scope. None => unrestricted;
+        [] => match nothing; else restrict path to those subtrees.
 
     Returns (where_sql, params) where where_sql includes the leading "WHERE".
     Always restricts to comic files (cbz/cbr) in the file_index.
@@ -5767,6 +5826,11 @@ def _build_metadata_where(filters):
         "(LOWER(name) LIKE '%.cbz' OR LOWER(name) LIKE '%.cbr')",
     ]
     params = []
+
+    prefix_clause, prefix_params = _metadata_prefix_clause(allowed_prefixes)
+    if prefix_clause is not None:
+        clauses.append(prefix_clause)
+        params.extend(prefix_params)
 
     for facet, column in (("publisher", "ci_publisher"), ("series", "ci_series")):
         values = filters.get(facet) if filters else None
@@ -5803,10 +5867,14 @@ def _build_metadata_where(filters):
     return "WHERE " + " AND ".join(clauses), params
 
 
-def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50):
+def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50,
+                    allowed_prefixes=None):
     """
     Return the grid payload for the metadata browser. Cached in-memory with
     a short TTL; invalidated whenever file_index rows change.
+
+    allowed_prefixes applies per-user folder scope (None = unrestricted, [] =
+    nothing); it is part of the cache key so scoped users don't share aggregates.
 
     axis='publisher' -> grouped by ci_publisher (publisher tiles)
     axis='series'    -> grouped by ci_series (series cards)
@@ -5819,7 +5887,8 @@ def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50):
     Returns {items, total, level}
     """
     filters = dict(filters or {})
-    cache_key = _mb_cache_key("browse", axis, filters, sort, offset, limit)
+    cache_key = _mb_cache_key(
+        "browse", axis, filters, sort, offset, limit, allowed_prefixes)
     cached = _mb_cache_get(cache_key)
     if cached is not None:
         return cached
@@ -5835,7 +5904,7 @@ def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50):
             axis = "issue"
 
         if axis == "issue":
-            where_sql, params = _build_metadata_where(filters)
+            where_sql, params = _build_metadata_where(filters, allowed_prefixes)
             c.execute(
                 "SELECT COUNT(*) AS n FROM file_index " + where_sql, params
             )
@@ -5873,7 +5942,7 @@ def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50):
 
         if axis == "publisher":
             column = "ci_publisher"
-            where_sql, params = _build_metadata_where(filters)
+            where_sql, params = _build_metadata_where(filters, allowed_prefixes)
             c.execute(
                 "SELECT " + column + " AS v, COUNT(*) AS n,"
                 " MIN(path) AS cover_path"
@@ -5907,7 +5976,7 @@ def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50):
             return out
 
         if axis == "series":
-            where_sql, params = _build_metadata_where(filters)
+            where_sql, params = _build_metadata_where(filters, allowed_prefixes)
             c.execute(
                 "SELECT ci_series AS v, ci_publisher AS publisher,"
                 " COUNT(*) AS n, MIN(CAST(ci_year AS INTEGER)) AS year,"
@@ -5944,7 +6013,7 @@ def metadata_browse(axis, filters, sort="alpha", offset=0, limit=50):
             return out
 
         if axis == "year":
-            where_sql, params = _build_metadata_where(filters)
+            where_sql, params = _build_metadata_where(filters, allowed_prefixes)
             yf = filters.get("year_from")
             yt = filters.get("year_to")
             single_decade = (
@@ -6357,8 +6426,12 @@ def filesystem_browse_issues(series_path, offset=0, limit=50):
         return {"items": [], "total": 0, "level": "issue"}
 
 
-def series_representative_path(series, publisher=None):
-    """Find a representative file path for a series (earliest issue)."""
+def series_representative_path(series, publisher=None, allowed_prefixes=None):
+    """Find a representative file path for a series (earliest issue).
+
+    allowed_prefixes applies per-user folder scope so the cover doesn't leak a
+    path from a folder the user can't see (None = unrestricted, [] = nothing).
+    """
     try:
         conn = get_db_connection()
         if not conn:
@@ -6369,6 +6442,10 @@ def series_representative_path(series, publisher=None):
         if publisher:
             where.append("ci_publisher = ?")
             params.append(publisher)
+        prefix_clause, prefix_params = _metadata_prefix_clause(allowed_prefixes)
+        if prefix_clause is not None:
+            where.append(prefix_clause)
+            params.extend(prefix_params)
         c.execute(
             "SELECT path FROM file_index WHERE " + " AND ".join(where) +
             " ORDER BY CAST(ci_number AS INTEGER), ci_number, name COLLATE NOCASE"
@@ -7307,6 +7384,59 @@ def set_user_libraries(user_id, library_ids):
         c.executemany(
             "INSERT OR IGNORE INTO library_permissions (user_id, library_id) VALUES (?, ?)",
             [(user_id, int(lib_id)) for lib_id in library_ids],
+        )
+        conn.commit()
+        return True
+    finally:
+        conn.close()
+
+
+def get_user_folder_paths(user_id):
+    """Return the sorted list of folder paths a user has been granted.
+
+    A grant covers the folder and every descendant. See
+    core/auth.py.folder_access_level for how these are enforced.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return []
+    try:
+        c = conn.cursor()
+        c.execute(
+            "SELECT folder_path FROM user_folder_permissions"
+            " WHERE user_id = ? ORDER BY folder_path",
+            (user_id,),
+        )
+        return [r[0] for r in c.fetchall()]
+    finally:
+        conn.close()
+
+
+def set_user_folders(user_id, paths):
+    """Replace a user's folder grants with the given iterable of absolute paths.
+
+    Paths are normalised and de-duplicated before storage. Mirrors
+    set_user_libraries (delete-then-insert replace).
+    """
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        c = conn.cursor()
+        c.execute("DELETE FROM user_folder_permissions WHERE user_id = ?", (user_id,))
+        rows, seen = [], set()
+        for p in paths or []:
+            if not p:
+                continue
+            norm = os.path.normpath(str(p))
+            if norm in seen:
+                continue
+            seen.add(norm)
+            rows.append((user_id, norm))
+        c.executemany(
+            "INSERT OR IGNORE INTO user_folder_permissions (user_id, folder_path)"
+            " VALUES (?, ?)",
+            rows,
         )
         conn.commit()
         return True

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -24,10 +24,12 @@ from core.database import (
     get_owner_user,
     get_user_by_id,
     get_user_by_username,
+    get_user_folder_paths,
     get_user_library_ids,
     list_users,
     rotate_api_token,
     set_api_browse_mode,
+    set_user_folders,
     set_user_libraries,
     set_user_password,
     update_user,
@@ -88,9 +90,10 @@ def put_browse_mode():
 
 
 def _user_payload(user):
-    """Attach the user's granted library ids to a public user dict."""
+    """Attach the user's granted library ids and folder paths to a public dict."""
     user = dict(user)
     user["library_ids"] = sorted(get_user_library_ids(user["id"]))
+    user["folder_paths"] = get_user_folder_paths(user["id"])
     return user
 
 
@@ -145,6 +148,7 @@ def create_user_route():
     display_name = body.get("display_name")
     email = body.get("email")
     library_ids = body.get("library_ids") or []
+    folder_paths = body.get("folder_paths") or []
 
     if not username:
         return jsonify({"success": False, "error": "username is required"}), 400
@@ -163,6 +167,8 @@ def create_user_route():
 
     if library_ids:
         set_user_libraries(user_id, library_ids)
+    if folder_paths:
+        set_user_folders(user_id, folder_paths)
 
     return jsonify({"success": True, "user": _user_payload(get_user_by_id(user_id))}), 201
 
@@ -185,6 +191,7 @@ def update_user_route(user_id):
     email = body.get("email")
     password = body.get("password")
     library_ids = body.get("library_ids")
+    folder_paths = body.get("folder_paths")
 
     if role is not None and role.lower() not in VALID_ROLES:
         return jsonify({"success": False, "error": "invalid role"}), 400
@@ -223,6 +230,8 @@ def update_user_route(user_id):
         set_user_password(user_id, password)
     if library_ids is not None:
         set_user_libraries(user_id, library_ids)
+    if folder_paths is not None:
+        set_user_folders(user_id, folder_paths)
 
     return jsonify({"success": True, "user": _user_payload(get_user_by_id(user_id))})
 

--- a/routes/api_v1.py
+++ b/routes/api_v1.py
@@ -154,6 +154,18 @@ def _authorized_file_row(file_id):
     return row
 
 
+def _folder_scope_prefixes():
+    """Per-user folder scope for the token user, applied to metadata-mode browse
+    (file_index reads). Returns None when unrestricted (owner / global token /
+    single-user install). Filesystem-mode browse is a live view and stays
+    unscoped, mirroring the File Manager exemption.
+    """
+    from flask import g
+    from core.auth import accessible_folder_prefixes
+
+    return accessible_folder_prefixes(getattr(g, "current_user", None))
+
+
 def _paginate_args():
     try:
         page = max(1, int(request.args.get("page", 1)))
@@ -352,6 +364,7 @@ def list_publishers():
             sort=sort,
             offset=offset,
             limit=page_size,
+            allowed_prefixes=_folder_scope_prefixes(),
         )
 
     return _paged_response(
@@ -410,6 +423,7 @@ def list_series():
             sort=sort,
             offset=offset,
             limit=page_size,
+            allowed_prefixes=_folder_scope_prefixes(),
         )
 
     return _paged_response(
@@ -498,6 +512,7 @@ def list_issues():
         sort=sort,
         offset=offset,
         limit=page_size,
+        allowed_prefixes=_folder_scope_prefixes(),
     )
 
     items = result.get("items", [])

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -23,7 +23,12 @@ from PIL import Image
 from core.app_logging import app_logger
 from core.config import config
 from helpers.library import get_library_roots, get_default_library, is_valid_library_path
-from core.auth import enforce_path_access, filter_paths_for_user, current_user
+from core.auth import (
+    enforce_path_access,
+    filter_paths_for_user,
+    accessible_folder_prefixes,
+    current_user,
+)
 from core.database import (
     get_directory_children, get_path_counts_batch, get_recent_files,
     invalidate_browse_cache, add_file_index_entry, delete_file_index_entry,
@@ -209,7 +214,9 @@ def api_metadata_browse():
         offset, limit = 0, 50
 
     filters = _parse_metadata_filters(request.args)
-    result = metadata_browse(axis, filters, sort=sort, offset=offset, limit=limit)
+    prefixes = accessible_folder_prefixes(current_user())
+    result = metadata_browse(axis, filters, sort=sort, offset=offset,
+                             limit=limit, allowed_prefixes=prefixes)
 
     for item in result.get('items', []):
         cover_path = item.get('cover_path') or item.get('path')
@@ -231,7 +238,8 @@ def api_metadata_series_cover():
     publisher = request.args.get('publisher')
     if not series:
         return jsonify({"error": "Missing series parameter"}), 400
-    path = series_representative_path(series, publisher)
+    prefixes = accessible_folder_prefixes(current_user())
+    path = series_representative_path(series, publisher, allowed_prefixes=prefixes)
     if not path:
         return jsonify({"path": None, "thumbnail_url": None})
     return jsonify({
@@ -308,7 +316,7 @@ def api_browse():
     if not path:
         path = DATA_DIR
 
-    denied = enforce_path_access(path)
+    denied = enforce_path_access(path, mode='browse')
     if denied:
         return denied
 
@@ -316,6 +324,14 @@ def api_browse():
         app_logger.info(f"/api/browse request for path: {path}")
 
         directories, files = get_directory_children(path)
+
+        # Folder-scope: keep navigable ancestor dirs (allow_traverse) so a user
+        # can walk down to a granted subfolder, but hide files/dirs outside their
+        # grants. No-op for owners / single-user installs.
+        user = current_user()
+        directories = filter_paths_for_user(
+            user, directories, key='path', allow_traverse=True)
+        files = filter_paths_for_user(user, files, key='path')
 
         processed_directories = []
         for d in directories:
@@ -545,6 +561,11 @@ def api_browse_metadata():
     if len(paths) > 100:
         return jsonify({"error": "Too many paths (max 100)"}), 400
 
+    # Folder-scope: only report on paths the user may see (no-op for owners).
+    paths = filter_paths_for_user(current_user(), paths, allow_traverse=True)
+    if not paths:
+        return jsonify({"metadata": {}})
+
     try:
         counts = get_path_counts_batch(paths)
 
@@ -591,6 +612,11 @@ def api_browse_thumbnails():
 
     if len(paths) > 50:
         return jsonify({"error": "Too many paths (max 50)"}), 400
+
+    # Folder-scope: only report on paths the user may see (no-op for owners).
+    paths = filter_paths_for_user(current_user(), paths, allow_traverse=True)
+    if not paths:
+        return jsonify({"thumbnails": {}})
 
     try:
         folder_thumbs = find_folder_thumbnails_batch(paths)
@@ -683,7 +709,7 @@ def api_browse_recursive():
     if not os.path.isdir(abs_path):
         return jsonify({"error": "Invalid path"}), 400
 
-    denied = enforce_path_access(path)
+    denied = enforce_path_access(path, mode='browse')
     if denied:
         return denied
 
@@ -705,7 +731,8 @@ def api_browse_recursive():
     search = request.args.get('search') or None
 
     rows, total, letters = get_files_recursive_paged(
-        path, offset=offset, limit=limit, letter=letter, search=search
+        path, offset=offset, limit=limit, letter=letter, search=search,
+        allowed_prefixes=accessible_folder_prefixes(current_user())
     )
 
     excluded_extensions = {".png", ".jpg", ".jpeg", ".gif", ".html", ".css",

--- a/routes/favorites.py
+++ b/routes/favorites.py
@@ -18,6 +18,7 @@ from core.database import (
     add_to_read, remove_to_read, get_to_read_items, is_to_read,
     clear_stats_cache_keys, clear_stats_cache_prefix, current_user_id
 )
+from core.auth import current_user, filter_paths_for_user
 from core.app_logging import app_logger
 
 
@@ -215,6 +216,8 @@ def get_to_read():
     """Get all 'to read' items."""
     try:
         items = get_to_read_items()
+        # Folder-scope: hide items in folders the user can no longer access.
+        items = filter_paths_for_user(current_user(), items, key='path')
         return jsonify({
             "success": True,
             "items": items

--- a/routes/opds.py
+++ b/routes/opds.py
@@ -237,16 +237,21 @@ def browse():
     if not is_valid_library_path(current_path):
         return Response("Access denied", status=403)
 
-    # Per-user: deny paths outside the user's granted libraries.
+    # Per-user folder scope: deny paths the user can't reach; allow 'traverse'
+    # ancestors so they can navigate down to a granted subfolder.
     from flask import g
-    from core.auth import is_login_required, user_can_access_path
-    if is_login_required() and not user_can_access_path(getattr(g, 'current_user', None), current_path):
+    from core.auth import is_login_required, folder_access_level, filter_paths_for_user
+    _opds_user = getattr(g, 'current_user', None)
+    if is_login_required() and folder_access_level(_opds_user, current_path) == 'none':
         return Response("Access denied", status=403)
 
     if not os.path.exists(current_path):
         return Response("Directory not found", status=404)
 
     directories, files = get_directory_listing_for_opds(current_path)
+    # Hide out-of-grant entries; keep navigable ancestor directories.
+    directories = filter_paths_for_user(_opds_user, directories, key='path', allow_traverse=True)
+    files = filter_paths_for_user(_opds_user, files, key='path')
 
     entries = []
 

--- a/routes/source_wall.py
+++ b/routes/source_wall.py
@@ -9,6 +9,7 @@ import threading
 from flask import Blueprint, request, jsonify, render_template
 from core.app_logging import app_logger
 from core.config import config
+from core.auth import enforce_path_access, filter_paths_for_user, current_user
 from helpers.library import is_valid_library_path
 from core.database import (
     get_source_wall_files,
@@ -62,8 +63,17 @@ def get_files():
     if not path or not is_valid_library_path(path):
         return jsonify({"success": False, "error": "Invalid path"}), 403
 
+    denied = enforce_path_access(path, mode='browse')
+    if denied:
+        return denied
+
     try:
         directories, files = get_source_wall_files(path)
+        # Folder-scope: keep navigable ancestor dirs, hide out-of-grant entries.
+        user = current_user()
+        directories = filter_paths_for_user(
+            user, directories, key='path', allow_traverse=True)
+        files = filter_paths_for_user(user, files, key='path')
         return jsonify({
             "success": True,
             "directories": directories,
@@ -93,6 +103,9 @@ def save_pending():
     for path, fields in updates.items():
         if not is_valid_library_path(path):
             return jsonify({"success": False, "error": f"Invalid path: {path}"}), 403
+        denied = enforce_path_access(path)
+        if denied:
+            return denied
         if not isinstance(fields, dict) or not fields:
             return jsonify({"success": False, "error": f"No fields for path: {path}"}), 400
         for field in fields.keys():
@@ -154,6 +167,9 @@ def reconcile_from_db():
     for path in paths:
         if not isinstance(path, str) or not is_valid_library_path(path):
             return jsonify({"success": False, "error": f"Invalid path: {path}"}), 403
+        denied = enforce_path_access(path)
+        if denied:
+            return denied
 
     # Deduplicate to preserve the distinct-path contract for bulk writes.
     unique_paths = list(dict.fromkeys(paths))
@@ -234,6 +250,11 @@ def suggest_values():
 
     if len(query) < 3:
         return jsonify({"success": True, "values": []})
+
+    if path:
+        denied = enforce_path_access(path, mode='browse')
+        if denied:
+            return denied
 
     values = get_distinct_ci_values(field, query, parent_path=path or None, limit=20)
     return jsonify({"success": True, "values": values})

--- a/templates/users.html
+++ b/templates/users.html
@@ -35,7 +35,8 @@
     Roles: <strong>Reader</strong> views comics and their own reading data ·
     <strong>Clerk</strong> adds file management, metadata &amp; downloads ·
     <strong>Store Owner</strong> has full administrative control.
-    Readers and Clerks only see the libraries granted to them.
+    Readers and Clerks only see the libraries — and, within them, the folders —
+    granted to them.
   </p>
 </div>
 
@@ -82,6 +83,18 @@
           <div class="form-text">Owners always have access to every library.</div>
         </div>
 
+        <div class="mb-2" id="folder-access-wrap">
+          <label class="form-label d-block">Folder access</label>
+          <div id="folder-trees" class="border rounded p-2" style="max-height:220px;overflow:auto">
+            <span class="text-muted small">Grant a library above to choose folders.</span>
+          </div>
+          <div class="form-text">
+            Check a folder to grant it and everything inside it. Checking a library
+            grants the whole library. A granted library with no folders checked
+            shows nothing. Owners always see everything.
+          </div>
+        </div>
+
         <div class="mb-2" id="tokens-section" style="display:none">
           <label class="form-label d-block">API tokens
             <span class="text-muted small">(mobile / OPDS)</span></label>
@@ -111,6 +124,8 @@
 {{ super() }}
 <script>
 let LIBRARIES = [];
+let FOLDER_SELECTED = new Set();   // minimal set of explicitly-granted folder paths
+const FOLDER_CHILDREN = {};        // path -> [child folder paths], lazily loaded
 
 const ROLE_LABEL = { reader: "Reader", clerk: "Clerk", owner: "Store Owner" };
 const ROLE_BADGE = { reader: "bg-secondary", clerk: "bg-info text-dark", owner: "bg-warning text-dark" };
@@ -171,6 +186,140 @@ function renderLibChecks(selected = []) {
              id="lib-${l.id}" ${selected.includes(l.id) ? "checked" : ""}>
       <label class="form-check-label" for="lib-${l.id}">${esc(l.name)}</label>
     </div>`).join("");
+  // Re-render the folder trees when library grants change (only granted
+  // libraries offer a folder tree). Preserve the current folder selection.
+  box.querySelectorAll(".lib-check").forEach(c =>
+    c.addEventListener("change", () => renderFolderTrees(Array.from(FOLDER_SELECTED))));
+}
+
+// ---- Folder-access tree picker -------------------------------------------
+
+function _folderJoin(parent, name) {
+  return parent.replace(/\/+$/, "") + "/" + name;
+}
+function _folderInherited(path) {
+  for (const s of FOLDER_SELECTED) {
+    if (path !== s && path.startsWith(s.replace(/\/+$/, "") + "/")) return true;
+  }
+  return false;
+}
+function _folderGranted(path) {
+  return FOLDER_SELECTED.has(path) || _folderInherited(path);
+}
+async function _fetchChildDirs(path) {
+  if (FOLDER_CHILDREN[path]) return FOLDER_CHILDREN[path];
+  try {
+    const resp = await fetch("/list-directories?path=" + encodeURIComponent(path));
+    const data = await resp.json();
+    const dirs = (data.directories || []).map(n => _folderJoin(path, n));
+    FOLDER_CHILDREN[path] = dirs;
+    return dirs;
+  } catch (e) { FOLDER_CHILDREN[path] = []; return []; }
+}
+function _refreshFolderChecks() {
+  document.querySelectorAll("#folder-trees .folder-node").forEach(n => {
+    if (!n._cb) return;
+    n._cb.checked = _folderGranted(n._path);
+    n._cb.disabled = _folderInherited(n._path);
+  });
+}
+function _makeFolderNode(path, label, depth) {
+  const wrap = document.createElement("div");
+  wrap.className = "folder-node";
+  wrap._path = path;
+
+  const row = document.createElement("div");
+  row.className = "d-flex align-items-center gap-1";
+  row.style.marginLeft = (depth * 16) + "px";
+
+  const caret = document.createElement("button");
+  caret.type = "button";
+  caret.className = "btn btn-sm btn-link p-0 text-muted";
+  caret.style.width = "1.1rem";
+  caret.innerHTML = '<i class="bi bi-chevron-right"></i>';
+
+  const cb = document.createElement("input");
+  cb.type = "checkbox";
+  cb.className = "form-check-input mt-0 folder-check";
+  cb.checked = _folderGranted(path);
+  cb.disabled = _folderInherited(path);
+  wrap._cb = cb;
+
+  const lbl = document.createElement("span");
+  lbl.className = "small";
+  lbl.textContent = label;
+
+  const childBox = document.createElement("div");
+  childBox.className = "folder-children";
+  childBox.style.display = "none";
+
+  cb.addEventListener("change", () => {
+    if (cb.checked) {
+      // Drop now-redundant descendant grants (parent covers them).
+      for (const s of Array.from(FOLDER_SELECTED)) {
+        if (s !== path && s.startsWith(path.replace(/\/+$/, "") + "/")) {
+          FOLDER_SELECTED.delete(s);
+        }
+      }
+      FOLDER_SELECTED.add(path);
+    } else {
+      FOLDER_SELECTED.delete(path);
+    }
+    _refreshFolderChecks();
+  });
+
+  caret.addEventListener("click", async () => {
+    const open = childBox.style.display !== "none";
+    if (open) {
+      childBox.style.display = "none";
+      caret.firstChild.className = "bi bi-chevron-right";
+      return;
+    }
+    childBox.style.display = "block";
+    caret.firstChild.className = "bi bi-chevron-down";
+    if (!childBox.dataset.loaded) {
+      childBox.dataset.loaded = "1";
+      const dirs = await _fetchChildDirs(path);
+      if (!dirs.length) {
+        const empty = document.createElement("div");
+        empty.className = "text-muted small fst-italic";
+        empty.style.marginLeft = ((depth + 1) * 16) + "px";
+        empty.textContent = "(no subfolders)";
+        childBox.appendChild(empty);
+      } else {
+        dirs.forEach(d => childBox.appendChild(
+          _makeFolderNode(d, d.split("/").pop(), depth + 1)));
+      }
+    }
+  });
+
+  row.appendChild(caret);
+  row.appendChild(cb);
+  row.appendChild(lbl);
+  wrap.appendChild(row);
+  wrap.appendChild(childBox);
+  return wrap;
+}
+function renderFolderTrees(selected = []) {
+  FOLDER_SELECTED = new Set(selected);
+  const box = document.getElementById("folder-trees");
+  const checkedLibIds = selectedLibs();
+  const libs = LIBRARIES.filter(l => checkedLibIds.includes(l.id));
+  box.innerHTML = "";
+  if (!libs.length) {
+    box.innerHTML =
+      "<span class='text-muted small'>Grant a library above to choose folders.</span>";
+    return;
+  }
+  libs.forEach(l => {
+    const libWrap = document.createElement("div");
+    libWrap.className = "mb-1";
+    libWrap.appendChild(_makeFolderNode(l.path, l.name, 0));
+    box.appendChild(libWrap);
+  });
+}
+function selectedFolders() {
+  return Array.from(FOLDER_SELECTED);
 }
 
 function openCreate() {
@@ -187,6 +336,7 @@ function openCreate() {
   document.getElementById("active-wrap").style.display = "none";
   document.getElementById("tokens-section").style.display = "none";
   renderLibChecks([]);
+  renderFolderTrees([]);
 }
 
 function openEdit(u) {
@@ -202,6 +352,7 @@ function openEdit(u) {
   document.getElementById("f-active").checked = !!u.is_active;
   document.getElementById("active-wrap").style.display = "block";
   renderLibChecks(u.library_ids || []);
+  renderFolderTrees(u.folder_paths || []);
   document.getElementById("tokens-section").style.display = "block";
   document.getElementById("new-token").classList.add("d-none");
   document.getElementById("token-name").value = "";
@@ -259,6 +410,7 @@ async function saveUser() {
     display_name: document.getElementById("f-display").value.trim(),
     role: document.getElementById("f-role").value,
     library_ids: selectedLibs(),
+    folder_paths: selectedFolders(),
   };
   const pw = document.getElementById("f-password").value;
   if (pw) payload.password = pw;

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -3,6 +3,8 @@ Integration tests for the multi-user data layer (PR1):
 user CRUD, password hashing, roles, per-user API tokens, library grants,
 and the owner-seeding / backfill startup routine.
 """
+import os
+
 import pytest
 
 from core.auth import ROLE_LEVELS, role_at_least
@@ -16,8 +18,11 @@ from core.database import (
     get_user_by_id,
     get_user_by_token_hash,
     get_user_by_username,
+    get_user_folder_paths,
     get_user_library_ids,
+    init_db,
     seed_owner_if_needed,
+    set_user_folders,
     set_user_libraries,
     set_user_password,
     user_has_library,
@@ -173,6 +178,45 @@ class TestLibraryGrants:
     def test_new_user_has_no_libraries_by_default(self, db_connection):
         uid = create_user("mia", password="pw")
         assert get_user_library_ids(uid) == set()
+
+
+# ---------------------------------------------------------------------------
+# Folder grants (refine library grants; see core/auth.folder_access_level)
+# ---------------------------------------------------------------------------
+class TestFolderGrants:
+    def test_set_and_get_roundtrip(self, db_connection):
+        uid = create_user("nadia", password="pw", role="reader")
+        set_user_folders(uid, ["/data/a/X", "/data/a/Y"])
+        assert get_user_folder_paths(uid) == [
+            os.path.normpath("/data/a/X"), os.path.normpath("/data/a/Y")]
+
+    def test_set_normalizes_and_dedups(self, db_connection):
+        uid = create_user("omar", password="pw")
+        set_user_folders(uid, ["/data/a/X/", "/data/a/X", "/data/a//Y"])
+        assert get_user_folder_paths(uid) == [
+            os.path.normpath("/data/a/X"), os.path.normpath("/data/a/Y")]
+
+    def test_set_replaces_prior(self, db_connection):
+        uid = create_user("peg", password="pw")
+        set_user_folders(uid, ["/data/a/X"])
+        set_user_folders(uid, ["/data/a/Y"])
+        assert get_user_folder_paths(uid) == [os.path.normpath("/data/a/Y")]
+
+    def test_new_user_has_no_folders(self, db_connection):
+        uid = create_user("quinn", password="pw")
+        assert get_user_folder_paths(uid) == []
+
+    def test_backfill_seeds_root_grants_on_upgrade(self, db_connection):
+        # Simulate a pre-feature DB: existing library grant, folder table absent.
+        # init_db() must recreate the table and seed a whole-library root grant.
+        uid = create_user("rick", password="pw", role="reader")
+        lib = create_library(name="A", path="/data/a")
+        set_user_libraries(uid, [lib])
+        db_connection.execute("DROP TABLE user_folder_permissions")
+        db_connection.commit()
+        init_db()
+        # The seeded grant equals the library's stored root path (normalized).
+        assert get_user_folder_paths(uid) == [os.path.normpath("/data/a")]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/test_folder_access.py
+++ b/tests/routes/test_folder_access.py
@@ -1,0 +1,207 @@
+"""
+Per-user folder-level access enforcement (refines library grants).
+
+A Reader granted Library A but only the folder A/Marvel sees Marvel and its
+descendants, can traverse the library root to reach it (siblings hidden), and is
+denied everything else — via browse, the metadata browser, the file-access gate,
+OPDS, and the token API. The File Manager (/list-directories, a live filesystem
+view) is deliberately NOT folder-scoped. Owners bypass all scoping; single-user
+(implicit-owner) mode enforces nothing.
+"""
+import os
+
+import pytest
+
+from core.database import (
+    create_user,
+    get_user_by_username,
+    set_user_folders,
+    set_user_libraries,
+)
+from tests.factories.db_factories import create_library, create_file_index_entry
+
+
+def _login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+LIB_A = "/data/LibA"
+LIB_B = "/data/LibB"
+GRANT = "/data/LibA/Marvel"          # granted subtree
+SIBLING = "/data/LibA/DC"            # ungranted sibling
+GRANTED_FILE = "/data/LibA/Marvel/XMen_001.cbz"
+HIDDEN_FILE = "/data/LibA/DC/Batman_001.cbz"
+
+
+class TestFolderAccessMultiUser:
+    @pytest.fixture(autouse=True)
+    def _setup(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        self.lib_a = create_library(name="Library A", path=LIB_A)
+        self.lib_b = create_library(name="Library B", path=LIB_B)
+        reader_id = get_user_by_username("reader")["id"]
+        set_user_libraries(reader_id, [self.lib_a])
+        set_user_folders(reader_id, [GRANT])   # only the Marvel subtree
+        yield
+
+    # --- Browse -----------------------------------------------------------
+    def test_browse_granted_folder(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get(f"/api/browse?path={GRANT}").status_code != 403
+
+    def test_browse_ungranted_sibling_denied(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get(f"/api/browse?path={SIBLING}").status_code == 403
+
+    def test_browse_ancestor_traverses_and_hides_siblings(self, client, db_connection):
+        # Library root lists Marvel (on the path to the grant) but not DC.
+        create_file_index_entry(name="Marvel", path=GRANT, entry_type="directory",
+                                parent=LIB_A)
+        create_file_index_entry(name="DC", path=SIBLING, entry_type="directory",
+                                parent=LIB_A)
+        _login(client, "reader", "readerpass")
+        resp = client.get(f"/api/browse?path={LIB_A}")
+        assert resp.status_code != 403
+        names = {d["name"] for d in resp.get_json()["directories"]}
+        assert names == {"Marvel"}
+
+    def test_browse_ungranted_library_denied(self, client):
+        _login(client, "reader", "readerpass")
+        assert client.get(f"/api/browse?path={LIB_B}").status_code == 403
+
+    def test_owner_browses_everything(self, client):
+        _login(client, "owner", "ownerpass")
+        assert client.get(f"/api/browse?path={SIBLING}").status_code != 403
+        assert client.get(f"/api/browse?path={LIB_B}").status_code != 403
+
+    # --- File-access gate + level helper ----------------------------------
+    def test_path_gate_full_only_under_grant(self):
+        from core.auth import user_can_access_path, folder_access_level
+
+        reader = get_user_by_username("reader")
+        owner = get_user_by_username("owner")
+        assert user_can_access_path(reader, GRANTED_FILE) is True
+        assert user_can_access_path(reader, HIDDEN_FILE) is False
+        # The library root is only traversable, never a full grant.
+        assert folder_access_level(reader, LIB_A) == "traverse"
+        assert user_can_access_path(reader, LIB_A) is False
+        assert user_can_access_path(owner, HIDDEN_FILE) is True
+
+    def test_granted_library_without_folders_sees_nothing(self):
+        # No-pick default: a library grant with no folder rows -> no access.
+        from core.auth import folder_access_level
+
+        create_user("bare", password="pw", role="reader")
+        bare = get_user_by_username("bare")
+        set_user_libraries(bare["id"], [self.lib_a])
+        assert folder_access_level(bare, GRANTED_FILE) == "none"
+
+    def test_accessible_prefixes(self):
+        from core.auth import accessible_folder_prefixes
+
+        reader = get_user_by_username("reader")
+        owner = get_user_by_username("owner")
+        assert accessible_folder_prefixes(reader) == [os.path.normpath(GRANT)]
+        assert accessible_folder_prefixes(owner) is None   # unrestricted
+
+    # --- Metadata browser (DB aggregate) ---------------------------------
+    def test_metadata_browse_scoped_to_grant(self, client, db_connection):
+        from core.database import invalidate_metadata_browser_cache
+
+        create_file_index_entry(name="XMen_001.cbz", path=GRANTED_FILE, parent=GRANT)
+        create_file_index_entry(name="Batman_001.cbz", path=HIDDEN_FILE, parent=SIBLING)
+        db_connection.execute(
+            "UPDATE file_index SET ci_publisher=?, ci_series=?, ci_year=? WHERE path=?",
+            ("Marvel", "X-Men", "1991", GRANTED_FILE))
+        db_connection.execute(
+            "UPDATE file_index SET ci_publisher=?, ci_series=?, ci_year=? WHERE path=?",
+            ("DC", "Batman", "1940", HIDDEN_FILE))
+        db_connection.commit()
+        invalidate_metadata_browser_cache()
+
+        _login(client, "reader", "readerpass")
+        pubs = {it["value"] for it in
+                client.get("/api/metadata/browse?axis=publisher").get_json()["items"]}
+        assert pubs == {"Marvel"}
+
+        _login(client, "owner", "ownerpass")
+        pubs = {it["value"] for it in
+                client.get("/api/metadata/browse?axis=publisher").get_json()["items"]}
+        assert pubs == {"Marvel", "DC"}
+
+    # --- Recursive "All Books" view (paginated, SQL-scoped) --------------
+    def test_recursive_paged_scoped_by_prefix(self, db_connection):
+        # /api/browse-recursive pushes folder scope into SQL via
+        # get_files_recursive_paged(allowed_prefixes=...); test that directly so
+        # totals/pagination stay correct (the route itself needs a real on-disk
+        # dir, which the DB-only test env doesn't have).
+        from core.database import get_files_recursive_paged
+
+        root = os.path.normpath(LIB_A)
+        grant = os.path.join(root, "Marvel")
+        sibling = os.path.join(root, "DC")
+        gfile = os.path.join(grant, "XMen_001.cbz")
+        hfile = os.path.join(sibling, "Batman_001.cbz")
+        create_file_index_entry(name="XMen_001.cbz", path=gfile, parent=grant)
+        create_file_index_entry(name="Batman_001.cbz", path=hfile, parent=sibling)
+
+        rows, total, _ = get_files_recursive_paged(root, allowed_prefixes=[grant])
+        assert total == 1
+        assert {r["name"] for r in rows} == {"XMen_001.cbz"}
+
+        # No-pick default: empty prefixes -> nothing.
+        _, total0, _ = get_files_recursive_paged(root, allowed_prefixes=[])
+        assert total0 == 0
+
+        # Unrestricted (owner) -> both files.
+        _, total_all, _ = get_files_recursive_paged(root, allowed_prefixes=None)
+        assert total_all == 2
+
+    # --- Dashboard sections (Want to Read) --------------------------------
+    def test_to_read_hides_inaccessible_folders(self, client, db_connection):
+        # A file marked "want to read" before a permission change must drop out
+        # of the list once the user loses access to its folder.
+        from core.database import add_to_read
+
+        reader_id = get_user_by_username("reader")["id"]
+        add_to_read(GRANTED_FILE, user_id=reader_id)
+        add_to_read(HIDDEN_FILE, user_id=reader_id)
+        _login(client, "reader", "readerpass")
+        paths = {it["path"] for it in
+                 client.get("/api/favorites/to-read").get_json()["items"]}
+        assert GRANTED_FILE in paths
+        assert HIDDEN_FILE not in paths
+
+    # --- File Manager exemption -------------------------------------------
+    def test_file_manager_not_folder_scoped(self, client):
+        # /list-directories is a live filesystem view; folder scope must NOT
+        # apply, so a Reader can still list an ungranted sibling here.
+        _login(client, "reader", "readerpass")
+        # Path is inside a real library -> passes is_valid_library_path; the
+        # folder-scope gate is intentionally absent, so this is never 403.
+        assert client.get(f"/list-directories?path={SIBLING}").status_code != 403
+
+
+class TestFolderAccessImplicitOwner:
+    """Single-user install: folder scope is a no-op."""
+
+    @pytest.fixture(autouse=True)
+    def _libs(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_library(name="Library A", path=LIB_A)
+        yield
+
+    def test_browse_any_folder_allowed(self, client):
+        assert client.get(f"/api/browse?path={SIBLING}").status_code != 403
+
+    def test_level_is_full_without_login(self):
+        from core.auth import folder_access_level
+        assert folder_access_level(None, HIDDEN_FILE) == "full"
+
+    def test_prefixes_unrestricted(self):
+        from core.auth import accessible_folder_prefixes
+        assert accessible_folder_prefixes(None) is None

--- a/tests/routes/test_library_access.py
+++ b/tests/routes/test_library_access.py
@@ -7,7 +7,12 @@ library scoping, and implicit-owner mode (single-user) enforces nothing.
 """
 import pytest
 
-from core.database import create_user, get_user_by_username, set_user_libraries
+from core.database import (
+    create_user,
+    get_user_by_username,
+    set_user_folders,
+    set_user_libraries,
+)
 from tests.factories.db_factories import create_library
 
 
@@ -28,8 +33,11 @@ class TestLibraryAccessMultiUser:
         create_user("reader", password="readerpass", role="reader")
         self.lib_a = create_library(name="Library A", path="/data/LibA")
         self.lib_b = create_library(name="Library B", path="/data/LibB")
-        # Reader is granted only Library A.
-        set_user_libraries(get_user_by_username("reader")["id"], [self.lib_a])
+        # Reader is granted only Library A, with a whole-library folder grant
+        # (equivalent to the upgrade backfill) so library-level scoping applies.
+        reader_id = get_user_by_username("reader")["id"]
+        set_user_libraries(reader_id, [self.lib_a])
+        set_user_folders(reader_id, ["/data/LibA"])
         yield
 
     # --- Browse -----------------------------------------------------------

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -195,6 +195,24 @@ class TestAdminUserApi:
         assert user["role"] == "clerk"
         assert user["library_ids"] == [lib]
 
+    def test_create_and_update_folder_grants(self, client, db_connection):
+        import os
+        from tests.factories.db_factories import create_library
+        lib = create_library(name="A", path="/data/a")
+        _login(client, "owner", "ownerpass")
+        resp = client.post("/api/admin/users", json={
+            "username": "folderuser", "password": "pw", "role": "reader",
+            "library_ids": [lib], "folder_paths": ["/data/a/X"],
+        })
+        assert resp.status_code == 201
+        assert resp.get_json()["user"]["folder_paths"] == [os.path.normpath("/data/a/X")]
+
+        uid = get_user_by_username("folderuser")["id"]
+        resp = client.put(f"/api/admin/users/{uid}",
+                          json={"folder_paths": ["/data/a/Y"]})
+        assert resp.status_code == 200
+        assert resp.get_json()["user"]["folder_paths"] == [os.path.normpath("/data/a/Y")]
+
     def test_create_duplicate_username_conflicts(self, client):
         _login(client, "owner", "ownerpass")
         resp = client.post("/api/admin/users", json={


### PR DESCRIPTION
## Summary

Extends the multi-user RBAC to per-**folder** access. An owner can grant a Reader/Clerk specific folders within a library (nested folders inherit the grant), on top of the existing library grants. Store Owner and single-user (implicit-owner) installs bypass all scoping and are unaffected.

## Access model (`core/auth.py`)

- `folder_access_level(user, path) -> 'full' | 'traverse' | 'none'` is the single source of truth. `full` = view + read here; `traverse` = ancestor of a grant (list it so the user can navigate down, siblings hidden); `none` = denied.
- `user_can_access_path` is strict `full` (file-serve/reader/OPDS/API — no direct-URL bypass).
- `enforce_path_access(path, mode=…)` — `browse` allows traversing ancestor dirs; `full` (default) for serving.
- `filter_paths_for_user(…, allow_traverse=…)` and `accessible_folder_prefixes(user)` for DB-aggregate scoping.

## Enforcement boundary

Scope **everything that reads `file_index`**: `/api/browse`, `/api/browse-recursive` (scope pushed into SQL so pagination/totals stay correct), metadata browser + series cover, batch counts/thumbnails, source wall, OPDS `browse`, and api_v1 metadata-mode browse. Dashboard sections **Want to Read** and **On the Stack** now hide items in folders the user can't access (Recently Added already filtered).

The **File Manager (`/list-directories`, `files.html`) is deliberately exempt** — it's a live filesystem view (api_v1 filesystem-mode browse likewise).

## Data & policy

- New `user_folder_permissions(user_id, folder_path)` table + `get_user_folder_paths` / `set_user_folders`.
- **No folder picks in a granted library = user sees nothing** there.
- One-time upgrade backfill seeds a root grant per existing `(user, library)`, so current installs keep full access until an owner narrows them.

## Admin

- `routes/admin.py` reads/writes `folder_paths`; `templates/users.html` gains a lazy folder-tree picker (checking a folder grants its subtree; stores the minimal set).

## Tests

- New `tests/routes/test_folder_access.py` (browse/traverse, metadata scope, file gate, recursive, Want-to-Read, File-Manager exemption, implicit-owner no-op).
- Folder-grant + upgrade-backfill tests in `tests/integration/test_users.py`; admin round-trip in `tests/routes/test_rbac.py`; `test_library_access.py` updated to the library+folder model.

**Verification:** full suite **2677 passed** (only the documented Windows WAL-lock `test_restore_round_trip` env flake, which passes in isolation); full route suite **772 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)