### PR TITLE
Reader-role: Gate management controls, View Reading lists, Self-service API tokens

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -337,6 +337,7 @@ _READER_WRITE_PREFIXES = (
     "/to-read",
     "/api/continue-reading",
     "/api/on-the-stack",
+    "/api/account/",           # a user managing their OWN API tokens (self-service)
 )
 
 # Read-only endpoints that use POST purely to carry a request body (a batch of
@@ -360,6 +361,7 @@ _CLERK_PREFIXES = (
     "/api/bulk-metadata",
     "/api/source-wall",
     "/api/weekly-packs",
+    "/logs/tail",              # raw app/monitor log content (can expose system info)
 )
 
 # Browser *pages* that are Clerk features (file management, pull list,
@@ -380,6 +382,9 @@ _CLERK_PAGE_PATHS = frozenset({
     "/publishers",       # Publishers
     "/metadata/history",  # Metadata History
     "/source-wall",      # Source Wall
+    "/logs",             # Logs viewer (can expose system info)
+    "/app-logs",         # Logs alias (redirects to /logs)
+    "/mon-logs",         # Logs alias (redirects to /logs)
 })
 
 

--- a/core/database.py
+++ b/core/database.py
@@ -8323,6 +8323,82 @@ def get_reading_lists(user_id=None):
         return []
 
 
+def get_all_reading_lists(viewer_id=None):
+    """
+    Get every reading list (global), with read_count scoped to the viewing user.
+
+    Mirrors get_reading_lists() but drops the ``WHERE rl.user_id = ?`` owner filter so
+    every user sees every list, while keeping the ``ir.user_id = ?`` read-count join so
+    the progress badge reflects the viewer's own reads. Used by the Reading Lists grid
+    page so readers can browse lists an admin/clerk imported. List mutations remain
+    clerk-gated at the route layer, and per-user readers (get_reading_lists) are left
+    intact for isolation-sensitive callers (e.g. bulk "Delete All").
+
+    Returns:
+        List of dictionaries containing reading list info
+    """
+    try:
+        uid = _resolve_user_id(viewer_id)
+        conn = get_db_connection()
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+
+        # All lists, but read_count is scoped to the viewing user so one user's
+        # progress doesn't inflate another's badge.
+        c.execute("""
+            SELECT rl.*,
+                   COUNT(DISTINCT rle.id) as entry_count,
+                   COUNT(DISTINCT ir.id) as read_count
+            FROM reading_lists rl
+            LEFT JOIN reading_list_entries rle ON rl.id = rle.reading_list_id
+            LEFT JOIN issues_read ir ON COALESCE(rle.manual_override_path, rle.matched_file_path) = ir.issue_path
+                                    AND ir.user_id = ?
+            GROUP BY rl.id
+            ORDER BY rl.created_at DESC
+        """, (uid,))
+
+        lists = [dict(row) for row in c.fetchall()]
+
+        import json
+
+        # Get covers for each list
+        for lst in lists:
+            c.execute(
+                """
+                SELECT COALESCE(manual_override_path, matched_file_path) as path
+                FROM reading_list_entries
+                WHERE reading_list_id = ?
+                AND COALESCE(manual_override_path, matched_file_path) IS NOT NULL
+                LIMIT 5
+            """,
+                (lst["id"],),
+            )
+
+            # Get valid covers from entries
+            covers = [row["path"] for row in c.fetchall() if row["path"]]
+
+            # If there's a specific thumbnail set, ensure it's first
+            if lst["thumbnail_path"]:
+                if lst["thumbnail_path"] in covers:
+                    covers.remove(lst["thumbnail_path"])
+                covers.insert(0, lst["thumbnail_path"])
+
+            # Limit to 5 covers
+            lst["covers"] = covers[:5]
+
+            # Parse tags JSON
+            try:
+                lst["tags"] = json.loads(lst.get("tags") or "[]")
+            except (json.JSONDecodeError, TypeError):
+                lst["tags"] = []
+
+        conn.close()
+        return lists
+    except Exception as e:
+        app_logger.error(f"Error getting all reading lists: {str(e)}")
+        return []
+
+
 def get_reading_list(list_id):
     """
     Get a specific reading list and its entries.

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -26,10 +26,17 @@ from flask import (
 
 from core.auth import (
     check_request_permitted,
+    current_user,
     is_login_required,
     load_current_user,
 )
-from core.database import update_last_login, verify_password
+from core.database import (
+    create_api_token,
+    delete_api_token,
+    list_api_tokens,
+    update_last_login,
+    verify_password,
+)
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -116,3 +123,56 @@ def login():
 def logout():
     session.clear()
     return redirect(url_for("auth.login"))
+
+
+# ---------------------------------------------------------------------------
+# Self-service account page: any logged-in user manages their OWN API tokens.
+#
+# Token minting used to be owner-only (via /api/admin). These routes let every
+# role (reader included) create/list/revoke tokens scoped to themselves. All
+# operations pass g.current_user["id"] to the user-scoped DB helpers, so a user
+# can never see or delete another user's tokens. The reader-write allowance for
+# the POST/DELETE lives in core.auth._READER_WRITE_PREFIXES ("/api/account/").
+# A token only ever authenticates as its owner, so it grants no privilege the
+# user doesn't already have.
+# ---------------------------------------------------------------------------
+
+
+@auth_bp.route("/account")
+def account():
+    """Self-service account page (currently: personal API tokens)."""
+    return render_template("account.html")
+
+
+@auth_bp.route("/api/account/tokens", methods=["GET"])
+def account_list_tokens():
+    """List the current user's API tokens (metadata only)."""
+    user = current_user()
+    if user is None:
+        return jsonify({"error": "unauthorized"}), 401
+    return jsonify({"success": True, "tokens": list_api_tokens(user["id"])})
+
+
+@auth_bp.route("/api/account/tokens", methods=["POST"])
+def account_create_token():
+    """Issue a new API token for the current user. Plaintext is returned once."""
+    user = current_user()
+    if user is None:
+        return jsonify({"error": "unauthorized"}), 401
+    body = request.get_json(silent=True) or {}
+    name = (body.get("name") or "").strip() or None
+    token = create_api_token(user["id"], name=name)
+    if not token:
+        return jsonify({"success": False, "error": "could not create token"}), 500
+    return jsonify({"success": True, "token": token, "name": name}), 201
+
+
+@auth_bp.route("/api/account/tokens/<int:token_id>", methods=["DELETE"])
+def account_delete_token(token_id):
+    """Revoke one of the current user's tokens (scoped to the owner)."""
+    user = current_user()
+    if user is None:
+        return jsonify({"error": "unauthorized"}), 401
+    if not delete_api_token(token_id, user_id=user["id"]):
+        return jsonify({"success": False, "error": "token not found"}), 404
+    return jsonify({"success": True})

--- a/routes/reading_lists.py
+++ b/routes/reading_lists.py
@@ -12,6 +12,7 @@ from core.database import (
     create_reading_list,
     add_reading_list_entry,
     get_reading_lists,
+    get_all_reading_lists,
     get_reading_list,
     update_reading_list_entry_match,
     delete_reading_list,
@@ -134,8 +135,13 @@ def _convert_github_blob_to_raw(url):
 
 @reading_lists_bp.route('/reading-lists')
 def index():
-    """View all reading lists."""
-    lists = get_reading_lists()
+    """View all reading lists.
+
+    Uses the global reader so every role (including readers) sees lists an
+    admin/clerk imported; management actions stay clerk-gated in the template
+    and at the route layer.
+    """
+    lists = get_all_reading_lists()
     return render_template('reading_lists.html', lists=lists)
 
 @reading_lists_bp.route('/reading-lists/<int:list_id>')

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,121 @@
+{% extends 'base.html' %}
+
+{% block title %}CLU: My Account{% endblock %}
+
+{% block content %}
+<div class="container py-4" id="account-app" style="max-width: 720px;">
+  <div class="d-flex align-items-center mb-3">
+    <h2 class="mb-0"><i class="bi bi-person-badge me-2"></i>My Account</h2>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h5 class="card-title mb-1"><i class="bi bi-key me-2"></i>API Tokens</h5>
+      <p class="text-muted small mb-3">
+        Personal bearer tokens for API/reader clients. A token acts as you and has
+        your access level. Send it as <code>Authorization: Bearer &lt;token&gt;</code>.
+        See the <a href="/api/v1/docs">API docs</a> for endpoints.
+      </p>
+
+      <div id="account-alert"></div>
+
+      <div id="tokens-list" class="border rounded p-2 small mb-3">
+        <span class="text-muted">Loading&hellip;</span>
+      </div>
+
+      <div class="input-group">
+        <input type="text" class="form-control" id="token-name"
+               placeholder="Token name (e.g. Phone)">
+        <button class="btn btn-outline-primary" type="button" onclick="createToken()">
+          <i class="bi bi-plus-lg me-1"></i>Create token
+        </button>
+      </div>
+
+      <div id="new-token" class="alert alert-success mt-3 d-none">
+        <strong>Copy this token now — it won't be shown again:</strong>
+        <div class="input-group mt-2">
+          <code id="new-token-value" class="form-control text-break bg-body"></code>
+          <button class="btn btn-outline-secondary" type="button" onclick="copyNewToken()"
+                  title="Copy to clipboard">
+            <i class="bi bi-clipboard"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    }[c]));
+  }
+
+  function alertMsg(msg) {
+    document.getElementById("account-alert").innerHTML =
+      `<div class="alert alert-danger">${esc(msg)}</div>`;
+  }
+
+  async function loadTokens() {
+    const box = document.getElementById("tokens-list");
+    try {
+      const resp = await fetch("/api/account/tokens");
+      const data = await resp.json().catch(() => ({}));
+      const tokens = (data && data.tokens) || [];
+      if (!tokens.length) {
+        box.innerHTML = "<span class='text-muted'>No tokens yet.</span>";
+        return;
+      }
+      box.innerHTML = tokens.map(t => `
+        <div class="d-flex justify-content-between align-items-center py-1">
+          <span>${esc(t.name || "(unnamed)")}
+            <span class="text-muted">· ${t.last_used_at ? "last used " + esc(t.last_used_at) : "never used"}</span>
+          </span>
+          <button class="btn btn-sm btn-outline-danger py-0" onclick="revokeToken(${t.id})">Revoke</button>
+        </div>`).join("");
+    } catch (e) {
+      box.innerHTML = "<span class='text-danger'>Failed to load tokens.</span>";
+    }
+  }
+
+  async function createToken() {
+    const name = document.getElementById("token-name").value.trim();
+    const resp = await fetch("/api/account/tokens", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok || !data.success) {
+      alertMsg(data.error || "Failed to create token.");
+      return;
+    }
+    document.getElementById("new-token-value").textContent = data.token;
+    document.getElementById("new-token").classList.remove("d-none");
+    document.getElementById("token-name").value = "";
+    loadTokens();
+  }
+
+  function copyNewToken() {
+    const val = document.getElementById("new-token-value").textContent;
+    navigator.clipboard.writeText(val).catch(() => {});
+  }
+
+  async function revokeToken(tokenId) {
+    if (!confirm("Revoke this token? Any client using it will lose access.")) return;
+    const resp = await fetch(`/api/account/tokens/${tokenId}`, { method: "DELETE" });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok || !data.success) {
+      alertMsg(data.error || "Failed to revoke token.");
+      return;
+    }
+    loadTokens();
+  }
+
+  document.addEventListener("DOMContentLoaded", loadTokens);
+</script>
+{% endblock %}

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -20,6 +20,10 @@
 </script>
 {% endblock %}
 {% block content %}
+{# Role gating: file-management actions (crop, edit, rebuild, delete, etc.) are
+   Clerk/Owner features. In implicit-owner mode current_user is the owner, so the
+   dropdown shows exactly as before; Readers never see it. #}
+{% set _can_manage = (g.current_user.role if g.get('current_user') else 'owner') in ['clerk', 'owner'] %}
 <div class="container-lg mt-4">
     <!-- Header Image Container -->
     <div id="collection-header-image" class="mb-3 d-none"></div>
@@ -67,12 +71,14 @@
 
                 <!-- Multi-Select Toggle & Refresh -->
                 <div class="d-flex align-items-center gap-2">
+                    {% if _can_manage %}
                     <button class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-1"
                         id="toggleCollectionSelectModeBtn" onclick="toggleCollectionSelectMode()"
                         title="Toggle multi-select mode">
                         <i class="bi bi-check2-square"></i>
                         <span>Multi-Select</span>
                     </button>
+                    {% endif %}
                     <button class="btn btn-light border btn-sm" onclick="refreshCurrentView(true, true)" title="Refresh">
                         <i class="bi bi-arrow-clockwise text-muted"></i>
                     </button>
@@ -219,6 +225,7 @@
                 <div class="item-name text-truncate text-dark" title=""></div>
                 <div class="item-meta text-muted small"></div>
             </div>
+            {% if _can_manage %}
             <div class="item-actions dropdown ms-2">
                 <button class="btn btn-link btn-sm p-0 text-dark no-propagation" type="button" data-bs-toggle="dropdown"
                     aria-expanded="false">
@@ -248,6 +255,7 @@
                             Delete</a></li>
                 </ul>
             </div>
+            {% endif %}
         </div>
     </div>
 </template>
@@ -442,6 +450,7 @@
 <!-- Toast Container -->
 {% include 'partials/toast_container.html' %}
 <!-- Bulk Action Bar -->
+{% if _can_manage %}
 <div id="collectionBulkActionBar" class="collection-bulk-action-bar" style="display: none;">
     <div class="container-lg d-flex align-items-center justify-content-between">
         <div class="d-flex align-items-center gap-3">
@@ -469,6 +478,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 <!-- Collection Folder Name Modal -->
 <div class="modal fade" id="collectionFolderNameModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">

--- a/templates/header.html
+++ b/templates/header.html
@@ -187,13 +187,13 @@
               </a>
             </li>
             {% endif %}
+            {% if _nav_is_clerk %}
             <li>
               <a href="{{ url_for('logs_page') }}"
                 class="dropdown-item {% if current_page == url_for('logs_page') %}active{% endif %}">
                 <i class="bi bi-journal-text me-2"></i>Logs
               </a>
             </li>
-            {% if _nav_is_clerk %}
             <li>
               <a href="{{ url_for('bulk_metadata.history_page') }}"
                 class="dropdown-item {% if current_page == url_for('bulk_metadata.history_page') %}active{% endif %}">
@@ -218,6 +218,12 @@
             </li>
             {% endif %}
             <li><hr class="dropdown-divider"></li>
+            <li>
+              <a href="{{ url_for('auth.account') }}"
+                class="dropdown-item {% if current_page == url_for('auth.account') %}active{% endif %}">
+                <i class="bi bi-key me-2"></i>API Tokens
+              </a>
+            </li>
             <li>
               <a href="/api/v1/docs"
                 class="dropdown-item {% if current_page == '/api/v1/docs' %}active{% endif %}">

--- a/templates/reading_list_view.html
+++ b/templates/reading_list_view.html
@@ -158,6 +158,10 @@
 {% endblock %}
 
 {% block content %}
+{# Role gating: add/export/sync/reorder/map/delete are Clerk/Owner features. Readers
+   get a view-only detail page and can still open/read matched issues. In
+   implicit-owner mode current_user is the owner, so everything shows as before. #}
+{% set _can_manage = (g.current_user.role if g.get('current_user') else 'owner') in ['clerk', 'owner'] %}
 <div class="container mt-4">
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
@@ -169,6 +173,7 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 id="reading-list-title">{{ reading_list.name }}</h2>
         <div class="d-flex align-items-center gap-2">
+            {% if _can_manage %}
             <button class="btn btn-success btn-sm" onclick="openAddIssueModal()">
                 <i class="bi bi-plus-lg me-1"></i>Add Issue
             </button>
@@ -184,6 +189,7 @@
             <button class="btn btn-outline-secondary btn-sm" id="reorderToggleBtn" onclick="toggleReorderMode()" title="Toggle reorder mode">
                 <i class="bi bi-arrows-move me-1"></i>Reorder
             </button>
+            {% endif %}
             <span class="badge bg-secondary">{{ reading_list.entries|length }} Issues</span>
         </div>
     </div>
@@ -211,12 +217,12 @@
                 </span>
             </div>
             {% else %}
-            <!-- Unmatched: clicking cover opens map modal -->
+            <!-- Unmatched: clicking cover opens map modal (managers only) -->
             <div class="book-cover unmatched"
-                onclick="openMapModal({{ entry.id }}, '{{ entry.series|replace("'", "\\'") }}', '{{ entry.issue_number }}', '{{ entry.volume or '' }}', '{{ entry.year or '' }}')">
+                {% if _can_manage %}onclick="openMapModal({{ entry.id }}, '{{ entry.series|replace("'", "\\'") }}', '{{ entry.issue_number }}', '{{ entry.volume or '' }}', '{{ entry.year or '' }}')"{% endif %}>
                 <div class="text-center p-2">
                     <i class="bi bi-question-circle display-6 mb-2"></i>
-                    <br>Click to map
+                    {% if _can_manage %}<br>Click to map{% endif %}
                 </div>
                 <span class="issue-badge issue-badge-unmatched">
                     #{{ entry.issue_number }}
@@ -229,7 +235,8 @@
                     <div class="book-title text-truncate">{{ entry.series }} #{{ entry.issue_number }}</div>
                     <div class="book-meta">{% if entry.year %}{{ entry.year }}{% endif %}</div>
                 </div>
-                <!-- Three-dots menu -->
+                <!-- Three-dots menu (managers only) -->
+                {% if _can_manage %}
                 <div class="dropdown">
                     <button class="btn btn-link btn-sm p-0 text-dark" type="button" data-bs-toggle="dropdown"
                         onclick="event.stopPropagation()">
@@ -266,12 +273,14 @@
                             </a></li>
                     </ul>
                 </div>
+                {% endif %}
             </div>
         </div>
         {% endfor %}
     </div>
 </div>
 
+{% if _can_manage %}
 <!-- Map File Modal -->
 <div class="modal fade" id="mapFileModal" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -301,6 +310,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 <!-- Comic Reader Modal -->
 <div id="comicReaderModal" class="comic-reader-modal" style="display: none;">
@@ -371,6 +381,7 @@
     </div>
 </div>
 
+{% if _can_manage %}
 <!-- GetComics Search Modal -->
 <div class="modal fade" id="getcomicsModal" tabindex="-1">
     <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
@@ -424,6 +435,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 <script>
     const LIST_ID = {{ reading_list.id }};

--- a/templates/reading_lists.html
+++ b/templates/reading_lists.html
@@ -6,6 +6,10 @@
 {% endblock %}
 
 {% block content %}
+{# Role gating: create/import/edit/delete are Clerk/Owner features. Readers get a
+   view-only page (browse + open/read). In implicit-owner mode current_user is the
+   owner, so everything shows exactly as before. #}
+{% set _can_manage = (g.current_user.role if g.get('current_user') else 'owner') in ['clerk', 'owner'] %}
 <div class="container py-5">
     <!-- Header Section -->
     <div class="mb-5 fade-in-down">
@@ -13,6 +17,7 @@
             <h2 class="display-4 fw-bold mb-1">Reading Lists</h2>
             <p class="text-muted lead mb-0">Discover and organize your comic journeys</p>
         </div>
+        {% if _can_manage %}
         <div class="d-flex gap-2 flex-wrap">
             <button class="btn btn-success d-flex align-items-center gap-2" data-bs-toggle="modal"
                 data-bs-target="#createListModal">
@@ -61,6 +66,7 @@
                 <span>Delete All</span>
             </button>
         </div>
+        {% endif %}
     </div>
 
     {% with messages = get_flashed_messages(with_categories=true) %}
@@ -128,10 +134,12 @@
 
             <!-- Background / Stack -->
             <div class="card-stack-container">
+                {% if _can_manage %}
                 <div class="card-select-checkbox" onclick="event.stopPropagation();">
                     <input type="checkbox" class="form-check-input list-select-cb"
                            data-list-id="{{ list.id }}" onchange="onListCheckboxChange(this)">
                 </div>
+                {% endif %}
                 {% if list.covers and list.covers|length > 0 %}
                 {% for cover in list.covers %}
                 <div class="card-stack-item"
@@ -155,7 +163,7 @@
             <!-- Content -->
             <div class="card-content text-primary">
                 <h3 class="card-title-lg text-truncate"
-                    onclick="event.stopPropagation(); editTitle({{ list.id }}, this)" title="Click to edit">
+                    {% if _can_manage %}onclick="event.stopPropagation(); editTitle({{ list.id }}, this)" title="Click to edit"{% endif %}>
                     {% if list.source %}<i class="bi bi-cloud-download me-1" title="Imported from {{ list.source }}"></i>{% else %}<i class="bi bi-pencil me-1" title="User-created"></i>{% endif %}
                     {{ list.name }}
                 </h3>
@@ -178,6 +186,7 @@
                         onclick="event.stopPropagation(); window.location.href='{{ url_for('reading_lists.view_list', list_id=list.id) }}'">
                         View Details
                     </button>
+                    {% if _can_manage %}
                     <button class="btn btn-secondary btn-sm"
                         onclick='event.stopPropagation(); openTagsModal({{ list.id }}, {{ list.tags|tojson|safe }})'
                         title="Manage Tags">
@@ -187,6 +196,7 @@
                         onclick="event.stopPropagation(); deleteReadingList({{ list.id }})">
                         <i class="bi bi-trash"></i>
                     </button>
+                    {% endif %}
                 </div>
 
                 {% if list.entry_count > 0 %}
@@ -207,6 +217,7 @@
             <i class="bi bi-journal-bookmark display-1 text-muted opacity-25"></i>
         </div>
         <h3 class="h2 text-muted mb-3">No reading lists yet</h3>
+        {% if _can_manage %}
         <p class="text-muted mb-4 lead">Create a new list, upload a CBL file, or import from GitHub.</p>
         <div class="d-flex gap-2 justify-content-center">
             <button class="btn btn-success btn-lg" data-bs-toggle="modal" data-bs-target="#createListModal">
@@ -216,10 +227,14 @@
                 <i class="bi bi-cloud-upload me-2"></i> Upload CBL
             </button>
         </div>
+        {% else %}
+        <p class="text-muted mb-4 lead">No reading lists have been shared yet.</p>
+        {% endif %}
     </div>
     {% endif %}
 </div>
 
+{% if _can_manage %}
 <!-- Bulk Action Bar -->
 <div id="readingListBulkActionBar" class="reading-list-bulk-action-bar" style="display: none;">
     <div class="container-lg d-flex align-items-center justify-content-between">
@@ -581,6 +596,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/tests/integration/test_favorites_insights_scope.py
+++ b/tests/integration/test_favorites_insights_scope.py
@@ -14,7 +14,9 @@ import models.timeline as timeline
 import wrapped
 from core.database import (
     add_favorite_series,
+    add_reading_list_entry,
     create_reading_list,
+    get_all_reading_lists,
     get_favorite_publishers,
     get_favorite_series,
     get_reading_lists,
@@ -140,3 +142,30 @@ class TestReadingListIsolation:
         names_b = {rl["name"] for rl in get_reading_lists(user_id=B)}
         assert names_a == {"A's List"}
         assert names_b == {"B's List"}
+
+    def test_get_all_reading_lists_is_global(self, db_connection):
+        # The grid reader shows every user's lists to whoever is viewing, so a
+        # reader can browse lists an admin/clerk imported. Per-user isolation
+        # (test_lists_are_per_user, above) is preserved on get_reading_lists().
+        create_reading_list("A's List", user_id=A)
+        create_reading_list("B's List", user_id=B)
+        for viewer in (A, B):
+            names = {rl["name"] for rl in get_all_reading_lists(viewer_id=viewer)}
+            assert names == {"A's List", "B's List"}
+
+    def test_get_all_reading_lists_read_count_scoped_to_viewer(self, db_connection):
+        # The list set is global, but the progress badge (read_count) must reflect
+        # the viewing user's own reads, not the list owner's or another user's.
+        list_id = create_reading_list("Shared", user_id=A)
+        path = "/data/DC/Batman/Batman 001.cbz"
+        add_reading_list_entry(list_id, {"series": "Batman", "issue_number": "1",
+                                         "matched_file_path": path})
+        mark_issue_read(path, user_id=A)
+
+        by_id = {rl["id"]: rl for rl in get_all_reading_lists(viewer_id=A)}
+        assert by_id[list_id]["entry_count"] == 1
+        assert by_id[list_id]["read_count"] == 1  # A read it
+
+        by_id_b = {rl["id"]: rl for rl in get_all_reading_lists(viewer_id=B)}
+        assert by_id_b[list_id]["entry_count"] == 1
+        assert by_id_b[list_id]["read_count"] == 0  # B has not

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -50,6 +50,16 @@ class TestRolePolicy:
         ("GET", "/publishers", "clerk"),
         ("GET", "/metadata/history", "clerk"),
         ("GET", "/source-wall", "clerk"),
+        # Logs viewer + raw log data are clerk-only (can expose system info).
+        ("GET", "/logs", "clerk"),
+        ("GET", "/logs/tail", "clerk"),
+        ("GET", "/app-logs", "clerk"),
+        ("GET", "/mon-logs", "clerk"),
+        # Self-service API tokens: a user manages their OWN tokens at any role.
+        ("GET", "/account", "reader"),
+        ("GET", "/api/account/tokens", "reader"),
+        ("POST", "/api/account/tokens", "reader"),
+        ("DELETE", "/api/account/tokens/5", "reader"),
         ("GET", "/config", "owner"),
         ("POST", "/api/config/file-processing", "owner"),
         ("GET", "/api/database/stats", "owner"),
@@ -117,13 +127,20 @@ class TestRbacMatrix:
     @pytest.mark.parametrize("path", [
         "/files", "/pull-list", "/releases", "/wanted", "/status",
         "/weekly-packs", "/series-search", "/publishers", "/metadata/history",
-        "/source-wall",
+        "/source-wall", "/logs", "/logs/tail", "/app-logs", "/mon-logs",
     ])
     def test_reader_denied_clerk_pages(self, client, path):
         # Clerk-only pages: a Reader hitting them by URL is redirected home
-        # (HTML deny → 302), never allowed to render the page.
+        # (HTML deny → 302), never allowed to render the page. Logs are here
+        # because raw app/monitor logs can expose system info.
         _login(client, "reader", "readerpass")
         assert client.get(path).status_code == 302
+
+    def test_clerk_allowed_logs(self, client):
+        _login(client, "clerk", "clerkpass")
+        # Clerk reaches the logs page and the raw log-tail data (never denied).
+        assert client.get("/logs").status_code == 200
+        assert client.get("/logs/tail").status_code != 302
 
     # Clerk
     def test_clerk_allowed_clerk_page(self, client):
@@ -313,6 +330,72 @@ class TestReadingDataScopedByRequest:
         assert is_issue_read("/data/alice.cbz", user_id=bid) is False
         assert is_issue_read("/data/bob.cbz", user_id=bid) is True
         assert is_issue_read("/data/bob.cbz", user_id=aid) is False
+
+
+# ---------------------------------------------------------------------------
+# Self-service API tokens: any logged-in user manages their OWN tokens
+# ---------------------------------------------------------------------------
+class TestSelfServiceApiTokens:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        yield
+
+    def test_reader_can_open_account_page(self, client):
+        # The self-service page renders for a reader (also exercises the nav's
+        # url_for('auth.account') link resolving).
+        _login(client, "reader", "readerpass")
+        resp = client.get("/account")
+        assert resp.status_code == 200
+        assert "API Tokens" in resp.get_data(as_text=True)
+
+    def test_reader_full_token_lifecycle(self, client):
+        _login(client, "reader", "readerpass")
+
+        # Create — reader may mint their own token (personal-data write).
+        resp = client.post("/api/account/tokens", json={"name": "Phone"})
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["token"]  # plaintext returned exactly once
+
+        # List — shows only the reader's own token, metadata only (no plaintext).
+        resp = client.get("/api/account/tokens")
+        assert resp.status_code == 200
+        tokens = resp.get_json()["tokens"]
+        assert [t["name"] for t in tokens] == ["Phone"]
+        assert "token" not in tokens[0] and "token_hash" not in tokens[0]
+
+        # Revoke — the reader can delete their own token.
+        tid = tokens[0]["id"]
+        assert client.delete(f"/api/account/tokens/{tid}").status_code == 200
+        assert client.get("/api/account/tokens").get_json()["tokens"] == []
+
+    def test_tokens_are_scoped_per_user(self, client):
+        # A token minted for the owner must not be listable or revocable by a
+        # reader through the self-service surface.
+        from core.database import create_api_token, get_user_by_username
+        owner_id = get_user_by_username("owner")["id"]
+        create_api_token(owner_id, name="owner-token")
+
+        _login(client, "reader", "readerpass")
+        assert client.get("/api/account/tokens").get_json()["tokens"] == []
+
+        # Discover the owner's token id (as owner) then try to revoke it as reader.
+        owner_client = client.application.test_client()
+        _login(owner_client, "owner", "ownerpass")
+        owner_tokens = owner_client.get(
+            f"/api/admin/users/{owner_id}/tokens").get_json()["tokens"]
+        owner_tid = owner_tokens[0]["id"]
+
+        resp = client.delete(f"/api/account/tokens/{owner_tid}")
+        assert resp.status_code == 404  # scoped delete: not this reader's token
+        # Owner's token survives.
+        assert len(owner_client.get(
+            f"/api/admin/users/{owner_id}/tokens").get_json()["tokens"]) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/test_reading_lists_routes.py
+++ b/tests/routes/test_reading_lists_routes.py
@@ -6,7 +6,7 @@ from io import BytesIO
 
 class TestReadingListIndex:
 
-    @patch("routes.reading_lists.get_reading_lists", return_value=[])
+    @patch("routes.reading_lists.get_all_reading_lists", return_value=[])
     def test_index_page(self, mock_get, client):
         resp = client.get("/reading-lists")
         assert resp.status_code == 200
@@ -404,3 +404,95 @@ class TestSummary:
         data = resp.get_json()
         assert len(data) == 2
         assert data[0]["name"] == "Batman"
+
+
+class TestReaderViewOnlyGating:
+    """Readers browse shared lists but see no management controls.
+
+    Backs the "let readers view any reading list" change: the grid is global
+    (get_all_reading_lists), while create/import/edit/delete/map/reorder controls
+    are Clerk/Owner-only in the templates. Mutations stay clerk-gated at the route
+    layer (covered in test_rbac.py); this asserts the rendered UI.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        from core.database import create_user
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("clerk", password="clerkpass", role="clerk")
+        create_user("reader", password="readerpass", role="reader")
+        yield
+
+    @staticmethod
+    def _login(client, username, password):
+        return client.post("/login", data={"username": username, "password": password})
+
+    def test_reader_sees_shared_list_without_controls(self, client):
+        from core.database import create_reading_list, get_user_by_username
+        clerk_id = get_user_by_username("clerk")["id"]
+        create_reading_list("Clerk Shared List", user_id=clerk_id)
+
+        self._login(client, "reader", "readerpass")
+        html = client.get("/reading-lists").get_data(as_text=True)
+
+        # Global grid: the reader sees the clerk-imported list...
+        assert "Clerk Shared List" in html
+        # ...but none of the management controls.
+        assert "Create List" not in html
+        assert "Delete All" not in html
+        assert 'id="readingListBulkActionBar"' not in html
+        assert 'id="createListModal"' not in html
+
+    def test_clerk_sees_controls(self, client):
+        from core.database import create_reading_list, get_user_by_username
+        clerk_id = get_user_by_username("clerk")["id"]
+        create_reading_list("Clerk Shared List", user_id=clerk_id)
+
+        self._login(client, "clerk", "clerkpass")
+        html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert "Clerk Shared List" in html
+        assert "Create List" in html
+        assert "Delete All" in html
+        assert 'id="readingListBulkActionBar"' in html
+
+    def test_reader_detail_view_is_view_only(self, client):
+        from core.database import (
+            add_reading_list_entry,
+            create_reading_list,
+            get_user_by_username,
+        )
+        clerk_id = get_user_by_username("clerk")["id"]
+        list_id = create_reading_list("Shared Arc", user_id=clerk_id)
+        add_reading_list_entry(list_id, {"series": "Batman", "issue_number": "1"})
+
+        self._login(client, "reader", "readerpass")
+        html = client.get(f"/reading-lists/{list_id}").get_data(as_text=True)
+
+        assert "Shared Arc" in html
+        # Reader can still open/read: the comic reader modal is present.
+        assert 'id="comicReaderModal"' in html
+        # But no management actions/modals.
+        assert "Add Issue" not in html
+        assert "Export CBL" not in html
+        assert 'id="addIssueModal"' not in html
+        assert 'id="mapFileModal"' not in html
+
+    def test_clerk_detail_view_has_controls(self, client):
+        from core.database import (
+            add_reading_list_entry,
+            create_reading_list,
+            get_user_by_username,
+        )
+        clerk_id = get_user_by_username("clerk")["id"]
+        list_id = create_reading_list("Shared Arc", user_id=clerk_id)
+        add_reading_list_entry(list_id, {"series": "Batman", "issue_number": "1"})
+
+        self._login(client, "clerk", "clerkpass")
+        html = client.get(f"/reading-lists/{list_id}").get_data(as_text=True)
+
+        assert "Add Issue" in html
+        assert "Export CBL" in html
+        assert 'id="addIssueModal"' in html


### PR DESCRIPTION
## Summary

Rounds out **reader-role** RBAC on the browser side. The centralized gate in `core/auth.py` already blocked reader *mutations*; this makes the UI match (no dead/forbidden controls) and closes two gaps: readers couldn't see shared reading lists, and only owners could mint API tokens.

## Changes

**Collection page (`templates/collection.html`)**
- Hide the per-item actions dropdown, the Multi-Select toggle, and the bulk action bar from readers (Clerk/Owner only). The `collection.js` consumers are already null-guarded, so no JS changes were needed.

**Reading Lists — readers can now browse lists an admin/clerk imported**
- `core/database.py`: new `get_all_reading_lists(viewer_id)` — global list set with `read_count` scoped to the viewer (no cross-user progress leakage). The index route uses it; `get_reading_lists()` (per-user) is left intact so per-user isolation and bulk "Delete All" stay caller-scoped.
- Gate create/import/edit/delete/map/reorder controls + modals in `reading_lists.html` and `reading_list_view.html`. Readers keep **View Details**, matched-cover reading, and the Comic Reader.

**Logs — hidden from readers (can expose system info)**
- Nav: Logs entry in the settings dropdown gated to Clerk/Owner.
- Routes: `/logs`, `/app-logs`, `/mon-logs` → clerk pages; `/logs/tail` (raw log data) → clerk prefix. A reader hitting them by URL is now denied.

**Self-service API tokens — previously owner-only via `/api/admin`**
- New `/account` page (`templates/account.html`) + `GET/POST/DELETE /api/account/tokens` in `routes/auth.py`, all scoped to `g.current_user["id"]`.
- `/api/account/` added to `_READER_WRITE_PREFIXES` so any role can manage their **own** tokens. A token only authenticates as its owner, granting no extra privilege.
- "API Tokens" nav link added to the settings dropdown for all users. Owner-only admin/global token UIs are untouched (additive).

## Testing
- DB: global-vs-isolated readers + viewer-scoped `read_count`.
- Reader/clerk render gating for reading lists (index + detail).
- Logs deny (reader → 302) / allow (clerk → 200).
- Full self-service token lifecycle + cross-user scoping (reader can't list/revoke another user's token).
- Full suite: **2715 passed, 6 skipped** (skips are POSIX-only permission tests on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)