### PR TITLE
Scope /api/insights reading stats to a per-user API token

### DIFF
--- a/app.py
+++ b/app.py
@@ -8049,31 +8049,35 @@ def insights_page():
 
 @app.route("/api/insights")
 def api_insights():
-    """Return library stats as JSON for Homepage custom API widget."""
-    from core.database import get_reading_stats_by_year
+    """Return library + per-user reading stats as JSON for the Homepage custom
+    API widget (gethomepage.dev ``customapi`` type — a flat JSON object).
 
-    library_stats = get_library_stats()
-    if not library_stats:
+    The library-wide counts (files, size, root folders) are global. The reading
+    counters (``issues_read``, ``pages_read``, ``time_reading*``) are per user:
+    present a per-user API token as ``Authorization: Bearer <token>`` (the same
+    tokens minted in Settings → Users for ``/api/v1``) and the numbers reflect
+    that account. Homepage's ``customapi`` widget supports this via its
+    per-widget ``headers`` option.
+
+    With no token the counters reflect the Store Owner, matching the previous
+    behaviour; a legacy global token also maps to the owner. A malformed or
+    unknown token is rejected with 401 so a misconfigured widget doesn't
+    silently surface the owner's stats.
+    """
+    from core.auth import resolve_optional_bearer_user
+    from models.stats import get_insights_stats
+
+    status, user = resolve_optional_bearer_user(
+        request.headers.get("Authorization", "")
+    )
+    if status == "invalid":
+        return jsonify({"error": "unauthorized"}), 401
+
+    payload = get_insights_stats(user_id=user["id"] if user else None)
+    if payload is None:
         return jsonify({"error": "Failed to get stats"}), 500
 
-    # Get reading stats (all-time)
-    reading_stats = get_reading_stats_by_year(None)
-    total_seconds = reading_stats.get("total_time", 0)
-    hours = total_seconds // 3600
-    minutes = (total_seconds % 3600) // 60
-
-    return jsonify(
-        {
-            "total_files": library_stats.get("total_files", 0),
-            "total_size": library_stats.get("total_size", 0),
-            "issues_read": library_stats.get("total_read", 0),
-            "root_folders": library_stats.get("root_folders", 0),
-            "pages_read": reading_stats.get("total_pages", 0),
-            "time_reading": total_seconds,
-            "time_reading_hours": hours,
-            "time_reading_minutes": minutes,
-        }
-    )
+    return jsonify(payload)
 
 
 @app.route("/api/reading-stats")

--- a/core/auth.py
+++ b/core/auth.py
@@ -90,6 +90,51 @@ def current_user():
     return user
 
 
+def resolve_optional_bearer_user(auth_header):
+    """Resolve an optional ``Authorization: Bearer <token>`` header to a user.
+
+    For endpoints that are public by default but can be *personalised* with an
+    API token (e.g. ``/api/insights`` for a Homepage widget). Returns a
+    ``(status, user)`` tuple:
+
+        ("anonymous", None)  no Bearer credentials — the caller should fall
+                             back to its default identity (the Store Owner).
+        ("ok", user_dict)    a valid per-user token, or the legacy global token
+                             (which maps to the Store Owner).
+        ("invalid", None)    a Bearer token was presented but matched nothing —
+                             the caller should reject with 401 so a
+                             misconfigured token isn't silently served as the
+                             owner's data.
+
+    Unlike the ``/api/v1`` gate this never 503s: a missing token is a valid
+    anonymous state, not an error. The per-user tokens are the same ones minted
+    in Settings → Users and used by ``/api/v1``.
+    """
+    import hmac
+    from core.database import (
+        _hash_token,
+        get_api_token,
+        get_user_by_token_hash,
+    )
+
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return "anonymous", None
+
+    presented = auth_header[len("Bearer "):].strip()
+    if not presented:
+        return "anonymous", None
+
+    user = get_user_by_token_hash(_hash_token(presented))
+    if user:
+        return "ok", user
+
+    legacy_token = get_api_token()
+    if legacy_token and hmac.compare_digest(presented, legacy_token):
+        return "ok", get_owner()
+
+    return "invalid", None
+
+
 def _wants_json():
     """True when the caller expects a JSON error rather than an HTML redirect."""
     return request.path.startswith("/api/") or request.path.startswith("/opds")

--- a/models/stats.py
+++ b/models/stats.py
@@ -54,6 +54,40 @@ def get_library_stats():
         app_logger.error(f"Error getting library stats: {e}")
         return stats
 
+def get_insights_stats(user_id=None):
+    """Build the flat stats payload served by ``/api/insights``.
+
+    Library-wide counts (files, size, root folders) are global; the reading
+    counters (``issues_read``, ``pages_read``, ``time_reading*``) are scoped to
+    ``user_id``. When ``user_id`` is None the reading counters resolve to the
+    current request user, or the Store Owner outside a request (see
+    ``get_reading_stats_by_year`` / ``_resolve_user_id``).
+
+    Returns None if library stats are unavailable so the caller can emit a 500.
+    """
+    from core.database import get_reading_stats_by_year
+
+    library_stats = get_library_stats()
+    if not library_stats:
+        return None
+
+    reading_stats = get_reading_stats_by_year(None, user_id=user_id)
+    total_seconds = reading_stats.get("total_time", 0) or 0
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+
+    return {
+        "total_files": library_stats.get("total_files", 0),
+        "total_size": library_stats.get("total_size", 0),
+        "issues_read": reading_stats.get("total_read", 0),
+        "root_folders": library_stats.get("root_folders", 0),
+        "pages_read": reading_stats.get("total_pages", 0),
+        "time_reading": total_seconds,
+        "time_reading_hours": hours,
+        "time_reading_minutes": minutes,
+    }
+
+
 def get_file_type_distribution():
     """
     Get the distribution of file types in the library.

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -215,6 +215,24 @@ def app(db_connection, tmp_path):
     def insights_page():
         return "stub", 200
 
+    # Mirrors app.py's /api/insights against the real helpers (app.py itself
+    # isn't importable here). Keep in sync with app.py:api_insights.
+    @test_app.route("/api/insights")
+    def api_insights():
+        from flask import jsonify, request as flask_request
+        from core.auth import resolve_optional_bearer_user
+        from models.stats import get_insights_stats
+
+        status, user = resolve_optional_bearer_user(
+            flask_request.headers.get("Authorization", "")
+        )
+        if status == "invalid":
+            return jsonify({"error": "unauthorized"}), 401
+        payload = get_insights_stats(user_id=user["id"] if user else None)
+        if payload is None:
+            return jsonify({"error": "Failed to get stats"}), 500
+        return jsonify(payload)
+
     @test_app.route("/logs")
     def logs_page():
         return "stub", 200

--- a/tests/routes/test_insights_api.py
+++ b/tests/routes/test_insights_api.py
@@ -1,0 +1,173 @@
+"""Tests for the /api/insights endpoint and its helpers.
+
+/api/insights is a public (login-gate-exempt) JSON endpoint for the
+gethomepage.dev `customapi` widget. It now supports an optional per-user API
+token: with a `Authorization: Bearer <token>` header the reading counters
+(issues_read / pages_read / time_reading*) are scoped to that user; without a
+token they reflect the Store Owner (backwards compatible).
+
+The route itself lives in app.py (not a blueprint); conftest registers an
+equivalent route against the same real helpers, so these exercise the wiring
+end-to-end. The helpers are also unit-tested directly.
+"""
+import pytest
+
+from core.auth import resolve_optional_bearer_user
+from core.database import (
+    create_api_token,
+    create_user,
+    get_owner_user,
+    mark_issue_read,
+    set_user_preference,
+)
+from models.stats import get_insights_stats
+
+
+READING_KEYS = {
+    "issues_read",
+    "pages_read",
+    "time_reading",
+    "time_reading_hours",
+    "time_reading_minutes",
+}
+ALL_KEYS = READING_KEYS | {"total_files", "total_size", "root_folders"}
+
+
+@pytest.fixture
+def two_readers(db_connection):
+    """Two reader accounts, each with a token and distinct reading history.
+
+    Alice: 2 issues, 30 pages, 3900s (1h 05m).
+    Bob:   1 issue, 5 pages, 120s.
+    """
+    alice = create_user("alice", role="reader")
+    bob = create_user("bob", role="reader")
+    token_a = create_api_token(alice)
+    token_b = create_api_token(bob)
+
+    mark_issue_read("/data/a1.cbz", page_count=20, time_spent=3600, user_id=alice)
+    mark_issue_read("/data/a2.cbz", page_count=10, time_spent=300, user_id=alice)
+    mark_issue_read("/data/b1.cbz", page_count=5, time_spent=120, user_id=bob)
+
+    return {
+        "alice": alice, "bob": bob,
+        "token_a": token_a, "token_b": token_b,
+    }
+
+
+# =============================================================================
+# resolve_optional_bearer_user
+# =============================================================================
+
+
+class TestResolveOptionalBearerUser:
+    def test_no_header_is_anonymous(self, db_connection):
+        assert resolve_optional_bearer_user("") == ("anonymous", None)
+
+    def test_non_bearer_header_is_anonymous(self, db_connection):
+        assert resolve_optional_bearer_user("Basic abc") == ("anonymous", None)
+
+    def test_empty_bearer_is_anonymous(self, db_connection):
+        assert resolve_optional_bearer_user("Bearer   ") == ("anonymous", None)
+
+    def test_valid_per_user_token_resolves_user(self, two_readers):
+        status, user = resolve_optional_bearer_user(
+            f"Bearer {two_readers['token_a']}"
+        )
+        assert status == "ok"
+        assert user["id"] == two_readers["alice"]
+
+    def test_unknown_token_is_invalid(self, two_readers):
+        assert resolve_optional_bearer_user("Bearer nope") == ("invalid", None)
+
+    def test_legacy_global_token_maps_to_owner(self, db_connection):
+        # Seed an owner so the legacy token has someone to map to.
+        create_user("owner", role="owner", display_name="Store Owner")
+        set_user_preference("api_token", "legacy-xyz", category="security")
+
+        status, user = resolve_optional_bearer_user("Bearer legacy-xyz")
+        assert status == "ok"
+        owner = get_owner_user()
+        assert user["id"] == owner["id"]
+
+
+# =============================================================================
+# get_insights_stats
+# =============================================================================
+
+
+class TestGetInsightsStats:
+    def test_shape_and_keys(self, two_readers):
+        payload = get_insights_stats(user_id=two_readers["alice"])
+        assert ALL_KEYS.issubset(payload.keys())
+
+    def test_scoped_reading_counters(self, two_readers):
+        alice = get_insights_stats(user_id=two_readers["alice"])
+        bob = get_insights_stats(user_id=two_readers["bob"])
+
+        assert alice["issues_read"] == 2
+        assert alice["pages_read"] == 30
+        assert alice["time_reading"] == 3900
+        assert alice["time_reading_hours"] == 1
+        assert alice["time_reading_minutes"] == 5
+
+        assert bob["issues_read"] == 1
+        assert bob["pages_read"] == 5
+        assert bob["time_reading"] == 120
+        assert bob["time_reading_hours"] == 0
+        assert bob["time_reading_minutes"] == 2
+
+
+# =============================================================================
+# /api/insights route
+# =============================================================================
+
+
+class TestInsightsRoute:
+    def test_no_token_returns_200(self, db_connection, client):
+        resp = client.get("/api/insights")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert ALL_KEYS.issubset(body.keys())
+
+    def test_invalid_token_returns_401(self, two_readers, client):
+        resp = client.get(
+            "/api/insights",
+            headers={"Authorization": "Bearer bogus-token"},
+        )
+        assert resp.status_code == 401
+        assert resp.get_json()["error"] == "unauthorized"
+
+    def test_per_user_token_scopes_stats(self, two_readers, client):
+        resp_a = client.get(
+            "/api/insights",
+            headers={"Authorization": f"Bearer {two_readers['token_a']}"},
+        )
+        resp_b = client.get(
+            "/api/insights",
+            headers={"Authorization": f"Bearer {two_readers['token_b']}"},
+        )
+        assert resp_a.status_code == 200 and resp_b.status_code == 200
+
+        a = resp_a.get_json()
+        b = resp_b.get_json()
+        assert a["issues_read"] == 2
+        assert a["pages_read"] == 30
+        assert a["time_reading"] == 3900
+        assert b["issues_read"] == 1
+        assert b["pages_read"] == 5
+        assert b["time_reading"] == 120
+
+    def test_legacy_token_maps_to_owner(self, db_connection, client):
+        owner_id = create_user("owner", role="owner", display_name="Store Owner")
+        set_user_preference("api_token", "legacy-abc", category="security")
+        mark_issue_read("/data/o.cbz", page_count=7, time_spent=60, user_id=owner_id)
+
+        resp = client.get(
+            "/api/insights",
+            headers={"Authorization": "Bearer legacy-abc"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["issues_read"] == 1
+        assert body["pages_read"] == 7


### PR DESCRIPTION
## Summary

`/api/insights` (the JSON endpoint for the [gethomepage.dev](https://gethomepage.dev) `customapi` widget) now supports **optional per-user API tokens**, scoping the reading counters to whichever user's token is presented — while staying backwards compatible with existing tokenless widgets.

The reading counters are now per user:
- `issues_read`
- `pages_read`
- `time_reading`
- `time_reading_hours`
- `time_reading_minutes`

Library-wide counts (`total_files`, `total_size`, `root_folders`) remain global.

## Behavior

| Request | Result |
|---|---|
| No `Authorization` header | `200` — Store Owner stats (unchanged from before) |
| `Bearer <per-user-token>` | `200` — that user's reading stats |
| `Bearer <legacy-global-token>` | `200` — Store Owner stats |
| `Bearer <unknown/malformed>` | `401` — so a misconfigured widget doesn't silently surface owner data |

Tokens are the same per-user tokens minted in **Settings → Users** and used by `/api/v1`. The resolution logic is identical to the `/api/v1` gate, except it never `503`s — a missing token is a valid anonymous state, not an error.

### Homepage `customapi` usage

```yaml
- Comics:
    widget:
      type: customapi
      url: http://clu:5577/api/insights
      headers:
        Authorization: Bearer <token>
      mappings:
        - field: issues_read
          label: Issues Read
        - field: pages_read
          label: Pages Read
        - field: time_reading_hours
          label: Hours
```

## Changes

- **`core/auth.py`** — new `resolve_optional_bearer_user(auth_header)` returning `(status, user)`: `"anonymous"` (no token → owner fallback), `"ok"` (valid per-user or legacy token), or `"invalid"` (→ 401).
- **`models/stats.py`** — new `get_insights_stats(user_id=None)` builds the flat payload; reading counters come consistently from `get_reading_stats_by_year(None, user_id=...)`.
- **`app.py`** — `api_insights()` slimmed to wire those two helpers.
- **`tests/routes/conftest.py`** — registers `/api/insights` against the real helpers (app.py isn't importable in the route harness; mirrors how the conftest already stubs other app.py routes).
- **`tests/routes/test_insights_api.py`** *(new)* — 12 tests: helpers directly + route end-to-end (token isolation, 401 on bad token, anonymous/legacy → owner).

## Testing

- New file: `tests/routes/test_insights_api.py` — 12 passing.
- Full suite green: **2693 passed, 6 skipped** (`test_pdf.py` excluded per the known env-only baseline; skips are POSIX permission semantics on Windows).

## Notes

`/api/insights` remains exempt from the login gate by design, so the tokenless owner-stats path keeps working for existing setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)