### PR TITLE
Weekly Packs: reconcile Recent Downloads status with live download state

### DIFF
--- a/api.py
+++ b/api.py
@@ -437,8 +437,19 @@ def worker():
         task = download_queue.get()
         if task is None:  # Shutdown signal if needed.
             break
-        process_download(task)
-        download_queue.task_done()
+        # An unhandled exception here would kill this thread for good — lose all
+        # three and every later download hangs at 'queued' forever. process_download
+        # touches download_progress[download_id] outside its inner try, so a
+        # cleared/dismissed entry is enough to raise KeyError.
+        try:
+            process_download(task)
+        except Exception as e:
+            monitor_logger.error(
+                f"Worker crashed processing {task.get('download_id')}: {e}",
+                exc_info=True,
+            )
+        finally:
+            download_queue.task_done()
 
 # Start a few worker threads for processing downloads.
 worker_threads = []

--- a/app.py
+++ b/app.py
@@ -1616,13 +1616,68 @@ def configure_scrape_index_schedule():
 
 
 # Function to perform scheduled Weekly Packs auto-download
+def _enqueue_weekly_pack(
+    pack_date, publisher, pixeldrain_url, format_pref, download_progress, download_queue
+):
+    """Queue one weekly pack download and record it in history.
+
+    Order matters: the history row must be written BEFORE queue.put(). A worker
+    can pick the task up and write 'downloading' immediately, and a later
+    'queued' write would clobber it back. The download_id is persisted on the
+    row so the status can be reconciled against live progress later.
+
+    Returns the download_id.
+    """
+    from core.database import log_weekly_pack_download
+
+    filename = f"{pack_date} {publisher} Week ({format_pref}).zip"
+    filename = filename.replace("/", "-").replace("\\", "-")
+    download_id = str(uuid.uuid4())
+
+    download_progress[download_id] = {
+        "url": pixeldrain_url,
+        "progress": 0,
+        "bytes_total": 0,
+        "bytes_downloaded": 0,
+        "status": "queued",
+        "filename": filename,
+        "error": None,
+        "provider": None,
+    }
+
+    log_weekly_pack_download(
+        pack_date,
+        publisher,
+        format_pref,
+        pixeldrain_url,
+        "queued",
+        download_id=download_id,
+    )
+
+    download_queue.put(
+        {
+            "download_id": download_id,
+            "url": pixeldrain_url,
+            "dest_filename": filename,
+            "internal": True,
+            "weekly_pack_info": {
+                "pack_date": pack_date,
+                "publisher": publisher,
+                "format": format_pref,
+            },
+        }
+    )
+
+    app_logger.info(f"📥 Queued weekly pack download: {filename}")
+    return download_id
+
+
 def scheduled_weekly_packs_download():
     """Auto-download weekly packs from GetComics on schedule."""
     try:
         from core.database import (
             get_weekly_packs_config,
             update_last_weekly_packs_run,
-            log_weekly_pack_download,
             is_weekly_pack_downloaded,
         )
         from models.getcomics import (
@@ -1634,9 +1689,20 @@ def scheduled_weekly_packs_download():
             get_weekly_pack_dates_in_range,
         )
         from api import download_queue, download_progress
+        from core.download_utils import reconcile_weekly_pack_history
 
         app_logger.info("📦 Starting scheduled Weekly Packs download...")
         start_time = time.time()
+
+        # True the history table up against live downloads first: rows frozen at
+        # 'queued'/'downloading' count as downloaded, so without this a pack that
+        # was interrupted or cancelled would never be retried.
+        try:
+            healed = reconcile_weekly_pack_history()
+            if healed:
+                app_logger.info(f"Reconciled {healed} stale weekly pack row(s)")
+        except Exception as e:
+            app_logger.error(f"Weekly pack reconciliation failed: {e}")
 
         # Get configuration
         config = get_weekly_packs_config()
@@ -1712,39 +1778,16 @@ def scheduled_weekly_packs_download():
                         )
                         continue
 
-                    filename = f"{pack_date} {publisher} Week ({format_pref}).zip"
-                    filename = filename.replace("/", "-").replace("\\", "-")
-                    download_id = str(uuid.uuid4())
-
-                    download_progress[download_id] = {
-                        "url": pixeldrain_url,
-                        "progress": 0,
-                        "bytes_total": 0,
-                        "bytes_downloaded": 0,
-                        "status": "queued",
-                        "filename": filename,
-                        "error": None,
-                        "provider": None,
-                    }
-
-                    task = {
-                        "download_id": download_id,
-                        "url": pixeldrain_url,
-                        "dest_filename": filename,
-                        "internal": True,
-                        "weekly_pack_info": {
-                            "pack_date": pack_date,
-                            "publisher": publisher,
-                            "format": format_pref,
-                        },
-                    }
-                    download_queue.put(task)
-                    log_weekly_pack_download(
-                        pack_date, publisher, format_pref, pixeldrain_url, "queued"
+                    _enqueue_weekly_pack(
+                        pack_date,
+                        publisher,
+                        pixeldrain_url,
+                        format_pref,
+                        download_progress,
+                        download_queue,
                     )
                     total_download_count += 1
                     latest_successful_pack = pack_date
-                    app_logger.info(f"📥 Queued weekly pack download: {filename}")
 
         else:
             # No start_date: just check the latest pack from homepage
@@ -1756,8 +1799,14 @@ def scheduled_weekly_packs_download():
 
             app_logger.info(f"Found weekly pack: {pack_date} -> {pack_url}")
 
-            # Check if we already downloaded this pack
-            if config["last_successful_pack"] == pack_date:
+            # Skip only when every selected publisher really is downloaded.
+            # last_successful_pack is written at QUEUE time, so on its own it
+            # would permanently block a pack whose downloads all failed or were
+            # interrupted.
+            if config["last_successful_pack"] == pack_date and all(
+                is_weekly_pack_downloaded(pack_date, pub, format_pref)
+                for pub in publishers
+            ):
                 app_logger.info(f"Already downloaded pack {pack_date}, skipping")
                 update_last_weekly_packs_run()
                 return
@@ -1771,39 +1820,22 @@ def scheduled_weekly_packs_download():
                 )
                 if download_links:
                     for publisher, pixeldrain_url in download_links.items():
-                        filename = f"{pack_date} {publisher} Week ({format_pref}).zip"
-                        filename = filename.replace("/", "-").replace("\\", "-")
-                        download_id = str(uuid.uuid4())
+                        if is_weekly_pack_downloaded(pack_date, publisher, format_pref):
+                            app_logger.debug(
+                                f"Already downloaded {pack_date} {publisher}, skipping"
+                            )
+                            continue
 
-                        download_progress[download_id] = {
-                            "url": pixeldrain_url,
-                            "progress": 0,
-                            "bytes_total": 0,
-                            "bytes_downloaded": 0,
-                            "status": "queued",
-                            "filename": filename,
-                            "error": None,
-                            "provider": None,
-                        }
-
-                        task = {
-                            "download_id": download_id,
-                            "url": pixeldrain_url,
-                            "dest_filename": filename,
-                            "internal": True,
-                            "weekly_pack_info": {
-                                "pack_date": pack_date,
-                                "publisher": publisher,
-                                "format": format_pref,
-                            },
-                        }
-                        download_queue.put(task)
-                        log_weekly_pack_download(
-                            pack_date, publisher, format_pref, pixeldrain_url, "queued"
+                        _enqueue_weekly_pack(
+                            pack_date,
+                            publisher,
+                            pixeldrain_url,
+                            format_pref,
+                            download_progress,
+                            download_queue,
                         )
                         total_download_count += 1
                         latest_successful_pack = pack_date
-                        app_logger.info(f"📥 Queued weekly pack download: {filename}")
 
         # Update last run timestamp
         update_last_weekly_packs_run(latest_successful_pack)
@@ -8434,6 +8466,20 @@ def start_background_services():
 
     # Configure GetComics schedule from database
     configure_getcomics_schedule()
+
+    # Any weekly pack still 'queued'/'downloading' at boot is orphaned — the
+    # download queue and progress dict are in-memory only. stale_after_seconds=0
+    # because download_progress is provably empty here, so no grace is needed.
+    try:
+        from core.download_utils import reconcile_weekly_pack_history
+
+        healed = reconcile_weekly_pack_history(progress={}, stale_after_seconds=0)
+        if healed:
+            app_logger.info(
+                f"Marked {healed} interrupted weekly pack download(s) from the previous run"
+            )
+    except Exception as e:
+        app_logger.error(f"Weekly pack reconciliation failed at startup: {e}")
 
     # Configure Weekly Packs schedule from database
     configure_weekly_packs_schedule()

--- a/core/database.py
+++ b/core/database.py
@@ -493,9 +493,17 @@ def init_db():
                 download_url TEXT,
                 status TEXT DEFAULT 'queued',
                 downloaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                download_id TEXT,
                 UNIQUE(pack_date, publisher, format)
             )
         """)
+
+        # Migration: link each row to its live api.download_progress entry so a
+        # stuck 'queued'/'downloading' row can be reconciled against real state.
+        c.execute("PRAGMA table_info(weekly_packs_history)")
+        wph_columns = [col[1] for col in c.fetchall()]
+        if "download_id" not in wph_columns:
+            c.execute("ALTER TABLE weekly_packs_history ADD COLUMN download_id TEXT")
 
         # Create wanted_issues table (cache pre-computed wanted issues)
         c.execute("""
@@ -4281,7 +4289,7 @@ def update_last_weekly_packs_run(pack_date=None):
 
 
 def log_weekly_pack_download(
-    pack_date, publisher, format_pref, download_url, status="queued"
+    pack_date, publisher, format_pref, download_url, status="queued", download_id=None
 ):
     """
     Record a weekly pack download attempt in history.
@@ -4292,6 +4300,10 @@ def log_weekly_pack_download(
         format_pref: Format ('JPG' or 'WEBP')
         download_url: The PIXELDRAIN download URL
         status: Download status ('queued', 'downloading', 'completed', 'failed')
+        download_id: The api.download_progress key for this download. Passing
+            None deliberately PRESERVES any id already on the row — that is what
+            lets api.py's status writes (which only know the pack's natural key)
+            update the row without losing the link to live progress.
 
     Returns:
         True if successful, False otherwise
@@ -4302,12 +4314,21 @@ def log_weekly_pack_download(
             return False
 
         c = conn.cursor()
+        # ON CONFLICT rather than INSERT OR REPLACE: the latter is a DELETE +
+        # INSERT, so it renumbers `id` and wipes columns the caller didn't pass
+        # (notably download_id).
         c.execute(
             """
-            INSERT OR REPLACE INTO weekly_packs_history (pack_date, publisher, format, download_url, status, downloaded_at)
-            VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            INSERT INTO weekly_packs_history
+                (pack_date, publisher, format, download_url, status, downloaded_at, download_id)
+            VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+            ON CONFLICT(pack_date, publisher, format) DO UPDATE SET
+                status        = excluded.status,
+                download_url  = excluded.download_url,
+                downloaded_at = CURRENT_TIMESTAMP,
+                download_id   = COALESCE(excluded.download_id, weekly_packs_history.download_id)
         """,
-            (pack_date, publisher, format_pref, download_url, status),
+            (pack_date, publisher, format_pref, download_url, status, download_id),
         )
 
         conn.commit()
@@ -4323,7 +4344,9 @@ def log_weekly_pack_download(
         return False
 
 
-def update_weekly_pack_status(pack_date, publisher, format_pref, status):
+def update_weekly_pack_status(
+    pack_date, publisher, format_pref, status, touch_timestamp=True
+):
     """
     Update the status of a weekly pack download.
 
@@ -4331,7 +4354,12 @@ def update_weekly_pack_status(pack_date, publisher, format_pref, status):
         pack_date: Date of the pack (e.g., "2026-01-14")
         publisher: Publisher name ('DC', 'Marvel', 'Image', 'INDIE')
         format_pref: Format ('JPG' or 'WEBP')
-        status: New status ('queued', 'downloading', 'completed', 'failed')
+        status: New status ('queued', 'downloading', 'completed', 'failed',
+            'cancelled', 'interrupted')
+        touch_timestamp: Whether to bump downloaded_at. Reconciliation passes
+            False — get_weekly_packs_history orders by downloaded_at, so a
+            background sweep that touched it would reshuffle the UI and turn the
+            "Downloaded" column into "last time we looked at this row".
 
     Returns:
         True if successful, False otherwise
@@ -4342,14 +4370,24 @@ def update_weekly_pack_status(pack_date, publisher, format_pref, status):
             return False
 
         c = conn.cursor()
-        c.execute(
-            """
-            UPDATE weekly_packs_history
-            SET status = ?, downloaded_at = CURRENT_TIMESTAMP
-            WHERE pack_date = ? AND publisher = ? AND format = ?
-        """,
-            (status, pack_date, publisher, format_pref),
-        )
+        if touch_timestamp:
+            c.execute(
+                """
+                UPDATE weekly_packs_history
+                SET status = ?, downloaded_at = CURRENT_TIMESTAMP
+                WHERE pack_date = ? AND publisher = ? AND format = ?
+            """,
+                (status, pack_date, publisher, format_pref),
+            )
+        else:
+            c.execute(
+                """
+                UPDATE weekly_packs_history
+                SET status = ?
+                WHERE pack_date = ? AND publisher = ? AND format = ?
+            """,
+                (status, pack_date, publisher, format_pref),
+            )
 
         conn.commit()
         conn.close()
@@ -4371,7 +4409,13 @@ def is_weekly_pack_downloaded(pack_date: str, publisher: str, format_pref: str) 
         format_pref: Format (JPG or WEBP)
 
     Returns:
-        True if already downloaded (status is 'queued' or 'completed'), False otherwise
+        True if already downloaded or genuinely in flight ('queued',
+        'downloading', 'completed'), False otherwise.
+
+    The whitelist is deliberate: any other status ('failed', 'cancelled',
+    'interrupted') leaves the pack eligible for re-download. Stuck rows are
+    healed into one of those by reconcile_weekly_pack_history() before the
+    scheduler consults this function.
     """
     try:
         conn = get_db_connection()
@@ -4397,6 +4441,60 @@ def is_weekly_pack_downloaded(pack_date: str, publisher: str, format_pref: str) 
         return False
 
 
+def get_stale_weekly_pack_rows(stale_after_seconds=900):
+    """
+    Get every weekly pack row still sitting in a non-terminal status.
+
+    Used by reconcile_weekly_pack_history() to true the history table up against
+    live download progress.
+
+    Args:
+        stale_after_seconds: Age past which a row with no download_id is
+            considered orphaned. Rows written by api.py carry no id, so a young
+            id-less row may belong to a download that is actually running.
+
+    Returns:
+        List of dicts with pack_date, publisher, format, status, download_id and
+        is_stale (bool), or empty list on error.
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+
+        c = conn.cursor()
+        # Staleness is computed in SQL: downloaded_at is CURRENT_TIMESTAMP (UTC),
+        # so comparing against a local datetime.now() would be off by the host's
+        # UTC offset.
+        c.execute(
+            """
+            SELECT pack_date, publisher, format, status, download_id,
+                   CASE WHEN downloaded_at <= datetime('now', ?) THEN 1 ELSE 0 END AS is_stale
+            FROM weekly_packs_history
+            WHERE status IN ('queued', 'downloading')
+        """,
+            (f"-{int(stale_after_seconds)} seconds",),
+        )
+        rows = c.fetchall()
+        conn.close()
+
+        return [
+            {
+                "pack_date": row[0],
+                "publisher": row[1],
+                "format": row[2],
+                "status": row[3],
+                "download_id": row[4],
+                "is_stale": bool(row[5]),
+            }
+            for row in rows
+        ]
+
+    except Exception as e:
+        app_logger.error(f"Failed to get stale weekly pack rows: {e}")
+        return []
+
+
 def get_weekly_packs_history(limit=20):
     """
     Get recent weekly pack download history.
@@ -4415,7 +4513,7 @@ def get_weekly_packs_history(limit=20):
         c = conn.cursor()
         c.execute(
             """
-            SELECT pack_date, publisher, format, download_url, status, downloaded_at
+            SELECT pack_date, publisher, format, download_url, status, downloaded_at, download_id
             FROM weekly_packs_history
             ORDER BY downloaded_at DESC
             LIMIT ?
@@ -4433,6 +4531,7 @@ def get_weekly_packs_history(limit=20):
                 "download_url": row[3],
                 "status": row[4],
                 "downloaded_at": row[5],
+                "download_id": row[6],
             }
             for row in rows
         ]

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -2,8 +2,22 @@
 
 Kept separate from ``api.py`` so the pure logic can be imported and tested
 without triggering api.py's import-time side effects (worker threads, DB
-connection, cloudscraper).
+connection, cloudscraper). Nothing here imports ``api`` or ``core.database`` at
+module scope; the weekly-pack reconciler reaches for both lazily.
 """
+
+import sys
+
+# Live api.download_progress status -> weekly_packs_history status. 'queued'
+# maps to itself and is filtered out before any write, so a genuinely queued
+# download never causes DB churn.
+_LIVE_TO_HISTORY_STATUS = {
+    'queued': 'queued',
+    'in_progress': 'downloading',
+    'complete': 'completed',
+    'error': 'failed',
+    'cancelled': 'cancelled',
+}
 
 
 def issue_number_to_int(issue_num) -> int | None:
@@ -55,3 +69,117 @@ def is_cloudflare_challenge(response) -> bool:
                 or b'challenge-platform' in snippet)
     except Exception:
         return False
+
+
+def _live_download_progress():
+    """Return ``api.download_progress`` if api is already imported, else None.
+
+    Deliberately reads ``sys.modules`` instead of importing: the monitor process
+    (and any test that hasn't loaded api) must get a safe ``None`` rather than
+    trigger api.py's import-time worker threads. Also rejects non-dict values so
+    a ``MagicMock`` stand-in can't produce nondeterministic lookups.
+    """
+    mod = sys.modules.get('api')
+    progress = getattr(mod, 'download_progress', None) if mod is not None else None
+    return progress if isinstance(progress, dict) else None
+
+
+def apply_live_weekly_pack_status(history, progress=None):
+    """Overlay live download state onto weekly-pack history rows, in place.
+
+    Reconciliation heals the stored status, but only on rows old enough to have
+    been swept; this makes the UI agree with the Status page immediately, and
+    adds a ``progress`` percentage for downloads that are actually running.
+
+    Args:
+        history: rows from ``get_weekly_packs_history()`` (each with download_id)
+        progress: live download-progress mapping; defaults to the live dict.
+
+    Returns the same list.
+    """
+    if progress is None:
+        progress = _live_download_progress() or {}
+
+    for item in history:
+        live = progress.get(item.get('download_id'))
+        if not isinstance(live, dict):
+            continue
+        item['status'] = _LIVE_TO_HISTORY_STATUS.get(live.get('status'), item.get('status'))
+        if item['status'] == 'downloading':
+            item['progress'] = int(live.get('progress') or 0)
+
+    return history
+
+
+def reconcile_weekly_pack_history(progress=None, stale_after_seconds=900):
+    """Sync stuck weekly-pack history rows against live download progress.
+
+    ``weekly_packs_history.status`` is only a mirror — the authoritative state
+    lives in the in-memory ``api.download_progress``. Restarts, cancellations,
+    cleared entries and crashed workers all leave rows frozen at 'queued' or
+    'downloading' forever, which also blocks re-download because
+    ``is_weekly_pack_downloaded()`` counts those as done. This resolves each
+    frozen row against live state, or marks it 'interrupted' when the download
+    it referred to no longer exists.
+
+    Args:
+        progress: live download-progress mapping. Defaults to
+            ``api.download_progress`` when api is already loaded; when neither is
+            available this is a no-op (zero reads of live state, zero writes).
+        stale_after_seconds: grace period before a row with no ``download_id``
+            is treated as orphaned. api.py's status writes carry no id, so a
+            young id-less row may belong to a download that is actually running.
+            Callers that know the progress dict is empty (app startup) pass 0.
+
+    Returns:
+        Number of rows whose status changed. Performs no writes at rest.
+
+    Assumes a single web worker (``gunicorn -w 1``): the progress dict lives in
+    one process. Under multiple workers this would need a DB-backed progress
+    store instead.
+    """
+    from core.app_logging import app_logger
+    from core.database import get_stale_weekly_pack_rows, update_weekly_pack_status
+
+    rows = get_stale_weekly_pack_rows(stale_after_seconds)
+    if not rows:
+        return 0
+
+    if progress is None:
+        progress = _live_download_progress()
+    if progress is None:
+        return 0
+
+    changed = 0
+    for row in rows:
+        download_id = row.get('download_id')
+        live = progress.get(download_id) if download_id else None
+        if not isinstance(live, dict):
+            live = None
+
+        if live is not None:
+            new_status = _LIVE_TO_HISTORY_STATUS.get(live.get('status'))
+            if not new_status or new_status == row.get('status'):
+                # Already agrees with live state, still queued, or a status we
+                # don't model — leave it. Keeps the steady state write-free.
+                continue
+        elif download_id or row.get('is_stale'):
+            # The download this row pointed at is gone (restart, cleared,
+            # dismissed), or it predates download_id tracking and has aged out.
+            new_status = 'interrupted'
+        else:
+            # Young row with no id: may belong to an in-flight download whose
+            # only writer is api.py (which never passes an id). Leave it alone.
+            continue
+
+        if update_weekly_pack_status(
+            row['pack_date'], row['publisher'], row['format'], new_status,
+            touch_timestamp=False,
+        ):
+            changed += 1
+            app_logger.info(
+                f"Reconciled weekly pack {row['pack_date']} {row['publisher']} "
+                f"{row['format']}: -> {new_status}"
+            )
+
+    return changed

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -46,14 +46,36 @@ def weekly_packs():
     """
     Weekly Packs page - configure automated weekly pack downloads from GetComics.
     """
-    from core.database import get_weekly_packs_config, get_weekly_packs_history
+    from core.database import get_weekly_packs_config
 
     config = get_weekly_packs_config()
-    history = get_weekly_packs_history(limit=20)
+    history = _weekly_pack_history_with_live_status(limit=20)
 
     return render_template('weekly_packs.html',
                          config=config,
                          history=history)
+
+
+def _weekly_pack_history_with_live_status(limit=20):
+    """Weekly pack history, trued up against live download progress.
+
+    The stored status is only a mirror of api.download_progress, so it can be
+    frozen at 'queued'/'downloading' (restart, cancellation, cleared entry).
+    Reconcile first — which heals the rows in the DB — then overlay the live
+    percentage for downloads that are genuinely in flight.
+    """
+    from core.database import get_weekly_packs_history
+    from core.download_utils import (
+        apply_live_weekly_pack_status,
+        reconcile_weekly_pack_history,
+    )
+
+    try:
+        reconcile_weekly_pack_history()
+    except Exception as e:
+        app_logger.error(f"Weekly pack reconciliation failed: {e}")
+
+    return apply_live_weekly_pack_status(get_weekly_packs_history(limit))
 
 
 # =============================================================================
@@ -795,12 +817,10 @@ def api_run_weekly_packs_now():
 
 @downloads_bp.route('/api/weekly-packs-history', methods=['GET'])
 def api_weekly_packs_history():
-    """Get recent weekly pack download history."""
+    """Get recent weekly pack download history, trued up against live downloads."""
     try:
-        from core.database import get_weekly_packs_history
-
         limit = request.args.get('limit', 20, type=int)
-        history = get_weekly_packs_history(limit)
+        history = _weekly_pack_history_with_live_status(limit)
 
         return jsonify({
             "success": True,

--- a/templates/weekly_packs.html
+++ b/templates/weekly_packs.html
@@ -203,7 +203,6 @@
             </button>
         </div>
         <div class="card-body">
-            {% if history %}
             <div class="table-responsive">
                 <table class="table table-sm table-hover">
                     <thead>
@@ -215,6 +214,8 @@
                             <th>Downloaded</th>
                         </tr>
                     </thead>
+                    <!-- Always rendered: the poller repaints this body, so it must
+                         exist even when the first pack hasn't been queued yet. -->
                     <tbody id="historyTable">
                         {% for item in history %}
                         <tr>
@@ -237,23 +238,27 @@
                                 {% elif item.status == 'queued' %}
                                 <span class="badge bg-info">Queued</span>
                                 {% elif item.status == 'downloading' %}
-                                <span class="badge bg-warning">Downloading</span>
+                                <span class="badge bg-warning">Downloading{% if item.progress %} {{ item.progress }}%{% endif %}</span>
+                                {% elif item.status == 'interrupted' %}
+                                <span class="badge bg-secondary" title="The download was still running when CLU restarted">Interrupted</span>
+                                {% elif item.status == 'cancelled' %}
+                                <span class="badge bg-secondary">Cancelled</span>
+                                {% elif item.status == 'failed' %}
+                                <span class="badge bg-danger">Failed</span>
                                 {% else %}
                                 <span class="badge bg-danger">{{ item.status }}</span>
                                 {% endif %}
                             </td>
                             <td>{{ item.downloaded_at }}</td>
                         </tr>
+                        {% else %}
+                        <tr>
+                            <td colspan="5" class="text-center text-muted py-4">No download history yet</td>
+                        </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </div>
-            {% else %}
-            <div class="text-center py-4 text-muted">
-                <i class="bi bi-inbox display-4 opacity-25"></i>
-                <p class="mt-2">No download history yet</p>
-            </div>
-            {% endif %}
         </div>
     </div>
 </div>
@@ -291,6 +296,10 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('refreshHistory').addEventListener('click', function() {
         refreshHistory();
     });
+
+    // Keep Recent Downloads in step with the Status page (guarded: no overlap,
+    // aborts a hung request, pauses while the tab is hidden).
+    CLU.startPoll(refreshHistory, 10000);
 });
 
 function loadStatus() {
@@ -426,8 +435,10 @@ function checkPackStatus() {
         });
 }
 
-function refreshHistory() {
-    fetch('/api/weekly-packs-history?limit=20')
+function refreshHistory(signal) {
+    // The endpoint reconciles stored status against live downloads, so this is
+    // what keeps the table in step with the Status page.
+    return fetch('/api/weekly-packs-history?limit=20', { signal })
         .then(response => response.json())
         .then(data => {
             if (data.success && data.history) {
@@ -466,7 +477,14 @@ function updateHistoryTable(history) {
         } else if (item.status === 'queued') {
             statusBadge = '<span class="badge bg-info">Queued</span>';
         } else if (item.status === 'downloading') {
-            statusBadge = '<span class="badge bg-warning">Downloading</span>';
+            const pct = item.progress ? ' ' + item.progress + '%' : '';
+            statusBadge = '<span class="badge bg-warning">Downloading' + pct + '</span>';
+        } else if (item.status === 'interrupted') {
+            statusBadge = '<span class="badge bg-secondary" title="The download was still running when CLU restarted">Interrupted</span>';
+        } else if (item.status === 'cancelled') {
+            statusBadge = '<span class="badge bg-secondary">Cancelled</span>';
+        } else if (item.status === 'failed') {
+            statusBadge = '<span class="badge bg-danger">Failed</span>';
         } else {
             statusBadge = '<span class="badge bg-danger">' + item.status + '</span>';
         }

--- a/tests/integration/test_database_schedules.py
+++ b/tests/integration/test_database_schedules.py
@@ -126,6 +126,104 @@ class TestWeeklyPacks:
 
         assert is_weekly_pack_downloaded("2099-01-01", "DC", "CBZ") is False
 
+    def test_log_download_persists_download_id(self, db_connection):
+        from core.database import log_weekly_pack_download, get_weekly_packs_history
+
+        log_weekly_pack_download(
+            "2024-02-01", "DC", "JPG", "https://example.com", "queued",
+            download_id="dl-abc",
+        )
+
+        row = next(h for h in get_weekly_packs_history() if h["pack_date"] == "2024-02-01")
+        assert row["download_id"] == "dl-abc"
+
+    def test_status_update_preserves_download_id(self, db_connection):
+        """api.py's status writes know the pack's natural key but not the
+        download_id — they must not wipe the link to live progress."""
+        from core.database import log_weekly_pack_download, get_weekly_packs_history
+
+        log_weekly_pack_download(
+            "2024-02-02", "Marvel", "JPG", "https://example.com", "queued",
+            download_id="dl-xyz",
+        )
+        log_weekly_pack_download(
+            "2024-02-02", "Marvel", "JPG", "https://example.com", "completed",
+        )
+
+        row = next(h for h in get_weekly_packs_history() if h["pack_date"] == "2024-02-02")
+        assert row["status"] == "completed"
+        assert row["download_id"] == "dl-xyz"
+
+    def test_upsert_preserves_row_id(self, db_connection):
+        """INSERT OR REPLACE would delete and re-insert, renumbering the row."""
+        from core.database import log_weekly_pack_download
+
+        log_weekly_pack_download("2024-02-03", "Image", "JPG", "https://example.com")
+        first = db_connection.execute(
+            "SELECT id FROM weekly_packs_history WHERE pack_date = '2024-02-03'"
+        ).fetchone()[0]
+
+        log_weekly_pack_download(
+            "2024-02-03", "Image", "JPG", "https://example.com", "completed"
+        )
+        second = db_connection.execute(
+            "SELECT id FROM weekly_packs_history WHERE pack_date = '2024-02-03'"
+        ).fetchone()[0]
+
+        assert first == second
+
+    @pytest.mark.parametrize("status", ["interrupted", "failed", "cancelled"])
+    def test_terminal_failure_statuses_allow_retry(self, db_connection, status):
+        from core.database import log_weekly_pack_download, is_weekly_pack_downloaded
+
+        log_weekly_pack_download("2024-02-04", "DC", "JPG", "https://example.com", status)
+        assert is_weekly_pack_downloaded("2024-02-04", "DC", "JPG") is False
+
+    def test_update_status_without_touching_timestamp(self, db_connection):
+        """Reconciliation must not reorder the history table on every sweep."""
+        from core.database import log_weekly_pack_download, update_weekly_pack_status
+
+        log_weekly_pack_download("2024-02-05", "DC", "JPG", "https://example.com")
+        before = db_connection.execute(
+            "SELECT downloaded_at FROM weekly_packs_history WHERE pack_date = '2024-02-05'"
+        ).fetchone()[0]
+
+        update_weekly_pack_status(
+            "2024-02-05", "DC", "JPG", "interrupted", touch_timestamp=False
+        )
+
+        row = db_connection.execute(
+            "SELECT status, downloaded_at FROM weekly_packs_history WHERE pack_date = '2024-02-05'"
+        ).fetchone()
+        assert row[0] == "interrupted"
+        assert row[1] == before
+
+    def test_get_stale_rows_only_returns_non_terminal(self, db_connection):
+        from core.database import log_weekly_pack_download, get_stale_weekly_pack_rows
+
+        log_weekly_pack_download("2024-02-06", "DC", "JPG", "u", "queued", download_id="a")
+        log_weekly_pack_download("2024-02-06", "Marvel", "JPG", "u", "downloading")
+        log_weekly_pack_download("2024-02-06", "Image", "JPG", "u", "completed")
+
+        rows = get_stale_weekly_pack_rows()
+        publishers = {r["publisher"] for r in rows if r["pack_date"] == "2024-02-06"}
+        assert publishers == {"DC", "Marvel"}
+
+        dc = next(r for r in rows if r["publisher"] == "DC")
+        assert dc["download_id"] == "a"
+        assert dc["status"] == "queued"
+        # Just written, so not yet past the default grace period.
+        assert dc["is_stale"] is False
+
+    def test_get_stale_rows_flags_aged_rows(self, db_connection):
+        from core.database import log_weekly_pack_download, get_stale_weekly_pack_rows
+
+        log_weekly_pack_download("2024-02-07", "DC", "JPG", "u", "downloading")
+
+        rows = get_stale_weekly_pack_rows(stale_after_seconds=0)
+        row = next(r for r in rows if r["pack_date"] == "2024-02-07")
+        assert row["is_stale"] is True
+
 
 class TestBrowseCache:
 

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -106,6 +106,33 @@ class TestFileIndexColumns:
         assert metadata_cols.issubset(columns)
 
 
+class TestWeeklyPacksHistoryColumns:
+    """download_id links a history row to its live api.download_progress entry,
+    which is what lets a stuck 'queued'/'downloading' row be reconciled."""
+
+    def test_core_columns(self, db_connection):
+        cur = db_connection.execute("PRAGMA table_info(weekly_packs_history)")
+        columns = {row[1] for row in cur.fetchall()}
+        expected = {
+            "id", "pack_date", "publisher", "format", "download_url",
+            "status", "downloaded_at", "download_id",
+        }
+        assert expected.issubset(columns)
+
+    def test_download_id_migration_is_idempotent(self, db_path):
+        """The ALTER TABLE must not run twice on an existing install."""
+        with patch("core.database.get_db_path", return_value=db_path):
+            from core.database import init_db
+            assert init_db() is True
+
+        conn = sqlite3.connect(db_path)
+        try:
+            cols = [row[1] for row in conn.execute("PRAGMA table_info(weekly_packs_history)")]
+        finally:
+            conn.close()
+        assert cols.count("download_id") == 1
+
+
 class TestIndexesExist:
 
     EXPECTED_INDEXES = [

--- a/tests/integration/test_weekly_pack_reconcile.py
+++ b/tests/integration/test_weekly_pack_reconcile.py
@@ -1,0 +1,161 @@
+"""Tests for weekly-pack history reconciliation (issue #467).
+
+``weekly_packs_history.status`` is only a mirror of the in-memory
+``api.download_progress``. Restarts, cancellations and cleared entries used to
+freeze rows at 'queued'/'downloading' forever — which also blocked re-download,
+because ``is_weekly_pack_downloaded()`` counts those as done.
+"""
+import pytest
+from unittest.mock import patch
+
+from core.download_utils import (
+    apply_live_weekly_pack_status,
+    reconcile_weekly_pack_history,
+    _live_download_progress,
+)
+
+
+def _seed(pack_date, publisher, status, download_id=None):
+    from core.database import log_weekly_pack_download
+
+    log_weekly_pack_download(
+        pack_date, publisher, "JPG", "https://example.com/pack.zip", status,
+        download_id=download_id,
+    )
+
+
+def _status(pack_date, publisher="DC"):
+    from core.database import get_weekly_packs_history
+
+    row = next(
+        h for h in get_weekly_packs_history(limit=100)
+        if h["pack_date"] == pack_date and h["publisher"] == publisher
+    )
+    return row["status"]
+
+
+class TestLiveStatusMapping:
+
+    @pytest.mark.parametrize("live_status,expected", [
+        ("in_progress", "downloading"),
+        ("complete", "completed"),
+        ("error", "failed"),
+        ("cancelled", "cancelled"),
+    ])
+    def test_maps_live_state_onto_row(self, db_connection, live_status, expected):
+        _seed("2026.01.07", "DC", "queued", download_id="dl-1")
+
+        changed = reconcile_weekly_pack_history(
+            progress={"dl-1": {"status": live_status}}
+        )
+
+        assert changed == 1
+        assert _status("2026.01.07") == expected
+
+    def test_still_queued_is_left_alone(self, db_connection):
+        _seed("2026.01.07", "DC", "queued", download_id="dl-1")
+
+        assert reconcile_weekly_pack_history(progress={"dl-1": {"status": "queued"}}) == 0
+        assert _status("2026.01.07") == "queued"
+
+    def test_already_downloading_is_not_rewritten(self, db_connection):
+        """The steady state must be write-free — this runs on every UI poll."""
+        _seed("2026.01.07", "DC", "downloading", download_id="dl-1")
+
+        assert reconcile_weekly_pack_history(
+            progress={"dl-1": {"status": "in_progress"}}
+        ) == 0
+
+    def test_unknown_live_status_is_left_alone(self, db_connection):
+        _seed("2026.01.07", "DC", "queued", download_id="dl-1")
+
+        assert reconcile_weekly_pack_history(progress={"dl-1": {"status": "???"}}) == 0
+        assert _status("2026.01.07") == "queued"
+
+
+class TestOrphanedRows:
+
+    def test_missing_live_entry_becomes_interrupted(self, db_connection):
+        """Restart, /clear_downloads or /dismiss_download drops the entry."""
+        _seed("2026.01.07", "DC", "downloading", download_id="dl-gone")
+
+        assert reconcile_weekly_pack_history(progress={}) == 1
+        assert _status("2026.01.07") == "interrupted"
+
+    def test_legacy_row_without_id_heals_once_stale(self, db_connection):
+        """Rows written before download_id tracking existed."""
+        _seed("2026.01.07", "DC", "queued")
+
+        assert reconcile_weekly_pack_history(progress={}, stale_after_seconds=0) == 1
+        assert _status("2026.01.07") == "interrupted"
+
+    def test_fresh_row_without_id_is_protected(self, db_connection):
+        """api.py's status writes carry no download_id, so a young id-less row
+        may belong to a download that is actually running."""
+        _seed("2026.01.07", "DC", "downloading")
+
+        assert reconcile_weekly_pack_history(progress={}) == 0
+        assert _status("2026.01.07") == "downloading"
+
+    def test_interrupted_row_is_eligible_for_redownload(self, db_connection):
+        from core.database import is_weekly_pack_downloaded
+
+        _seed("2026.01.07", "DC", "downloading", download_id="dl-gone")
+        reconcile_weekly_pack_history(progress={})
+
+        assert is_weekly_pack_downloaded("2026.01.07", "DC", "JPG") is False
+
+
+class TestNoOpPaths:
+
+    def test_no_stale_rows_means_no_progress_lookup(self, db_connection):
+        _seed("2026.01.07", "DC", "completed", download_id="dl-1")
+
+        with patch("core.download_utils._live_download_progress") as mock_live:
+            assert reconcile_weekly_pack_history() == 0
+        mock_live.assert_not_called()
+
+    def test_no_progress_source_writes_nothing(self, db_connection):
+        """The monitor process (which never imports api) must not clobber rows."""
+        _seed("2026.01.07", "DC", "downloading", download_id="dl-1")
+
+        with patch("core.download_utils._live_download_progress", return_value=None):
+            assert reconcile_weekly_pack_history() == 0
+        assert _status("2026.01.07") == "downloading"
+
+    def test_non_dict_progress_source_is_rejected(self):
+        from unittest.mock import MagicMock
+
+        with patch.dict("sys.modules", {"api": MagicMock()}):
+            assert _live_download_progress() is None
+
+    def test_missing_api_module_is_safe(self):
+        import sys
+
+        saved = sys.modules.pop("api", None)
+        try:
+            assert _live_download_progress() is None
+        finally:
+            if saved is not None:
+                sys.modules["api"] = saved
+
+
+class TestApplyLiveStatus:
+
+    def test_overlays_status_and_progress(self):
+        history = [{"pack_date": "2026.01.07", "status": "queued", "download_id": "dl-1"}]
+
+        apply_live_weekly_pack_status(
+            history, progress={"dl-1": {"status": "in_progress", "progress": 42}}
+        )
+
+        assert history[0]["status"] == "downloading"
+        assert history[0]["progress"] == 42
+
+    def test_rows_without_live_entry_are_untouched(self):
+        history = [{"pack_date": "2026.01.07", "status": "completed", "download_id": None}]
+
+        apply_live_weekly_pack_status(history, progress={})
+
+        assert history[0]["status"] == "completed"
+        assert "progress" not in history[0]

--- a/tests/routes/test_downloads_routes.py
+++ b/tests/routes/test_downloads_routes.py
@@ -224,6 +224,50 @@ class TestWeeklyPacksHistory:
         assert data["success"] is True
         assert len(data["history"]) == 1
 
+    @patch("core.database.get_weekly_packs_history", return_value=[
+        {"pack_date": "2024-01-01", "publisher": "DC", "status": "queued",
+         "download_id": "dl-1"},
+    ])
+    def test_live_status_overrides_stored_status(self, mock_hist, client):
+        """A row stuck at 'queued' must report what the Status page shows."""
+        import sys
+
+        sys.modules["api"].download_progress = {"dl-1": {"status": "complete"}}
+        try:
+            resp = client.get("/api/weekly-packs-history")
+        finally:
+            sys.modules["api"].download_progress = {}
+
+        assert resp.status_code == 200
+        assert resp.get_json()["history"][0]["status"] == "completed"
+
+    @patch("core.database.get_weekly_packs_history", return_value=[
+        {"pack_date": "2024-01-01", "publisher": "DC", "status": "downloading",
+         "download_id": "dl-1"},
+    ])
+    def test_in_flight_row_carries_progress(self, mock_hist, client):
+        import sys
+
+        sys.modules["api"].download_progress = {
+            "dl-1": {"status": "in_progress", "progress": 37}
+        }
+        try:
+            resp = client.get("/api/weekly-packs-history")
+        finally:
+            sys.modules["api"].download_progress = {}
+
+        item = resp.get_json()["history"][0]
+        assert item["status"] == "downloading"
+        assert item["progress"] == 37
+
+    @patch("core.download_utils.reconcile_weekly_pack_history",
+           side_effect=Exception("db down"))
+    @patch("core.database.get_weekly_packs_history", return_value=[])
+    def test_reconcile_failure_does_not_break_the_page(self, mock_hist, mock_rec, client):
+        resp = client.get("/api/weekly-packs-history")
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
 
 class TestRunWeeklyPacksNow:
 


### PR DESCRIPTION
Closes #467

## Problem

The **Recent Downloads** table on the Weekly Packs page showed packs stuck at **Queued** / **Downloading** that never completed, while the Status page showed the truth.

`weekly_packs_history.status` is only a *mirror* of the in-memory `api.download_progress`, written from three spots inside `process_download`. Any path that bypassed them froze the row forever:

- app restart or crash (the queue and progress dict are in-memory only);
- cancellation — `process_download` returns before any DB write;
- `/clear_downloads` / `/dismiss_download` deleting the live entry;
- `/retry_download` rebuilding the task without `weekly_pack_info`;
- `worker()` had no `try/except`, so one unhandled exception killed a queue thread permanently;
- a race: `queue.put()` ran *before* the `'queued'` write, so a fast worker's `downloading` could be clobbered back.

Nothing reconciled the table afterwards, and because `is_weekly_pack_downloaded()` counts `queued`/`downloading` as done, a frozen row also **permanently blocked re-download** — the pack could never self-heal.

## Fix

Each history row is now linked to its live download by a new `download_id` column, and one shared reconciler trues the table up against real state at three reliable hooks: **app startup**, the **top of the scheduler run**, and the **page / API read paths**. Keying on `download_id` (rather than the pack's natural key) is what makes the cancel path and `/retry_download` — which reuses the same id — self-healing with no change to api.py's download logic.

| Live `download_progress` | History status |
|---|---|
| `in_progress` | `downloading` |
| `complete` | `completed` |
| `error` | `failed` |
| `cancelled` | `cancelled` |
| entry gone (restart / cleared) | `interrupted` |

`interrupted` is kept distinct from `failed` so "the container restarted" doesn't read as "bad URL"; both are outside `is_weekly_pack_downloaded()`'s whitelist, so either way the pack becomes eligible for re-download.

### Changes

- **`core/database.py`** — `download_id` column (CREATE + `PRAGMA`-guarded, idempotent migration). `log_weekly_pack_download` moves from `INSERT OR REPLACE` (a DELETE+INSERT that renumbered `id` and wiped columns) to `ON CONFLICT … DO UPDATE`, with `COALESCE` preserving the id so api.py's existing status writes keep working untouched. New `get_stale_weekly_pack_rows()` computes staleness **in SQL** (`downloaded_at` is UTC). The previously dead `update_weekly_pack_status` is revived with `touch_timestamp=False` so background sweeps don't reorder the history table.
- **`core/download_utils.py`** — `reconcile_weekly_pack_history()` and `apply_live_weekly_pack_status()`. Reads `sys.modules['api']` instead of importing it, so the separate monitor process (which must never pull in api.py) gets a safe no-op. Zero writes at rest, so the 10s UI poll is cheap.
- **`app.py`** — `_enqueue_weekly_pack()` collapses two near-identical queueing blocks and writes the history row **before** `queue.put()`. The no-Start-Date branch no longer skips a pack on `last_successful_pack` alone — that flag is written at *queue* time, so a pack whose downloads all failed was blocked forever; it now also requires every selected publisher to actually be downloaded.
- **`api.py`** — one edit: `worker()` guards `process_download` and moves `task_done()` into `finally`. This is the only stuck-status cause the reconciler cannot detect — lose all three threads and every later download genuinely hangs at "queued".
- **`templates/weekly_packs.html`** — Interrupted / Cancelled / Failed badges, live `n%` on Downloading, table body always rendered (so the poller can fill it on a fresh install), and a 10s `CLU.startPoll` refresh matching the Status page.

## Testing

Full suite: **2863 passed, 6 skipped, 0 failed.**

New coverage in `tests/integration/test_weekly_pack_reconcile.py` (status mappings, orphaned rows, the grace period protecting young id-less rows, no-op paths), plus schema-column and migration-idempotency tests, `download_id` persistence/preservation and row-id stability tests, and route tests asserting `/api/weekly-packs-history` reflects live status and progress.

Also verified against a **copy** of a real `comic_utils.db`: the migration adds the column exactly once with no row loss; a pre-fix stuck row heals to `interrupted` and becomes re-downloadable; an in-flight pack reports `downloading 61%` with a second poll writing nothing; api.py's completion write preserves `download_id`; a cancelled pack becomes retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
