### PR TITLE
Match wanted issues whose series name contains apostrophes or slashes

### DIFF
--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -170,6 +170,28 @@ def get_series_name_from_files(mapped_path, db_series_name):
     return db_series_name
 
 
+# Apostrophe variants: ASCII, curly single quotes, modifier letter apostrophe.
+_APOS_CLASS = "['‘’ʼ]"
+_APOS_RE = re.compile(_APOS_CLASS)
+
+
+def _word_regex(word):
+    """Escape one series-name word, making apostrophes optional in both directions.
+
+    A possessive is written inconsistently across sources and filenames
+    ("World's Finest" vs "Worlds Finest"), so the apostrophe must never be a
+    hard requirement — nor may its absence be. An apostrophe in the name
+    becomes optional; a word ending in "s" without one gains an optional
+    apostrophe before that "s".
+    """
+    if _APOS_RE.search(word):
+        parts = [re.escape(p) for p in _APOS_RE.split(word)]
+        return (_APOS_CLASS + "?").join(parts)
+    if len(word) > 1 and word[-1].lower() == "s":
+        return re.escape(word[:-1]) + _APOS_CLASS + "?" + re.escape(word[-1])
+    return re.escape(word)
+
+
 def generate_filename_pattern(custom_pattern, series_name, issue_number):
     """
     Convert CUSTOM_RENAME_PATTERN to a precise regex for matching a specific issue.
@@ -224,14 +246,17 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
             the_prefix = r'(?:The[\s\-_]+)?'
             working_name = series_name[4:]  # Remove "The " from name
 
-        # Remove apostrophes and ampersands entirely first
-        # Handles possessives: "Night's" -> "Nights"
-        # Handles ampersands: "Black & White" -> "Black White" (files often omit &)
-        temp_name = working_name.replace("'", "").replace("&", "")
-        # Then normalize other punctuation - replace :, -, etc. with space for consistent handling
+        # Remove ampersands entirely first \u2014 files often omit them
+        # ("Black & White" -> "Black White"); the separator class below absorbs
+        # one that is present. Apostrophes are kept here and made optional
+        # per-word below, so the possessive can differ between name and file.
+        temp_name = working_name.replace("&", "")
+        # Then normalize other punctuation - replace :, -, /, etc. with space for consistent handling
         # This allows "Nemesis: Forever", "Nemesis - Forever", "Nemesis Forever" to all match
+        # Slashes are separators too: a name like "Batman / Superman" can never
+        # appear literally in a filename ("/" is a path separator).
         # Include Unicode dashes: en dash \u2013, em dash \u2014, horizontal bar \u2015
-        normalized_name = re.sub(r'[\s\-_:;,\.\u2010-\u2015\u2212]+', ' ', temp_name).strip()
+        normalized_name = re.sub(r'[\s\-_:;,\./\\\u2010-\u2015\u2212]+', ' ', temp_name).strip()
 
         # Build series pattern word-by-word, making common connecting words optional
         # Files often omit words like "and", "of", "the" (e.g., "Magik Colossus" for "Magik and Colossus")
@@ -240,7 +265,7 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         words = normalized_name.split()
         pattern_parts = []
         for i, word in enumerate(words):
-            escaped_word = re.escape(word)
+            escaped_word = _word_regex(word)
             if word.lower() in OPTIONAL_WORDS:
                 pattern_parts.append(f"(?:{escaped_word}{sep})?")
             else:

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -291,6 +291,63 @@ class TestTitleAgnosticMatching:
         assert not self._regex().match("Hidden Springs 002.cbz")
 
 
+class TestPunctuationInSeriesName:
+    """Apostrophes and slashes in a series name must not block matching.
+
+    Regression for "Batman / Superman: World's Finest" #51 never matching
+    'Batman-Superman - World's Finest 051 (2026).cbz': the apostrophe was
+    deleted from the name ("Worlds") so the file's "World's" could not match,
+    and the "/" compiled to a literal that no filename can ever contain.
+    """
+
+    def _regex(self, name, number="51"):
+        match_pattern = strip_empty_groups(
+            strip_month_token(
+                strip_title_token(
+                    strip_year_token("{series_name} {issue_number} ({volume_year})")
+                )
+            )
+        )
+        return generate_filename_pattern(match_pattern, name, number)
+
+    def test_slash_name_matches_dashed_file(self):
+        regex = self._regex("Batman / Superman: World's Finest")
+        assert regex.match("Batman-Superman - World's Finest 051 (2026).cbz")
+
+    def test_folder_derived_name_matches_apostrophe_file(self):
+        regex = self._regex("Batman - Superman - World's Finest")
+        assert regex.match("Batman-Superman - World's Finest 051 (2026).cbz")
+
+    def test_apostrophe_in_name_optional_in_file(self):
+        regex = self._regex("Batman / Superman: World's Finest")
+        assert regex.match("Batman-Superman - Worlds Finest 051 (2026).cbz")
+
+    def test_apostrophe_in_file_optional_in_name(self):
+        regex = self._regex("Batman Superman Worlds Finest")
+        assert regex.match("Batman-Superman - World's Finest 051 (2026).cbz")
+
+    def test_curly_apostrophe_matches(self):
+        regex = self._regex("Batman / Superman: World’s Finest")
+        assert regex.match("Batman-Superman - World's Finest 051 (2026).cbz")
+
+    def test_wrong_issue_still_rejected(self):
+        regex = self._regex("Batman / Superman: World's Finest")
+        assert not regex.match("Batman-Superman - World's Finest 052 (2026).cbz")
+
+    def test_different_series_still_rejected(self):
+        regex = self._regex("Batman / Superman: World's Finest")
+        assert not regex.match("Superman - World's Finest 051 (2026).cbz")
+
+    def test_slash_series_matches_dash_file(self):
+        regex = self._regex("Spider-Man/Deadpool", "7")
+        assert regex.match("Spider-Man - Deadpool 007 (2016).cbz")
+
+    def test_optional_apostrophe_does_not_over_match(self):
+        # The trailing-"s" allowance must not let a shorter series name match.
+        regex = self._regex("Ultimates", "5")
+        assert not regex.match("Ultimate 005 (2024).cbz")
+
+
 # ---- search-alias matching (Thor -> Mortal Thor) ------------------------
 
 class TestBuildSeriesMatchNames:


### PR DESCRIPTION
## Problem

Auto match-and-move left a downloaded file sitting in TARGET even though it was an exact match for a wanted issue:

```
MISSING: 'Batman / Superman: World's Finest' #51 (mapped: /data/DC Comics/Batman - Superman - World's Finest (2022))
   FILE: /comic downloads/processed/Batman-Superman - World's Finest 051 (2026).cbz
```

## Cause

`generate_filename_pattern` (`helpers/collection.py`) builds the regex the wanted-issue scan matches filenames against. Two flaws in its series-name normalization made this pair unmatchable:

1. **Apostrophes were deleted from the name** — `World's Finest` became `Worlds Finest`. The separator class only allows `'` *between* words, so the compiled `Worlds` could never match the file's `World's`. This alone broke the match even via the folder-derived name.
2. **`/` was not a normalized separator** — the DB name `Batman / Superman: World's Finest` compiled a literal `/` into the regex. A filename can never contain a path separator, so any series with a slash never matches by DB name.

The ComicInfo.xml fallback didn't rescue it: a fresh download has no `ComicInfo.xml`.

## Fix

- New `_word_regex()` helper makes apostrophes optional in **both** directions — an apostrophe in the name becomes optional, and a word ending in `s` without one gains an optional apostrophe before it — so `World's` ↔ `Worlds` match either way, curly `’` included.
- `/` and `\` join the punctuation-normalization class alongside `-`, `:`, `_`, so `Batman / Superman` normalizes to the same words as `Batman-Superman`.

## Knock-on

The same builder backs `match_issues_to_collection`, so before this fix that series would also report *every* issue as missing whenever the filename-regex path was relied on. The fix corrects both the collection scan and match-and-move.

## Tests

New `TestPunctuationInSeriesName` in `tests/unit/test_filename_pattern.py` — 9 cases: the slash name, the folder-derived name, apostrophe present/absent on either side, curly apostrophe, plus negative guards (wrong issue `#052`, different series `Superman - World's Finest`, and `Ultimates` not matching `Ultimate 005` so the trailing-`s` allowance can't over-match).

Full suite: **2872 passed, 6 skipped** (`test_pdf.py` excluded — pre-existing local env gap, `pdf2image` not installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
