### PR TITLE
Guard recurring fetch pollers so a slow reverse proxy can't freeze the browser

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,14 @@ except FileNotFoundError:
         # Neither tool available - skip rarfile setup
         pass
 from api import app
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+# Honor nginx/reverse-proxy X-Forwarded-* headers so url_for, redirects, and
+# scheme detection reflect the external request rather than the internal
+# gunicorn socket. No-op when the headers are absent (direct/root access), so
+# there is no behavior change for non-proxied deployments.
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+
 import core.app_state as app_state
 from routes.favorites import favorites_bp
 
@@ -7805,8 +7813,19 @@ def active_operations():
     return jsonify({"operations": ops, "notifications": notifications})
 
 
+# Short-TTL cache for the WATCH-folder walk. The badge poller hits this every
+# 15s per open tab; without a cache each request re-walks the whole WATCH tree
+# and, on a slow/network-mounted dir, can tie up gunicorn's limited threads.
+_watch_count_cache = {"value": None, "ts": 0.0}
+_WATCH_COUNT_TTL = 5.0  # seconds
+
+
 @app.route("/watch-count")
 def watch_count():
+    now = time.time()
+    if _watch_count_cache["value"] is not None and (now - _watch_count_cache["ts"]) < _WATCH_COUNT_TTL:
+        return jsonify({"total_files": _watch_count_cache["value"]})
+
     watch_dir = config.get("SETTINGS", "WATCH", fallback="/temp")
     ignored_exts = config.get("SETTINGS", "IGNORED_EXTENSIONS", fallback=".crdownload")
     ignored = set(ext.strip().lower() for ext in ignored_exts.split(",") if ext.strip())
@@ -7819,6 +7838,9 @@ def watch_count():
             if any(f.lower().endswith(ext) for ext in ignored):
                 continue
             total += 1
+
+    _watch_count_cache["value"] = total
+    _watch_count_cache["ts"] = now
     return jsonify({"total_files": total})
 
 

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -2366,7 +2366,10 @@ function finalizeMoveUI(hasErrors) {
 // Poll /api/operations until all move op_ids finish, then show toast and refresh panels.
 function waitForMoveCompletion(opIds, label, itemCount) {
   if (!Array.isArray(opIds)) opIds = [opIds];
+  let busy = false;  // skip a tick if the previous poll is still in-flight
   const interval = setInterval(() => {
+    if (busy) return;
+    busy = true;
     fetch('/api/operations').then(r => r.json()).then(data => {
       const ops = data.operations || [];
       const pending = opIds.filter(id => {
@@ -2389,7 +2392,7 @@ function waitForMoveCompletion(opIds, label, itemCount) {
         clearAllDropHoverStates();
         finalizeMoveUI(errors.length > 0);
       }
-    }).catch(() => {});
+    }).catch(() => {}).finally(() => { busy = false; });
   }, 2000);
   setTimeout(() => clearInterval(interval), 1800000); // 30min safety
 }
@@ -2397,7 +2400,10 @@ function waitForMoveCompletion(opIds, label, itemCount) {
 // Poll /api/operations until a batch-rename op finishes, then toast and refresh.
 // The heavy work runs in a background thread server-side, so the UI stays responsive.
 function waitForRenameCompletion(opId, itemCount, refreshFn) {
+  let busy = false;  // skip a tick if the previous poll is still in-flight
   const interval = setInterval(() => {
+    if (busy) return;
+    busy = true;
     fetch('/api/operations').then(r => r.json()).then(data => {
       const ops = data.operations || [];
       const op = ops.find(o => o.id === opId);
@@ -2411,7 +2417,7 @@ function waitForRenameCompletion(opId, itemCount, refreshFn) {
           'success');
       }
       if (typeof refreshFn === 'function') refreshFn();
-    }).catch(() => {});
+    }).catch(() => {}).finally(() => { busy = false; });
   }, 2000);
   setTimeout(() => clearInterval(interval), 1800000); // 30min safety
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -132,13 +132,38 @@
     })();
   </script>
 
+  <!-- Guarded polling helper — shared by all recurring pollers -->
+  <script>
+    window.CLU = window.CLU || {};
+    // Guarded interval poller: never overlaps, aborts a hung request, pauses
+    // while the tab is hidden. Prevents stalled responses (e.g. behind a slow
+    // reverse proxy) from piling up in-flight fetches and exhausting the
+    // browser's per-origin connection pool, which freezes the tab.
+    CLU.startPoll = function (fn, intervalMs, opts) {
+      opts = opts || {};
+      var timeoutMs = opts.timeout || 10000;
+      var inFlight = false;
+      function tick() {
+        if (inFlight || document.hidden) return;   // skip overlap + background tabs
+        inFlight = true;
+        var ctrl = new AbortController();
+        var t = setTimeout(function () { ctrl.abort(); }, timeoutMs);
+        Promise.resolve(fn(ctrl.signal))
+          .catch(function () { })                   // caller already logs
+          .finally(function () { clearTimeout(t); inFlight = false; });
+      }
+      if (opts.immediate !== false) tick();         // run once now
+      return setInterval(tick, intervalMs);
+    };
+  </script>
+
   {% block scripts %}
   <script>
     let lastFileWatchCount = 0;
     let lastDownloadCount = 0;
 
-    function updateOperationsIndicator() {
-      fetch('/api/operations')
+    function updateOperationsIndicator(signal) {
+      return fetch('/api/operations', { signal })
         .then(res => res.json())
         .then(data => {
           const indicator = document.getElementById('ops-indicator');
@@ -204,8 +229,8 @@
         .catch(() => {});
     }
 
-    function updateFileWatchBadge() {
-      fetch('/watch-count')
+    function updateFileWatchBadge(signal) {
+      return fetch('/watch-count', { signal })
         .then(res => res.json())
         .then(data => {
           const badge = document.getElementById('file-watch-badge');
@@ -229,8 +254,8 @@
         .catch(err => console.error("Failed to update file watch badge:", err));
     }
 
-    function updateDownloadBadge() {
-      fetch('/download_summary')
+    function updateDownloadBadge(signal) {
+      return fetch('/download_summary', { signal })
         .then(response => response.json())
         .then(data => {
           const badge = document.getElementById('download-badge');
@@ -254,8 +279,8 @@
         .catch(err => console.error("Failed to update download badge:", err));
     }
 
-    function updateScrapeBadge() {
-      fetch('/scrape-status')
+    function updateScrapeBadge(signal) {
+      return fetch('/scrape-status', { signal })
         .then(response => response.json())
         .then(data => {
           const badge = document.getElementById('scrape-badge');
@@ -273,8 +298,8 @@
         .catch(err => console.error("Failed to update scrape badge:", err));
     }
 
-    function checkForUpdates() {
-      fetch('/api/version-check')
+    function checkForUpdates(signal) {
+      return fetch('/api/version-check', { signal })
         .then(res => res.json())
         .then(data => {
           const versionBadge = document.getElementById('version-badge');
@@ -301,20 +326,11 @@
 
     // ✅ Run only after the DOM is ready
     document.addEventListener('DOMContentLoaded', () => {
-      updateFileWatchBadge();
-      setInterval(updateFileWatchBadge, 15000);
-
-      updateDownloadBadge();
-      setInterval(updateDownloadBadge, 15000);
-
-      updateScrapeBadge();
-      setInterval(updateScrapeBadge, 30000);  // Update every 5 seconds for more responsive progress
-
-      checkForUpdates();
-      setInterval(checkForUpdates, 3600000);  // Check every hour
-
-      updateOperationsIndicator();
-      setInterval(updateOperationsIndicator, 3000);
+      CLU.startPoll(updateFileWatchBadge, 15000);
+      CLU.startPoll(updateDownloadBadge, 15000);
+      CLU.startPoll(updateScrapeBadge, 30000);
+      CLU.startPoll(checkForUpdates, 3600000);   // Check every hour
+      CLU.startPoll(updateOperationsIndicator, 3000);
     });
   </script>
   {% endblock %}

--- a/templates/config.html
+++ b/templates/config.html
@@ -2713,8 +2713,11 @@
 
                 // Poll until last_sync changes (sync completed)
                 let attempts = 0;
+                let busy = false;  // skip a tick if the previous poll is still in-flight
                 const maxAttempts = 20;
                 const pollInterval = setInterval(async () => {
+                    if (busy) return;
+                    busy = true;
                     attempts++;
                     try {
                         const statusResp = await fetch('/api/komga/sync/status', { headers: { 'Cache-Control': 'no-cache' } });
@@ -2736,6 +2739,8 @@
                         }
                     } catch (e) {
                         // Keep polling on transient errors
+                    } finally {
+                        busy = false;
                     }
                 }, 3000);
             } else {

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -403,7 +403,10 @@
         }
 
         function pollScan(opId) {
+            let busy = false;  // skip a tick if the previous poll is still in-flight
             automapPoll = setInterval(() => {
+                if (busy) return;
+                busy = true;
                 fetch('/api/pull-list/scan/status?op_id=' + encodeURIComponent(opId))
                     .then(r => r.json())
                     .then(data => {
@@ -423,7 +426,8 @@
                             showAutomapError(data.error || 'Scan failed');
                         }
                     })
-                    .catch(err => { clearInterval(automapPoll); showAutomapError(err.message); });
+                    .catch(err => { clearInterval(automapPoll); showAutomapError(err.message); })
+                    .finally(() => { busy = false; });
             }, 1000);
         }
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -53,8 +53,8 @@
 {{ super() }}
     <script>
     // Function to fetch all download statuses and update the table.
-    function fetchStatus() {
-      fetch('/download_status_all')
+    function fetchStatus(signal) {
+      return fetch('/download_status_all', { signal })
         .then(response => response.json())
         .then(data => {
           const tbody = document.querySelector('#downloads-table tbody');
@@ -245,9 +245,8 @@
       });
     });
 
-    // Poll the status endpoint every second.
-    setInterval(fetchStatus, 1000);
-    fetchStatus();
+    // Poll the status endpoint every second (guarded: no overlap, self-aborts).
+    CLU.startPoll(fetchStatus, 1000);
 
     // Toast notification system for status.html
     function showToast(message, type = 'info', duration = 5000) {

--- a/templates/wanted.html
+++ b/templates/wanted.html
@@ -603,7 +603,9 @@
 
     // Poll for refresh completion
     function pollRefreshStatus() {
-        fetch('/api/wanted-status')
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), 10000);  // recover if the request hangs
+        fetch('/api/wanted-status', { signal: ctrl.signal })
             .then(r => r.json())
             .then(data => {
                 if (data.refreshing) {
@@ -616,7 +618,8 @@
             .catch(e => {
                 // On error, try reloading anyway
                 setTimeout(() => location.reload(), 2000);
-            });
+            })
+            .finally(() => clearTimeout(t));
     }
 
     // Auto-poll when in loading state


### PR DESCRIPTION
## Problem

A user running CLU behind an nginx reverse proxy reported the browser console filling with:

```
Failed to update file watch badge: TypeError: NetworkError when attempting to fetch resource.
Failed to update download badge: TypeError: NetworkError when attempting to fetch resource.
```

…after which the tab becomes unresponsive ("crashes"), and the only recovery is to change the nginx **port and proxy target** — which works because a new port is a new browser *origin* with a fresh connection pool.

## Root cause

Every recurring poller in the frontend fired on a bare `setInterval` with **no in-flight guard, no timeout, and no `AbortController`**:

| Poller | URL | Interval |
|---|---|---|
| `updateOperationsIndicator` | `/api/operations` | 3s |
| `updateFileWatchBadge` | `/watch-count` | 15s |
| `updateDownloadBadge` | `/download_summary` | 15s |
| `updateScrapeBadge` | `/scrape-status` | 30s |
| `checkForUpdates` | `/api/version-check` | 1h |
| `fetchStatus` | `/download_status_all` | **1s** |

When any response stalls behind the proxy, the fast pollers keep issuing **new** fetches while prior ones are still pending. Browsers cap ~6 connections per origin, so stuck requests saturate the pool and every subsequent request (including navigation) queues behind them — the tab freezes. The error is `NetworkError` (connection-level), not a 404, which rules out sub-path routing as the primary cause.

## Changes

**Frontend**
- Add a shared `CLU.startPoll(fn, intervalMs)` helper in `base.html`: skips a tick if the previous request is still in-flight, aborts a request that hangs >10s, and pauses while the tab is hidden.
- Route the five `base.html` badge pollers and `status.html`'s 1s `/download_status_all` poller through it (functions now `return` their fetch chain and accept an abort `signal`).
- Add in-flight guards to the action-triggered pollers in `files.js` (move/rename), `pull_list.html`, and `config.html`; add a 10s abort timeout to `wanted.html`'s recursion.

**Backend** (`api.py` intentionally untouched)
- Wrap `app.wsgi_app` in `ProxyFix` so nginx `X-Forwarded-*` headers are honored for `url_for`/redirects/scheme. No-op when the headers are absent, so **no regression** for non-proxied/root deployments.
- Add a 5s TTL cache to `/watch-count` so the 15s badge poll can't re-walk a slow/network-mounted WATCH tree on every request and tie up gunicorn's limited threads.

## Sub-path note (deferred)

If CLU is actually mounted under a sub-path (e.g. `example.com/clu/`), the hardcoded root-absolute `fetch`/`EventSource` URLs would need to become prefix-relative — a larger, separate change. That failure mode produces **404s**, not the `NetworkError` reported here, so it's very likely not this issue. The `ProxyFix` `x_prefix=1` lays the groundwork if it's later confirmed.

## Verification

- App boots; `/watch-count`, `/download_summary`, `/health` return valid JSON; the TTL cache returns consistent values.
- `curl -H "X-Forwarded-Proto: https" -H "X-Forwarded-Prefix: /clu" …` returns 200 — `ProxyFix` no-ops.
- Pages render with the helper present; each poller issues one request per interval and cancels after ~10s on a stall.
- `pytest`: **2505 passed**, 6 expected POSIX skips. (`test_reports_corruption` flaked once under full-suite ordering and passes in isolation and within its own file — a pre-existing Windows ordering flake unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)