### PR TITLE
Series page: Add Delete Issue Option to Dropdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,19 @@ tests/
 - Bootswatch themes (26 themes supported)
 - Bootstrap 5 with custom CSS in `static/css/`
 
+#### User Feedback — never use native JS dialogs
+**Never** use `alert()`, `confirm()`, or `prompt()`. Always use a Bootstrap **Modal**
+(confirmations, anything needing a decision or input) or a **Toast** (success,
+error, and status messages).
+
+- Confirmations: `CLU.showDeleteConfirmation()` / the `window._cluDelete` contract
+  (`static/js/clu-delete.js` + `partials/modal_delete_confirm.html`), or a
+  purpose-built modal in the page template.
+- Messages: `CLU.showToast(title, message, type)`, `CLU.showSuccess()`,
+  `CLU.showError()` from `static/js/clu-utils.js`.
+- A page using toasts must include `partials/toast_container.html`, otherwise
+  `CLU.showToast` falls back to `alert()`.
+
 ## Configuration
 
 Settings in `core/config.py` define defaults merged with `/config/config.ini`. Key settings:

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -884,6 +884,85 @@ def reconcile_wanted_for_series(series_id):
         return 0
 
 
+def rebuild_wanted_for_series(series_id):
+    """
+    Recompute the wanted cache for one series from what is actually on disk.
+
+    reconcile_wanted_for_series only *removes* rows that a file now satisfies, so
+    it can't put an issue back on the wanted list after its file is deleted. This
+    rewrites the series' rows in both directions — the same computation
+    ``app.refresh_wanted_cache_background`` performs for every series, scoped to
+    one — so a deleted issue is wanted again immediately instead of waiting for
+    the next full refresh.
+
+    Args:
+        series_id: Metron series ID
+
+    Returns:
+        Number of wanted issues cached for the series.
+    """
+    from core.database import (
+        get_series_by_id,
+        get_issues_for_series,
+        invalidate_collection_status_for_series,
+        get_manual_status_for_series,
+        save_wanted_issues_for_series,
+    )
+    from models.issue import IssueObj, SeriesObj
+
+    if not series_id:
+        return 0
+
+    try:
+        series = get_series_by_id(series_id)
+        if not series:
+            return 0
+
+        mapped_path = series.get("mapped_path")
+        if not mapped_path or not os.path.exists(mapped_path):
+            return 0
+
+        issues = get_issues_for_series(series_id)
+        if not issues:
+            return 0
+
+        # Force a fresh scan so the just-changed folder is re-read.
+        invalidate_collection_status_for_series(series_id)
+
+        # Unmonitored series carry no wanted rows — the nightly rebuild clears
+        # the cache and then skips them, so mirror that end state here.
+        if series.get("monitored") == 0:
+            save_wanted_issues_for_series(
+                series_id, series.get("name", ""), series.get("volume"), []
+            )
+            return 0
+
+        issue_objs = [IssueObj(i) for i in issues]
+        series_obj = SeriesObj(series)
+        status = match_issues_to_collection(mapped_path, issue_objs, series_obj)
+        manual_status = get_manual_status_for_series(series_id)
+
+        wanted_list = []
+        for issue in issues:
+            issue_num = str(issue.get("number", ""))
+            if status.get(issue_num, {}).get("found"):
+                continue
+            if issue_num in manual_status:
+                continue
+            wanted_list.append(issue)
+
+        save_wanted_issues_for_series(
+            series_id, series.get("name", ""), series.get("volume"), wanted_list
+        )
+        app_logger.info(
+            f"Rebuilt wanted cache for series {series_id}: {len(wanted_list)} wanted"
+        )
+        return len(wanted_list)
+    except Exception as e:
+        app_logger.error(f"Failed to rebuild wanted for series {series_id}: {e}")
+        return 0
+
+
 def _series_id_for_path(file_path):
     """
     Resolve the mapped series that owns a file (or directory) path.

--- a/routes/series.py
+++ b/routes/series.py
@@ -1293,6 +1293,88 @@ def check_series_collection(series_id):
         return jsonify({"error": str(e)}), 500
 
 
+@series_bp.route(
+    "/api/series/<int:series_id>/issue/<issue_number>/delete-file", methods=["POST"]
+)
+def delete_issue_file(series_id, issue_number):
+    """
+    Delete an issue's file from the collection and put the issue back on the
+    wanted list.
+
+    The file goes to the trash (honouring the trash settings), any manual
+    owned/skipped mark is cleared, and the series' collection-status and wanted
+    caches are rebuilt — so the issue shows as Wanted on the series page and is
+    picked up again by auto-download.
+
+    Body:
+        path: Path of the file to delete (absolute, or relative to the mapped
+              folder). Must resolve inside this series' mapped folder.
+    """
+    from core.database import get_series_mapping, clear_manual_status
+    from helpers.collection import rebuild_wanted_for_series
+    from helpers.trash import move_to_trash
+
+    data = request.get_json(silent=True) or {}
+    file_path = (data.get("path") or "").strip()
+    if not file_path:
+        return jsonify({"error": "Missing file path"}), 400
+
+    mapped_path = get_series_mapping(series_id)
+    if not mapped_path:
+        return jsonify({"error": "Series not mapped"}), 404
+
+    target = (
+        file_path
+        if os.path.isabs(file_path)
+        else os.path.join(mapped_path, file_path)
+    )
+
+    # Only files inside the series' own folder can be deleted through here —
+    # the path comes from the browser, so it can't be trusted on its own.
+    real_target = os.path.normcase(os.path.realpath(target))
+    real_root = os.path.normcase(os.path.realpath(mapped_path))
+    if real_target != real_root and not real_target.startswith(real_root + os.sep):
+        app_logger.error(
+            f"Refused to delete {target}: outside mapped folder for series {series_id}"
+        )
+        return jsonify({"error": "File is not inside the mapped series folder"}), 403
+
+    if os.path.isdir(target):
+        return jsonify({"error": "Path is a directory, not an issue file"}), 400
+
+    if not os.path.exists(target):
+        return jsonify({"error": "File does not exist"}), 404
+
+    try:
+        result = move_to_trash(target)
+    except Exception as e:
+        app_logger.error(f"Error deleting issue file {target}: {e}")
+        return jsonify({"error": str(e)}), 500
+
+    try:
+        from app import update_index_on_delete
+
+        update_index_on_delete(target)
+    except Exception as e:
+        app_logger.error(f"Failed to update file index for {target}: {e}")
+
+    # A leftover "owned" mark would keep the issue off the wanted list.
+    clear_manual_status(series_id, issue_number)
+
+    wanted_count = rebuild_wanted_for_series(series_id)
+    app_logger.info(
+        f"Deleted file for series {series_id} issue {issue_number}: {target}"
+    )
+
+    return jsonify(
+        {
+            "success": True,
+            "trashed": result.get("trashed", False),
+            "wanted_count": wanted_count,
+        }
+    )
+
+
 # =============================================================================
 # Manual Status
 # =============================================================================

--- a/static/js/clu-delete.js
+++ b/static/js/clu-delete.js
@@ -47,7 +47,8 @@
    * Show a single-file delete confirmation modal.
    * @param {string} path  - Full file path
    * @param {string} name  - Display name
-   * @param {Object} [options] - { size: number, type: string, showDetails: boolean }
+   * @param {Object} [options] - { size: number, type: string, showDetails: boolean,
+   *                               note: string }
    */
   CLU.showDeleteConfirmation = function (path, name, options) {
     _currentDeletePath = path;
@@ -72,6 +73,19 @@
         if (pathEl) pathEl.textContent = path;
       } else {
         detailsEl.style.display = 'none';
+      }
+    }
+
+    // Extra consequence the caller wants spelled out (e.g. "the issue goes
+    // back on the wanted list"). Hidden unless a note is supplied.
+    var noteEl = document.getElementById('deleteExtraNote');
+    if (noteEl) {
+      if (opts.note) {
+        noteEl.textContent = opts.note;
+        noteEl.style.display = '';
+      } else {
+        noteEl.textContent = '';
+        noteEl.style.display = 'none';
       }
     }
 

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -514,6 +514,11 @@ function refreshCollectionStatus() {
                                                             onclick="executeIssueScript('add', '${escapedPath}'); return false;">
                                                             <i class="bi bi-file-plus me-2"></i>Add Blank to End
                                                         </a></li>
+                                                    <li><hr class="dropdown-divider"></li>
+                                                    <li><a class="dropdown-item text-danger" href="#"
+                                                            onclick="deleteIssueFile('${escapedPath}', '${issueNum}'); return false;">
+                                                            <i class="bi bi-trash me-2"></i>Delete Issue
+                                                        </a></li>
                                                 </ul>
                                             </div>
                                         </div>
@@ -650,6 +655,46 @@ function executeIssueScript(scriptType, filePath) {
         onError: function () {}
     };
     CLU.executeStreamingOp(scriptType, filePath);
+}
+
+/**
+ * Delete an issue's file from the collection and mark the issue as wanted again.
+ * The file is moved to the trash and any manual owned/skipped mark is cleared.
+ * @param {string} filePath - Full path to the file
+ * @param {string} issueNumber - Issue number the file satisfies
+ */
+function deleteIssueFile(filePath, issueNumber) {
+    if (!seriesData || !seriesData.id) {
+        console.error('No series data available');
+        return;
+    }
+    if (!window.CLU || typeof CLU.showDeleteConfirmation !== 'function') {
+        console.error('clu-delete.js not loaded');
+        return;
+    }
+
+    const fileName = filePath.split('/').pop();
+
+    // Contract for clu-delete.js — set per call because the endpoint carries
+    // the issue number.
+    window._cluDelete = {
+        deleteEndpoint: `/api/series/${seriesData.id}/issue/${encodeURIComponent(issueNumber)}/delete-file`,
+        deletePayload: function (path) {
+            return { path: path };
+        },
+        onDeleteComplete: function () {
+            CLU.showSuccess(`Deleted — issue #${issueNumber} is wanted again`);
+            // Re-scan the folder so the row flips to Wanted.
+            refreshCollectionStatus();
+        },
+        onDeleteError: function (path, error) {
+            CLU.showError('Failed to delete issue: ' + (error || 'Unknown error'));
+        }
+    };
+
+    CLU.showDeleteConfirmation(filePath, fileName, {
+        note: `Issue #${issueNumber} goes back on the wanted list.`
+    });
 }
 
 /**

--- a/templates/partials/modal_delete_confirm.html
+++ b/templates/partials/modal_delete_confirm.html
@@ -14,6 +14,8 @@
           <strong>Path:</strong> <span id="deleteFilePath" class="text-break"></span>
         </div>
         <p class="text-warning"><i class="bi bi-trash3"></i> This file will be moved to the Trash.</p>
+        <!-- Optional caller-supplied note (CLU.showDeleteConfirmation options.note) -->
+        <p id="deleteExtraNote" class="text-muted small mb-0" style="display: none;"></p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/templates/series.html
+++ b/templates/series.html
@@ -372,6 +372,13 @@
                                                     onclick="executeIssueScript('add', '{{ status.get('file_path')|replace('\\', '/')|e }}'); return false;">
                                                     <i class="bi bi-file-plus me-2"></i>Add Blank to End
                                                 </a></li>
+                                            <li>
+                                                <hr class="dropdown-divider">
+                                            </li>
+                                            <li><a class="dropdown-item text-danger" href="#"
+                                                    onclick="deleteIssueFile('{{ status.get('file_path')|replace('\\', '/')|e }}', '{{ issue.number }}'); return false;">
+                                                    <i class="bi bi-trash me-2"></i>Delete Issue
+                                                </a></li>
                                         </ul>
                                     </div>
                                 </div>
@@ -487,6 +494,10 @@
 
 <!-- CBZ Info Modal (shared partial – driven by clu-cbz-info.js) -->
 {% include 'partials/modal_cbz_info.html' %}
+
+<!-- Delete Confirmation Modal (shared partial – driven by clu-delete.js) -->
+<!-- CLU.showToast writes into the .toast-container already defined below. -->
+{% include 'partials/modal_delete_confirm.html' %}
 
 <!-- Mark Issue Modal -->
 <div class="modal fade" id="markIssueModal" tabindex="-1" aria-labelledby="markIssueModalLabel" aria-hidden="true">
@@ -1549,6 +1560,7 @@
 <script src="{{ url_for('static', filename='js/clu-cbz-crop.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-edit.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-info.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-delete.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/files.js') }}?v={{ range(1000, 9999) | random }}&t=202502"></script>
 <script src="{{ url_for('static', filename='js/series.js') }}?v={{ range(1, 10000) | random }}"></script>
 {% endblock %}

--- a/tests/integration/test_reconcile_wanted.py
+++ b/tests/integration/test_reconcile_wanted.py
@@ -95,6 +95,71 @@ class TestReconcileWantedForSeries:
         assert "5" in remaining
 
 
+class TestRebuildWantedForSeries:
+    """Unlike reconcile (prune-only), rebuild must also add issues back."""
+
+    def test_deleted_file_returns_to_wanted(self, db_connection, tmp_path):
+        from core.database import save_wanted_issues_for_series, get_cached_wanted_issues
+        from helpers.collection import rebuild_wanted_for_series
+
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        series_id = create_series(name="Batman", mapped_path=str(series_dir))
+        create_issue(series_id=series_id, number="5")
+        id6 = create_issue(series_id=series_id, number="6")
+
+        # #5 satisfied by a file, #6 outstanding.
+        issue_file = series_dir / "Batman #5.cbz"
+        issue_file.write_bytes(b"stub")
+        save_wanted_issues_for_series(series_id, "Batman", 2020, [_wanted(id6, "6")])
+
+        # The file is deleted -> #5 must come back on the wanted list.
+        issue_file.unlink()
+
+        count = rebuild_wanted_for_series(series_id)
+        assert count == 2
+
+        numbers = sorted(w["issue_number"] for w in get_cached_wanted_issues()
+                         if w["series_id"] == series_id)
+        assert numbers == ["5", "6"]
+
+    def test_manually_marked_issue_stays_off_wanted(self, db_connection, tmp_path):
+        from core.database import set_manual_status, get_cached_wanted_issues
+        from helpers.collection import rebuild_wanted_for_series
+
+        series_dir = tmp_path / "Flash"
+        series_dir.mkdir()
+        series_id = create_series(name="Flash", mapped_path=str(series_dir))
+        create_issue(series_id=series_id, number="1")
+        create_issue(series_id=series_id, number="2")
+
+        set_manual_status(series_id, "2", "skipped")
+
+        assert rebuild_wanted_for_series(series_id) == 1
+        numbers = [w["issue_number"] for w in get_cached_wanted_issues()
+                   if w["series_id"] == series_id]
+        assert numbers == ["1"]
+
+    def test_unmonitored_series_carries_no_wanted_rows(self, db_connection, tmp_path):
+        from core.database import (
+            save_wanted_issues_for_series,
+            get_cached_wanted_issues,
+            set_series_monitored,
+        )
+        from helpers.collection import rebuild_wanted_for_series
+
+        series_dir = tmp_path / "Robin"
+        series_dir.mkdir()
+        series_id = create_series(name="Robin", mapped_path=str(series_dir))
+        id1 = create_issue(series_id=series_id, number="1")
+        save_wanted_issues_for_series(series_id, "Robin", 2020, [_wanted(id1, "1")])
+
+        set_series_monitored(series_id, False)
+
+        assert rebuild_wanted_for_series(series_id) == 0
+        assert not any(w["series_id"] == series_id for w in get_cached_wanted_issues())
+
+
 class TestReconcileWantedForPath:
 
     def test_path_reconcile_removes_wanted(self, db_connection, tmp_path):

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -1,6 +1,7 @@
 """Tests for routes/series.py -- series management endpoints."""
 import io
 import json
+import os
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -249,6 +250,80 @@ class TestDeleteSeriesMapping:
     def test_delete_failure(self, mock_rm, client):
         resp = client.delete("/api/series/100/mapping")
         assert resp.status_code == 500
+
+
+class TestDeleteIssueFile:
+    """POST /api/series/<id>/issue/<num>/delete-file — trash it, want it again."""
+
+    @pytest.fixture
+    def series_dir(self, tmp_path):
+        d = tmp_path / "data" / "Batman"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_missing_path(self, client):
+        resp = client.post("/api/series/100/issue/1/delete-file", json={})
+        assert resp.status_code == 400
+
+    @patch("core.database.get_series_mapping", return_value=None)
+    def test_series_not_mapped(self, mock_map, client):
+        resp = client.post("/api/series/100/issue/1/delete-file",
+                             json={"path": "Batman 001.cbz"})
+        assert resp.status_code == 404
+
+    @patch("helpers.trash.move_to_trash")
+    def test_rejects_path_outside_mapped_folder(self, mock_trash, client,
+                                                series_dir, tmp_path):
+        outside = tmp_path / "data" / "secret.cbz"
+        outside.write_bytes(b"x")
+
+        with patch("core.database.get_series_mapping", return_value=str(series_dir)):
+            resp = client.post("/api/series/100/issue/1/delete-file",
+                                 json={"path": str(outside)})
+
+        assert resp.status_code == 403
+        mock_trash.assert_not_called()
+        assert outside.exists()
+
+    def test_missing_file(self, client, series_dir):
+        with patch("core.database.get_series_mapping", return_value=str(series_dir)):
+            resp = client.post("/api/series/100/issue/1/delete-file",
+                                 json={"path": "Batman 001.cbz"})
+        assert resp.status_code == 404
+
+    def test_rejects_directory(self, client, series_dir):
+        (series_dir / "extras").mkdir()
+        with patch("core.database.get_series_mapping", return_value=str(series_dir)):
+            resp = client.post("/api/series/100/issue/1/delete-file",
+                                 json={"path": "extras"})
+        assert resp.status_code == 400
+
+    @patch("helpers.collection.rebuild_wanted_for_series", return_value=3)
+    @patch("core.database.clear_manual_status", return_value=True)
+    def test_delete_marks_issue_wanted(self, mock_clear, mock_rebuild,
+                                       client, series_dir):
+        target = series_dir / "Batman 001 (2020).cbz"
+        target.write_bytes(b"cbz")
+
+        def _fake_trash(path):
+            os.remove(path)
+            return {"trashed": True, "path": path}
+
+        with patch("core.database.get_series_mapping", return_value=str(series_dir)), \
+                patch("helpers.trash.move_to_trash", side_effect=_fake_trash):
+            resp = client.post("/api/series/100/issue/1/delete-file",
+                                 json={"path": str(target).replace("\\", "/")})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["trashed"] is True
+        assert data["wanted_count"] == 3
+        assert not target.exists()
+
+        # A stale "owned" mark would keep the issue off the wanted list.
+        mock_clear.assert_called_once_with(100, "1")
+        mock_rebuild.assert_called_once_with(100)
 
 
 class TestManualStatus:


### PR DESCRIPTION
## What

Adds a **Delete Issue** entry to the issue dropdown on the series page. The file is moved to the Trash and the issue goes straight back on the wanted list — it shows as **Wanted** on the page, and auto-download picks it up again immediately rather than waiting for the nightly refresh.

## Changes

**Backend**
- `routes/series.py` — new `POST /api/series/<id>/issue/<num>/delete-file`. Validates the browser-supplied path resolves *inside* that series' mapped folder (403 otherwise), rejects directories/missing files, trashes the file via `move_to_trash()`, updates the file index, clears any manual `owned`/`skipped` mark (a stale "owned" row would keep the issue off the wanted list), then rebuilds the collection-status and wanted caches.
- `helpers/collection.py` — new `rebuild_wanted_for_series()`. The existing `reconcile_wanted_for_series` only *prunes* satisfied rows, so it can't add an issue back after a deletion. This is the per-series version of what `refresh_wanted_cache_background()` does library-wide (invalidate collection status → re-match → exclude found/manually-marked → save). Unmonitored series carry no wanted rows, matching the nightly rebuild's end state.

**Frontend**
- `templates/series.html` + `static/js/series.js` — the dropdown entry is added to **both** the server-rendered markup and the copy `refreshCollectionStatus()` re-renders; they have to stay in sync or the option disappears after any refresh.
- Confirmation uses the shared delete modal (`clu-delete.js` + `partials/modal_delete_confirm.html`), and success/failure are toasts (`CLU.showSuccess` / `CLU.showError`) — no native JS dialogs.
- The shared modal gained an optional `#deleteExtraNote` line (`CLU.showDeleteConfirmation` `options.note`) so a caller can spell out the consequence; hidden when absent, so the four existing callers are unaffected.
- `CLAUDE.md` records the rule: never `alert()` / `confirm()` / `prompt()` — Modal for decisions, Toast for messages.

## Tests

- `tests/routes/test_series_routes.py::TestDeleteIssueFile` — missing path, unmapped series, a path escaping the mapped folder (403, nothing trashed), missing file, directory, and the success path asserting the file is gone, the manual mark cleared, and wanted rebuilt.
- `tests/integration/test_reconcile_wanted.py::TestRebuildWantedForSeries` — deleted file returns to wanted, manually-marked issues stay off, unmonitored series stays empty.

Full suite: **2940 passed, 6 skipped** (skips are POSIX-only permission tests on Windows).

## Note

The file goes to the Trash rather than being permanently deleted, so it's recoverable from the Trash panel — but the wanted list and auto-download treat it as missing right away and may re-download it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
