### PR TITLE
Weekly Packs: Check Status targets first not-downloaded pack after Start Date

### DIFF
--- a/app.py
+++ b/app.py
@@ -1627,6 +1627,7 @@ def scheduled_weekly_packs_download():
         from models.getcomics import (
             find_latest_weekly_pack_url,
             check_weekly_pack_availability,
+            get_weekly_pack_page_status,
             parse_weekly_pack_page,
             get_weekly_pack_url_for_date,
             get_weekly_pack_dates_in_range,
@@ -1665,7 +1666,8 @@ def scheduled_weekly_packs_download():
                 f"Checking {len(pack_dates)} potential pack dates from {start_date} to {today}"
             )
 
-            for pack_date in pack_dates:
+            # Process oldest-first so we backfill in chronological order.
+            for pack_date in reversed(pack_dates):
                 # Check if all publishers for this pack have been downloaded
                 all_downloaded = all(
                     is_weekly_pack_downloaded(pack_date, pub, format_pref)
@@ -1677,12 +1679,19 @@ def scheduled_weekly_packs_download():
                     )
                     continue
 
-                # Construct URL and check availability
+                # Construct URL and check status
                 pack_url = get_weekly_pack_url_for_date(pack_date)
                 app_logger.info(f"Checking pack {pack_date} -> {pack_url}")
 
-                if not check_weekly_pack_availability(pack_url):
-                    app_logger.info(f"Pack {pack_date} links not ready yet")
+                status = get_weekly_pack_page_status(pack_url)
+                if status == "missing":
+                    # No pack was published on this date (e.g. Tuesday when the
+                    # release was Wednesday). Skip without triggering a retry.
+                    app_logger.debug(f"Pack {pack_date} page does not exist, skipping")
+                    continue
+                if status != "available":
+                    # 'pending' (links not ready) or 'error' (transient failure).
+                    app_logger.info(f"Pack {pack_date} links not ready yet ({status})")
                     any_not_ready = True
                     continue
 

--- a/models/getcomics.py
+++ b/models/getcomics.py
@@ -2288,17 +2288,31 @@ def find_latest_weekly_pack_url():
         return (None, None)
 
 
-def check_weekly_pack_availability(pack_url: str) -> bool:
+def get_weekly_pack_page_status(pack_url: str) -> str:
     """
-    Check if weekly pack download links are available yet.
+    Determine the status of a weekly pack page.
     Uses cloudscraper to bypass Cloudflare protection.
 
+    Unlike a plain availability boolean, this distinguishes a page that does
+    not exist (e.g. a Tuesday/Wednesday date with no pack that week) from a
+    page whose links simply aren't ready yet. That lets callers skip missing
+    dates instead of treating them as "not ready" and retrying forever.
+
     Returns:
-        True if download links are present, False if still pending
+        One of:
+            'available' - download links are present
+            'pending'   - page exists but links are not ready yet
+            'missing'   - page does not exist (HTTP 404)
+            'error'     - request/parse failed for another reason
     """
     try:
-        logger.info(f"Checking weekly pack availability: {pack_url}")
+        logger.info(f"Checking weekly pack status: {pack_url}")
         resp = scraper.get(pack_url, timeout=30)
+
+        if resp.status_code == 404:
+            logger.info(f"Weekly pack page not found (404): {pack_url}")
+            return 'missing'
+
         resp.raise_for_status()
 
         page_text = resp.text.lower()
@@ -2314,7 +2328,7 @@ def check_weekly_pack_availability(pack_url: str) -> bool:
         for phrase in not_ready_phrases:
             if phrase in page_text:
                 logger.info(f"Weekly pack links not ready yet (found: '{phrase}')")
-                return False
+                return 'pending'
 
         # Check if PIXELDRAIN links exist
         soup = BeautifulSoup(resp.text, 'html.parser')
@@ -2322,14 +2336,80 @@ def check_weekly_pack_availability(pack_url: str) -> bool:
 
         if pixeldrain_links:
             logger.info(f"Weekly pack links are available ({len(pixeldrain_links)} PIXELDRAIN links found)")
-            return True
+            return 'available'
 
         logger.info("No PIXELDRAIN links found on weekly pack page")
-        return False
+        return 'pending'
 
     except Exception as e:
-        logger.error(f"Error checking pack availability: {e}")
-        return False
+        # A 404 is handled above via resp.status_code; anything reaching here
+        # (network error, non-404 HTTP error, parse failure) is a transient
+        # error, not a definitive "missing" or "not ready" verdict.
+        status_code = getattr(getattr(e, 'response', None), 'status_code', None)
+        if status_code == 404:
+            logger.info(f"Weekly pack page not found (404): {pack_url}")
+            return 'missing'
+        logger.error(f"Error checking pack status: {e}")
+        return 'error'
+
+
+def check_weekly_pack_availability(pack_url: str) -> bool:
+    """
+    Check if weekly pack download links are available yet.
+
+    Thin wrapper over get_weekly_pack_page_status() kept for backwards
+    compatibility with existing callers.
+
+    Returns:
+        True if download links are present, False otherwise
+    """
+    return get_weekly_pack_page_status(pack_url) == 'available'
+
+
+def find_first_actionable_weekly_pack(start_date: str, publishers: list,
+                                      format_pref: str, is_downloaded_fn) -> dict:
+    """
+    Find the oldest weekly pack on/after start_date that still needs attention.
+
+    Iterates candidate Tue/Wed pack dates from start_date forward (oldest
+    first), skipping dates whose publishers are all already downloaded and
+    dates whose page doesn't exist (404). Returns the first date whose page
+    exists and isn't fully downloaded.
+
+    Args:
+        start_date: Start date in YYYY-MM-DD format
+        publishers: List of publishers to consider (e.g. ['DC', 'Marvel'])
+        format_pref: 'JPG' or 'WEBP'
+        is_downloaded_fn: Callable(pack_date, publisher, format_pref) -> bool.
+            Injected to avoid coupling this module to core.database.
+
+    Returns:
+        dict with keys 'pack_date', 'pack_url', 'status' ('available' |
+        'pending' | 'error') for the first actionable pack, or None if every
+        in-range pack is already downloaded or missing.
+    """
+    from datetime import datetime
+
+    today = datetime.now().strftime('%Y-%m-%d')
+    # Newest-first; reverse to process oldest-first.
+    pack_dates = get_weekly_pack_dates_in_range(start_date, today)
+
+    for pack_date in reversed(pack_dates):
+        if publishers and all(
+            is_downloaded_fn(pack_date, pub, format_pref) for pub in publishers
+        ):
+            continue
+
+        pack_url = get_weekly_pack_url_for_date(pack_date)
+        status = get_weekly_pack_page_status(pack_url)
+
+        if status == 'missing':
+            # No pack published on this date (e.g. Tuesday when release was Wed).
+            continue
+
+        return {'pack_date': pack_date, 'pack_url': pack_url, 'status': status}
+
+    return None
 
 
 def parse_weekly_pack_page(pack_url: str, format_preference: str, publishers: list) -> dict:

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -813,10 +813,62 @@ def api_weekly_packs_history():
 
 @downloads_bp.route('/api/check-weekly-pack-status', methods=['GET'])
 def api_check_weekly_pack_status():
-    """Check if the latest weekly pack has links available."""
-    try:
-        from models.getcomics import find_latest_weekly_pack_url, check_weekly_pack_availability
+    """
+    Check weekly pack status.
 
+    When a start_date is configured, report on the FIRST (oldest) pack on/after
+    that date that hasn't been downloaded yet — mirroring what the scheduler
+    will actually process next. Without a start_date, fall back to reporting the
+    latest pack from the GetComics homepage.
+    """
+    try:
+        from core.database import get_weekly_packs_config, is_weekly_pack_downloaded
+        from models.getcomics import (
+            find_latest_weekly_pack_url,
+            check_weekly_pack_availability,
+            find_first_actionable_weekly_pack,
+        )
+
+        config = get_weekly_packs_config() or {}
+        start_date = config.get("start_date")
+
+        # Start_date mode: find the oldest not-yet-downloaded pack in range.
+        if start_date:
+            publishers = config.get("publishers") or []
+            format_pref = config.get("format") or "JPG"
+
+            result = find_first_actionable_weekly_pack(
+                start_date, publishers, format_pref, is_weekly_pack_downloaded
+            )
+
+            if not result:
+                return jsonify({
+                    "success": True,
+                    "found": False,
+                    "start_date": start_date,
+                    "message": f"All packs on/after {start_date} already downloaded"
+                })
+
+            status = result["status"]
+            available = status == "available"
+            if available:
+                message = "Links available"
+            elif status == "error":
+                message = "Could not reach pack page (try again later)"
+            else:
+                message = "Links not ready yet"
+
+            return jsonify({
+                "success": True,
+                "found": True,
+                "pack_date": result["pack_date"],
+                "pack_url": result["pack_url"],
+                "links_available": available,
+                "start_date": start_date,
+                "message": message
+            })
+
+        # No start_date: report the latest pack from the homepage.
         pack_url, pack_date = find_latest_weekly_pack_url()
         if not pack_url:
             return jsonify({

--- a/templates/weekly_packs.html
+++ b/templates/weekly_packs.html
@@ -402,12 +402,18 @@ function checkPackStatus() {
 
             if (data.success) {
                 if (data.found) {
-                    const status = data.links_available
-                        ? `<strong>${data.pack_date}</strong> - Links are available!`
-                        : `<strong>${data.pack_date}</strong> - Links not ready yet`;
+                    // When a start date drives the check, this is the first pack
+                    // not yet downloaded on/after that date.
+                    const context = data.start_date
+                        ? ` — first pack not downloaded since ${data.start_date}`
+                        : '';
+                    const detail = data.links_available
+                        ? 'Links are available!'
+                        : (data.message || 'Links not ready yet');
+                    const status = `<strong>${data.pack_date}</strong>${context}. ${detail}`;
                     showStatus(status, data.links_available ? 'success' : 'warning');
                 } else {
-                    showStatus(data.message, 'warning');
+                    showStatus(data.message, data.start_date ? 'info' : 'warning');
                 }
             } else {
                 showStatus('Error: ' + data.error, 'danger');

--- a/tests/mocked/test_getcomics.py
+++ b/tests/mocked/test_getcomics.py
@@ -1810,6 +1810,140 @@ class TestCheckWeeklyPackAvailability:
 
 
 # ===================================================================
+# get_weekly_pack_page_status (tri-state)
+# ===================================================================
+
+class TestGetWeeklyPackPageStatus:
+
+    @patch("models.getcomics.scraper")
+    def test_available_when_pixeldrain_links_present(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(PACK_READY_HTML)
+
+        from models.getcomics import get_weekly_pack_page_status
+        assert get_weekly_pack_page_status("https://getcomics.org/pack") == "available"
+
+    @patch("models.getcomics.scraper")
+    def test_pending_when_not_ready_message(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(PACK_NOT_READY_HTML)
+
+        from models.getcomics import get_weekly_pack_page_status
+        assert get_weekly_pack_page_status("https://getcomics.org/pack") == "pending"
+
+    @patch("models.getcomics.scraper")
+    def test_pending_when_no_links(self, mock_scraper):
+        mock_scraper.get.return_value = _mock_response(PACK_NO_LINKS_HTML)
+
+        from models.getcomics import get_weekly_pack_page_status
+        assert get_weekly_pack_page_status("https://getcomics.org/pack") == "pending"
+
+    @patch("models.getcomics.scraper")
+    def test_missing_on_404(self, mock_scraper):
+        # A 404 page (no pack that day) must be distinguished from "not ready".
+        mock_scraper.get.return_value = _mock_response(PACK_NO_LINKS_HTML, status_code=404)
+
+        from models.getcomics import get_weekly_pack_page_status
+        assert get_weekly_pack_page_status("https://getcomics.org/pack") == "missing"
+
+    @patch("models.getcomics.scraper")
+    def test_error_on_request_exception(self, mock_scraper):
+        mock_scraper.get.side_effect = Exception("Timeout")
+
+        from models.getcomics import get_weekly_pack_page_status
+        assert get_weekly_pack_page_status("https://getcomics.org/pack") == "error"
+
+
+# ===================================================================
+# find_first_actionable_weekly_pack
+# ===================================================================
+
+class TestFindFirstActionableWeeklyPack:
+
+    # newest-first, as get_weekly_pack_dates_in_range returns them
+    DATES = ["2026.01.21", "2026.01.14", "2026.01.07"]
+
+    @patch("models.getcomics.get_weekly_pack_page_status")
+    @patch("models.getcomics.get_weekly_pack_dates_in_range")
+    def test_returns_oldest_not_downloaded_available(self, mock_dates, mock_status):
+        mock_dates.return_value = list(self.DATES)
+        mock_status.return_value = "available"
+        # Oldest (2026.01.07) already downloaded -> skip to next oldest.
+        is_downloaded = lambda date, pub, fmt: date == "2026.01.07"
+
+        from models.getcomics import find_first_actionable_weekly_pack
+        result = find_first_actionable_weekly_pack(
+            "2026-01-01", ["DC", "Marvel"], "JPG", is_downloaded
+        )
+
+        assert result["pack_date"] == "2026.01.14"
+        assert result["status"] == "available"
+        assert result["pack_url"] == "https://getcomics.org/other-comics/2026-01-14-weekly-pack/"
+
+    @patch("models.getcomics.get_weekly_pack_page_status")
+    @patch("models.getcomics.get_weekly_pack_dates_in_range")
+    def test_skips_missing_dates(self, mock_dates, mock_status):
+        mock_dates.return_value = list(self.DATES)
+        # Oldest date has no pack page (404); next oldest is available.
+        mock_status.side_effect = lambda url: (
+            "missing" if "2026-01-07" in url else "available"
+        )
+        is_downloaded = lambda date, pub, fmt: False
+
+        from models.getcomics import find_first_actionable_weekly_pack
+        result = find_first_actionable_weekly_pack(
+            "2026-01-01", ["DC"], "JPG", is_downloaded
+        )
+
+        assert result["pack_date"] == "2026.01.14"
+
+    @patch("models.getcomics.get_weekly_pack_page_status")
+    @patch("models.getcomics.get_weekly_pack_dates_in_range")
+    def test_returns_pending_pack(self, mock_dates, mock_status):
+        mock_dates.return_value = list(self.DATES)
+        mock_status.return_value = "pending"
+        is_downloaded = lambda date, pub, fmt: False
+
+        from models.getcomics import find_first_actionable_weekly_pack
+        result = find_first_actionable_weekly_pack(
+            "2026-01-01", ["DC"], "JPG", is_downloaded
+        )
+
+        # Oldest pending pack is actionable and reported as-is.
+        assert result["pack_date"] == "2026.01.07"
+        assert result["status"] == "pending"
+
+    @patch("models.getcomics.get_weekly_pack_page_status")
+    @patch("models.getcomics.get_weekly_pack_dates_in_range")
+    def test_returns_none_when_all_downloaded(self, mock_dates, mock_status):
+        mock_dates.return_value = list(self.DATES)
+        is_downloaded = lambda date, pub, fmt: True
+
+        from models.getcomics import find_first_actionable_weekly_pack
+        result = find_first_actionable_weekly_pack(
+            "2026-01-01", ["DC"], "JPG", is_downloaded
+        )
+
+        assert result is None
+        mock_status.assert_not_called()
+
+    @patch("models.getcomics.get_weekly_pack_page_status")
+    @patch("models.getcomics.get_weekly_pack_dates_in_range")
+    def test_empty_publishers_does_not_skip(self, mock_dates, mock_status):
+        mock_dates.return_value = list(self.DATES)
+        mock_status.return_value = "available"
+
+        def is_downloaded(date, pub, fmt):  # would raise if called with empty pubs
+            raise AssertionError("is_downloaded should not be consulted")
+
+        from models.getcomics import find_first_actionable_weekly_pack
+        result = find_first_actionable_weekly_pack(
+            "2026-01-01", [], "JPG", is_downloaded
+        )
+
+        # Oldest date returned; downloaded-check skipped when no publishers.
+        assert result["pack_date"] == "2026.01.07"
+
+
+# ===================================================================
 # parse_weekly_pack_page
 # ===================================================================
 

--- a/tests/routes/test_downloads_routes.py
+++ b/tests/routes/test_downloads_routes.py
@@ -233,3 +233,63 @@ class TestRunWeeklyPacksNow:
             resp = client.post("/api/run-weekly-packs-now")
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
+
+
+class TestCheckWeeklyPackStatus:
+
+    @patch("models.getcomics.find_first_actionable_weekly_pack")
+    @patch("core.database.get_weekly_packs_config")
+    def test_start_date_mode_reports_first_actionable(self, mock_config, mock_find, client):
+        mock_config.return_value = {
+            "start_date": "2026-01-01",
+            "publishers": ["DC", "Marvel"],
+            "format": "JPG",
+        }
+        mock_find.return_value = {
+            "pack_date": "2026.01.14",
+            "pack_url": "https://getcomics.org/other-comics/2026-01-14-weekly-pack/",
+            "status": "available",
+        }
+
+        resp = client.get("/api/check-weekly-pack-status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["found"] is True
+        assert data["pack_date"] == "2026.01.14"
+        assert data["links_available"] is True
+        assert data["start_date"] == "2026-01-01"
+        # start_date drives the check, not the homepage.
+        args = mock_find.call_args[0]
+        assert args[0] == "2026-01-01"
+
+    @patch("models.getcomics.find_first_actionable_weekly_pack", return_value=None)
+    @patch("core.database.get_weekly_packs_config")
+    def test_start_date_mode_all_downloaded(self, mock_config, mock_find, client):
+        mock_config.return_value = {
+            "start_date": "2026-01-01",
+            "publishers": ["DC"],
+            "format": "JPG",
+        }
+
+        resp = client.get("/api/check-weekly-pack-status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["found"] is False
+        assert data["start_date"] == "2026-01-01"
+
+    @patch("models.getcomics.check_weekly_pack_availability", return_value=True)
+    @patch("models.getcomics.find_latest_weekly_pack_url",
+           return_value=("https://getcomics.org/other-comics/2026-02-04-weekly-pack/", "2026.02.04"))
+    @patch("core.database.get_weekly_packs_config", return_value={"start_date": None})
+    def test_no_start_date_uses_homepage(self, mock_config, mock_latest, mock_avail, client):
+        resp = client.get("/api/check-weekly-pack-status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["found"] is True
+        assert data["pack_date"] == "2026.02.04"
+        assert data["links_available"] is True
+        assert "start_date" not in data
+        mock_latest.assert_called_once()


### PR DESCRIPTION
## Context

On the **Weekly Packs** page, the **Check Pack Status** button (`/api/check-weekly-pack-status`) only ever inspected the *single newest* pack scraped from the GetComics homepage and **ignored the configured Start Date entirely**. Meanwhile the scheduler *does* honor Start Date — it backfills every not-yet-downloaded Tue/Wed pack in range. So the button and the actual operation disagreed: a user with a Start Date set clicked "Check Status," saw only the latest homepage pack, and couldn't tell what the scheduler was working through.

This PR makes the status check honor Start Date (reporting the **first / oldest not-yet-downloaded pack** on/after it) and fixes a related retry bug.

## Changes

- **`models/getcomics.py`**
  - New `get_weekly_pack_page_status()` — tri-state (`available` / `pending` / `missing` / `error`) so a non-existent page (404) is distinguishable from "links not ready."
  - New `find_first_actionable_weekly_pack()` — scans oldest-first from Start Date, skips already-downloaded and 404 dates, returns the first pack needing attention (injected `is_downloaded_fn` keeps `models/` decoupled from `core.database`).
  - `check_weekly_pack_availability()` is now a thin wrapper over the status function (existing callers/tests unchanged).
- **`routes/downloads.py`** — `/api/check-weekly-pack-status` honors Start Date; falls back to homepage-latest when unset.
- **`app.py`** — scheduler backfills **oldest-first** and treats 404 (missing) weeks as skip instead of "not ready," fixing an **endless daily-retry loop** caused by the date generator emitting both a Tuesday and a Wednesday each week when only one pack exists.
- **`templates/weekly_packs.html`** — status message surfaces the Start Date context and the "all downloaded" case.

## Tests

- `tests/mocked/test_getcomics.py` — tri-state `get_weekly_pack_page_status` (404→missing, not-ready→pending, pixeldrain→available, error) and `find_first_actionable_weekly_pack` (skips downloaded, skips missing, returns oldest/pending, empty-publishers).
- `tests/routes/test_downloads_routes.py` — `/api/check-weekly-pack-status` start-date mode, all-downloaded, and homepage fallback.

Full suite: **2719 passed, 6 skipped** (excluding the known env-only `test_pdf.py`).

## Verification

Set a Start Date a few weeks back with publishers selected, click **Check Pack Status** — it reports the oldest pack you haven't downloaded and its ready/not-ready state (not the newest homepage pack). A Tuesday/Wednesday 404 week no longer reports "not ready."

🤖 Generated with [Claude Code](https://claude.com/claude-code)