### PR TITLE
Fix issue-to-file matching and repair the poisoned collection cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Key configurable lists (in `config.ini` under `[SETTINGS]`):
 | Setting | Purpose | Default |
 |---------|---------|---------|
 | `VARIANT_TYPES` | Publication format keywords | annual,quarterly,tpB,oneshot,... |
-| `PUBLICATION_TYPES` | Series type keywords | annual,quarterly |
+| `PUBLICATION_TYPES` | Series type keywords — also keeps annuals/specials from matching as regular issues in `helpers/collection.py` | annual,quarterly |
 | `SEQUEL_KEYWORDS` | Volume/sequel keywords | season,volume,book,part,chapter |
 | `CROSSOVER_KEYWORDS` | Crossover detection keywords | meets,vs,versus,x-over,crossover |
 

--- a/app.py
+++ b/app.py
@@ -8458,6 +8458,15 @@ def start_background_services():
     threading.Thread(target=start_metadata_scanner_background, daemon=True).start()
     app_logger.info("🔄 Metadata scanner initialization queued (waiting for index)...")
 
+    # Rebuild the issue->file cache if the one-time boundary purge emptied it,
+    # so On the Stack / Pull List counts aren't blank until each series is opened.
+    try:
+        from models.library_automap import start_collection_status_rebuild
+
+        start_collection_status_rebuild(app)
+    except Exception as e:
+        app_logger.error(f"Failed to start collection status rebuild: {e}")
+
     # Configure rebuild schedule from database
     configure_rebuild_schedule()
 

--- a/core/database.py
+++ b/core/database.py
@@ -878,6 +878,37 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_collection_status_series ON collection_status(series_id)"
         )
 
+        # One-time purge of collection_status rows written by the pre-boundary
+        # matcher. generate_filename_pattern had a trailing (?!\d) but no leading
+        # (?<!\d), so issue #1 matched "Nightwing 051 (2016).cbz" and dozens of
+        # issues were cached as owned all pointing at one wrong file. Both tables
+        # are pure derived caches (manual owned/skipped lives in
+        # issue_manual_status and is untouched), so dropping them makes the next
+        # series view / wanted refresh re-match with the fixed pattern.
+        c.execute(
+            "SELECT value FROM user_preferences "
+            "WHERE key = 'collection_status_boundary_purge'"
+        )
+        if not c.fetchone():
+            try:
+                c.execute("DELETE FROM collection_status")
+                purged = c.rowcount
+                # wanted_issues is derived from collection_status; emptying it
+                # makes get_wanted_cache_age() return None, which the Wanted page
+                # already treats as stale and rebuilds.
+                c.execute("DELETE FROM wanted_issues")
+                c.execute(
+                    "INSERT OR REPLACE INTO user_preferences (key, value, category, updated_at) "
+                    "VALUES ('collection_status_boundary_purge', 'true', 'migration', CURRENT_TIMESTAMP)"
+                )
+                if purged:
+                    app_logger.info(
+                        f"Purged {purged} cached collection-status rows "
+                        "(issue-number boundary fix); series will re-match on next view"
+                    )
+            except sqlite3.OperationalError:
+                pass
+
         # Create issue_manual_status table (for manually marking issues as owned/skipped)
         c.execute("""
             CREATE TABLE IF NOT EXISTS issue_manual_status (
@@ -10524,6 +10555,31 @@ def get_collection_status_for_series(series_id):
     except Exception as e:
         app_logger.error(f"Failed to get collection status for series {series_id}: {e}")
         return None
+    finally:
+        if conn:
+            conn.close()
+
+
+def count_collection_status_rows():
+    """Return the number of cached issue->file matches across all series.
+
+    Used at startup to detect a cache the one-time boundary purge emptied:
+    nothing else rebuilds it until each series page is opened, so "On the Stack"
+    (which reads this table directly), the Pull List counts and the series pages
+    would all stay blank until then.
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return 0
+        c = conn.cursor()
+        c.execute("SELECT COUNT(*) FROM collection_status")
+        row = c.fetchone()
+        return row[0] if row else 0
+    except Exception as e:
+        app_logger.error(f"Failed to count collection status rows: {e}")
+        return 0
     finally:
         if conn:
             conn.close()

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -276,8 +276,21 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
 
         # Normalize issue number - handle leading zeros (1, 01, 001 all match)
         issue_num_clean = str(issue_number).strip().lstrip('0') or '0'
-        # Match issue number with optional leading zeros
-        issue_pattern = r'0*' + re.escape(issue_num_clean) + r'(?!\d)'
+        # Match issue number with optional leading zeros, anchored on BOTH sides
+        # so it can never match a fragment of a longer number.
+        #   (?<!\d)   the digit run must start here. Without it the separator
+        #             below absorbed " 05" and issue #1 matched
+        #             "Nightwing 051 (2016).cbz" - every issue 1-40 came back
+        #             "owned", all pointing at #51's file.
+        #   (?<!\d\.) not the fractional half of a point issue: #1 must not
+        #             match the trailing "1" of "001.1".
+        #   (?!\d)    the digit run must end here ("1" is not "10").
+        #   (?!\.\d)  not the whole half of a point issue: #1 must not claim
+        #             "001.5.cbz". A bare "(?!\.)" would wrongly reject
+        #             "Nightwing 001.cbz", so only a digit after the dot counts.
+        issue_pattern = (
+            r'(?<!\d)(?<!\d\.)0*' + re.escape(issue_num_clean) + r'(?!\d)(?!\.\d)'
+        )
 
         # Now substitute our patterns back in
         pattern = pattern.replace('<<<SERIES>>>', f'(?:{series_pattern})')
@@ -289,8 +302,11 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         pattern = pattern.replace('<<<TITLE>>>', r'[^()]*?')
 
         # Make spaces between components flexible (allow punctuation like trailing periods)
-        # This handles cases like "K.O. 003" where there's punctuation before the space
-        pattern = pattern.replace(') (', r").+?(" )
+        # This handles cases like "K.O. 003" where there's punctuation before the space.
+        # The separator may be empty: with the (?<!\d) guard on the issue pattern
+        # above it can no longer swallow leading digits, and ".+?" would otherwise
+        # regress "Nightwing001.cbz" (no separator at all) to a non-match.
+        pattern = pattern.replace(') (', r").*?(" )
 
         # Defensive: drop any unrecognized {token} (and an empty "()" it may
         # leave behind) so a stray placeholder never becomes a literal regex
@@ -309,6 +325,68 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
     except Exception as e:
         app_logger.debug(f"Failed to generate filename pattern: {e}")
         return None
+
+
+# Collected editions: they reprint a run and renumber from 1, so they can never
+# stand in for a single issue. Deliberately NOT the wider VARIANT_TYPES list
+# used by the GetComics scorer — that one carries adjectives ("absolute",
+# "deluxe", "prestige", "gallery") which are common in real issue titles
+# ("Nightwing 117 - Absolute Power"), and excluding those files would report
+# owned issues as missing and re-download them.
+_COLLECTED_EDITION_TYPES = (
+    'tpb', 'trade paperback', 'omnibus', 'hardcover', 'one-shot', 'oneshot',
+    'giant-size',
+)
+
+
+def _publication_type_keywords():
+    """Keywords marking a publication with its own issue numbering.
+
+    PUBLICATION_TYPES (default "annual,quarterly") is user-editable, so a
+    library with another recurring special can add it.
+    """
+    try:
+        from models.getcomics import get_publication_types
+
+        pub_types = get_publication_types()
+    except Exception:
+        pub_types = ['annual', 'quarterly']
+    return list(pub_types) + list(_COLLECTED_EDITION_TYPES)
+
+
+def _normalize_for_keywords(text):
+    """Lower-case, punctuation-free, space-padded form for whole-word tests."""
+    return " " + re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).strip() + " "
+
+
+def names_other_publication_type(filename, series_name):
+    """True when ``filename`` advertises a publication format the series is not.
+
+    "Nightwing 2022 Annual Annual 001 (2023).cbz" sitting in the Nightwing
+    folder was being reported as Nightwing #1, because every matching tier lets
+    arbitrary text sit between the series name and the issue number: the
+    rename-pattern separator is a wildcard, the ComicInfo tier compares series
+    names by substring, and the filename fallback only looks for " 001 ".
+    An annual/TPB/omnibus restarts its numbering at 1, so it can never stand in
+    for a regular issue of the parent series.
+
+    Only the text before the first "(" is considered, so release tags
+    ("(2023) (Digital) (Deluxe-Empire)") can't trip the check, and a series that
+    *is* the format ("Nightwing Annual") keeps its own files.
+    """
+    name_part = os.path.splitext(filename or "")[0].split("(")[0]
+    haystack = _normalize_for_keywords(name_part)
+    series_haystack = _normalize_for_keywords(series_name)
+    for keyword in _publication_type_keywords():
+        kw = _normalize_for_keywords(keyword)
+        if kw == " ":
+            continue
+        plural = kw[:-1] + "s "  # " annual " -> " annuals "
+        in_file = kw in haystack or plural in haystack
+        in_series = kw in series_haystack or plural in series_haystack
+        if in_file and not in_series:
+            return True
+    return False
 
 
 def extract_comicinfo(file_path):
@@ -407,6 +485,9 @@ def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None
     regex_cache = {}         # (name, issue_number) -> compiled regex or None
     # Per-file ComicInfo memo (archive opened at most once).
     comicinfo_cache = {}
+    # (filename, series) -> "this file is an annual/TPB/... of another
+    # publication", memoized so the whole-word scan stays O(files + issues).
+    variant_skip_cache = {}
 
     remaining = list(files)  # (filename, src) tuples; matched files removed
     matches = []
@@ -465,6 +546,17 @@ def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None
         check_num = str(issue_number).strip().lstrip("0") or "0"
         matched = None
         for filename, src in remaining:
+            # A downloaded annual/TPB would otherwise satisfy issue #1 and get
+            # moved into (and renamed inside) the series folder — the same
+            # publication-type confusion the series page hit, but destructive.
+            skip_key = (filename, mn_key)
+            if skip_key not in variant_skip_cache:
+                variant_skip_cache[skip_key] = bool(match_names) and all(
+                    names_other_publication_type(filename, n) for n in match_names
+                )
+            if variant_skip_cache[skip_key]:
+                continue
+
             match_result = any(r.match(filename) for r in regexes)
 
             # Fallback: ComicInfo.xml (archive opened at most once per file).
@@ -598,6 +690,15 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
     try:
         for filename in os.listdir(mapped_path):
             if filename.lower().endswith(comic_extensions):
+                # An annual/TPB/omnibus in the series folder numbers its own
+                # issues from 1, so it must never be offered to any tier below:
+                # all three would happily match "... Annual 001 ..." as #1.
+                if names_other_publication_type(filename, series_name):
+                    app_logger.debug(
+                        f"Skipping '{filename}' for series '{series_name}': "
+                        "names a different publication type"
+                    )
+                    continue
                 file_path = os.path.join(mapped_path, filename)
                 local_files.append(file_path)
                 try:
@@ -622,6 +723,13 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
     # ComicInfo.xml is read at most once per file across all issues (shared with
     # the scan path via extract_comicinfo_cached).
     comicinfo_cache = {}
+    # Files already assigned to an issue by a PRECISE match (4a/4b). Without
+    # this one archive could be reported as owned for many issues at once - the
+    # series page showed dozens of owned issues whose "view file" all opened the
+    # same archive. The loose 4c filename fallback deliberately does NOT consume:
+    # a range/collected file ("Nightwing 001-006.cbz") may legitimately satisfy
+    # several issues, and claiming it would mark the rest missing.
+    claimed = set()
 
     for issue in issues:
         issue_num = str(getattr(issue, 'number', '') or (issue.get('number', '') if isinstance(issue, dict) else ''))
@@ -639,6 +747,8 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
             pattern_regex = generate_filename_pattern(custom_pattern, series_name, issue_num)
             if pattern_regex:
                 for file_path, metadata in file_metadata.items():
+                    if file_path in claimed:
+                        continue
                     if pattern_regex.search(metadata['filename']):
                         match_found = True
                         matched_file = file_path
@@ -648,6 +758,8 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
         # 4b: Fallback to ComicInfo.xml matching
         if not match_found:
             for file_path, metadata in file_metadata.items():
+                if file_path in claimed:
+                    continue
                 # Lazy-load ComicInfo.xml only when needed (once per file).
                 ci = extract_comicinfo_cached(file_path, comicinfo_cache)
                 if ci.get('number'):
@@ -682,6 +794,9 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
                         break
                 if match_found:
                     break
+
+        if matched_via in ('pattern', 'comicinfo'):
+            claimed.add(matched_file)
 
         results[issue_num] = {
             'found': match_found,

--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -940,6 +940,19 @@ def get_scan_job(op_id):
         return dict(job) if job else None
 
 
+def _refresh_wanted_cache():
+    """Clear and rebuild the wanted-issue cache from collection_status.
+
+    A seam, not just a shortcut: importing ``app`` runs its module-level
+    startup (which creates /downloads and friends), so a test that patched
+    ``app.refresh_wanted_cache_background`` had to import the whole Flask app
+    and died with EPERM on CI. Callers here patch this function instead.
+    """
+    from app import refresh_wanted_cache_background
+
+    refresh_wanted_cache_background()
+
+
 def _run_rematch_job(op_id, app):
     # Same contract as _run_scan_job: no context of its own, so push one.
     with app.app_context():
@@ -976,14 +989,12 @@ def _run_rematch_job_inner(op_id, app):
     # collection status is already rebuilt and the job is ``done``, so a
     # wanted-cache rebuild failure must not flip it to ``error``.
     #
-    # refresh_wanted_cache_background (not reconcile_wanted_for_series) is the
-    # right call here: reconcile only *removes* satisfied rows, but this
-    # correction runs the other way — issues that were wrongly reported as owned
-    # must be added back to wanted.
+    # _refresh_wanted_cache (not reconcile_wanted_for_series) is the right call
+    # here: reconcile only *removes* satisfied rows, but this correction runs
+    # the other way — issues that were wrongly reported as owned must be added
+    # back to wanted.
     try:
-        from app import refresh_wanted_cache_background
-
-        refresh_wanted_cache_background()
+        _refresh_wanted_cache()
     except Exception as e:
         app_logger.error(f"automap: rematch job {op_id} wanted rebuild failed: {e}")
 
@@ -1045,9 +1056,7 @@ def rebuild_collection_status_if_empty(app):
         # job: the collection status is already rebuilt, and the wanted cache
         # rebuilds itself on the next Wanted page view regardless.
         try:
-            from app import refresh_wanted_cache_background
-
-            refresh_wanted_cache_background()
+            _refresh_wanted_cache()
         except Exception as e:
             app_logger.error(f"automap: post-rebuild wanted refresh failed: {e}")
         return rebuilt

--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -657,7 +657,7 @@ def _sync_and_match_ids(api, series_ids):
         _sync_and_match(api, series_id)
 
 
-def match_unmatched_mapped_series(api):
+def match_unmatched_mapped_series(api, force=False, progress_cb=None):
     """Sync + match every mapped series that has no cached collection status.
 
     Covers the series just auto-mapped (which have none) plus any previously
@@ -665,6 +665,13 @@ def match_unmatched_mapped_series(api):
     operations indicator so the user can watch this long tail (it pulls issues
     from Metron/ComicVine, one series at a time under rate limits) instead of it
     running invisibly.
+
+    ``force=True`` re-matches EVERY mapped series, discarding its cached status
+    first — used by the Pull List "Re-match Files" action to rebuild a cache that
+    a buggy matcher wrote. ``progress_cb(current, total, name)`` lets a polled
+    job mirror the nav operation's progress.
+
+    Returns the number of series processed.
     """
     from core.app_state import (
         complete_operation,
@@ -674,6 +681,7 @@ def match_unmatched_mapped_series(api):
     from core.database import (
         get_all_mapped_series,
         get_collection_status_for_series,
+        invalidate_collection_status_for_series,
     )
 
     worklist = []
@@ -681,25 +689,34 @@ def match_unmatched_mapped_series(api):
         series_id = row.get("id")
         if not series_id:
             continue
-        if get_collection_status_for_series(series_id):
+        if not force and get_collection_status_for_series(series_id):
             continue  # already matched — leave it (and its Metron budget) alone
         worklist.append(row)
 
     if not worklist:
-        return
+        return 0
 
-    op_id = register_operation("match", "Matching library to issues", total=len(worklist))
+    label = "Re-matching library to issues" if force else "Matching library to issues"
+    op_id = register_operation("match", label, total=len(worklist))
     try:
         for index, row in enumerate(worklist):
-            update_operation(
-                op_id, current=index,
-                detail=row.get("name") or f"Series {row.get('id')}",
-            )
+            name = row.get("name") or f"Series {row.get('id')}"
+            update_operation(op_id, current=index, detail=name)
+            if progress_cb:
+                progress_cb(index, len(worklist), name)
+            if force:
+                # _sync_and_match already passes use_cache=False, but the DELETE
+                # matters anyway: save_collection_status_bulk is INSERT OR REPLACE
+                # and never deletes, so rows for issues that no longer exist would
+                # survive — and a series whose folder has since disappeared returns
+                # early from _sync_and_match, keeping its poisoned rows forever.
+                invalidate_collection_status_for_series(row["id"])
             _sync_and_match(api, row["id"])
         complete_operation(op_id)
     except Exception:
         complete_operation(op_id, error=True)
         raise
+    return len(worklist)
 
 
 def repair_volume_named_series(api):
@@ -921,3 +938,123 @@ def get_scan_job(op_id):
         _prune_jobs_locked()
         job = _jobs.get(op_id)
         return dict(job) if job else None
+
+
+def _run_rematch_job(op_id, app):
+    # Same contract as _run_scan_job: no context of its own, so push one.
+    with app.app_context():
+        _run_rematch_job_inner(op_id, app)
+
+
+def _run_rematch_job_inner(op_id, app):
+    """Force a re-match of every mapped series, then rebuild the wanted cache."""
+    try:
+        api = metron.get_flask_api(app)
+
+        def progress(current, total, name):
+            _update_job(op_id, current=current, total=total, detail=name)
+
+        rematched = match_unmatched_mapped_series(api, force=True, progress_cb=progress)
+        with _jobs_lock:
+            job = _jobs.get(op_id)
+            if job:
+                job.update(
+                    status="done",
+                    result={"rematched": rematched},
+                    current=job.get("total", 0),
+                    finished_at=time.time(),
+                )
+    except Exception as e:
+        app_logger.error(f"automap: rematch job {op_id} failed: {e}")
+        with _jobs_lock:
+            job = _jobs.get(op_id)
+            if job:
+                job.update(status="error", error=str(e), finished_at=time.time())
+        return
+
+    # Best-effort tail OUTSIDE the try, same rule as _run_scan_job_inner: the
+    # collection status is already rebuilt and the job is ``done``, so a
+    # wanted-cache rebuild failure must not flip it to ``error``.
+    #
+    # refresh_wanted_cache_background (not reconcile_wanted_for_series) is the
+    # right call here: reconcile only *removes* satisfied rows, but this
+    # correction runs the other way — issues that were wrongly reported as owned
+    # must be added back to wanted.
+    try:
+        from app import refresh_wanted_cache_background
+
+        refresh_wanted_cache_background()
+    except Exception as e:
+        app_logger.error(f"automap: rematch job {op_id} wanted rebuild failed: {e}")
+
+
+def start_rematch_job(app):
+    """Start a background full collection re-match. Returns the job id to poll.
+
+    Shares the scan job store, so the client polls /api/pull-list/scan/status.
+    """
+    op_id = uuid.uuid4().hex
+    with _jobs_lock:
+        _prune_jobs_locked()
+        _jobs[op_id] = {
+            "id": op_id,
+            "status": "running",
+            "current": 0,
+            "total": 0,
+            "detail": "Starting...",
+            "result": None,
+            "error": None,
+            "started_at": time.time(),
+        }
+    threading.Thread(target=_run_rematch_job, args=(op_id, app), daemon=True).start()
+    return op_id
+
+
+def rebuild_collection_status_if_empty(app):
+    """Repopulate an empty collection_status cache, then refresh wanted.
+
+    The one-time boundary purge (``core/database.py`` init_db) empties the cache
+    so the fixed matcher can rewrite it — but nothing rebuilds it until the user
+    opens each series page, so after the upgrade "On the Stack" (which reads
+    collection_status directly), the Pull List collection counts and every
+    series page come back blank.
+
+    Series whose issues are already cached re-match from the filesystem alone,
+    so this costs no API calls for an existing library. No-op when the cache
+    still holds rows. Returns the number of series matched.
+    """
+    with app.app_context():
+        try:
+            from core.database import count_collection_status_rows
+
+            if count_collection_status_rows():
+                return 0
+
+            rebuilt = match_unmatched_mapped_series(metron.get_flask_api(app))
+            if not rebuilt:
+                return 0
+            app_logger.info(
+                f"Rebuilt collection status for {rebuilt} series "
+                "(cache was empty after the issue-matching fix)"
+            )
+        except Exception as e:
+            app_logger.error(f"automap: collection status rebuild failed: {e}")
+            return 0
+
+        # Best-effort tail, outside the try for the same reason as the rematch
+        # job: the collection status is already rebuilt, and the wanted cache
+        # rebuilds itself on the next Wanted page view regardless.
+        try:
+            from app import refresh_wanted_cache_background
+
+            refresh_wanted_cache_background()
+        except Exception as e:
+            app_logger.error(f"automap: post-rebuild wanted refresh failed: {e}")
+        return rebuilt
+
+
+def start_collection_status_rebuild(app):
+    """Run :func:`rebuild_collection_status_if_empty` in a daemon thread."""
+    threading.Thread(
+        target=rebuild_collection_status_if_empty, args=(app,), daemon=True
+    ).start()

--- a/routes/series.py
+++ b/routes/series.py
@@ -437,6 +437,25 @@ def scan_library_automap_status():
     return jsonify(payload)
 
 
+@series_bp.route("/api/pull-list/rematch", methods=["POST"])
+def rematch_library_collection():
+    """Force a re-match of EVERY mapped series against the files on disk.
+
+    /api/pull-list/scan only folds in unmapped folders, and its tail skips any
+    series that already has a cached collection status — so a cache written by a
+    buggy matcher is never corrected. This discards the cached status for every
+    mapped series, re-runs the matcher, and rebuilds the wanted cache.
+
+    Returns an ``op_id`` the client polls via /api/pull-list/scan/status (the
+    re-match shares the scan job store).
+    """
+    from flask import current_app
+    from models import library_automap
+
+    op_id = library_automap.start_rematch_job(current_app._get_current_object())
+    return jsonify({"success": True, "op_id": op_id})
+
+
 @series_bp.route("/api/pull-list/apply", methods=["POST"])
 def apply_library_automap():
     """Apply user-selected review matches from the auto-map scan."""

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -15,6 +15,10 @@
                 title="Scan library folders and auto-map series from series.json / cvinfo sidecars">
                 <i class="bi bi-magic me-1"></i>Scan Library
             </button>
+            <button type="button" class="btn btn-outline-secondary" id="rematchFilesBtn"
+                title="Re-check every mapped series against the files on disk and rebuild owned/missing">
+                <i class="bi bi-arrow-repeat me-1"></i>Re-match Files
+            </button>
             <a href="{{ url_for('series.wanted') }}" class="btn btn-outline-warning">
                 <i class="bi bi-star me-1"></i>Wanted Issues
             </a>
@@ -402,6 +406,21 @@
                 .catch(err => showAutomapError(err.message));
         }
 
+        function startRematch() {
+            if (!automapModal) return;
+            resetAutomapUI();
+            document.getElementById('automapDetail').textContent =
+                'Re-matching every mapped series…';
+            automapModal.show();
+            fetch('/api/pull-list/rematch', { method: 'POST' })
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.success) throw new Error(data.error || 'Failed to start re-match');
+                    pollScan(data.op_id);
+                })
+                .catch(err => showAutomapError(err.message));
+        }
+
         function pollScan(opId) {
             let busy = false;  // skip a tick if the previous poll is still in-flight
             automapPoll = setInterval(() => {
@@ -441,6 +460,16 @@
         function renderResults(result) {
             document.getElementById('automapProgress').classList.add('d-none');
             document.getElementById('automapResults').classList.remove('d-none');
+
+            // Re-match job: a different result shape (no applied/review/skipped).
+            if (result && result.rematched !== undefined) {
+                document.getElementById('automapSummary').innerHTML =
+                    `<strong>Re-matched ${result.rematched}</strong> mapped series against the files on disk.`
+                    + `<div class="small text-muted mt-2"><i class="bi bi-hourglass-split me-1"></i>`
+                    + `Rebuilding the Wanted list in the background.</div>`;
+                document.getElementById('automapReload').classList.remove('d-none');
+                return;
+            }
 
             const applied = result.applied || 0;
             const reviewN = (result.review || []).length;
@@ -543,6 +572,8 @@
         if (scanBtn) scanBtn.addEventListener('click', startScan);
         const scanBtnEmpty = document.getElementById('scanLibraryBtnEmpty');
         if (scanBtnEmpty) scanBtnEmpty.addEventListener('click', startScan);
+        const rematchBtn = document.getElementById('rematchFilesBtn');
+        if (rematchBtn) rematchBtn.addEventListener('click', startRematch);
 
         if (automapModalEl) {
             automapModalEl.addEventListener('hidden.bs.modal', () => {

--- a/tests/integration/test_collection_status_matching.py
+++ b/tests/integration/test_collection_status_matching.py
@@ -1,0 +1,226 @@
+"""End-to-end matching of a series' issues against the files on disk.
+
+Covers helpers/collection.py: match_issues_to_collection. The reported bug was
+that issue #1 was satisfied by "Nightwing 051 (2016).cbz" - the compiled rename
+pattern had no leading digit boundary - and that one file could be claimed by
+many issues because matched files were never consumed.
+"""
+import pytest
+from tests.factories.db_factories import create_series, create_issue
+
+RENAME_PATTERN = "{series_name} {issue_number} ({volume_year})"
+
+
+def _objs(series_id):
+    from core.database import get_series_by_id, get_issues_for_series
+    from models.issue import IssueObj, SeriesObj
+
+    series = get_series_by_id(series_id)
+    issues = get_issues_for_series(series_id)
+    return [IssueObj(i) for i in issues], SeriesObj(series)
+
+
+def _setup(tmp_path, filenames, numbers, pattern=RENAME_PATTERN, name="Nightwing"):
+    from core.database import set_user_preference
+
+    if pattern is not None:
+        set_user_preference("custom_rename_pattern", pattern, category="file_processing")
+
+    series_dir = tmp_path / name
+    series_dir.mkdir()
+    for filename in filenames:
+        (series_dir / filename).write_bytes(b"stub")
+
+    series_id = create_series(name=name, volume=2016, mapped_path=str(series_dir))
+    for number in numbers:
+        create_issue(series_id=series_id, number=number)
+    return series_id, str(series_dir)
+
+
+class TestIssueNumberBoundary:
+    """A file must only satisfy the issue it actually is."""
+
+    def test_issue_one_is_not_satisfied_by_issue_51s_file(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Nightwing 051 (2016).cbz"], ["1", "51"]
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["51"]["found"] is True
+        assert status["1"]["found"] is False
+        assert status["1"]["file_path"] is None
+
+    def test_issue_ten_is_not_satisfied_by_issue_110s_file(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Nightwing 110 (2016).cbz"], ["10", "110"]
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["110"]["found"] is True
+        assert status["10"]["found"] is False
+
+    def test_owned_issues_map_to_their_own_file(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            ["Nightwing 051 (2016).cbz", "Nightwing 052 (2016).cbz"],
+            ["1", "51", "52"],
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["51"]["file_path"].endswith("Nightwing 051 (2016).cbz")
+        assert status["52"]["file_path"].endswith("Nightwing 052 (2016).cbz")
+        assert status["1"]["found"] is False
+
+
+class TestFileClaiming:
+    """A precise match consumes its file so it can't be reported twice."""
+
+    def test_one_file_is_claimed_by_only_one_issue(self, db_connection, tmp_path):
+        """Two issue rows that normalize to the same number ("7" and "07") both
+        compile to the same pattern. Only one may take the single file on disk -
+        without consumption both reported it and the series looked one issue
+        more complete than it was.
+
+        The filename has no separator before the number so the loose 4c fallback
+        (which deliberately does not consume) cannot rescue the second issue -
+        this isolates the precise-tier claim.
+        """
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Nightwing007 (2016).cbz"], ["7", "07"]
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        found_paths = [s["file_path"] for s in status.values() if s["found"]]
+        assert len(found_paths) == 1
+        assert len(found_paths) == len(set(found_paths))
+
+    def test_distinct_issues_keep_their_own_files(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            ["Nightwing 001 (2016).cbz", "Nightwing 002 (2016).cbz"],
+            ["1", "2"],
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["file_path"].endswith("Nightwing 001 (2016).cbz")
+        assert status["2"]["file_path"].endswith("Nightwing 002 (2016).cbz")
+
+    def test_duplicate_copies_do_not_starve_the_issue(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            ["Nightwing 001 (2016).cbz", "Nightwing 001 (2016) (Digital).cbz"],
+            ["1"],
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["found"] is True
+
+    def test_range_file_still_satisfies_multiple_issues(self, db_connection, tmp_path):
+        """The loose filename fallback must NOT consume: a collected/range file
+        legitimately covers several issues, and claiming it would mark the rest
+        missing and trigger re-downloads."""
+        from helpers.collection import match_issues_to_collection
+
+        # An empty rename pattern skips the precise tier entirely, so both
+        # issues resolve through the generic "[\s\-_]0*N" fallback.
+        series_id, path = _setup(
+            tmp_path, ["Nightwing 001-006 (2016).cbz"], ["1", "6"], pattern=""
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["found"] is True
+        assert status["6"]["found"] is True
+        assert status["1"]["file_path"] == status["6"]["file_path"]
+
+
+class TestPublicationTypeGuard:
+    """An annual/TPB in the series folder numbers its own issues from 1, so it
+    must not be offered to any matching tier as a regular issue."""
+
+    def test_annual_does_not_satisfy_issue_one(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Nightwing 2022 Annual Annual 001 (2023).cbz"], ["1"]
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["found"] is False
+        assert status["1"]["file_path"] is None
+
+    def test_annual_does_not_steal_the_real_issue_file(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            [
+                "Nightwing 2022 Annual Annual 001 (2023).cbz",
+                "Nightwing 001 (2016).cbz",
+            ],
+            ["1"],
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["file_path"].endswith("Nightwing 001 (2016).cbz")
+
+    def test_annual_is_not_rescued_by_the_loose_fallback(self, db_connection, tmp_path):
+        """Without a rename pattern the generic " 001 " fallback would match the
+        annual too, so the guard has to run before every tier."""
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            ["Nightwing 2022 Annual Annual 001 (2023).cbz"],
+            ["1"],
+            pattern="",
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["found"] is False
+
+    def test_annual_series_still_matches_its_own_issues(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            ["Nightwing 2022 Annual Annual 001 (2023).cbz"],
+            ["1"],
+            name="Nightwing 2022 Annual",
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["found"] is True

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -278,3 +278,79 @@ class TestForeignKeys:
 
         cur = db_connection.execute("SELECT COUNT(*) FROM issues WHERE series_id=999")
         assert cur.fetchone()[0] == 0
+
+
+class TestCollectionStatusBoundaryPurge:
+    """One-time purge of caches written by the pre-boundary issue matcher.
+
+    generate_filename_pattern had no leading digit boundary, so issue #1 matched
+    "Nightwing 051 (2016).cbz". The cached rows survive the code fix, so init_db
+    drops them once, guarded by a user_preferences marker.
+    """
+
+    def _seed_poisoned_cache(self, conn):
+        from tests.factories.db_factories import create_series, create_issue
+
+        series_id = create_series(name="Nightwing", mapped_path="/data/Nightwing")
+        issue_id = create_issue(series_id=series_id, number="1")
+
+        conn.execute(
+            "INSERT INTO collection_status "
+            "(series_id, issue_id, issue_number, found, file_path, matched_via) "
+            "VALUES (?, ?, '1', 1, '/data/Nightwing/Nightwing 051 (2016).cbz', 'pattern')",
+            (series_id, issue_id),
+        )
+        conn.execute(
+            "INSERT INTO wanted_issues (series_id, issue_id, issue_number) "
+            "VALUES (?, ?, '2')",
+            (series_id, issue_id),
+        )
+        conn.execute(
+            "DELETE FROM user_preferences WHERE key = 'collection_status_boundary_purge'"
+        )
+        conn.commit()
+        return series_id, issue_id
+
+    def _counts(self, conn):
+        cs = conn.execute("SELECT COUNT(*) FROM collection_status").fetchone()[0]
+        wi = conn.execute("SELECT COUNT(*) FROM wanted_issues").fetchone()[0]
+        return cs, wi
+
+    def test_purges_poisoned_rows_and_sets_marker(self, db_connection, db_path):
+        self._seed_poisoned_cache(db_connection)
+
+        with patch("core.database.get_db_path", return_value=db_path):
+            from core.database import init_db
+            assert init_db() is True
+
+        assert self._counts(db_connection) == (0, 0)
+        marker = db_connection.execute(
+            "SELECT value FROM user_preferences WHERE key='collection_status_boundary_purge'"
+        ).fetchone()
+        assert marker is not None
+
+    def test_does_not_repurge_once_marked(self, db_connection, db_path):
+        series_id, issue_id = self._seed_poisoned_cache(db_connection)
+
+        with patch("core.database.get_db_path", return_value=db_path):
+            from core.database import init_db
+            init_db()
+
+            # Rows written *after* the purge are freshly matched and must survive
+            # a later startup.
+            db_connection.execute(
+                "INSERT INTO collection_status "
+                "(series_id, issue_id, issue_number, found, file_path, matched_via) "
+                "VALUES (?, ?, '51', 1, '/data/Nightwing/Nightwing 051 (2016).cbz', 'pattern')",
+                (series_id, issue_id),
+            )
+            db_connection.execute(
+                "INSERT INTO wanted_issues (series_id, issue_id, issue_number) "
+                "VALUES (?, ?, '1')",
+                (series_id, issue_id),
+            )
+            db_connection.commit()
+
+            init_db()
+
+        assert self._counts(db_connection) == (1, 1)

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -866,7 +866,7 @@ class TestRematchJob:
             with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
                  patch.object(library_automap, "match_unmatched_mapped_series",
                               return_value=7) as m, \
-                 patch("app.refresh_wanted_cache_background"):
+                 patch.object(library_automap, "_refresh_wanted_cache"):
                 library_automap._run_rematch_job_inner(op_id, app=MagicMock())
             assert m.call_args.kwargs["force"] is True
             job = library_automap._jobs[op_id]
@@ -882,7 +882,7 @@ class TestRematchJob:
             with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
                  patch.object(library_automap, "match_unmatched_mapped_series",
                               return_value=1), \
-                 patch("app.refresh_wanted_cache_background") as refresh:
+                 patch.object(library_automap, "_refresh_wanted_cache") as refresh:
                 library_automap._run_rematch_job_inner(op_id, app=MagicMock())
             refresh.assert_called_once()
         finally:
@@ -897,8 +897,8 @@ class TestRematchJob:
             with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
                  patch.object(library_automap, "match_unmatched_mapped_series",
                               return_value=3), \
-                 patch("app.refresh_wanted_cache_background",
-                       side_effect=RuntimeError("boom")):
+                 patch.object(library_automap, "_refresh_wanted_cache",
+                              side_effect=RuntimeError("boom")):
                 library_automap._run_rematch_job_inner(op_id, app=MagicMock())
             job = library_automap._jobs[op_id]
             assert job["status"] == "done"
@@ -948,7 +948,7 @@ class TestCollectionStatusRebuild:
              patch.object(library_automap.metron, "get_flask_api", return_value=None), \
              patch.object(library_automap, "match_unmatched_mapped_series",
                           return_value=4) as m, \
-             patch("app.refresh_wanted_cache_background") as refresh:
+             patch.object(library_automap, "_refresh_wanted_cache") as refresh:
             rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
         assert rebuilt == 4
         # Not a forced re-match: the purge already emptied the table, so the
@@ -961,7 +961,7 @@ class TestCollectionStatusRebuild:
              patch.object(library_automap.metron, "get_flask_api", return_value=None), \
              patch.object(library_automap, "match_unmatched_mapped_series",
                           return_value=0), \
-             patch("app.refresh_wanted_cache_background") as refresh:
+             patch.object(library_automap, "_refresh_wanted_cache") as refresh:
             rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
         assert rebuilt == 0
         refresh.assert_not_called()
@@ -980,8 +980,8 @@ class TestCollectionStatusRebuild:
              patch.object(library_automap.metron, "get_flask_api", return_value=None), \
              patch.object(library_automap, "match_unmatched_mapped_series",
                           return_value=2), \
-             patch("app.refresh_wanted_cache_background",
-                   side_effect=RuntimeError("boom")):
+             patch.object(library_automap, "_refresh_wanted_cache",
+                          side_effect=RuntimeError("boom")):
             rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
         assert rebuilt == 2
 

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -434,6 +434,68 @@ class TestSyncAndMatch:
             library_automap.match_unmatched_mapped_series(api=None)
         reg.assert_not_called()
 
+    # --- force / progress_cb: the "Re-match Files" path -------------------
+
+    def test_force_rematches_already_matched_series(self):
+        rows = [{"id": 1, "name": "Batman"}, {"id": 2, "name": "Saga"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series",
+                   return_value=[{"issue_number": "1"}]), \
+             patch("core.database.invalidate_collection_status_for_series") as inv, \
+             patch.object(library_automap, "_sync_and_match") as sm:
+            n = library_automap.match_unmatched_mapped_series(api=None, force=True)
+        assert n == 2
+        assert [c.args[1] for c in sm.call_args_list] == [1, 2]
+        assert [c.args[0] for c in inv.call_args_list] == [1, 2]
+
+    def test_force_invalidates_before_matching(self):
+        # Order matters: the DELETE must precede the re-match so rows for issues
+        # that no longer exist can't survive the INSERT OR REPLACE.
+        calls = []
+        rows = [{"id": 7, "name": "Batman"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch("core.database.invalidate_collection_status_for_series",
+                   side_effect=lambda sid: calls.append(("invalidate", sid))), \
+             patch.object(library_automap, "_sync_and_match",
+                          side_effect=lambda api, sid: calls.append(("match", sid))):
+            library_automap.match_unmatched_mapped_series(api=None, force=True)
+        assert calls == [("invalidate", 7), ("match", 7)]
+
+    def test_non_force_does_not_invalidate(self):
+        rows = [{"id": 1, "name": "Batman"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch("core.database.invalidate_collection_status_for_series") as inv, \
+             patch.object(library_automap, "_sync_and_match"):
+            library_automap.match_unmatched_mapped_series(api=None)
+        inv.assert_not_called()
+
+    def test_progress_cb_receives_each_series(self):
+        seen = []
+        rows = [{"id": 1, "name": "Batman"}, {"id": 2, "name": "Saga"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch("core.database.invalidate_collection_status_for_series"), \
+             patch.object(library_automap, "_sync_and_match"):
+            library_automap.match_unmatched_mapped_series(
+                api=None, force=True,
+                progress_cb=lambda c, t, n: seen.append((c, t, n)),
+            )
+        assert seen == [(0, 2, "Batman"), (1, 2, "Saga")]
+
+    def test_force_label_is_rematch(self):
+        rows = [{"id": 1, "name": "Batman"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch("core.database.invalidate_collection_status_for_series"), \
+             patch.object(library_automap, "_sync_and_match"), \
+             patch("core.app_state.register_operation", return_value="op1") as reg, \
+             patch("core.app_state.update_operation"), \
+             patch("core.app_state.complete_operation"):
+            library_automap.match_unmatched_mapped_series(api=None, force=True)
+        assert reg.call_args.args[1] == "Re-matching library to issues"
+
 
 class TestDefaultMonitorOff:
     """On import, a fully-owned Cancelled/Completed series defaults Monitor off."""
@@ -786,3 +848,145 @@ class TestScanJobResilience:
             assert "walk blew up" in job["error"]
         finally:
             library_automap._jobs.pop(op_id, None)
+
+
+class TestRematchJob:
+    """_run_rematch_job_inner mirrors the scan job's resilience contract."""
+
+    def _seed_job(self, op_id):
+        library_automap._jobs[op_id] = {
+            "id": op_id, "status": "running", "current": 0, "total": 0,
+            "detail": "", "result": None, "error": None,
+        }
+
+    def test_job_done_with_rematched_count(self):
+        op_id = "test-rematch-done"
+        self._seed_job(op_id)
+        try:
+            with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+                 patch.object(library_automap, "match_unmatched_mapped_series",
+                              return_value=7) as m, \
+                 patch("app.refresh_wanted_cache_background"):
+                library_automap._run_rematch_job_inner(op_id, app=MagicMock())
+            assert m.call_args.kwargs["force"] is True
+            job = library_automap._jobs[op_id]
+            assert job["status"] == "done"
+            assert job["result"]["rematched"] == 7
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_wanted_cache_is_rebuilt_on_success(self):
+        op_id = "test-rematch-wanted"
+        self._seed_job(op_id)
+        try:
+            with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+                 patch.object(library_automap, "match_unmatched_mapped_series",
+                              return_value=1), \
+                 patch("app.refresh_wanted_cache_background") as refresh:
+                library_automap._run_rematch_job_inner(op_id, app=MagicMock())
+            refresh.assert_called_once()
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_wanted_rebuild_failure_keeps_job_done(self):
+        # The tail runs OUTSIDE the try; a wanted-rebuild blow-up must not
+        # discard a completed re-match.
+        op_id = "test-rematch-tail-fail"
+        self._seed_job(op_id)
+        try:
+            with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+                 patch.object(library_automap, "match_unmatched_mapped_series",
+                              return_value=3), \
+                 patch("app.refresh_wanted_cache_background",
+                       side_effect=RuntimeError("boom")):
+                library_automap._run_rematch_job_inner(op_id, app=MagicMock())
+            job = library_automap._jobs[op_id]
+            assert job["status"] == "done"
+            assert job["error"] is None
+            assert job["result"]["rematched"] == 3
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_match_failure_marks_job_error(self):
+        op_id = "test-rematch-fail"
+        self._seed_job(op_id)
+        try:
+            with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+                 patch.object(library_automap, "match_unmatched_mapped_series",
+                              side_effect=RuntimeError("db gone")):
+                library_automap._run_rematch_job_inner(op_id, app=MagicMock())
+            job = library_automap._jobs[op_id]
+            assert job["status"] == "error"
+            assert "db gone" in job["error"]
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_start_rematch_job_registers_and_returns_id(self):
+        with patch.object(library_automap.threading, "Thread") as T:
+            op_id = library_automap.start_rematch_job(MagicMock())
+        try:
+            assert library_automap._jobs[op_id]["status"] == "running"
+            T.assert_called_once()
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+
+class TestCollectionStatusRebuild:
+    """rebuild_collection_status_if_empty repairs the cache the one-time
+    boundary purge emptied. Without it On the Stack, the Pull List counts and
+    the series pages stay blank until every series page is opened by hand."""
+
+    def test_no_op_when_cache_still_has_rows(self):
+        with patch("core.database.count_collection_status_rows", return_value=42), \
+             patch.object(library_automap, "match_unmatched_mapped_series") as m:
+            rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
+        assert rebuilt == 0
+        m.assert_not_called()
+
+    def test_rebuilds_when_cache_is_empty(self):
+        with patch("core.database.count_collection_status_rows", return_value=0), \
+             patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+             patch.object(library_automap, "match_unmatched_mapped_series",
+                          return_value=4) as m, \
+             patch("app.refresh_wanted_cache_background") as refresh:
+            rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
+        assert rebuilt == 4
+        # Not a forced re-match: the purge already emptied the table, so the
+        # plain "series without cached status" worklist covers everything.
+        assert m.call_args.kwargs.get("force") is None
+        refresh.assert_called_once()
+
+    def test_nothing_to_rebuild_skips_the_wanted_refresh(self):
+        with patch("core.database.count_collection_status_rows", return_value=0), \
+             patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+             patch.object(library_automap, "match_unmatched_mapped_series",
+                          return_value=0), \
+             patch("app.refresh_wanted_cache_background") as refresh:
+            rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
+        assert rebuilt == 0
+        refresh.assert_not_called()
+
+    def test_match_failure_is_swallowed(self):
+        # Runs on the startup thread: a failure must never take the app down.
+        with patch("core.database.count_collection_status_rows", return_value=0), \
+             patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+             patch.object(library_automap, "match_unmatched_mapped_series",
+                          side_effect=RuntimeError("db gone")):
+            rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
+        assert rebuilt == 0
+
+    def test_wanted_refresh_failure_keeps_the_rebuild(self):
+        with patch("core.database.count_collection_status_rows", return_value=0), \
+             patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+             patch.object(library_automap, "match_unmatched_mapped_series",
+                          return_value=2), \
+             patch("app.refresh_wanted_cache_background",
+                   side_effect=RuntimeError("boom")):
+            rebuilt = library_automap.rebuild_collection_status_if_empty(MagicMock())
+        assert rebuilt == 2
+
+    def test_start_collection_status_rebuild_spawns_a_daemon_thread(self):
+        with patch.object(library_automap.threading, "Thread") as T:
+            library_automap.start_collection_status_rebuild(MagicMock())
+        T.assert_called_once()
+        assert T.call_args.kwargs["daemon"] is True

--- a/tests/routes/test_pull_list_automap.py
+++ b/tests/routes/test_pull_list_automap.py
@@ -66,6 +66,36 @@ class TestScanStatusRoute:
         assert data["error"] == "boom"
 
 
+class TestRematchRoute:
+    """POST /api/pull-list/rematch — force a re-match of every mapped series.
+
+    The scan tail skips series that already have a cached collection status, so
+    this is the only way to rebuild a cache a buggy matcher wrote.
+    """
+
+    def test_rematch_starts_job(self, client):
+        with patch("models.library_automap.start_rematch_job",
+                   return_value="rm123") as start:
+            resp = client.post("/api/pull-list/rematch")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["op_id"] == "rm123"
+        start.assert_called_once()
+
+    def test_rematch_is_post_only(self, client):
+        assert client.get("/api/pull-list/rematch").status_code == 405
+
+    def test_rematch_job_polls_via_scan_status(self, client):
+        # The rematch job lives in the same _jobs store, so the existing status
+        # endpoint must hand back its result shape unchanged.
+        job = {"status": "done", "current": 12, "total": 12, "detail": "",
+               "result": {"rematched": 12}}
+        with patch("models.library_automap.get_scan_job", return_value=job):
+            resp = client.get("/api/pull-list/scan/status?op_id=rm123")
+        assert resp.get_json()["result"]["rematched"] == 12
+
+
 class TestApplyRoute:
     def test_no_items_is_400(self, client):
         resp = client.post("/api/pull-list/apply", json={"items": []})

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -15,6 +15,7 @@ from helpers.collection import (
     strip_month_token,
     strip_empty_groups,
     build_series_match_names,
+    names_other_publication_type,
 )
 
 
@@ -400,3 +401,156 @@ class TestAliasMatching:
             generate_filename_pattern(match_pattern, n, "11") for n in names
         ]
         assert any(r.match("Thor 011.cbz") for r in regexes)
+
+
+# ---- issue-number boundary ----------------------------------------------
+
+class TestIssueNumberBoundary:
+    """The issue number must be a whole number, never a fragment of a longer one.
+
+    Regression: the compiled pattern had a trailing (?!\\d) but no leading
+    boundary, and the literal space between the series and issue groups became
+    ".+?". So issue #1 matched 'Nightwing 051 (2016).cbz' (".+?" ate " 05") and
+    the series page showed issues 001-040 as owned, every one of them opening
+    #51's file.
+    """
+
+    def _regex(self, number, name="Nightwing"):
+        return generate_filename_pattern(
+            "{series_name} {issue_number} ({volume_year})", name, number
+        )
+
+    def test_issue_1_does_not_match_051(self):
+        assert not self._regex("1").match("Nightwing 051 (2016).cbz")
+
+    def test_issue_1_does_not_match_101(self):
+        assert not self._regex("1").match("Nightwing 101 (2016).cbz")
+
+    def test_issue_10_does_not_match_110(self):
+        assert not self._regex("10").match("Nightwing 110 (2016).cbz")
+
+    def test_issue_0_does_not_match_100(self):
+        assert not self._regex("0").match("Nightwing 100 (2016).cbz")
+
+    def test_issue_1_still_matches_its_own_file(self):
+        assert self._regex("1").match("Nightwing 001 (2016).cbz")
+        assert self._regex("1").match("Nightwing 1 (2016).cbz")
+
+    def test_issue_51_still_matches_051(self):
+        assert self._regex("51").match("Nightwing 051 (2016).cbz")
+
+    def test_issue_10_still_matches_010(self):
+        assert self._regex("10").match("Nightwing 010 (2016).cbz")
+
+    def test_volume_token_in_filename_still_matches(self):
+        # The separator must still absorb a "v4" volume token, digits and all.
+        assert self._regex("1").match("Nightwing v4 001 (2016).cbz")
+
+    def test_digits_in_series_name_still_match(self):
+        assert self._regex("44", "Spider-Man 2099").match(
+            "Spider-Man 2099 044 (1992).cbz"
+        )
+        assert self._regex("1", "Top 10").match("Top 10 001 (1999).cbz")
+
+    def test_series_name_digits_are_not_read_as_the_issue(self):
+        assert not self._regex("2099", "Spider-Man 2099").match(
+            "Spider-Man 2099 044 (1992).cbz"
+        )
+        assert not self._regex("1", "Top 10").match("Top 10 010 (1999).cbz")
+
+    def test_whole_issue_does_not_claim_point_issue_file(self):
+        assert not self._regex("1").match("Nightwing 001.1 (2016).cbz")
+
+    def test_point_issue_matches_its_own_file(self):
+        assert self._regex("1.1").match("Nightwing 001.1 (2016).cbz")
+
+    def test_dot_between_name_and_number_still_matches(self):
+        # The leading guard rejects the "1" of "051" without rejecting a dot
+        # used as a name/number separator.
+        assert self._regex("1").match("Nightwing.001 (2016).cbz")
+
+    def test_no_separator_filename_still_matches(self):
+        # Guards the ".+?" -> ".*?" change: the separator may be empty.
+        assert self._regex("1").match("Nightwing001 (2016).cbz")
+
+
+class TestIssueNumberBoundaryWithoutYear:
+    """Same boundary rules on the year-stripped (wanted-matching) pattern,
+    where the trailing ".*" makes over-matching easier."""
+
+    def _regex(self, number):
+        return generate_filename_pattern(
+            strip_year_token("{series_name} {issue_number} ({volume_year})"),
+            "Nightwing", number,
+        )
+
+    def test_issue_1_does_not_match_051(self):
+        assert not self._regex("1").match("Nightwing 051.cbz")
+
+    def test_issue_10_does_not_match_110(self):
+        assert not self._regex("10").match("Nightwing 110.cbz")
+
+    def test_issue_1_does_not_claim_point_issue_file(self):
+        assert not self._regex("1").match("Nightwing 001.5.cbz")
+
+    def test_point_issue_matches_its_own_file(self):
+        assert self._regex("1.5").match("Nightwing 001.5.cbz")
+
+    def test_plain_file_still_matches(self):
+        assert self._regex("1").match("Nightwing 001.cbz")
+        assert self._regex("1").match("Nightwing 001 - The Dawn.cbz")
+
+
+class TestNamesOtherPublicationType:
+    """helpers.collection.names_other_publication_type.
+
+    "Nightwing 2022 Annual Annual 001 (2023).cbz" was being matched as
+    Nightwing #1: every matching tier tolerates arbitrary text between the
+    series name and the issue number, and an annual restarts at 1.
+    """
+
+    def test_annual_is_other_publication_for_the_main_series(self):
+        assert names_other_publication_type(
+            "Nightwing 2022 Annual Annual 001 (2023).cbz", "Nightwing"
+        )
+
+    def test_annual_series_keeps_its_own_annual(self):
+        assert not names_other_publication_type(
+            "Nightwing 2022 Annual Annual 001 (2023).cbz", "Nightwing 2022 Annual"
+        )
+
+    def test_plain_issue_is_not_flagged(self):
+        assert not names_other_publication_type(
+            "Nightwing 001 (2016).cbz", "Nightwing"
+        )
+
+    def test_release_tags_do_not_trip_the_check(self):
+        # Only the text before the first "(" is considered, so scene tags that
+        # happen to carry a format word can't disqualify a real issue file.
+        assert not names_other_publication_type(
+            "Nightwing 001 (2016) (Digital) (Deluxe-Empire).cbz", "Nightwing"
+        )
+
+    def test_tpb_is_other_publication(self):
+        assert names_other_publication_type(
+            "Nightwing TPB Vol 01 (2017).cbz", "Nightwing"
+        )
+
+    def test_plural_form_is_detected(self):
+        assert names_other_publication_type(
+            "Nightwing Annuals 001 (2023).cbz", "Nightwing"
+        )
+
+    def test_issue_title_adjective_is_not_flagged(self):
+        # "absolute"/"deluxe"/"prestige" live in the GetComics VARIANT_TYPES
+        # list but are ordinary issue-title words ("Absolute Power"). Flagging
+        # them would report an owned issue as missing and re-download it.
+        assert not names_other_publication_type(
+            "Nightwing 117 - Absolute Power (2024).cbz", "Nightwing"
+        )
+
+    def test_keyword_inside_a_word_is_not_a_match(self):
+        # Whole-word only: "Annualized" must not disqualify the file.
+        assert not names_other_publication_type(
+            "Nightwing Annualized 001 (2023).cbz", "Nightwing"
+        )


### PR DESCRIPTION
## The bug

On `/series/nightwing-v4-981` the collection scan reported issues 001–040 as owned when none of 001–050 are, and "View CBZ Info" opened the wrong archive — #1 showed #51's file, #10 showed #110's.

`generate_filename_pattern()` built the issue-number regex with a trailing digit boundary but **no leading one**, and rewrote the literal space between the series and issue groups into a lazy wildcard. For the shipped pattern `{series_name} {issue_number} ({volume_year})`, Nightwing #1 compiled to:

```
(?:Nightwing).+?(0*1(?!\d)) \(\d{4}\).*\.(?:cbz|cbr|zip|rar)$
```

`.+?` ate `" 05"`, `0*` matched empty, and `1` matched the trailing digit of `051`.

Both consumers were poisoned: `collection_status` (owned/missing, Pull List counts, auto-unmonitor) and `wanted_issues` — which is why the genuinely missing issues never appeared as wanted or got downloaded.

## Changes

**`helpers/collection.py`**
- Issue number anchored on both sides: `(?<!\d)(?<!\d\.)0*N(?!\d)(?!\.\d)`. Separator relaxed `.+?` → `.*?` so a file with no separator (`Nightwing001.cbz`) still matches.
- One file, one issue: a precise tier (rename pattern / ComicInfo) now consumes its file. The loose filename fallback deliberately does **not** — a collected range file (`Nightwing 001-006.cbz`) legitimately satisfies several issues.
- New `names_other_publication_type()`: `Nightwing 2022 Annual Annual 001 (2023).cbz` was matched as Nightwing #1 by *all three* tiers (wildcard separator in 4a, substring series compare in 4b, bare `" 001 "` in 4c). Annuals/TPBs renumber from 1, so the file is excluded from the pool before any tier sees it. Applied to the wanted matcher too, where the same confusion would **move and rename** a downloaded annual into the series folder.

**`core/database.py`** — one-time purge of `collection_status` + `wanted_issues`, gated on a `user_preferences` marker. Both are pure derived caches; manual owned/skipped lives in `issue_manual_status` and is untouched.

**`models/library_automap.py` + `app.py`** — `rebuild_collection_status_if_empty()` runs at startup. `get_on_the_stack_items` reads `collection_status` directly, so the purge alone left the collection dashboard, Pull List counts and every series page blank until each was opened by hand. API-free for a library whose issues are already cached; no-ops once the cache has rows.

**`routes/series.py` + `templates/pull_list.html`** — new **Re-match Files** button (`POST /api/pull-list/rematch`). Scan Library skips series that already have cached status, so it can never correct a cache a buggy matcher wrote. Reuses the existing job store, modal and progress polling, then rebuilds the wanted cache via `refresh_wanted_cache_background`.

## Deliberate trade-offs

- The keyword list for the publication-type guard is `PUBLICATION_TYPES` (user-editable) plus a fixed collected-edition set — **not** the wider `VARIANT_TYPES` used by the GetComics scorer. That list carries adjectives (`absolute`, `deluxe`, `prestige`, `gallery`) that appear in real issue titles; `Nightwing 117 - Absolute Power (2024).cbz` would have been excluded and re-downloaded.
- Only the filename text before the first `(` is scanned, so release tags (`(2023) (Digital) (Deluxe-Empire)`) can't disqualify a real issue file.
- `(?!\.\d)` means a filename that is *both* dot-separated and year-stripped (`Nightwing.001.2016.cbz`) no longer matches on the rename-pattern tier. CLU's renamer never produces that form and the ComicInfo tier still covers it.

## Upgrade path

`init_db()` (app.py:190) completes the purge before `start_background_services()` (app.py:8509) spawns the rebuild thread, so the ordering is deterministic — the Stack repopulates progressively during startup rather than going blank. Users can also click **Re-match Files** at any time.

## Tests

`2931 passed, 6 skipped` — full suite, no failures.

- `tests/unit/test_filename_pattern.py` — issue-number boundary matrix (with and without the year token) + 8 tests for the publication-type guard, including the "Absolute Power" false-positive case
- `tests/integration/test_collection_status_matching.py` (new) — the reported bug end-to-end, file claiming, range files, and the annual through each tier
- `tests/integration/test_database_schema.py` — purge migration runs once and sets its marker
- `tests/routes/test_pull_list_automap.py` — the new route (project rule: every new route gets a routes test)
- `tests/mocked/test_library_automap.py` — `force`/`progress_cb`, the rematch job's resilience contract, and the startup rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)
