### PR TITLE
Fix browser-extension downloads blocked by the login gate

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -31,7 +31,16 @@ def _auth_enabled():
     )
 
 
-_EXEMPT_PREFIXES = ("/login", "/logout", "/static/", "/opds", "/api/insights", "/api/v1/")
+# Download endpoints (api.py) are auth-free by design so the browser extension
+# — which sends no Flask session cookie — can queue downloads. "/download"
+# prefix-matches /download, /download_status, /download_status_all and
+# /download_summary; the management endpoints are listed explicitly.
+_EXEMPT_PREFIXES = (
+    "/login", "/logout", "/static/", "/opds", "/api/insights", "/api/v1/",
+    "/download",
+    "/cancel_download", "/retry_download", "/dismiss_download",
+    "/clear_downloads", "/clear_failed_downloads",
+)
 
 
 @auth_bp.before_app_request

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -96,3 +96,18 @@ class TestAuthEnabled:
     def test_static_exempt_from_auth(self, client):
         r = client.get("/static/images/clu.png")
         assert r.status_code != 302 or "/login" not in r.headers.get("Location", "")
+
+    def test_download_exempt_from_auth(self, client):
+        # The browser extension POSTs {link:...} with no session cookie; the auth
+        # gate must not redirect it to /login (regression: multi-user login gate).
+        r = client.post(
+            "/download",
+            json={"link": "https://example.com/x.cbz"},
+            follow_redirects=False,
+        )
+        assert r.status_code != 302
+        assert "/login" not in r.headers.get("Location", "")
+
+    def test_download_status_exempt_from_auth(self, client):
+        r = client.get("/download_status_all", follow_redirects=False)
+        assert r.status_code != 302


### PR DESCRIPTION
## Problem

The Chrome extension's "Send to CLU" (right-click and injected-icon) downloads silently stopped working. The icon flashes green as if successful, but nothing is queued, nothing appears in the Downloads page, and neither `api.py` nor `monitor.py` log anything.

## Root cause

The `require_login` hook in `routes/auth.py` (a `before_app_request` registered via `auth_bp`) guards **every** route but only exempted `/login`, `/logout`, `/static/`, `/opds`, `/api/insights`, `/api/v1/`. `POST /download` — the endpoint the extension calls — was **not** exempt.

When login is required (both `CLU_USERNAME`/`CLU_PASSWORD` set, or 2+ user accounts on `feature/multi-user`), the extension's `fetch` sends no Flask session cookie, so the gate returns `302 → /login`. The extension follows the redirect (default `redirect: "follow"`), receives the login page with HTTP 200, and reports success (it only checks `response.ok`) — while `download()` was never reached. Hence: no queue entry, no logs, no browser error.

## Fix

Add the download endpoints to `_EXEMPT_PREFIXES` in `routes/auth.py`:

- `/download` prefix-covers `/download`, `/download_status/<id>`, `/download_status_all`, `/download_summary`.
- The management endpoints (`/cancel_download`, `/retry_download`, `/dismiss_download`, `/clear_downloads`, `/clear_failed_downloads`) are listed explicitly.

The exemption is checked at the top of the hook (before the user/role lookup), so it also clears reader-role 403s on multi-user. A prefix grep confirms every `/download*` route lives in `api.py`'s download subsystem — no library/file-serving route shares the prefix — so nothing sensitive is un-gated. This restores the pre-existing, intended auth-free download surface the extension relies on. **`api.py` is untouched.**

## Tests

Added to `tests/routes/test_auth.py` under `TestAuthEnabled`:
- `test_download_exempt_from_auth` — `POST /download` with no session is not redirected to `/login`.
- `test_download_status_exempt_from_auth` — `/download_status_all` is not gated.

All 12 auth tests pass.

## Note

This branch is based on `main`, where the gate only activates with `CLU_USERNAME`/`CLU_PASSWORD`. `feature/multi-user` has the identical `_EXEMPT_PREFIXES` tuple line, so this change merges cleanly there and fixes the multi-user case (login required once a 2nd account exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)