### PR TITLE
Strip provider IDs from ComicInfo credit values

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ from core.memory_utils import (
     get_global_monitor,
 )
 from core.app_logging import app_logger, APP_LOG, MONITOR_LOG, read_log_tail
+from core.metadata_normalize import normalize_credit_list, strip_provider_ids
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections import OrderedDict
 from core.version import __version__
@@ -5282,10 +5283,12 @@ def api_backfill_reading_metadata():
             try:
                 comic_info = read_comicinfo_from_zip(issue_path)
                 if comic_info:
-                    writer = comic_info.get("Writer", "")
-                    penciller = comic_info.get("Penciller", "")
-                    characters = comic_info.get("Characters", "")
-                    publisher = comic_info.get("Publisher", "")
+                    # Strip "[3258]"-style provider IDs, or this route would
+                    # re-dirty issues_read after the migration cleaned it.
+                    writer = normalize_credit_list(comic_info.get("Writer", ""))
+                    penciller = normalize_credit_list(comic_info.get("Penciller", ""))
+                    characters = normalize_credit_list(comic_info.get("Characters", ""))
+                    publisher = strip_provider_ids(comic_info.get("Publisher", ""))
 
                     c.execute(
                         """

--- a/core/database.py
+++ b/core/database.py
@@ -11,6 +11,19 @@ from datetime import datetime
 from typing import Optional
 from core.config import config, CONFIG_DIR
 from core.app_logging import app_logger
+from core.metadata_normalize import (
+    normalize_credit_list,
+    split_credit_list,
+    strip_provider_ids,
+)
+
+# Bumped when a one-shot *data* migration must run (schema migrations use
+# PRAGMA table_info presence checks instead). Stored in PRAGMA user_version and
+# written only after the migration completes, so a crash mid-backfill leaves
+# the previous value in place and the work re-runs on the next startup.
+#   1 = strip provider IDs ("Ron Lim [3258]") from credit columns in
+#       file_index, file_metadata_tags and issues_read.
+CURRENT_DATA_MIGRATION_VERSION = 1
 
 
 def get_db_path():
@@ -290,6 +303,12 @@ def init_db():
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_file_index_publisher ON file_index(ci_publisher)"
         )
+        # Collation-matched companion for browse-by-publisher's exact NOCASE
+        # match (see idx_fmt_kind_value_nocase for the credit-side equivalent).
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_file_index_publisher_nocase"
+            " ON file_index(ci_publisher COLLATE NOCASE) WHERE type = 'file'"
+        )
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_file_index_series ON file_index(ci_series)"
         )
@@ -338,6 +357,13 @@ def init_db():
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_fmt_value"
             " ON file_metadata_tags(value)"
+        )
+        # Browse-by-credit matches case-insensitively (the padded-LIKE it
+        # replaced was case-insensitive), so it needs a collation-matched
+        # index or the planner falls back to a full scan per request.
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fmt_kind_value_nocase"
+            " ON file_metadata_tags(kind, value COLLATE NOCASE)"
         )
 
         # Create rebuild_schedule table (store file index rebuild schedule)
@@ -1492,10 +1518,32 @@ def init_db():
         if _elapsed > 1:
             app_logger.info(f"Tag backfill check took {_elapsed:.1f}s")
 
+        # One-shot data migrations are gated on PRAGMA user_version — a
+        # built-in header field, free to read, so startup stays cheap. A
+        # bracket predicate can't serve as the guard: values we intentionally
+        # keep ("[uncredited]") match it forever, so it would never go quiet.
+        c.execute("PRAGMA user_version")
+        _needs_credit_normalization = (
+            (c.fetchone()[0] or 0) < CURRENT_DATA_MIGRATION_VERSION
+        )
+        if _needs_credit_normalization:
+            # A database with no rows has no legacy data to clean, so mark the
+            # migration done now rather than spawning a thread to discover
+            # that (fresh installs and every test database land here).
+            c.execute(
+                "SELECT 1 WHERE EXISTS (SELECT 1 FROM file_index LIMIT 1)"
+                " OR EXISTS (SELECT 1 FROM issues_read LIMIT 1)"
+            )
+            if c.fetchone() is None:
+                c.execute(f"PRAGMA user_version = {CURRENT_DATA_MIGRATION_VERSION}")
+                _needs_credit_normalization = False
+
         conn.close()
         # A new/re-initialised DB invalidates any cached metadata browser
         # results from a previous connection (important for test isolation).
         invalidate_metadata_browser_cache()
+        global _tags_table_complete
+        _tags_table_complete = False
         app_logger.info("Database initialized successfully")
 
         # Run ANALYZE in a background thread so it doesn't block startup.
@@ -1515,11 +1563,15 @@ def init_db():
 
         threading.Thread(target=_background_analyze, daemon=True).start()
 
-        if _needs_tag_backfill:
+        if _needs_tag_backfill or _needs_credit_normalization:
             app_logger.info(
-                "file_metadata_tags backfill needed — running in background"
+                "Background metadata backfill needed — running in background "
+                f"(tags={_needs_tag_backfill}, "
+                f"credit_normalization={_needs_credit_normalization})"
             )
-            _start_backfill_tags_async()
+            _start_backfill_tags_async(
+                normalize_credits=_needs_credit_normalization
+            )
 
         return True
     except Exception as e:
@@ -3301,6 +3353,10 @@ def update_file_metadata(file_id, metadata_dict, scanned_at, has_comicinfo=None)
         if not conn:
             return False
 
+        # Strip "[3258]"-style provider IDs from credit columns before they
+        # reach either file_index or file_metadata_tags.
+        metadata_dict = _normalize_ci_metadata(metadata_dict)
+
         c = conn.cursor()
         c.execute(
             """
@@ -3696,15 +3752,16 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
         ci_count = str(comicinfo_dict.get("Count", "") or "")
         ci_volume = str(comicinfo_dict.get("Volume", "") or "")
         ci_year = str(comicinfo_dict.get("Year", "") or "")
-        ci_writer = str(comicinfo_dict.get("Writer", "") or "")
-        ci_penciller = str(comicinfo_dict.get("Penciller", "") or "")
-        ci_inker = str(comicinfo_dict.get("Inker", "") or "")
-        ci_colorist = str(comicinfo_dict.get("Colorist", "") or "")
-        ci_letterer = str(comicinfo_dict.get("Letterer", "") or "")
-        ci_coverartist = str(comicinfo_dict.get("CoverArtist", "") or "")
-        ci_publisher = str(comicinfo_dict.get("Publisher", "") or "")
-        ci_genre = str(comicinfo_dict.get("Genre", "") or "")
-        ci_characters = str(comicinfo_dict.get("Characters", "") or "")
+        # Credit/character/genre lists are provider-ID-stripped on the way in.
+        ci_writer = normalize_credit_list(comicinfo_dict.get("Writer", ""))
+        ci_penciller = normalize_credit_list(comicinfo_dict.get("Penciller", ""))
+        ci_inker = normalize_credit_list(comicinfo_dict.get("Inker", ""))
+        ci_colorist = normalize_credit_list(comicinfo_dict.get("Colorist", ""))
+        ci_letterer = normalize_credit_list(comicinfo_dict.get("Letterer", ""))
+        ci_coverartist = normalize_credit_list(comicinfo_dict.get("CoverArtist", ""))
+        ci_publisher = strip_provider_ids(comicinfo_dict.get("Publisher", ""))
+        ci_genre = normalize_credit_list(comicinfo_dict.get("Genre", ""))
+        ci_characters = normalize_credit_list(comicinfo_dict.get("Characters", ""))
         scanned_at = time.time()
 
         app_logger.info(
@@ -5034,6 +5091,12 @@ def mark_issue_read(
         uid = _resolve_user_id(user_id)
         c = conn.cursor()
 
+        # Strip provider IDs so Insights trend counts don't fragment.
+        writer = normalize_credit_list(writer)
+        penciller = normalize_credit_list(penciller)
+        characters = normalize_credit_list(characters)
+        publisher = strip_provider_ids(publisher)
+
         if read_at:
             c.execute(
                 """
@@ -5334,24 +5397,136 @@ def get_reading_trends(field_name, year=None, limit=10, user_id=None):
         rows = c.fetchall()
         conn.close()
 
-        # Count occurrences of each value (splitting comma-separated)
+        # Count occurrences of each value (splitting comma-separated).
+        # split_credit_list strips "[3258]"-style provider IDs, so a person
+        # counts once even if issues_read hasn't been backfilled yet.
+        #
+        # Keyed case-insensitively (keeping the first spelling seen) because
+        # each entry links straight to /browse/<field>/<name>, which matches
+        # COLLATE NOCASE — a case-split count here would disagree with the
+        # number of comics the user then sees.
         counts = {}
+        labels = {}
         for row in rows:
             value = row[0]
             if value:
-                # Split by comma and count each individual value
-                for item in value.split(","):
-                    item = item.strip()
-                    if item:
-                        counts[item] = counts.get(item, 0) + 1
+                for item in split_credit_list(value):
+                    key = item.casefold()
+                    labels.setdefault(key, item)
+                    counts[key] = counts.get(key, 0) + 1
 
         # Sort by count descending and return top N
         sorted_items = sorted(counts.items(), key=lambda x: x[1], reverse=True)[:limit]
-        return [{"name": name, "count": count} for name, count in sorted_items]
+        return [{"name": labels[key], "count": count} for key, count in sorted_items]
 
     except Exception as e:
         app_logger.error(f"Failed to get reading trends for {field_name}: {e}")
         return []
+
+
+# Browse-by-metadata categories. writer/penciller/characters are answered from
+# file_metadata_tags via an indexed exact join (they are comma-separated lists);
+# publisher is a scalar column and stays on file_index.
+_BROWSE_FIELD_COLUMNS = {
+    "writer": "ci_writer",
+    "penciller": "ci_penciller",
+    "characters": "ci_characters",
+    "publisher": "ci_publisher",
+}
+_BROWSE_TAG_KINDS = {"writer", "penciller", "characters"}
+
+_FILE_ROW_COLUMNS = (
+    "name", "path", "size", "ci_series", "ci_number", "ci_year", "ci_publisher",
+)
+# Restrict to actual comic files. Two spellings because the browse queries
+# alias file_index as `fi` while the tag-completeness probe does not.
+_COMIC_FILE_CLAUSE = (
+    "type = 'file'"
+    " AND (LOWER(name) LIKE '%.cbz' OR LOWER(name) LIKE '%.cbr')"
+)
+_COMIC_FILE_CLAUSE_FI = (
+    "fi.type = 'file'"
+    " AND (LOWER(fi.name) LIKE '%.cbz' OR LOWER(fi.name) LIKE '%.cbr')"
+)
+
+
+# Sticky once True: every ci_* write path syncs file_metadata_tags, so a
+# complete tag table cannot become incomplete again. Reset by init_db() so
+# tests against a fresh database don't inherit another DB's answer.
+_tags_table_complete = False
+
+
+def _tags_are_complete(c):
+    """True when file_metadata_tags covers every file that has credit data.
+
+    Decides whether the exact tag join can be trusted. A file with no credits
+    legitimately has no tag rows, so the probe looks for the real failure
+    case — credits present in ci_* but nothing exploded into the tag table,
+    which is what a mid-flight backfill looks like.
+    """
+    global _tags_table_complete
+    if _tags_table_complete:
+        return True
+
+    credit_clause = " OR ".join(
+        f"{col} IS NOT NULL AND {col} != ''" for col in _NORMALIZED_LIST_COLUMNS
+    )
+    c.execute(
+        "SELECT 1 FROM file_index WHERE " + _COMIC_FILE_CLAUSE +
+        " AND (" + credit_clause + ")"
+        " AND NOT EXISTS ("
+        "   SELECT 1 FROM file_metadata_tags WHERE file_path = file_index.path"
+        " ) LIMIT 1"
+    )
+    if c.fetchone() is None:
+        _tags_table_complete = True
+    return _tags_table_complete
+
+
+def _browse_match_sql(field_name, value, select_expr, order_sql=""):
+    """Build the (sql, params) pair matching `value` in `field_name`.
+
+    Returns the exact-match form: an indexed join on file_metadata_tags for
+    credit lists, or an exact NOCASE column compare for publisher.
+    """
+    if field_name in _BROWSE_TAG_KINDS:
+        sql = (
+            "SELECT " + select_expr +
+            " FROM file_index fi"
+            " JOIN file_metadata_tags t ON t.file_path = fi.path"
+            " WHERE t.kind = ? AND t.value = ? COLLATE NOCASE"
+            " AND " + _COMIC_FILE_CLAUSE_FI
+            + order_sql
+        )
+        return sql, (field_name, value)
+
+    sql = (
+        "SELECT " + select_expr +
+        " FROM file_index fi"
+        " WHERE fi.ci_publisher = ? COLLATE NOCASE"
+        " AND " + _COMIC_FILE_CLAUSE_FI
+        + order_sql
+    )
+    return sql, (value,)
+
+
+def _browse_fallback_sql(field_name, value, select_expr, order_sql=""):
+    """Legacy substring-LIKE form, used only while the tag table is incomplete.
+
+    Matches dirty rows by construction: `value` has already been normalized to
+    "Ron Lim", and LIKE '%Ron Lim%' still finds a column reading
+    "Ron Lim [3258]".
+    """
+    column = _BROWSE_FIELD_COLUMNS[field_name]
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    sql = (
+        "SELECT " + select_expr +
+        " FROM file_index fi"
+        " WHERE " + _COMIC_FILE_CLAUSE_FI +
+        " AND fi." + column + " LIKE ? ESCAPE '\\'"
+        + order_sql
+    )
+    return sql, (f"%{escaped}%",)
 
 
 def get_files_by_metadata(field_name, value, limit=50, offset=0):
@@ -5367,18 +5542,14 @@ def get_files_by_metadata(field_name, value, limit=50, offset=0):
     Returns:
         Dict with 'files' list and 'total' count
     """
-    field_mapping = {
-        "writer": "ci_writer",
-        "penciller": "ci_penciller",
-        "characters": "ci_characters",
-        "publisher": "ci_publisher",
-    }
-
-    if field_name not in field_mapping:
+    if field_name not in _BROWSE_FIELD_COLUMNS:
         app_logger.warning(f"Invalid field name for metadata browse: {field_name}")
         return {"files": [], "total": 0}
 
-    db_column = field_mapping[field_name]
+    # Stale bookmarks and the CBZ-info modal still carry "Ron Lim [3258]".
+    value = strip_provider_ids(value)
+    if not value:
+        return {"files": [], "total": 0}
 
     try:
         conn = get_db_connection()
@@ -5387,34 +5558,30 @@ def get_files_by_metadata(field_name, value, limit=50, offset=0):
 
         c = conn.cursor()
 
-        # Use LIKE with wildcards to handle comma-separated values
-        like_pattern = f"%{value}%"
-
-        # Get total count first
-        # db_column is validated via field_mapping above
-        count_query = (
-            "SELECT COUNT(*) FROM file_index"
-            " WHERE type = 'file'"
-            " AND (LOWER(name) LIKE '%.cbz' OR LOWER(name) LIKE '%.cbr')"
-            " AND " + db_column + " LIKE ?"
+        # Use CAST for numeric sorting of issue numbers (handles "8" before "18")
+        order_sql = (
+            " ORDER BY fi.ci_series COLLATE NOCASE,"
+            " CAST(fi.ci_number AS INTEGER) ASC, fi.ci_number ASC"
         )
-        c.execute(count_query, (like_pattern,))
+        select_expr = ", ".join("fi." + col for col in _FILE_ROW_COLUMNS)
+
+        # The exact join is only trustworthy once the tag table covers every
+        # file with credits; until then the legacy substring match is used so
+        # a mid-backfill browse returns a superset rather than a silent
+        # fraction of the library.
+        builder = (_browse_match_sql if _tags_are_complete(c)
+                   else _browse_fallback_sql)
+
+        count_sql, params = builder(field_name, value, "COUNT(*)")
+        c.execute(count_sql, params)
         total = c.fetchone()[0]
 
-        # Get paginated results
-        # Use CAST for numeric sorting of issue numbers (handles "8" before "18")
-        select_query = (
-            "SELECT name, path, size, ci_series, ci_number, ci_year, ci_publisher"
-            " FROM file_index"
-            " WHERE type = 'file'"
-            " AND (LOWER(name) LIKE '%.cbz' OR LOWER(name) LIKE '%.cbr')"
-            " AND " + db_column + " LIKE ?"
-            " ORDER BY ci_series COLLATE NOCASE, CAST(ci_number AS INTEGER) ASC, ci_number ASC"
-            " LIMIT ? OFFSET ?"
-        )
-        c.execute(select_query, (like_pattern, limit, offset))
+        rows = []
+        if total:
+            sel_sql, params = builder(field_name, value, select_expr, order_sql)
+            c.execute(sel_sql + " LIMIT ? OFFSET ?", params + (limit, offset))
+            rows = c.fetchall()
 
-        rows = c.fetchall()
         conn.close()
 
         files = []
@@ -5452,20 +5619,17 @@ def get_files_by_metadata_grouped(field_name, value):
     Returns:
         Dict with 'groups' list, 'total' count, and 'nested' flag
     """
-    field_mapping = {
-        "writer": "ci_writer",
-        "penciller": "ci_penciller",
-        "characters": "ci_characters",
-        "publisher": "ci_publisher",
-    }
-
-    if field_name not in field_mapping:
+    if field_name not in _BROWSE_FIELD_COLUMNS:
         app_logger.warning(f"Invalid field name for metadata browse: {field_name}")
         return {"groups": [], "total": 0, "nested": False}
 
-    search_column = field_mapping[field_name]
     # Writer/penciller use nested grouping (publisher -> series)
     use_nested = field_name in ("writer", "penciller")
+
+    # Stale bookmarks and the CBZ-info modal still carry "Ron Lim [3258]".
+    value = strip_provider_ids(value)
+    if not value:
+        return {"groups": [], "total": 0, "nested": use_nested}
 
     try:
         conn = get_db_connection()
@@ -5473,23 +5637,23 @@ def get_files_by_metadata_grouped(field_name, value):
             return {"groups": [], "total": 0, "nested": use_nested}
 
         c = conn.cursor()
-        like_pattern = f"%{value}%"
 
         # Query all matching files, ordered for grouping
         # Use CAST for numeric sorting of issue numbers (handles "8" before "18")
-        # search_column is validated via field_mapping above
-        query = (
-            "SELECT name, path, size, ci_series, ci_number, ci_year, ci_publisher"
-            " FROM file_index"
-            " WHERE type = 'file'"
-            " AND (LOWER(name) LIKE '%.cbz' OR LOWER(name) LIKE '%.cbr')"
-            " AND " + search_column + " LIKE ?"
-            " ORDER BY ci_publisher COLLATE NOCASE, ci_series COLLATE NOCASE,"
-            "          CAST(ci_number AS INTEGER) ASC, ci_number ASC"
+        order_sql = (
+            " ORDER BY fi.ci_publisher COLLATE NOCASE, fi.ci_series COLLATE NOCASE,"
+            " CAST(fi.ci_number AS INTEGER) ASC, fi.ci_number ASC"
         )
-        c.execute(query, (like_pattern,))
+        select_expr = ", ".join("fi." + col for col in _FILE_ROW_COLUMNS)
 
+        # See get_files_by_metadata: exact join once the tag table is complete,
+        # legacy substring match while the backfill is still in flight.
+        builder = (_browse_match_sql if _tags_are_complete(c)
+                   else _browse_fallback_sql)
+        query, params = builder(field_name, value, select_expr, order_sql)
+        c.execute(query, params)
         rows = c.fetchall()
+
         conn.close()
 
         total = len(rows)
@@ -5603,19 +5767,52 @@ _TAG_KINDS = [
     ("genre",       "ci_genre"),
 ]
 
+# Credit/character/genre columns are comma-separated lists of people or tags;
+# external taggers append "[<provider id>]" to each entry. Normalised on every
+# write so "Ron Lim" and "Ron Lim [3258]" never fragment into two people.
+_NORMALIZED_LIST_COLUMNS = tuple(col for _, col in _TAG_KINDS)
+
+# Scalar (single-value) columns that also carry provider IDs, e.g.
+# "Marvel [31]". Not comma-split — a publisher name may contain a comma.
+_NORMALIZED_SCALAR_COLUMNS = ("ci_publisher",)
+
+# Every column touched by the credit normalisation, in file_index order.
+_NORMALIZED_CI_COLUMNS = _NORMALIZED_LIST_COLUMNS + _NORMALIZED_SCALAR_COLUMNS
+
+
+def _normalize_ci_value(column, value):
+    """Normalise a single ci_* value according to its column's policy."""
+    if column in _NORMALIZED_LIST_COLUMNS:
+        return normalize_credit_list(value)
+    if column in _NORMALIZED_SCALAR_COLUMNS:
+        return strip_provider_ids(value)
+    return value
+
+
+def _normalize_ci_metadata(metadata_dict):
+    """Return a copy of a ci_* dict with credit columns provider-ID-stripped.
+
+    Deliberately leaves ci_title / ci_series / ci_number / ci_count /
+    ci_volume / ci_year alone: brackets there are part of the real value
+    (variant descriptors, bracketed subtitles), and ci_series in particular is
+    exact-matched by series_representative_path() and grouped-by in
+    metadata_browse(), so rewriting it would silently re-key series.
+    """
+    out = dict(metadata_dict)
+    for col in _NORMALIZED_CI_COLUMNS:
+        if col in out:
+            out[col] = _normalize_ci_value(col, out[col])
+    return out
+
 
 def _split_tag_values(raw):
-    """Split a comma-separated ci_* column into a set of clean tokens."""
-    if not raw:
-        return ()
-    out = []
-    seen = set()
-    for part in raw.split(","):
-        v = part.strip()
-        if v and v not in seen:
-            seen.add(v)
-            out.append(v)
-    return tuple(out)
+    """Split a comma-separated ci_* column into a set of clean tokens.
+
+    Provider IDs ("Ron Lim [3258]") are stripped here as well as at the write
+    sites, so the tag table is correct even for rows whose ci_* columns have
+    not yet been through the one-time backfill.
+    """
+    return split_credit_list(raw)
 
 
 def _sync_tags_for_file(conn, file_path, ci_values):
@@ -5708,30 +5905,157 @@ def _backfill_file_metadata_tags(conn, chunk_size=500, progress_cb=None):
     app_logger.info(f"file_metadata_tags backfill inserted {total} rows")
 
 
-def _start_backfill_tags_async():
+def _backfill_normalize_credits(conn, chunk_size=500, progress_cb=None):
     """
-    Kick off the file_metadata_tags backfill in a daemon thread so app
-    startup isn't blocked. Safe to call multiple times — only one backfill
-    runs at a time and the work is idempotent (skips already-tagged files).
+    One-shot: strip numeric provider IDs from the credit columns of every
+    file_index row, rebuild that row's file_metadata_tags entries, then do the
+    same for issues_read. Sets PRAGMA user_version on success.
+
+    Chunked with a monotonic id cursor rather than "re-select rows that still
+    match a bracket predicate": rows holding only non-numeric brackets
+    ("[uncredited]") keep matching such a predicate after we process them, so
+    a predicate-driven loop would never terminate. The id cursor always
+    advances, so the pass is finite and resumable.
+    """
+    c = conn.cursor()
+    columns = list(_NORMALIZED_CI_COLUMNS)
+    col_sql = ", ".join(columns)
+
+    # Cheap short-circuit: skip the whole file_index walk when no credit
+    # column contains a bracket at all. LIKE treats '[' and ']' as ordinary
+    # characters (unlike GLOB, which would need the error-prone '*[[]*[]]*'),
+    # so '%[%]%' means literally "…[…]…". This still matches "[uncredited]",
+    # which is harmless — it just means we walk the table and change nothing.
+    bracket_clause = " OR ".join(f"{col} LIKE '%[%]%'" for col in columns)
+    c.execute(f"SELECT 1 FROM file_index WHERE {bracket_clause} LIMIT 1")
+    has_brackets = c.fetchone() is not None
+
+    changed = emptied = 0
+    last_id = 0
+    while has_brackets:
+        c.execute(
+            f"SELECT id, path, {col_sql} FROM file_index"
+            " WHERE id > ? ORDER BY id LIMIT ?",
+            (last_id, chunk_size),
+        )
+        rows = c.fetchall()
+        if not rows:
+            break
+        last_id = rows[-1][0]
+
+        for row in rows:
+            path = row[1]
+            current = dict(zip(columns, row[2:]))
+            cleaned = {
+                col: _normalize_ci_value(col, current[col]) for col in columns
+            }
+            # Compare against "" for NULLs so an all-NULL row is not rewritten.
+            if all(cleaned[col] == (current[col] or "") for col in columns):
+                continue
+
+            c.execute(
+                "UPDATE file_index SET "
+                + ", ".join(f"{col} = ?" for col in columns)
+                + " WHERE id = ?",
+                tuple(cleaned[col] for col in columns) + (row[0],),
+            )
+            changed += 1
+            emptied += sum(
+                1 for col in columns if current[col] and not cleaned[col]
+            )
+
+            # Delete-then-insert is required: file_metadata_tags is
+            # WITHOUT ROWID keyed on (file_path, kind, value), so an in-place
+            # UPDATE of `value` can collide with an existing row when two
+            # dirty spellings normalize to the same name.
+            if path:
+                _sync_tags_for_file(conn, path, cleaned)
+
+        conn.commit()
+        invalidate_metadata_browser_cache()  # let the UI see progress
+        if progress_cb:
+            progress_cb(done=changed, last_id=last_id)
+
+    # issues_read carries its own copy of the credits (Insights trend counts).
+    ir_columns = ["writer", "penciller", "characters", "publisher"]
+    ir_changed = 0
+    last_id = 0
+    while True:
+        c.execute(
+            "SELECT id, " + ", ".join(ir_columns) + " FROM issues_read"
+            " WHERE id > ? ORDER BY id LIMIT ?",
+            (last_id, chunk_size),
+        )
+        rows = c.fetchall()
+        if not rows:
+            break
+        last_id = rows[-1][0]
+
+        for row in rows:
+            current = dict(zip(ir_columns, row[1:]))
+            cleaned = {
+                "writer": normalize_credit_list(current["writer"]),
+                "penciller": normalize_credit_list(current["penciller"]),
+                "characters": normalize_credit_list(current["characters"]),
+                "publisher": strip_provider_ids(current["publisher"]),
+            }
+            if all(cleaned[col] == (current[col] or "") for col in ir_columns):
+                continue
+            c.execute(
+                "UPDATE issues_read SET "
+                + ", ".join(f"{col} = ?" for col in ir_columns)
+                + " WHERE id = ?",
+                tuple(cleaned[col] for col in ir_columns) + (row[0],),
+            )
+            ir_changed += 1
+
+        conn.commit()
+
+    # Only now is the migration complete — a crash before this point re-runs it.
+    c.execute(f"PRAGMA user_version = {CURRENT_DATA_MIGRATION_VERSION}")
+    conn.commit()
+    app_logger.info(
+        f"Credit normalization backfill: {changed} file_index rows, "
+        f"{ir_changed} issues_read rows updated "
+        f"({emptied} credit values emptied — they held only a provider ID)"
+    )
+    return changed, ir_changed
+
+
+def _start_backfill_tags_async(normalize_credits=False):
+    """
+    Kick off the background metadata backfills in a daemon thread so app
+    startup isn't blocked. Safe to call multiple times — only one thread runs
+    at a time and both passes are idempotent.
+
+    The two passes are deliberately serialized in a single thread: they both
+    write file_metadata_tags, so running them concurrently would race.
     """
     global _backfill_thread
     if _backfill_thread is not None and _backfill_thread.is_alive():
         return
 
     def _runner():
+        conn = None
         try:
-            app_logger.info("file_metadata_tags backfill started (background)")
             conn = get_db_connection()
             if not conn:
                 app_logger.warning("Backfill: could not open db connection")
                 return
-            try:
-                _backfill_file_metadata_tags(conn)
-            finally:
-                conn.close()
+
+            app_logger.info("file_metadata_tags backfill started (background)")
+            _backfill_file_metadata_tags(conn)
             app_logger.info("file_metadata_tags backfill finished")
+
+            if normalize_credits:
+                app_logger.info("Credit normalization backfill started (background)")
+                _backfill_normalize_credits(conn)
+                app_logger.info("Credit normalization backfill finished")
         except Exception as e:
-            app_logger.error(f"file_metadata_tags backfill failed: {e}")
+            app_logger.error(f"Background metadata backfill failed: {e}")
+        finally:
+            if conn:
+                conn.close()
 
     _backfill_thread = threading.Thread(
         target=_runner, name="metadata-tags-backfill", daemon=True
@@ -12004,6 +12328,8 @@ def update_file_index_ci_field(path, field, value):
         app_logger.error(f"Invalid ci field: {field}")
         return False
 
+    value = _normalize_ci_value(field, value)
+
     try:
         conn = get_db_connection()
         if not conn:
@@ -12014,9 +12340,28 @@ def update_file_index_ci_field(path, field, value):
             f"UPDATE file_index SET {field} = ? WHERE path = ?",
             (value, path),
         )
-        conn.commit()
         affected = c.rowcount
+
+        # Keep file_metadata_tags in step — browse reads that table, so a
+        # Source Wall edit that skipped this would silently stop being
+        # browsable. Re-read the row so every tag kind is rebuilt, not just
+        # the edited one.
+        if affected > 0 and field in _NORMALIZED_LIST_COLUMNS:
+            c.execute(
+                "SELECT " + ", ".join(_NORMALIZED_LIST_COLUMNS) +
+                " FROM file_index WHERE path = ?",
+                (path,),
+            )
+            row = c.fetchone()
+            if row:
+                _sync_tags_for_file(
+                    conn, path, dict(zip(_NORMALIZED_LIST_COLUMNS, row))
+                )
+
+        conn.commit()
         conn.close()
+        if affected > 0:
+            invalidate_metadata_browser_cache()
         return affected > 0
     except Exception as e:
         app_logger.error(f"Failed to update ci field {field} for {path}: {e}")
@@ -12156,16 +12501,18 @@ def get_distinct_ci_values(field, query, parent_path=None, limit=20):
         rows = c.fetchall()
         conn.close()
 
-        # Collect unique individual values (split comma-separated)
-        query_lower = query.lower()
+        # Collect unique individual values (split comma-separated). Provider
+        # IDs are stripped so the suggestion offered is the canonical name,
+        # even for rows the backfill hasn't reached — the SQL prefilter above
+        # still finds them because it matches the raw column.
+        query_lower = strip_provider_ids(query).lower() or query.lower()
         seen = set()
         for row in rows:
             raw = row[0]
             if not raw:
                 continue
-            for part in raw.split(','):
-                part = part.strip()
-                if part and query_lower in part.lower():
+            for part in split_credit_list(raw):
+                if query_lower in part.lower():
                     seen.add(part)
 
         # Sort: starts-with first, then alphabetical

--- a/core/metadata_normalize.py
+++ b/core/metadata_normalize.py
@@ -1,0 +1,94 @@
+"""
+Canonicalise ComicInfo credit/character values.
+
+External taggers (ComicTagger, Metron/ComicVine plugins) append their own
+provider ID to credit values:
+
+    <Penciller>Ron Lim [3258]</Penciller>
+    <Characters>Aquaman [2357]</Characters>
+
+CLU stores what it reads, so "Ron Lim" and "Ron Lim [3258]" fragment into two
+distinct people across browse pages and Insights counts. These helpers strip
+*numeric-only* bracketed segments and leave every other bracket alone —
+"[uncredited]", "[Bruce Wayne]", "[1st printing]" are meaningful and are kept
+verbatim.
+
+This module deliberately has no project imports: it is a leaf used by
+core/database.py, app.py and routes/.
+"""
+
+import re
+
+# A bracketed run of ASCII digits, optionally padded: "[3258]", "[ 41502 ]".
+# Deliberately [0-9] and not \d — \d matches Arabic-Indic and other Unicode
+# digits, which are far more likely to be part of a real name than a
+# provider ID.
+_PROVIDER_ID_RE = re.compile(r"\[\s*[0-9]+\s*\]")
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def strip_provider_ids(text):
+    """
+    Remove numeric bracketed provider IDs from a single value.
+
+    "Ron Lim [3258]"       -> "Ron Lim"
+    "Ron [3258] Lim"       -> "Ron Lim"
+    "[3258]"               -> ""
+    "Ron Lim [uncredited]" -> "Ron Lim [uncredited]"   (non-numeric: kept)
+    None / "" / 0          -> ""
+
+    Non-str input is coerced with str(). Whitespace is only collapsed when a
+    substitution actually happened, so clean values come back unchanged apart
+    from a .strip() — this keeps the one-time backfill from churning rows it
+    has no reason to touch.
+    """
+    if not text:
+        return ""
+    s = str(text)
+    if "[" not in s:
+        return s.strip()
+    cleaned = _PROVIDER_ID_RE.sub(" ", s)
+    if cleaned == s:
+        return s.strip()
+    return _WHITESPACE_RE.sub(" ", cleaned).strip()
+
+
+def split_credit_list(text, sep=","):
+    """
+    Tokenise a comma-separated credit/character field into cleaned, ordered,
+    case-insensitively de-duplicated tokens.
+
+    "Ron Lim [3258], Ron Lim"  -> ("Ron Lim",)
+    "A [1],,B"                 -> ("A", "B")
+    "[3258]"                   -> ()
+    None / ""                  -> ()
+
+    De-dup keeps the first spelling seen. This is the single tokenizer for the
+    whole app — core.database._split_tag_values delegates here.
+    """
+    if not text:
+        return ()
+    out = []
+    seen = set()
+    for part in str(text).split(sep):
+        value = strip_provider_ids(part)
+        if not value:
+            continue
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(value)
+    return tuple(out)
+
+
+def normalize_credit_list(text, sep=","):
+    """
+    Canonical string form of a credit list: cleaned tokens joined with ", ".
+
+    "Ron Lim [3258], Ron Lim" -> "Ron Lim"
+    "A [1],B [2]"             -> "A, B"
+    "[3258]"                  -> ""
+    """
+    return ", ".join(split_credit_list(text, sep))

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -22,6 +22,7 @@ from flask import (Blueprint, request, jsonify, render_template, redirect,
 from PIL import Image
 from core.app_logging import app_logger
 from core.config import config
+from core.metadata_normalize import strip_provider_ids
 from helpers.library import get_library_roots, get_default_library, is_valid_library_path
 from core.auth import (
     enforce_path_access,
@@ -270,7 +271,9 @@ def browse_by_metadata(category, name):
         flash(f"Invalid browse category: {category}", "error")
         return redirect(url_for('insights_page'))
 
-    decoded_name = unquote(name)
+    # Links from the CBZ Info modal carry the raw XML value, which may still
+    # hold a tagger's provider ID ("Ron Lim [3258]"). Show the canonical name.
+    decoded_name = strip_provider_ids(unquote(name)) or unquote(name)
 
     result = get_files_by_metadata_grouped(normalized_category, decoded_name)
 
@@ -810,7 +813,7 @@ def api_browse_by_metadata(category, name):
     if not normalized_category:
         return jsonify({"error": "Invalid category"}), 400
 
-    decoded_name = unquote(name)
+    decoded_name = strip_provider_ids(unquote(name)) or unquote(name)
     limit = request.args.get('limit', 50, type=int)
     offset = request.args.get('offset', 0, type=int)
 

--- a/routes/source_wall.py
+++ b/routes/source_wall.py
@@ -157,6 +157,13 @@ def reconcile_from_db():
 
     Treats the DB as the source of truth — any non-empty ci_ field is written;
     files with all-empty ci_ values are skipped (nothing to write).
+
+    Note: credit/character values in file_index are provider-ID-normalized
+    (see core/metadata_normalize.py), so reconciling writes "Ron Lim" where
+    the on-disk XML may have said "Ron Lim [3258]", and re-spaces lists as
+    "A, B". That is intended — the provider ID is not part of the creator's
+    name — but it does mean this route is the one path that propagates the
+    normalization back to disk.
     """
     data = request.get_json(silent=True) or {}
     paths = data.get('paths') or []

--- a/static/js/clu-cbz-info.js
+++ b/static/js/clu-cbz-info.js
@@ -6,7 +6,7 @@
  *           CLU.cbzPagePrev, CLU.cbzPageNext
  *
  * Depends on: clu-utils.js (CLU.showToast, CLU.showError, CLU.showSuccess,
- *             CLU.formatFileSize, CLU.escapeHtml)
+ *             CLU.formatFileSize, CLU.escapeHtml, CLU.splitCreditList)
  *
  * External contract:
  *   window._cluCbzInfo = {
@@ -79,20 +79,20 @@
       fields: [
         { key: 'Writer', label: 'Writer', browse: 'writer' },
         { key: 'Penciller', label: 'Penciller', browse: 'penciller' },
-        { key: 'Inker', label: 'Inker' },
-        { key: 'Colorist', label: 'Colorist' },
-        { key: 'Letterer', label: 'Letterer' },
-        { key: 'CoverArtist', label: 'Cover Artist' },
-        { key: 'Editor', label: 'Editor' }
+        { key: 'Inker', label: 'Inker', list: true },
+        { key: 'Colorist', label: 'Colorist', list: true },
+        { key: 'Letterer', label: 'Letterer', list: true },
+        { key: 'CoverArtist', label: 'Cover Artist', list: true },
+        { key: 'Editor', label: 'Editor', list: true }
       ]
     },
     {
       title: 'Content Details',
       fields: [
-        { key: 'Genre', label: 'Genre' },
-        { key: 'Characters', label: 'Characters' },
-        { key: 'Teams', label: 'Teams' },
-        { key: 'Locations', label: 'Locations' },
+        { key: 'Genre', label: 'Genre', list: true },
+        { key: 'Characters', label: 'Characters', browse: 'characters' },
+        { key: 'Teams', label: 'Teams', list: true },
+        { key: 'Locations', label: 'Locations', list: true },
         { key: 'StoryArc', label: 'Story Arc' },
         { key: 'SeriesGroup', label: 'Series Group' },
         { key: 'MainCharacterOrTeam', label: 'Main Character/Team' },
@@ -369,15 +369,17 @@
             else if (value !== 'Yes' && value !== 'No') value = 'Unknown';
           }
           if (field.key === 'CommunityRating' && value > 0) value = value + '/5';
-          if (field.browse) {
-            value = String(value).split(',')
-              .map(function (n) { return n.trim(); })
-              .filter(function (n) { return n; })
-              .map(function (n) {
-                return '<a href="/browse/' + field.browse + '/' +
-                  encodeURIComponent(n) + '">' + CLU.escapeHtml(n) + '</a>';
-              })
-              .join(', ');
+          // Comma-separated name lists: drop the tagger's "[3258]" provider
+          // IDs so a 20-character cast reads as names rather than noise, and
+          // link the ones /browse/<category>/<name> can resolve.
+          if (field.browse || field.list) {
+            var names = CLU.splitCreditList(value);
+            value = names.map(function (n) {
+              if (!field.browse) return CLU.escapeHtml(n);
+              return '<a href="/browse/' + field.browse + '/' +
+                encodeURIComponent(n) + '">' + CLU.escapeHtml(n) + '</a>';
+            }).join(', ');
+            if (!value) return;   // nothing left once IDs were stripped
           }
           html += '<li><strong>' + field.label + ':</strong> ' + value + '</li>';
         }

--- a/static/js/clu-utils.js
+++ b/static/js/clu-utils.js
@@ -27,6 +27,38 @@
     return div.innerHTML;
   };
 
+  // ── stripProviderIds / splitCreditList ──────────────────────────────────
+
+  // Mirrors core/metadata_normalize.py — keep the two in step. Matches a
+  // bracketed run of ASCII digits only ("[3258]", "[ 41502 ]"), so meaningful
+  // annotations like "[uncredited]" or "[Bruce Wayne]" survive.
+  var _PROVIDER_ID_RE = /\[\s*[0-9]+\s*\]/g;
+
+  /**
+   * Remove numeric bracketed provider IDs from a single value.
+   * "Ron Lim [3258]" -> "Ron Lim";  "[3258]" -> "";  "X [uncredited]" -> as-is.
+   */
+  CLU.stripProviderIds = function (text) {
+    if (!text) return '';
+    var s = String(text);
+    if (s.indexOf('[') === -1) return s.trim();
+    var cleaned = s.replace(_PROVIDER_ID_RE, ' ');
+    if (cleaned === s) return s.trim();
+    return cleaned.replace(/\s+/g, ' ').trim();
+  };
+
+  /**
+   * Split a comma-separated credit/character field into cleaned tokens,
+   * dropping empties. Order is preserved and duplicates are kept, so the
+   * modal still reflects what the file actually lists.
+   */
+  CLU.splitCreditList = function (text) {
+    if (!text) return [];
+    return String(text).split(',')
+      .map(CLU.stripProviderIds)
+      .filter(function (v) { return v; });
+  };
+
   // ── lazyLoadGcdCover ────────────────────────────────────────────────────
 
   /**

--- a/tests/integration/test_browse_by_metadata.py
+++ b/tests/integration/test_browse_by_metadata.py
@@ -1,0 +1,199 @@
+"""
+Integration: get_files_by_metadata / get_files_by_metadata_grouped.
+
+These were previously untested. Covers the switch from substring LIKE to an
+exact, case-insensitive, indexed match against file_metadata_tags.
+"""
+
+import pytest
+
+
+def _seed(conn, name, penciller=None, publisher="Marvel", series="Silver Surfer",
+          number="1", writer=None, characters=None):
+    conn.execute(
+        "INSERT INTO file_index (name, path, type, size, parent, has_comicinfo,"
+        " ci_penciller, ci_writer, ci_characters, ci_publisher, ci_series, ci_number)"
+        " VALUES (?,?,'file',1024,'/data',1,?,?,?,?,?,?)",
+        (name, "/data/" + name, penciller, writer, characters,
+         publisher, series, number),
+    )
+    conn.commit()
+
+
+def _sync_all_tags(conn):
+    """Mirror the production backfill order: tags first, then normalization."""
+    from core.database import (
+        _backfill_file_metadata_tags,
+        _backfill_normalize_credits,
+    )
+    _backfill_file_metadata_tags(conn)
+    _backfill_normalize_credits(conn)
+
+
+def _all_names(result):
+    names = []
+    for group in result["groups"]:
+        if result["nested"]:
+            for s in group["series"]:
+                names.extend(f["name"] for f in s["files"])
+        else:
+            names.extend(f["name"] for f in group["files"])
+    return sorted(names)
+
+
+@pytest.fixture
+def library(db_connection):
+    _seed(db_connection, "A1.cbz", penciller="Ron Lim [3258]")
+    _seed(db_connection, "A2.cbz", penciller="Ron Lim")
+    _seed(db_connection, "A3.cbz", penciller="Ron Limbaugh", series="Other")
+    _seed(db_connection, "A4.cbz", penciller="Roger Stern [41502]",
+          publisher="DC [10]", series="Avengers")
+    _sync_all_tags(db_connection)
+    return db_connection
+
+
+class TestGrouped:
+    def test_merges_dirty_and_clean_spellings(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        r = get_files_by_metadata_grouped("penciller", "Ron Lim")
+        assert r["total"] == 2
+        assert _all_names(r) == ["A1.cbz", "A2.cbz"]
+
+    def test_stale_link_with_provider_id_still_resolves(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        r = get_files_by_metadata_grouped("penciller", "Ron Lim [3258]")
+        assert r["total"] == 2
+        assert _all_names(r) == ["A1.cbz", "A2.cbz"]
+
+    def test_match_is_case_insensitive(self, library):
+        """The padded LIKE this replaced was case-insensitive; keep that."""
+        from core.database import get_files_by_metadata_grouped
+
+        assert get_files_by_metadata_grouped("penciller", "ron lim")["total"] == 2
+        assert get_files_by_metadata_grouped("penciller", "RON LIM")["total"] == 2
+
+    def test_no_longer_substring_matches_a_different_person(self, library):
+        """'Ron Lim' used to match 'Ron Limbaugh' via LIKE '%Ron Lim%'."""
+        from core.database import get_files_by_metadata_grouped
+
+        r = get_files_by_metadata_grouped("penciller", "Ron Limbaugh")
+        assert _all_names(r) == ["A3.cbz"]
+        assert "A3.cbz" not in _all_names(
+            get_files_by_metadata_grouped("penciller", "Ron Lim")
+        )
+
+    def test_unknown_name_returns_empty(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        r = get_files_by_metadata_grouped("penciller", "Nobody At All")
+        assert r == {"groups": [], "total": 0, "nested": True}
+
+    def test_publisher_matches_scalar_column(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        r = get_files_by_metadata_grouped("publisher", "Marvel")
+        assert r["total"] == 3
+        assert r["nested"] is False
+        r = get_files_by_metadata_grouped("publisher", "dc [10]")
+        assert _all_names(r) == ["A4.cbz"]
+
+    def test_nested_shape_for_writer_and_penciller(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        r = get_files_by_metadata_grouped("penciller", "Ron Lim")
+        assert r["nested"] is True
+        group = r["groups"][0]
+        assert set(group) == {"name", "count", "series"}
+        assert group["name"] == "Marvel"
+        assert set(group["series"][0]) == {"name", "count", "files"}
+
+    def test_flat_shape_for_characters_and_publisher(self, db_connection):
+        from core.database import get_files_by_metadata_grouped
+
+        _seed(db_connection, "C1.cbz", characters="Aquaman [2357]")
+        _seed(db_connection, "C2.cbz", characters="Aquaman")
+        _sync_all_tags(db_connection)
+
+        r = get_files_by_metadata_grouped("characters", "Aquaman")
+        assert r["nested"] is False
+        assert r["total"] == 2
+        assert set(r["groups"][0]) == {"name", "count", "files"}
+
+    def test_invalid_field(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        assert get_files_by_metadata_grouped("nope", "x") == {
+            "groups": [], "total": 0, "nested": False
+        }
+
+    def test_bare_provider_id_matches_nothing(self, library):
+        from core.database import get_files_by_metadata_grouped
+
+        assert get_files_by_metadata_grouped("penciller", "[3258]")["total"] == 0
+
+
+class TestPaged:
+    def test_totals_and_pagination(self, library):
+        from core.database import get_files_by_metadata
+
+        r = get_files_by_metadata("penciller", "Ron Lim", limit=1, offset=0)
+        assert r["total"] == 2
+        assert len(r["files"]) == 1
+
+        r2 = get_files_by_metadata("penciller", "Ron Lim", limit=1, offset=1)
+        assert r2["total"] == 2
+        assert r2["files"][0]["name"] != r["files"][0]["name"]
+
+    def test_stale_link_resolves(self, library):
+        from core.database import get_files_by_metadata
+
+        assert get_files_by_metadata("penciller", "Ron Lim [3258]")["total"] == 2
+
+    def test_file_shape_unchanged(self, library):
+        from core.database import get_files_by_metadata
+
+        f = get_files_by_metadata("penciller", "Ron Lim")["files"][0]
+        assert set(f) == {
+            "name", "path", "size", "series", "number", "year", "publisher"
+        }
+
+    def test_like_wildcards_in_name_are_escaped(self, db_connection):
+        """A '%' in a credit name must not turn into a match-everything query."""
+        from core.database import get_files_by_metadata
+
+        _seed(db_connection, "W1.cbz", penciller="Ron Lim")
+        _sync_all_tags(db_connection)
+        assert get_files_by_metadata("penciller", "%")["total"] == 0
+
+    def test_invalid_field(self, library):
+        from core.database import get_files_by_metadata
+
+        assert get_files_by_metadata("nope", "x") == {"files": [], "total": 0}
+
+
+class TestBackfillWindowFallback:
+    def test_falls_back_to_substring_while_tags_incomplete(self, db_connection):
+        """Mid-backfill the tag table is partial; browse must return a superset
+        rather than a silent fraction of the library."""
+        import core.database as db
+
+        _seed(db_connection, "B1.cbz", penciller="Ron Lim [3258]")
+        _seed(db_connection, "B2.cbz", penciller="Ron Lim")
+        # Deliberately no tag rows — simulates the backfill still running.
+        db._tags_table_complete = False
+
+        r = db.get_files_by_metadata_grouped("penciller", "Ron Lim")
+        assert r["total"] == 2, "fallback must find both spellings"
+
+    def test_uses_exact_match_once_tags_complete(self, db_connection):
+        import core.database as db
+
+        _seed(db_connection, "B1.cbz", penciller="Ron Lim")
+        _seed(db_connection, "B2.cbz", penciller="Ron Limbaugh")
+        _sync_all_tags(db_connection)
+        db._tags_table_complete = False  # force a fresh probe
+
+        r = db.get_files_by_metadata_grouped("penciller", "Ron Lim")
+        assert _all_names(r) == ["B1.cbz"], "exact match must exclude Ron Limbaugh"

--- a/tests/integration/test_credit_normalization.py
+++ b/tests/integration/test_credit_normalization.py
@@ -1,0 +1,362 @@
+"""
+Integration: provider-ID stripping across the ci_* write paths, the
+file_metadata_tags projection, issues_read, and the one-time backfill.
+"""
+
+import pytest
+
+
+def _insert_file(conn, path, name="Issue.cbz", **ci):
+    cols = {
+        "name": name,
+        "path": path,
+        "type": "file",
+        "size": 1024,
+        "parent": "/data",
+        "has_comicinfo": 1,
+    }
+    cols.update(ci)
+    conn.execute(
+        f"INSERT INTO file_index ({','.join(cols)}) VALUES ({','.join('?' * len(cols))})",
+        list(cols.values()),
+    )
+    conn.commit()
+    return conn.execute(
+        "SELECT id FROM file_index WHERE path = ?", (path,)
+    ).fetchone()[0]
+
+
+def _tags(conn, path, kind):
+    return sorted(
+        r[0]
+        for r in conn.execute(
+            "SELECT value FROM file_metadata_tags WHERE file_path = ? AND kind = ?",
+            (path, kind),
+        )
+    )
+
+
+class TestWritePathsNormalize:
+    def test_update_file_metadata_strips_ids(self, db_connection):
+        from core.database import update_file_metadata
+
+        fid = _insert_file(db_connection, "/data/A.cbz")
+        assert update_file_metadata(
+            fid,
+            {
+                "ci_writer": "Roger Stern [41502]",
+                "ci_penciller": "Ron Lim [3258], Joe Sinnott [77]",
+                "ci_characters": "Aquaman [2357]",
+                "ci_publisher": "Marvel [31]",
+                # Non-credit columns must survive their brackets untouched.
+                "ci_number": "3 [Variant Cover]",
+                "ci_series": "Silver Surfer [1987]",
+            },
+            123.0,
+            1,
+        )
+
+        row = db_connection.execute(
+            "SELECT ci_writer, ci_penciller, ci_characters, ci_publisher,"
+            " ci_number, ci_series FROM file_index WHERE id = ?",
+            (fid,),
+        ).fetchone()
+        assert row["ci_writer"] == "Roger Stern"
+        assert row["ci_penciller"] == "Ron Lim, Joe Sinnott"
+        assert row["ci_characters"] == "Aquaman"
+        assert row["ci_publisher"] == "Marvel"
+        assert row["ci_number"] == "3 [Variant Cover]"
+        assert row["ci_series"] == "Silver Surfer [1987]"
+
+    def test_update_file_metadata_syncs_clean_tags(self, db_connection):
+        from core.database import update_file_metadata
+
+        fid = _insert_file(db_connection, "/data/B.cbz")
+        update_file_metadata(
+            fid, {"ci_penciller": "Ron Lim [3258]"}, 123.0, 1
+        )
+        assert _tags(db_connection, "/data/B.cbz", "penciller") == ["Ron Lim"]
+
+    def test_update_file_index_from_comicinfo_strips_ids(self, db_connection):
+        from core.database import update_file_index_from_comicinfo
+
+        _insert_file(db_connection, "/data/C.cbz")
+        assert update_file_index_from_comicinfo(
+            "/data/C.cbz",
+            {
+                "Writer": "Roger Stern [41502]",
+                "Characters": "Aquaman [2357], Batman [uncredited]",
+                "Publisher": "DC [10]",
+            },
+        )
+        row = db_connection.execute(
+            "SELECT ci_writer, ci_characters, ci_publisher FROM file_index"
+            " WHERE path = ?",
+            ("/data/C.cbz",),
+        ).fetchone()
+        assert row["ci_writer"] == "Roger Stern"
+        # Non-numeric brackets are meaningful and must be preserved.
+        assert row["ci_characters"] == "Aquaman, Batman [uncredited]"
+        assert row["ci_publisher"] == "DC"
+
+    def test_update_ci_field_strips_and_syncs_tags(self, db_connection):
+        """Source Wall edits must land in file_metadata_tags — browse reads it."""
+        from core.database import update_file_index_ci_field
+
+        _insert_file(db_connection, "/data/D.cbz", ci_penciller="Old Name")
+        assert update_file_index_ci_field(
+            "/data/D.cbz", "ci_penciller", "Ron Lim [3258]"
+        )
+
+        assert db_connection.execute(
+            "SELECT ci_penciller FROM file_index WHERE path = ?", ("/data/D.cbz",)
+        ).fetchone()[0] == "Ron Lim"
+        assert _tags(db_connection, "/data/D.cbz", "penciller") == ["Ron Lim"]
+
+    def test_update_ci_field_replaces_stale_tags(self, db_connection):
+        from core.database import update_file_index_ci_field
+
+        _insert_file(db_connection, "/data/E.cbz")
+        update_file_index_ci_field("/data/E.cbz", "ci_penciller", "First Artist")
+        update_file_index_ci_field("/data/E.cbz", "ci_penciller", "Second Artist")
+        assert _tags(db_connection, "/data/E.cbz", "penciller") == ["Second Artist"]
+
+    def test_mark_issue_read_strips_ids(self, db_connection):
+        from core.database import mark_issue_read
+
+        assert mark_issue_read(
+            "/data/F.cbz",
+            writer="Roger Stern [41502]",
+            penciller="Ron Lim [3258]",
+            characters="Aquaman [2357]",
+            publisher="Marvel [31]",
+        )
+        row = db_connection.execute(
+            "SELECT writer, penciller, characters, publisher FROM issues_read"
+            " WHERE issue_path = ?",
+            ("/data/F.cbz",),
+        ).fetchone()
+        assert tuple(row) == ("Roger Stern", "Ron Lim", "Aquaman", "Marvel")
+
+
+class TestLongCharacterList:
+    """A real Superman issue: 23 characters, every one carrying a provider ID."""
+
+    RAW = (
+        "Adam Zeller [13042], Allie [5557], Angie [13041], Bibbo [12960], "
+        "Cat Grant [8346], Dabney Donovan [13038], Guardian [7644], "
+        "Gunn [13046], Halloran [13044], Jimmy Olsen [3213], "
+        "Johnny Dakota [13045], Lex Luthor [41952], Lois Lane [1808], "
+        "Maggie Sawyer [5379], Mr. Drysdale [13043], Noose [13037], "
+        "Perry White [1809], Rough House [13035], Simone DeNiege [13028], "
+        "Superman [1807], The Mob [9948], Toby Raines [71342], Torcher [13036]"
+    )
+
+    def test_every_character_is_split_and_cleaned(self, db_connection):
+        from core.database import update_file_metadata
+
+        fid = _insert_file(db_connection, "/data/superman.cbz")
+        update_file_metadata(fid, {"ci_characters": self.RAW}, 1.0, 1)
+
+        tags = _tags(db_connection, "/data/superman.cbz", "characters")
+        assert len(tags) == 23
+        # Spot-check the awkward ones: a period, a leading article, two words.
+        for expected in ("Superman", "Lex Luthor", "Mr. Drysdale", "The Mob",
+                         "Simone DeNiege", "Toby Raines"):
+            assert expected in tags
+        assert not any("[" in t for t in tags)
+
+    def test_each_character_is_individually_browsable(self, db_connection):
+        """Every name in the list must resolve on /browse/characters/<name>."""
+        from core.database import (
+            get_files_by_metadata_grouped,
+            update_file_metadata,
+        )
+
+        fid = _insert_file(db_connection, "/data/superman.cbz",
+                           name="Superman 001.cbz")
+        update_file_metadata(fid, {"ci_characters": self.RAW}, 1.0, 1)
+
+        for name in ("Superman", "Lois Lane", "Mr. Drysdale", "The Mob"):
+            r = get_files_by_metadata_grouped("characters", name)
+            assert r["total"] == 1, f"{name} should resolve to the issue"
+
+        # And the stale link form, straight off the XML, resolves identically.
+        assert get_files_by_metadata_grouped(
+            "characters", "Superman [1807]")["total"] == 1
+
+    def test_shared_character_merges_across_differing_ids(self, db_connection):
+        """Two files whose taggers disagree on the ID still count as one
+        character — the case that fragments Insights' Top Characters."""
+        from core.database import (
+            get_files_by_metadata_grouped,
+            update_file_metadata,
+        )
+
+        for i, value in enumerate(
+            ["Superman [1807]", "Superman", "Superman [99999]"]
+        ):
+            fid = _insert_file(db_connection, f"/data/s{i}.cbz", name=f"s{i}.cbz")
+            update_file_metadata(fid, {"ci_characters": value}, 1.0, 1)
+
+        assert get_files_by_metadata_grouped("characters", "Superman")["total"] == 3
+
+
+class TestSplitTagValues:
+    def test_strips_ids_and_dedupes_case_insensitively(self):
+        from core.database import _split_tag_values
+
+        assert _split_tag_values("Ron Lim [3258], Ron Lim, RON LIM") == ("Ron Lim",)
+
+    def test_empty(self):
+        from core.database import _split_tag_values
+
+        assert _split_tag_values(None) == ()
+        assert _split_tag_values("") == ()
+
+
+class TestBackfill:
+    def _seed_dirty(self, conn):
+        _insert_file(
+            conn, "/data/1.cbz", ci_penciller="Ron Lim [3258]",
+            ci_characters="Aquaman [2357]", ci_publisher="Marvel [31]",
+        )
+        _insert_file(
+            conn, "/data/2.cbz", ci_penciller="Ron Lim",
+            ci_characters="Aquaman", ci_publisher="Marvel",
+        )
+        _insert_file(
+            conn, "/data/3.cbz", ci_penciller="Roger Stern [41502]",
+            ci_characters="Batman [uncredited]", ci_publisher="DC",
+        )
+        conn.execute(
+            "INSERT INTO issues_read (user_id, issue_path, writer, publisher)"
+            " VALUES (1, '/data/1.cbz', 'Roger Stern [41502]', 'Marvel [31]')"
+        )
+        conn.commit()
+
+    def test_cleans_file_index_and_issues_read(self, db_connection):
+        from core.database import _backfill_normalize_credits
+
+        self._seed_dirty(db_connection)
+        files, reads = _backfill_normalize_credits(db_connection)
+        # Rows 1 and 3 are dirty; row 2 is already clean and must not be
+        # rewritten (the backfill only touches rows whose values change).
+        assert files == 2
+        assert reads == 1
+
+        pencillers = [
+            r[0] for r in db_connection.execute(
+                "SELECT ci_penciller FROM file_index ORDER BY path"
+            )
+        ]
+        assert pencillers == ["Ron Lim", "Ron Lim", "Roger Stern"]
+        assert db_connection.execute(
+            "SELECT ci_characters FROM file_index WHERE path = '/data/3.cbz'"
+        ).fetchone()[0] == "Batman [uncredited]"
+        assert tuple(db_connection.execute(
+            "SELECT writer, publisher FROM issues_read"
+        ).fetchone()) == ("Roger Stern", "Marvel")
+
+    def test_merges_two_spellings_into_one_tag(self, db_connection):
+        """The WITHOUT ROWID PK on (file_path, kind, value) makes an in-place
+        UPDATE of `value` collide; the backfill must delete-then-insert.
+
+        Runs the two passes in the order _start_backfill_tags_async does —
+        tags first, then normalization — since the normalize pass only
+        re-syncs tags for rows it actually changed.
+        """
+        from core.database import (
+            _backfill_file_metadata_tags,
+            _backfill_normalize_credits,
+        )
+
+        self._seed_dirty(db_connection)
+        _backfill_file_metadata_tags(db_connection)
+        _backfill_normalize_credits(db_connection)
+
+        rows = db_connection.execute(
+            "SELECT value, COUNT(*) FROM file_metadata_tags"
+            " WHERE kind = 'penciller' GROUP BY value ORDER BY value"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("Roger Stern", 1), ("Ron Lim", 2)]
+
+    def test_is_idempotent_and_sets_user_version(self, db_connection):
+        from core.database import (
+            CURRENT_DATA_MIGRATION_VERSION,
+            _backfill_normalize_credits,
+        )
+
+        self._seed_dirty(db_connection)
+        _backfill_normalize_credits(db_connection)
+        assert db_connection.execute("PRAGMA user_version").fetchone()[0] == (
+            CURRENT_DATA_MIGRATION_VERSION
+        )
+        assert _backfill_normalize_credits(db_connection) == (0, 0)
+
+    def test_leaves_clean_library_untouched(self, db_connection):
+        from core.database import _backfill_normalize_credits
+
+        _insert_file(db_connection, "/data/clean.cbz", ci_penciller="Ron Lim")
+        assert _backfill_normalize_credits(db_connection) == (0, 0)
+
+    def test_launcher_runs_tags_before_normalization(self, db_connection):
+        """Order matters: the normalize pass only re-syncs tags for rows it
+        changed, so the tag backfill must populate everything else first."""
+        import core.database as db
+
+        calls = []
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(db, "_backfill_file_metadata_tags",
+                       lambda conn, **kw: calls.append("tags"))
+            mp.setattr(db, "_backfill_normalize_credits",
+                       lambda conn, **kw: calls.append("normalize"))
+            mp.setattr(db, "_backfill_thread", None)
+            db._start_backfill_tags_async(normalize_credits=True)
+            db._backfill_thread.join(timeout=10)
+
+        assert calls == ["tags", "normalize"]
+
+    def test_launcher_skips_normalization_when_not_needed(self, db_connection):
+        import core.database as db
+
+        calls = []
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(db, "_backfill_file_metadata_tags",
+                       lambda conn, **kw: calls.append("tags"))
+            mp.setattr(db, "_backfill_normalize_credits",
+                       lambda conn, **kw: calls.append("normalize"))
+            mp.setattr(db, "_backfill_thread", None)
+            db._start_backfill_tags_async(normalize_credits=False)
+            db._backfill_thread.join(timeout=10)
+
+        assert calls == ["tags"]
+
+    def test_empties_a_value_that_is_only_an_id(self, db_connection):
+        from core.database import _backfill_normalize_credits
+
+        _insert_file(db_connection, "/data/bare.cbz", ci_penciller="[3258]")
+        _backfill_normalize_credits(db_connection)
+        assert db_connection.execute(
+            "SELECT ci_penciller FROM file_index WHERE path = '/data/bare.cbz'"
+        ).fetchone()[0] == ""
+
+
+class TestReadingTrends:
+    def test_counts_merge_across_spellings(self, db_connection):
+        from core.database import get_reading_trends
+
+        for i, writer in enumerate(
+            ["Roger Stern [41502]", "Roger Stern", "ROGER STERN"]
+        ):
+            db_connection.execute(
+                "INSERT INTO issues_read (user_id, issue_path, writer)"
+                " VALUES (1, ?, ?)",
+                (f"/data/t{i}.cbz", writer),
+            )
+        db_connection.commit()
+
+        trends = get_reading_trends("writer", user_id=1)
+        assert len(trends) == 1
+        assert trends[0]["name"] == "Roger Stern"
+        assert trends[0]["count"] == 3

--- a/tests/routes/test_browse_metadata_routes.py
+++ b/tests/routes/test_browse_metadata_routes.py
@@ -1,0 +1,153 @@
+"""
+Routes: /browse/<category>/<name> and /api/browse/<category>/<name>.
+
+Previously untested. Covers provider-ID normalization of the incoming name so
+links carrying "Ron Lim [3258]" resolve to the same page as "Ron Lim".
+"""
+
+from urllib.parse import quote
+
+import pytest
+
+
+def _seed(conn, name, **ci):
+    cols = {
+        "name": name,
+        "path": "/data/" + name,
+        "type": "file",
+        "size": 1024,
+        "parent": "/data",
+        "has_comicinfo": 1,
+        "ci_publisher": "Marvel",
+        "ci_series": "Silver Surfer",
+        "ci_number": "1",
+    }
+    cols.update(ci)
+    conn.execute(
+        f"INSERT INTO file_index ({','.join(cols)}) VALUES ({','.join('?' * len(cols))})",
+        list(cols.values()),
+    )
+    conn.commit()
+
+
+@pytest.fixture
+def library(db_connection):
+    from core.database import (
+        _backfill_file_metadata_tags,
+        _backfill_normalize_credits,
+    )
+    _seed(db_connection, "A1.cbz", ci_penciller="Ron Lim [3258]")
+    _seed(db_connection, "A2.cbz", ci_penciller="Ron Lim")
+    _seed(db_connection, "A3.cbz", ci_writer="Roger Stern [41502]")
+    _backfill_file_metadata_tags(db_connection)
+    _backfill_normalize_credits(db_connection)
+    return db_connection
+
+
+class TestBrowsePage:
+    def test_clean_name_renders(self, client, library):
+        resp = client.get("/browse/penciller/" + quote("Ron Lim"))
+        assert resp.status_code == 200
+        assert b"Ron Lim" in resp.data
+
+    def test_stale_link_with_provider_id_resolves(self, client, library):
+        """The CBZ Info modal links the raw XML value, brackets and all."""
+        resp = client.get("/browse/penciller/" + quote("Ron Lim [3258]"))
+        assert resp.status_code == 200
+        # Header shows the canonical name, not the tagger's ID.
+        assert b"[3258]" not in resp.data
+        assert b"Ron Lim" in resp.data
+
+    def test_both_spellings_give_the_same_count(self, client, library):
+        clean = client.get("/browse/penciller/" + quote("Ron Lim")).data
+        dirty = client.get("/browse/penciller/" + quote("Ron Lim [3258]")).data
+        assert b"2 comics" in clean
+        assert b"2 comics" in dirty
+
+    def test_artist_alias_maps_to_penciller(self, client, library):
+        resp = client.get("/browse/artist/" + quote("Ron Lim"))
+        assert resp.status_code == 200
+        assert b"2 comics" in resp.data
+
+    def test_writer_category(self, client, library):
+        resp = client.get("/browse/writer/" + quote("Roger Stern"))
+        assert resp.status_code == 200
+        assert b"Roger Stern" in resp.data
+
+    def test_unknown_name_shows_empty_state(self, client, library):
+        resp = client.get("/browse/penciller/" + quote("Nobody At All"))
+        assert resp.status_code == 200
+        assert b"No comics found" in resp.data
+
+    def test_invalid_category_redirects(self, client, library):
+        resp = client.get("/browse/bogus/" + quote("Ron Lim"))
+        assert resp.status_code == 302
+        assert "/insights" in resp.headers["Location"]
+
+    @pytest.mark.parametrize(
+        "character",
+        [
+            "Superman",
+            "Mr. Drysdale",        # period
+            "The Mob",             # leading article
+            "Simone DeNiege",      # internal capitals
+            "Lois Lane",           # space
+            "Bibbo",               # single word
+        ],
+    )
+    def test_character_links_from_the_cbz_info_modal_resolve(
+        self, client, db_connection, character
+    ):
+        """The CBZ Info modal builds /browse/characters/<encodeURIComponent(n)>
+        from names it strips client-side; every one must route and resolve."""
+        from core.database import update_file_metadata
+
+        db_connection.execute(
+            "INSERT INTO file_index (name, path, type, size, parent,"
+            " has_comicinfo, ci_series, ci_number)"
+            " VALUES ('S1.cbz','/data/S1.cbz','file',1,'/data',1,'Superman','1')"
+        )
+        db_connection.commit()
+        fid = db_connection.execute(
+            "SELECT id FROM file_index WHERE path='/data/S1.cbz'"
+        ).fetchone()[0]
+        update_file_metadata(
+            fid,
+            {"ci_characters": "Superman [1807], Lois Lane [1808], "
+                              "Mr. Drysdale [13043], The Mob [9948], "
+                              "Simone DeNiege [13028], Bibbo [12960]"},
+            1.0, 1,
+        )
+
+        # quote() with no safe chars mirrors JS encodeURIComponent closely
+        # enough for these names (space -> %20, period untouched).
+        resp = client.get("/browse/characters/" + quote(character))
+        assert resp.status_code == 200
+        assert b"1 comic" in resp.data
+
+
+class TestBrowseApi:
+    def test_returns_matching_files(self, client, library):
+        resp = client.get("/api/browse/penciller/" + quote("Ron Lim"))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 2
+        assert sorted(f["name"] for f in data["files"]) == ["A1.cbz", "A2.cbz"]
+        assert all("thumbnail_url" in f for f in data["files"])
+
+    def test_stale_link_resolves(self, client, library):
+        resp = client.get("/api/browse/penciller/" + quote("Ron Lim [3258]"))
+        assert resp.get_json()["total"] == 2
+
+    def test_pagination(self, client, library):
+        resp = client.get(
+            "/api/browse/penciller/" + quote("Ron Lim") + "?limit=1&offset=0"
+        )
+        data = resp.get_json()
+        assert data["total"] == 2
+        assert len(data["files"]) == 1
+
+    def test_invalid_category(self, client, library):
+        resp = client.get("/api/browse/bogus/" + quote("Ron Lim"))
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()

--- a/tests/unit/test_metadata_normalize.py
+++ b/tests/unit/test_metadata_normalize.py
@@ -1,0 +1,123 @@
+"""Unit tests for core.metadata_normalize — provider-ID stripping."""
+
+import pytest
+
+from core.metadata_normalize import (
+    normalize_credit_list,
+    split_credit_list,
+    strip_provider_ids,
+)
+
+
+class TestStripProviderIds:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # The target cases from real ComicInfo.xml files
+            ("Ron Lim [3258]", "Ron Lim"),
+            ("Roger Stern [41502]", "Roger Stern"),
+            ("Aquaman [2357]", "Aquaman"),
+            # Spacing variants
+            ("Ron Lim[3258]", "Ron Lim"),
+            ("Ron Lim [ 3258 ]", "Ron Lim"),
+            ("Ron Lim  [3258]", "Ron Lim"),
+            ("  Ron Lim [3258]  ", "Ron Lim"),
+            # Mid-string and repeated IDs
+            ("Ron [3258] Lim", "Ron Lim"),
+            ("Ron Lim [3258] [41]", "Ron Lim"),
+            # A bare ID is not a name
+            ("[3258]", ""),
+            ("[ 3258 ]", ""),
+        ],
+    )
+    def test_strips_numeric_ids(self, raw, expected):
+        assert strip_provider_ids(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "Ron Lim [uncredited]",
+            "Batman [Bruce Wayne]",
+            "Jack Kirby [1st printing]",
+            "Alan Smithee [as A. Smithee]",
+            # Unicode digits are not ASCII digits — far more likely part of a name
+            "Ron Lim [٣٢٥٨]",
+        ],
+    )
+    def test_preserves_non_numeric_brackets(self, raw):
+        assert strip_provider_ids(raw) == raw
+
+    @pytest.mark.parametrize("raw", [None, "", 0, [], {}])
+    def test_empty_input(self, raw):
+        assert strip_provider_ids(raw) == ""
+
+    def test_unicode_names_survive(self):
+        assert strip_provider_ids("Ronald Müller [12]") == "Ronald Müller"
+        assert strip_provider_ids("张三 [77]") == "张三"
+
+    def test_clean_values_keep_internal_whitespace(self):
+        # No substitution happened, so no whitespace collapse — only .strip().
+        assert strip_provider_ids("  Ron   Lim  ") == "Ron   Lim"
+
+    def test_collapses_whitespace_only_on_a_hit(self):
+        assert strip_provider_ids("  Ron   Lim [1]  ") == "Ron Lim"
+
+    def test_coerces_non_string(self):
+        assert strip_provider_ids(1234) == "1234"
+
+
+class TestSplitCreditList:
+    def test_splits_and_strips(self):
+        assert split_credit_list("Ron Lim [3258], Joe Sinnott [99]") == (
+            "Ron Lim",
+            "Joe Sinnott",
+        )
+
+    def test_dedupes_dirty_against_clean(self):
+        assert split_credit_list("Ron Lim [3258], Ron Lim") == ("Ron Lim",)
+
+    def test_dedupe_is_case_insensitive_first_spelling_wins(self):
+        assert split_credit_list("Batman, BATMAN") == ("Batman",)
+
+    def test_drops_empty_and_bare_id_tokens(self):
+        assert split_credit_list("A [1],,B") == ("A", "B")
+        assert split_credit_list("[3258]") == ()
+        assert split_credit_list(",") == ()
+        assert split_credit_list(", ,") == ()
+
+    @pytest.mark.parametrize("raw", [None, "", 0])
+    def test_empty_input(self, raw):
+        assert split_credit_list(raw) == ()
+
+    def test_preserves_order(self):
+        assert split_credit_list("C, A, B") == ("C", "A", "B")
+
+    def test_custom_separator(self):
+        assert split_credit_list("A [1]; B [2]", sep=";") == ("A", "B")
+
+
+class TestNormalizeCreditList:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Ron Lim [3258], Ron Lim", "Ron Lim"),
+            ("A [1],B [2]", "A, B"),
+            ("[3258]", ""),
+            # Re-joined with ", " so a stripped trailing token leaves no gap
+            ("Ron Lim [3258], Joe", "Ron Lim, Joe"),
+            ("Ron Lim,Joe", "Ron Lim, Joe"),
+        ],
+    )
+    def test_normalizes(self, raw, expected):
+        assert normalize_credit_list(raw) == expected
+
+    def test_is_idempotent(self):
+        once = normalize_credit_list("Ron Lim [3258], Joe Sinnott [99]")
+        assert normalize_credit_list(once) == once
+
+    def test_clean_list_is_unchanged(self):
+        assert normalize_credit_list("Ron Lim, Joe Sinnott") == "Ron Lim, Joe Sinnott"
+
+    @pytest.mark.parametrize("raw", [None, "", 0])
+    def test_empty_input(self, raw):
+        assert normalize_credit_list(raw) == ""


### PR DESCRIPTION
## Problem

External taggers (ComicTagger, Metron/ComicVine plugins) append their own provider ID to credit and character values:

```xml
<Penciller>Ron Lim [3258]</Penciller>
<Writer>Roger Stern [41502]</Writer>
<Characters>Adam Zeller [13042], Allie [5557], Angie [13041], ...</Characters>
```

CLU stored these verbatim, so `Ron Lim` and `Ron Lim [3258]` behaved as two different artists — browse pages showed a partial library for either spelling, and Insights split one person's count across two rows.

## Approach

**Database-only.** `ComicInfo.xml` on disk is never rewritten, so the raw value stays recoverable and a 100k-comic library is fixed by a table walk rather than by opening 100k archives.

**Numeric brackets only.** `[3258]` goes; `[uncredited]`, `[Bruce Wayne]`, `[1st printing]` are meaningful and are preserved. Deterministic, not fuzzy — similarity thresholds would wrongly merge `Jim Lee` / `Jim Lees`.

## Changes

- **`core/metadata_normalize.py`** — new leaf module: `strip_provider_ids`, `split_credit_list`, `normalize_credit_list`.
- **Write paths** normalize at the database layer, the complete set of choke points: `update_file_metadata`, `update_file_index_from_comicinfo`, `update_file_index_ci_field`, `mark_issue_read`, `_split_tag_values`. `ci_title` / `ci_series` / `ci_number` are deliberately untouched — brackets there are part of the real value (`3 [Jorge Jiménez Cover]`), and `ci_series` is exact-matched by `series_representative_path`.
- **One-shot backfill** over `file_index`, `file_metadata_tags` and `issues_read`, gated on `PRAGMA user_version` (verified unused in this repo). Chunked by monotonic id with commits between chunks. Runs automatically on next startup; no operator action.
- **Browse** now matches exactly via an indexed `COLLATE NOCASE` join on `file_metadata_tags` — a table that was already populated on every write but **read by nothing in production**.
- **Insights** trend counts fold case-insensitively so a count agrees with what clicking through actually shows.
- **CBZ Info modal** links `Characters` to `/browse/characters/<name>` and shows canonical names for all comma-list credit fields.

## Two latent bugs fixed along the way

- **`update_file_index_ci_field` never called `_sync_tags_for_file`** (`core/database.py`), so Source Wall single-field edits left `file_metadata_tags` permanently stale. Harmless while nothing read that table — silent data loss the moment browse did.
- **Browse used `LIKE '%value%'`**, so `Ron Lim` also matched `Ron Limbaugh`. Now correctly separate, with a regression test.

## Reviewer notes

- **`/api/source-wall/reconcile-from-db` will now write cleaned names to disk.** It explicitly treats `file_index` as the source of truth, so post-normalization it writes `Ron Lim` where the XML said `Ron Lim [3258]`. This is the one path that propagates normalization to disk. It is user-invoked and documented in the route docstring — flagging it because it contradicts a naive reading of "database-only".
- **Backfill ordering is load-bearing.** The normalize pass only re-syncs tags for rows it actually changed, so the tags backfill must run first. The launcher enforces this and two tests pin it.
- **Rollback leaves `user_version` at 1**, so re-applying would skip the backfill. Bump `CURRENT_DATA_MIGRATION_VERSION` to 2 or run `PRAGMA user_version = 0` if you roll back and forward again.
- A value that is *only* an ID (`[3258]`) normalizes to empty. Correct — a bare ID is not a name — and the backfill logs an `emptied` count so it is visible.
- Suggest a DB backup before first launch, since the provider ID is unrecoverable from the DB afterwards (though it remains on disk).

## Verification

Full suite: **2832 passed, 6 skipped, 0 failures**.

New coverage — `get_files_by_metadata*` and `/browse/<category>/<name>` had **zero tests** before this PR:

| File | Covers |
|---|---|
| `tests/unit/test_metadata_normalize.py` | 44 cases: mid-string, padded, multiple, bare ID, non-numeric brackets, Unicode digits, dedupe |
| `tests/integration/test_credit_normalization.py` | Write paths, tag sync, backfill idempotency, `WITHOUT ROWID` PK collision, launcher ordering, a real 23-character cast |
| `tests/integration/test_browse_by_metadata.py` | Merge across spellings, case-insensitivity, the `Ron Limbaugh` regression, LIKE-wildcard escaping, backfill-window fallback |
| `tests/routes/test_browse_metadata_routes.py` | Both URL forms, 6 real character-name shapes, invalid category |

Checked rather than assumed:

- `EXPLAIN QUERY PLAN` reports `SEARCH file_metadata_tags USING COVERING INDEX idx_fmt_kind_value_nocase` — the new NOCASE index is actually chosen, not scanned past.
- The JS helper in `clu-utils.js` was diffed against the Python one over 20 shared inputs via node: **0 mismatches**, including the Arabic-Indic digit case and the full 23-name character list.

Not covered: the JS helper has no committed test — this repo has no JS test runner (`package.json` absent). Parity was verified manually as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
