### PR TITLE
Surface Usenet/NZB download progress on the Status page

### DIFF
--- a/models/download_clients/base.py
+++ b/models/download_clients/base.py
@@ -85,6 +85,11 @@ class DownloadStatus:
 
     ``storage_path`` is the completed file/directory the PR 2 mover will
     consume to hand the finished download to CLU's WATCH folder.
+
+    ``status`` is the normalized terminal/lifecycle state the poller relies
+    on (``downloading`` / ``complete`` / ``failed``). ``stage`` is the raw,
+    human‑readable stage reported by the client while active (Downloading,
+    Verifying, Repairing, Extracting, Moving, …) — display only.
     """
     client_id: str
     name: Optional[str] = None
@@ -92,6 +97,9 @@ class DownloadStatus:
     percent: Optional[float] = None
     category: Optional[str] = None
     storage_path: Optional[str] = None
+    stage: Optional[str] = None
+    bytes_total: Optional[int] = None
+    bytes_downloaded: Optional[int] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -101,6 +109,9 @@ class DownloadStatus:
             "percent": self.percent,
             "category": self.category,
             "storage_path": self.storage_path,
+            "stage": self.stage,
+            "bytes_total": self.bytes_total,
+            "bytes_downloaded": self.bytes_downloaded,
         }
 
 
@@ -170,6 +181,14 @@ class BaseDownloadClient(ABC):
     def get_history(self) -> List[DownloadStatus]:
         """Return completed downloads (for the PR 2 poller/mover). PR 2 seam."""
         raise NotImplementedError("get_history is implemented in PR 2")
+
+    def get_queue(self) -> List[DownloadStatus]:
+        """Return active (in‑progress) downloads with live percent/stage/bytes.
+
+        Overridden by concrete clients. Defaults to an empty list so callers
+        (the Usenet poller) can invoke it safely on any client.
+        """
+        return []
 
     def get_status(self, client_id: str) -> Optional[DownloadStatus]:
         """Return the status of a single download by client id. PR 2 seam."""

--- a/models/download_clients/nzbget_client.py
+++ b/models/download_clients/nzbget_client.py
@@ -27,6 +27,40 @@ def _normalize_nzbget_status(raw: str) -> str:
     return "downloading"
 
 
+# NZBGet listgroups Status -> friendly display stage.
+_NZBGET_STAGE_MAP = {
+    "QUEUED": "Queued",
+    "PAUSED": "Paused",
+    "DOWNLOADING": "Downloading",
+    "FETCHING": "Downloading",
+    "PP_QUEUED": "Post-processing",
+    "LOADING_PARS": "Verifying",
+    "VERIFYING_SOURCES": "Verifying",
+    "REPAIRING": "Repairing",
+    "VERIFYING_REPAIRED": "Verifying",
+    "RENAMING": "Renaming",
+    "UNPACKING": "Extracting",
+    "MOVING": "Moving",
+    "EXECUTING_SCRIPT": "Running script",
+    "PP_FINISHED": "Finishing",
+}
+
+
+def _pretty_nzbget_stage(raw: str):
+    """Map an NZBGet listgroups Status to a human‑readable stage, or None."""
+    if not raw:
+        return None
+    return _NZBGET_STAGE_MAP.get(raw.upper(), raw.replace("_", " ").title())
+
+
+def _mb_to_bytes(mb):
+    """Convert an NZBGet MB value to bytes, or None if not numeric."""
+    try:
+        return int(float(mb) * 1024 * 1024)
+    except (TypeError, ValueError):
+        return None
+
+
 @register_download_client
 class NZBGetClient(BaseDownloadClient):
     """NZBGet download client using the JSON-RPC API."""
@@ -175,21 +209,43 @@ class NZBGetClient(BaseDownloadClient):
             app_logger.error(f"NZBGet get_history failed: {e}")
             return []
 
+    def get_queue(self) -> List[DownloadStatus]:
+        """Return active (in‑progress) downloads with live percent/stage/bytes.
+
+        Maps every ``listgroups`` group: percent from ``FileSizeMB``/
+        ``RemainingSizeMB``, bytes from the same, and a friendly ``stage`` from
+        the group ``Status`` (VERIFYING_SOURCES → Verifying, UNPACKING →
+        Extracting, MOVING → Moving, …).
+        """
+        try:
+            out = []
+            for g in self._rpc("listgroups", [0]) or []:
+                remaining = g.get("RemainingSizeMB") or 0
+                total = (g.get("FileSizeMB") or 0) or 1
+                pct = max(0.0, min(100.0, (1 - remaining / total) * 100))
+                downloaded_mb = g.get("DownloadedSizeMB")
+                if downloaded_mb is None:
+                    downloaded_mb = max(0, (g.get("FileSizeMB") or 0) - remaining)
+                out.append(DownloadStatus(
+                    client_id=str(g.get("NZBID", "")),
+                    name=g.get("NZBName"),
+                    status="downloading",
+                    percent=pct,
+                    category=g.get("Category"),
+                    stage=_pretty_nzbget_stage(g.get("Status", "")),
+                    bytes_total=_mb_to_bytes(g.get("FileSizeMB")),
+                    bytes_downloaded=_mb_to_bytes(downloaded_mb),
+                ))
+            return out
+        except Exception as e:
+            app_logger.error(f"NZBGet get_queue failed: {e}")
+            return []
+
     def get_status(self, client_id: str) -> Optional[DownloadStatus]:
         """Return the status of a single download by NZBID (active then history)."""
-        try:
-            for g in self._rpc("listgroups", [0]) or []:
-                if str(g.get("NZBID", "")) == str(client_id):
-                    remaining = g.get("RemainingSizeMB") or 0
-                    total = (g.get("FileSizeMB") or 0) or 1
-                    pct = max(0.0, min(100.0, (1 - remaining / total) * 100))
-                    return DownloadStatus(
-                        client_id=str(client_id), name=g.get("NZBName"),
-                        status="downloading", percent=pct, category=g.get("Category"),
-                    )
-        except Exception as e:
-            app_logger.error(f"NZBGet get_status listgroups failed: {e}")
-
+        for g in self.get_queue():
+            if g.client_id == str(client_id):
+                return g
         for h in self.get_history():
             if h.client_id == str(client_id):
                 return h

--- a/models/download_clients/sabnzbd_client.py
+++ b/models/download_clients/sabnzbd_client.py
@@ -22,6 +22,31 @@ def _normalize_sab_status(raw: str) -> str:
         return "failed"
     return "downloading"
 
+
+def _to_float(val):
+    """Parse a value to float, or None if not numeric."""
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mb_to_bytes(mb):
+    """Convert a SABnzbd MB value (string/number) to bytes, or None."""
+    f = _to_float(mb)
+    return int(f * 1024 * 1024) if f is not None else None
+
+
+def _mb_downloaded(mb, mbleft):
+    """Downloaded MB = total - remaining, clamped at 0; None if unknown."""
+    total = _to_float(mb)
+    left = _to_float(mbleft)
+    if total is None:
+        return None
+    if left is None:
+        left = 0.0
+    return max(0.0, total - left)
+
 # Short timeout so a wrong host/port fails fast instead of hanging the UI.
 _TIMEOUT = 10
 
@@ -177,11 +202,16 @@ class SABnzbdClient(BaseDownloadClient):
             app_logger.error(f"SABnzbd get_history failed: {e}")
             return []
 
-    def get_status(self, client_id: str) -> Optional[DownloadStatus]:
-        """Return the status of a single download by nzo_id (queue then history)."""
+    def get_queue(self) -> List[DownloadStatus]:
+        """Return active (in‑progress) downloads with live percent/stage/bytes.
+
+        Maps every queue slot: SAB's slot ``status`` field carries the real
+        stage (Downloading/Verifying/Repairing/Extracting/Moving/Queued), and
+        ``mb``/``mbleft`` give the size and remaining bytes.
+        """
         cfg = self.config
         if not cfg or not cfg.api_key:
-            return None
+            return []
         url = f"{self._base_url()}/api"
         try:
             import requests
@@ -192,20 +222,31 @@ class SABnzbdClient(BaseDownloadClient):
                 timeout=_TIMEOUT,
             )
             resp.raise_for_status()
+            out = []
             for s in (resp.json().get("queue") or {}).get("slots") or []:
-                if s.get("nzo_id") == client_id:
-                    pct = None
-                    try:
-                        pct = float(s.get("percentage"))
-                    except (TypeError, ValueError):
-                        pct = None
-                    return DownloadStatus(
-                        client_id=client_id, name=s.get("filename"),
-                        status="downloading", percent=pct, category=s.get("cat"),
-                    )
+                out.append(DownloadStatus(
+                    client_id=s.get("nzo_id", ""),
+                    name=s.get("filename"),
+                    status="downloading",
+                    percent=_to_float(s.get("percentage")),
+                    category=s.get("cat"),
+                    stage=(s.get("status") or "").title() or None,
+                    bytes_total=_mb_to_bytes(s.get("mb")),
+                    bytes_downloaded=_mb_to_bytes(_mb_downloaded(s.get("mb"), s.get("mbleft"))),
+                ))
+            return out
         except Exception as e:
-            app_logger.error(f"SABnzbd get_status queue lookup failed: {e}")
+            app_logger.error(f"SABnzbd get_queue failed: {e}")
+            return []
 
+    def get_status(self, client_id: str) -> Optional[DownloadStatus]:
+        """Return the status of a single download by nzo_id (queue then history)."""
+        cfg = self.config
+        if not cfg or not cfg.api_key:
+            return None
+        for s in self.get_queue():
+            if s.client_id == client_id:
+                return s
         for h in self.get_history():
             if h.client_id == client_id:
                 return h

--- a/models/usenet.py
+++ b/models/usenet.py
@@ -24,11 +24,16 @@ from core.app_logging import app_logger
 # Comic/container extensions we hand off to the WATCH pipeline.
 _COMIC_EXTS = {".cbz", ".cbr", ".cbt", ".pdf", ".zip", ".rar"}
 
-# How often the completion poller checks client history.
+# How often the completion poller runs while idle (winding down before exit).
 _POLL_INTERVAL = 15
+# Faster cadence while jobs are active, so cached progress stays fresh without
+# hammering the download client (two calls per client per round).
+_ACTIVE_POLL_INTERVAL = 5
 
 # In-memory tracking of submitted Usenet jobs, keyed by our download_id.
-# Each value: {client_type, client_id, filename, status, error, series, issue}.
+# Each value: {client_type, client_id, filename, status, error, series, issue,
+# percent, stage, bytes_total, bytes_downloaded}. The last four are cached by
+# the poller from the client's live queue for the status page.
 usenet_downloads: dict = {}
 _jobs_lock = threading.Lock()
 _poller_thread = None
@@ -367,6 +372,10 @@ def grab_nzb(nzb_url, filename, series=None, issue=None):
             "error": None,
             "series": series,
             "issue": issue,
+            "percent": 0,
+            "stage": "Queued",
+            "bytes_total": None,
+            "bytes_downloaded": None,
         }
     app_logger.info(
         f"Submitted NZB to {client_type} for {filename} (client_id={result.client_id})"
@@ -400,7 +409,12 @@ def _pending_jobs():
 
 
 def _poll_loop():
-    """Poll the active client's history until all jobs reach a terminal state."""
+    """Poll the active client until all jobs reach a terminal state.
+
+    Each round fetches the client's queue (live progress) and history
+    (terminal state) once per client type, caches live percent/stage/bytes on
+    active jobs for the status page, and imports completed downloads.
+    """
     idle_rounds = 0
     while True:
         pending = _pending_jobs()
@@ -412,29 +426,37 @@ def _poll_loop():
             continue
         idle_rounds = 0
 
-        # Group pending jobs by client type; fetch each client's history once.
-        histories = {}
+        # Group pending jobs by client type; fetch each client's queue+history once.
+        statuses = {}
         for job in pending.values():
             ct = job["client_type"]
-            if ct not in histories:
-                histories[ct] = _history_for(ct)
+            if ct not in statuses:
+                statuses[ct] = _statuses_for(ct)
 
         for download_id, job in pending.items():
-            hist = histories.get(job["client_type"]) or {}
-            status = hist.get(str(job["client_id"]))
+            status = (statuses.get(job["client_type"]) or {}).get(str(job["client_id"]))
             if status is None:
-                continue  # still downloading / not yet in history
+                continue  # not yet visible in queue or history
             if status.status == "complete":
                 imported = _import_completed(status.storage_path, job["filename"])
-                _set_status(download_id, "complete" if imported else "complete_no_move")
+                _set_status(download_id, "complete" if imported else "complete_no_move",
+                            percent=100)
             elif status.status == "failed":
                 _set_status(download_id, "failed", error="Download failed at client")
+            else:
+                # Still active — cache live progress for the status page.
+                _update_progress(download_id, status)
 
-        time.sleep(_POLL_INTERVAL)
+        time.sleep(_ACTIVE_POLL_INTERVAL)
 
 
-def _history_for(client_type):
-    """Return {client_id: DownloadStatus} for a client type, or {} on error."""
+def _statuses_for(client_type):
+    """Return a merged {client_id: DownloadStatus} for a client type, or {}.
+
+    Combines the live queue (active items with progress/stage/bytes) with
+    history (terminal state); history wins so a completed/failed item is not
+    masked by a stale queue entry.
+    """
     try:
         from core.database import get_download_client_config
         from models.download_clients import (
@@ -447,17 +469,37 @@ def _history_for(client_type):
         client = get_download_client_by_name(
             client_type, DownloadClientConfig.from_dict(cfg)
         )
-        return {h.client_id: h for h in client.get_history()}
+        merged = {}
+        for q in client.get_queue():
+            merged[q.client_id] = q
+        for h in client.get_history():
+            merged[h.client_id] = h
+        return merged
     except Exception as e:
-        app_logger.error(f"Usenet history fetch failed for {client_type}: {e}")
+        app_logger.error(f"Usenet status fetch failed for {client_type}: {e}")
         return {}
 
 
-def _set_status(download_id, status, error=None):
+def _update_progress(download_id, status):
+    """Cache live percent/stage/bytes from a DownloadStatus onto a job."""
     with _jobs_lock:
-        if download_id in usenet_downloads:
-            usenet_downloads[download_id]["status"] = status
-            usenet_downloads[download_id]["error"] = error
+        job = usenet_downloads.get(download_id)
+        if job is None:
+            return
+        job["percent"] = status.percent
+        job["stage"] = status.stage
+        job["bytes_total"] = status.bytes_total
+        job["bytes_downloaded"] = status.bytes_downloaded
+
+
+def _set_status(download_id, status, error=None, percent=None):
+    with _jobs_lock:
+        job = usenet_downloads.get(download_id)
+        if job is not None:
+            job["status"] = status
+            job["error"] = error
+            if percent is not None:
+                job["percent"] = percent
 
 
 def _import_completed(storage_path, filename) -> bool:

--- a/templates/status.html
+++ b/templates/status.html
@@ -52,86 +52,111 @@
 {% block scripts %}
 {{ super() }}
     <script>
-    // Function to fetch all download statuses and update the table.
-    function fetchStatus(signal) {
-      return fetch('/download_status_all', { signal })
-        .then(response => response.json())
-        .then(data => {
-          const tbody = document.querySelector('#downloads-table tbody');
-          tbody.innerHTML = ''; // Clear previous rows.
-          for (const [downloadId, details] of Object.entries(data)) {
+    // Provider/client icon definitions, keyed by provider or client_type.
+    const providerMap = {
+      pixeldrain:   { icon: 'bi-cloud-arrow-down', color: 'text-primary',  label: 'Pixeldrain' },
+      mega:         { img: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/mega-nz.png', label: 'Mega' },
+      getcomics:    { icon: 'bi-download',         color: 'text-success',  label: 'GetComics' },
+      comicbookplus:{ icon: 'bi-book',             color: 'text-info',     label: 'CBP' },
+      sabnzbd:      { icon: 'bi-hdd-network',      color: 'text-warning',  label: 'SABnzbd' },
+      nzbget:       { icon: 'bi-cloud-download',   color: 'text-info',     label: 'NZBGet' },
+    };
+
+    const mb = bytes => (bytes / (1024 * 1024)).toFixed(2);
+
+    // Shared cell builders so direct and Usenet rows render identically.
+    function providerCell(providerKey) {
+      const td = document.createElement('td');
+      const prov = providerMap[providerKey];
+      if (prov && prov.img) {
+        td.innerHTML = `<img src="${prov.img}" alt="${prov.label}" title="${prov.label}" style="width:18px;height:18px;vertical-align:text-bottom;"> <small>${prov.label}</small>`;
+      } else if (prov) {
+        td.innerHTML = `<i class="bi ${prov.icon} ${prov.color}" title="${prov.label}"></i> <small>${prov.label}</small>`;
+      } else {
+        td.innerHTML = '<i class="bi bi-hourglass-split text-muted" title="Pending"></i>';
+      }
+      return td;
+    }
+
+    function progressCell(progress) {
+      const pct = Math.max(0, Math.min(100, Math.round(progress || 0)));
+      const td = document.createElement('td');
+      const progressBar = document.createElement('div');
+      progressBar.className = 'progress';
+      const progressInner = document.createElement('div');
+      progressInner.className = 'progress-bar';
+      progressInner.style.width = pct + '%';
+      progressInner.setAttribute('aria-valuenow', pct);
+      progressInner.setAttribute('aria-valuemin', '0');
+      progressInner.setAttribute('aria-valuemax', '100');
+      progressInner.textContent = pct + '%';
+      progressBar.appendChild(progressInner);
+      td.appendChild(progressBar);
+      return td;
+    }
+
+    function bytesCell(downloaded, total) {
+      const td = document.createElement('td');
+      if (total && downloaded) {
+        td.textContent = `${mb(downloaded)} MB / ${mb(total)} MB`;
+      } else {
+        td.textContent = '—';
+      }
+      return td;
+    }
+
+    function statusCell(text, cssClass, title) {
+      const td = document.createElement('td');
+      td.textContent = text;
+      if (cssClass) td.className = cssClass;
+      if (title) td.title = title;
+      return td;
+    }
+
+    function filenameCell(filename) {
+      const td = document.createElement('td');
+      td.textContent = filename ? filename.split('/').pop() : 'N/A';
+      return td;
+    }
+
+    // Map a Usenet job's status/stage to a display label + styling.
+    function usenetStatusDisplay(job) {
+      switch (job.status) {
+        case 'complete':
+          return { text: 'Complete', cssClass: 'text-success' };
+        case 'complete_no_move':
+          return { text: 'Complete (import pending)', cssClass: 'text-warning',
+                   title: 'Finished at the client but CLU could not move the file into WATCH' };
+        case 'failed':
+          return { text: 'Failed', cssClass: 'text-danger fw-bold', title: job.error || 'Download failed at client' };
+        default:
+          return { text: job.stage || 'Downloading', cssClass: '' };
+      }
+    }
+
+    // Render direct (api.py) download rows into the table body.
+    function renderDirectRows(tbody, data) {
+      for (const [downloadId, details] of Object.entries(data)) {
             const tr = document.createElement('tr');
-
-            // Filename - display only the base file name.
-            const tdFilename = document.createElement('td');
-            if (details.filename) {
-              tdFilename.textContent = details.filename.split('/').pop();
-            } else {
-              tdFilename.textContent = 'N/A';
-            }
-            tr.appendChild(tdFilename);
-
-            // Provider icon
-            const tdProvider = document.createElement('td');
-            const providerMap = {
-              pixeldrain:   { icon: 'bi-cloud-arrow-down', color: 'text-primary',  label: 'Pixeldrain' },
-              mega:         { img: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/mega-nz.png', label: 'Mega' },
-              getcomics:    { icon: 'bi-download',         color: 'text-success',  label: 'GetComics' },
-              comicbookplus:{ icon: 'bi-book',             color: 'text-info',     label: 'CBP' },
-            };
-            const prov = providerMap[details.provider];
-            if (prov && prov.img) {
-              tdProvider.innerHTML = `<img src="${prov.img}" alt="${prov.label}" title="${prov.label}" style="width:18px;height:18px;vertical-align:text-bottom;"> <small>${prov.label}</small>`;
-            } else if (prov) {
-              tdProvider.innerHTML = `<i class="bi ${prov.icon} ${prov.color}" title="${prov.label}"></i> <small>${prov.label}</small>`;
-            } else {
-              tdProvider.innerHTML = '<i class="bi bi-hourglass-split text-muted" title="Pending"></i>';
-            }
-            tr.appendChild(tdProvider);
-
-            // Progress with a Bootstrap progress bar.
-            const tdProgress = document.createElement('td');
-            const progressBar = document.createElement('div');
-            progressBar.className = 'progress';
-            const progressInner = document.createElement('div');
-            progressInner.className = 'progress-bar';
-            progressInner.style.width = details.progress + '%';
-            progressInner.setAttribute('aria-valuenow', details.progress);
-            progressInner.setAttribute('aria-valuemin', '0');
-            progressInner.setAttribute('aria-valuemax', '100');
-            progressInner.textContent = details.progress + '%';
-            progressBar.appendChild(progressInner);
-            tdProgress.appendChild(progressBar);
-            tr.appendChild(tdProgress);
-
-            // Downloaded Bytes
-            const tdBytes = document.createElement('td');
-            if (details.bytes_total && details.bytes_downloaded) {
-              const mb = (bytes => (bytes / (1024 * 1024)).toFixed(2));
-              tdBytes.textContent = `${mb(details.bytes_downloaded)} MB / ${mb(details.bytes_total)} MB`;
-            } else {
-              tdBytes.textContent = '—';
-            }
-            tr.appendChild(tdBytes);
+            tr.appendChild(filenameCell(details.filename));
+            tr.appendChild(providerCell(details.provider));
+            tr.appendChild(progressCell(details.progress));
+            tr.appendChild(bytesCell(details.bytes_downloaded, details.bytes_total));
 
             // Status
-            const tdStatus = document.createElement('td');
-            tdStatus.textContent = details.status;
-            
-            // Add visual styling for error status
+            let statusClass = '';
             if (details.status === 'error') {
-              tdStatus.className = 'text-danger fw-bold';
-            } else if (details.status === 'completed') {
-              tdStatus.className = 'text-success';
+              statusClass = 'text-danger fw-bold';
+            } else if (details.status === 'complete') {
+              statusClass = 'text-success';
             } else if (details.status === 'cancelled') {
-              tdStatus.className = 'text-warning';
+              statusClass = 'text-warning';
             }
-            
-            tr.appendChild(tdStatus);
+            tr.appendChild(statusCell(details.status, statusClass, details.error));
 
             // Actions cell (Cancel/Retry buttons)
             const tdActions = document.createElement('td');
-            
+
             if (details.status === 'in_progress' || details.status === 'queued') {
               // Cancel button for in-progress downloads
               const cancelIcon = document.createElement('i');
@@ -206,8 +231,41 @@
             tr.appendChild(tdActions);
 
             tbody.appendChild(tr);
-          }
-        });
+      }
+    }
+
+    // Render Usenet (SABnzbd/NZBGet) download rows — view-only, no actions.
+    function renderUsenetRows(tbody, downloads) {
+      for (const job of downloads) {
+        const tr = document.createElement('tr');
+        tr.appendChild(filenameCell(job.filename));
+        tr.appendChild(providerCell(job.client_type));
+        const isDone = job.status === 'complete' || job.status === 'complete_no_move';
+        tr.appendChild(progressCell(isDone ? 100 : job.percent));
+        tr.appendChild(bytesCell(job.bytes_downloaded, job.bytes_total));
+        const disp = usenetStatusDisplay(job);
+        tr.appendChild(statusCell(disp.text, disp.cssClass, disp.title));
+        tr.appendChild(document.createElement('td')); // no actions
+        tbody.appendChild(tr);
+      }
+    }
+
+    // Fetch both direct (api.py) and Usenet download statuses and rebuild the table.
+    function fetchStatus(signal) {
+      const direct = fetch('/download_status_all', { signal })
+        .then(r => r.json())
+        .catch(() => ({}));
+      // Usenet endpoint may 404/500 when unconfigured — never let it break the poll.
+      const usenet = fetch('/api/usenet/downloads', { signal })
+        .then(r => r.ok ? r.json() : { success: false })
+        .then(d => (d && d.success && Array.isArray(d.downloads)) ? d.downloads : [])
+        .catch(() => []);
+      return Promise.all([direct, usenet]).then(([data, usenetDownloads]) => {
+        const tbody = document.querySelector('#downloads-table tbody');
+        tbody.innerHTML = ''; // Clear previous rows.
+        renderDirectRows(tbody, data || {});
+        renderUsenetRows(tbody, usenetDownloads);
+      });
     }
 
     // Event listener for the Clear Completed/Cancelled Downloads button.

--- a/tests/mocked/test_nzbget_client.py
+++ b/tests/mocked/test_nzbget_client.py
@@ -140,3 +140,35 @@ class TestNZBGetHistory:
         assert by_id["7"].status == "complete"
         assert by_id["7"].storage_path == "/done/Batman 1"
         assert by_id["8"].status == "failed"
+
+
+class TestNZBGetQueue:
+
+    @patch("requests.post")
+    def test_queue_maps_stage_and_bytes(self, mock_post):
+        # listgroups Status -> friendly stage; MB fields -> percent/bytes.
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"result": [
+                {"NZBID": 7, "NZBName": "Batman 1", "Status": "UNPACKING",
+                 "FileSizeMB": 100, "RemainingSizeMB": 40, "DownloadedSizeMB": 60,
+                 "Category": "comics"},
+            ]}))
+        by_id = {g.client_id: g for g in _client().get_queue()}
+        st = by_id["7"]
+        assert st.status == "downloading"
+        assert round(st.percent) == 60
+        assert st.stage == "Extracting"
+        assert st.bytes_total == 100 * 1024 * 1024
+        assert st.bytes_downloaded == 60 * 1024 * 1024
+
+    @patch("requests.post")
+    def test_verifying_stage(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"result": [
+                {"NZBID": 9, "NZBName": "Superman 5", "Status": "VERIFYING_SOURCES",
+                 "FileSizeMB": 50, "RemainingSizeMB": 0},
+            ]}))
+        st = {g.client_id: g for g in _client().get_queue()}["9"]
+        assert st.stage == "Verifying"

--- a/tests/mocked/test_sabnzbd_client.py
+++ b/tests/mocked/test_sabnzbd_client.py
@@ -122,3 +122,20 @@ class TestSABnzbdHistory:
         st = _client().get_status("a")
         assert st.status == "downloading"
         assert st.percent == 42.0
+
+    @patch("requests.get")
+    def test_get_queue_maps_stage_and_bytes(self, mock_get):
+        # SAB's slot 'status' field carries the live stage; mb/mbleft give size.
+        mock_get.return_value = MagicMock(
+            status_code=200, raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"queue": {"slots": [
+                {"nzo_id": "a", "filename": "Batman 1", "percentage": "60",
+                 "status": "Repairing", "mb": "100", "mbleft": "40", "cat": "comics"},
+            ]}}))
+        by_id = {s.client_id: s for s in _client().get_queue()}
+        st = by_id["a"]
+        assert st.status == "downloading"
+        assert st.percent == 60.0
+        assert st.stage == "Repairing"
+        assert st.bytes_total == 100 * 1024 * 1024
+        assert st.bytes_downloaded == 60 * 1024 * 1024

--- a/tests/mocked/test_usenet.py
+++ b/tests/mocked/test_usenet.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import models.usenet as un
 from models.indexers import NZBSearchResult
-from models.download_clients import NZBSubmitResult
+from models.download_clients import NZBSubmitResult, DownloadStatus
 
 
 class TestSourcePriority:
@@ -221,6 +221,64 @@ class TestGrabNzb:
         client.add_nzb.return_value = NZBSubmitResult(success=False, error="bad")
         mock_get_client.return_value = client
         assert un.grab_nzb("https://x/a.nzb", "x.cbz") is None
+
+
+class TestPollerProgress:
+
+    def test_update_progress_caches_live_fields(self):
+        un.usenet_downloads.clear()
+        un.usenet_downloads["d1"] = {
+            "client_type": "sabnzbd", "client_id": "nzo_1", "filename": "Batman 1.cbz",
+            "status": "downloading", "error": None, "series": "Batman", "issue": "1",
+            "percent": 0, "stage": "Queued", "bytes_total": None, "bytes_downloaded": None,
+        }
+        st = DownloadStatus(client_id="nzo_1", status="downloading", percent=55.0,
+                            stage="Repairing", bytes_total=100, bytes_downloaded=55)
+        un._update_progress("d1", st)
+        job = un.usenet_downloads["d1"]
+        assert job["percent"] == 55.0
+        assert job["stage"] == "Repairing"
+        assert job["bytes_total"] == 100
+        assert job["bytes_downloaded"] == 55
+        # The status endpoint helper surfaces the cached fields.
+        snap = {d["download_id"]: d for d in un.get_usenet_downloads()}
+        assert snap["d1"]["stage"] == "Repairing"
+        assert snap["d1"]["percent"] == 55.0
+
+    def test_set_status_terminal_sets_percent(self):
+        un.usenet_downloads.clear()
+        un.usenet_downloads["d1"] = {"status": "downloading", "error": None, "percent": 40}
+        un._set_status("d1", "complete", percent=100)
+        assert un.usenet_downloads["d1"]["status"] == "complete"
+        assert un.usenet_downloads["d1"]["percent"] == 100
+        un._set_status("d1", "failed", error="boom")
+        assert un.usenet_downloads["d1"]["status"] == "failed"
+        assert un.usenet_downloads["d1"]["error"] == "boom"
+
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_download_client_config", return_value={"api_key": "k"})
+    def test_statuses_for_merges_queue_and_history(self, mock_cfg, mock_get_client):
+        client = MagicMock()
+        client.get_queue.return_value = [
+            DownloadStatus(client_id="active1", status="downloading", percent=30, stage="Downloading"),
+            DownloadStatus(client_id="both", status="downloading", percent=99, stage="Moving"),
+        ]
+        client.get_history.return_value = [
+            DownloadStatus(client_id="both", status="complete", storage_path="/done"),
+            DownloadStatus(client_id="done1", status="complete", storage_path="/done1"),
+        ]
+        mock_get_client.return_value = client
+        merged = un._statuses_for("sabnzbd")
+        # History wins for an item present in both queue and history.
+        assert merged["both"].status == "complete"
+        assert merged["both"].storage_path == "/done"
+        assert merged["active1"].status == "downloading"
+        assert merged["active1"].stage == "Downloading"
+        assert merged["done1"].status == "complete"
+
+    @patch("core.database.get_download_client_config", return_value=None)
+    def test_statuses_for_no_config_returns_empty(self, mock_cfg):
+        assert un._statuses_for("sabnzbd") == {}
 
 
 class TestImportCompleted:

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -229,14 +229,23 @@ class TestIndexers:
 class TestUsenetDownloads:
 
     @patch("models.usenet.get_usenet_downloads", return_value=[
-        {"download_id": "x", "filename": "Batman 1.cbz", "status": "downloading"},
+        {"download_id": "x", "filename": "Batman 1.cbz", "status": "downloading",
+         "client_type": "sabnzbd", "percent": 42, "stage": "Repairing",
+         "bytes_total": 104857600, "bytes_downloaded": 52428800},
     ])
     def test_list(self, mock_dl, client):
         resp = client.get("/api/usenet/downloads")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["success"] is True
-        assert data["downloads"][0]["filename"] == "Batman 1.cbz"
+        dl = data["downloads"][0]
+        assert dl["filename"] == "Batman 1.cbz"
+        # Enriched live-progress fields flow through to the status page.
+        assert dl["client_type"] == "sabnzbd"
+        assert dl["percent"] == 42
+        assert dl["stage"] == "Repairing"
+        assert dl["bytes_total"] == 104857600
+        assert dl["bytes_downloaded"] == 52428800
 
     @patch("models.usenet.usenet_precedes_getcomics", return_value=True)
     @patch("core.database.get_active_download_client", return_value={"client_type": "nzbget"})


### PR DESCRIPTION
## Context

CLU supports Usenet downloads via SABnzbd/NZBGet clients + Newznab indexers. When an NZB is grabbed it's submitted to the active client and tracked in the in-memory `usenet_downloads` dict — but this was **invisible in the UI**. The Download Status page (`status.html`) only rendered direct HTTP downloads (GetComics/Pixeldrain/Mega/CBP), and the Usenet poller only checked the client's *history* (terminal states) every 15s — no live %, byte counts, or post-processing stage.

This surfaces Usenet downloads on the Status page, in the same table as direct downloads, with live progress, byte counts, and the client's current stage (Downloading → Verifying → Repairing → Extracting → Moving → Complete, plus failures). View-only — cancel/retry stays in SABnzbd/NZBGet.

## Changes

- **`DownloadStatus`** (`base.py`): add `stage`, `bytes_total`, `bytes_downloaded`; add a default `get_queue()` seam.
- **Adapters**: `get_queue()` on both clients maps live `percent`, the client's real `stage`, and bytes from the queue (SAB `mb`/`mbleft`; NZBGet `listgroups` MB fields + a `_pretty_nzbget_stage()` map). `get_status()` reuses `get_queue()`.
- **Poller** (`models/usenet.py`): new `_statuses_for()` merges queue+history once per client per round (history wins for terminal items); caches `percent`/`stage`/`bytes_*` onto active jobs; runs ~5s while active vs 15s idle.
- **`status.html`**: fetches `/api/usenet/downloads` alongside `/download_status_all` and merges rows into one table with SABnzbd/NZBGet icons (view-only). Drive-by fix: the success styling checked `'completed'` but the backend only ever writes `'complete'` — corrected.

## Notes

- **No changes to `api.py`** — the auth-free download surface and `/download_status_all` are untouched; `status.html` merges the two feeds client-side.
- Completion still depends on the existing import path (client must complete into a CLU-reachable folder); otherwise the row shows **"Complete (import pending)"** — now visible.
- Follow-ups (out of scope): cancel/retry of Usenet downloads from CLU; persisting state across restarts; speed/ETA columns.

## Testing

Added coverage for `get_queue()` stage/bytes mapping (both clients), the poller's progress caching + queue/history merge, and enriched fields flowing through `/api/usenet/downloads`. Full suite: **2722 passed, 6 skipped** (POSIX-only permission tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)