### PR TITLE
Narrow issue searches with the issue's year, collapse the rest

### DIFF
--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -383,6 +383,22 @@ def list_usenet_downloads():
         return jsonify({"error": str(e)}), 500
 
 
+def _as_year(value):
+    """Coerce a request value to a 4-digit year int, or None.
+
+    Scoring compares the year numerically (``int(y) != search.year``), so a
+    string year would never match and would penalize every result. Accepts a
+    bare year or anything starting with one (e.g. a "2026-01-14" store date).
+    """
+    if value is None:
+        return None
+    try:
+        year = int(str(value).strip()[:4])
+    except (TypeError, ValueError):
+        return None
+    return year if 1900 <= year <= 2100 else None
+
+
 @download_clients_bp.route('/api/usenet/search', methods=['POST'])
 def usenet_search():
     """Manual Usenet search for a series/issue across enabled indexers.
@@ -412,7 +428,7 @@ def usenet_search():
         if has_indexers:
             res = search_usenet_for_issue(
                 series, issue,
-                issue_year=data.get('issue_year'),
+                issue_year=_as_year(data.get('issue_year')),
                 series_volume=data.get('series_volume'),
             )
             results = sorted(res.get("all_results", []),

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -535,10 +535,14 @@ function refreshCollectionStatus() {
                                 } else {
                                     // Not found - show search with mark dropdown
                                     const seriesName = seriesData.name ? seriesData.name.replace(/'/g, "\\'") : '';
+                                    // Year comes off the row (server-rendered from the
+                                    // issue's store/cover date) so the search stays as
+                                    // narrow as it is before a refresh.
+                                    const issueYear = row.dataset.issueYear || '';
                                     actionCell.innerHTML = `
                                         <div class="btn-group" role="group">
                                             <button class="btn btn-sm btn-outline-primary"
-                                                onclick="searchGetComics('${seriesName}', '${issueNum}')"
+                                                onclick="searchGetComics('${seriesName}', '${issueNum}', '${issueYear}')"
                                                 title="Search GetComics">
                                                 <i class="bi bi-search"></i>
                                             </button>

--- a/templates/series.html
+++ b/templates/series.html
@@ -1217,7 +1217,7 @@
             }
 
             const fmtSize = (b) => b ? (b / (1024 * 1024)).toFixed(0) + ' MB' : '';
-            const cards = data.results.map((r) => {
+            const usenetCard = (r) => {
                 const badge = r.decision === 'ACCEPT'
                     ? '<span class="badge bg-success ms-1">Match</span>'
                     : (r.decision === 'FALLBACK'
@@ -1234,11 +1234,57 @@
                     </button>
                 </div>
             </div>`;
-            }).join('');
-            return { html: header + clientNote + errNote + cards, usenetFirst };
+            };
+            return {
+                html: header + clientNote + errNote + usenetResultList(data.results, usenetCard),
+                usenetFirst,
+            };
         } catch (e) {
             return { html: `<div class="alert alert-danger">Usenet error: ${escapeHtmlGC(e.message)}</div>`, usenetFirst: false };
         }
+    }
+
+    // Only badged results (Match/Pack) are shown up front; everything the
+    // scorer rejected — chiefly wrong-year releases of the same issue number —
+    // is hidden behind a toggle. If nothing scored well enough to badge, show
+    // the lot rather than an empty section.
+    function usenetResultList(results, cardFor) {
+        const matched = results.filter(
+            r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK');
+        if (!matched.length) {
+            return results.map(cardFor).join('');
+        }
+
+        const others = results.filter(
+            r => r.decision !== 'ACCEPT' && r.decision !== 'FALLBACK');
+        let html = matched.map(cardFor).join('');
+        if (others.length) {
+            html += `
+            <div class="text-center my-2">
+                <button class="btn btn-sm btn-outline-secondary" type="button"
+                    onclick="toggleUsenetOthers(this)">
+                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false)}
+                </button>
+            </div>
+            <div id="usenetOtherResults" class="d-none" data-count="${others.length}">
+                ${others.map(cardFor).join('')}
+            </div>`;
+        }
+        return html;
+    }
+
+    function usenetOthersLabel(count, expanded) {
+        const noun = count === 1 ? 'result' : 'results';
+        return `${expanded ? 'Hide' : 'Show'} ${count} lower-scoring ${noun}`;
+    }
+
+    function toggleUsenetOthers(btn) {
+        const el = document.getElementById('usenetOtherResults');
+        if (!el) return;
+        const hidden = el.classList.toggle('d-none');
+        const count = Number(el.dataset.count) || 0;
+        btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
+            usenetOthersLabel(count, !hidden);
     }
 
     async function grabUsenet(btn, nzbUrl) {

--- a/templates/series.html
+++ b/templates/series.html
@@ -1244,38 +1244,41 @@
         }
     }
 
-    // Only badged results (Match/Pack) are shown up front; everything the
-    // scorer rejected — chiefly wrong-year releases of the same issue number —
-    // is hidden behind a toggle. If nothing scored well enough to badge, show
-    // the lot rather than an empty section.
+    // Only badged results (Match/Pack) are shown up front; everything else —
+    // chiefly wrong-year releases of the same issue number — is hidden behind
+    // a toggle. Indexers can return 50+ hits for one issue, and an unfiltered
+    // list pushes the GetComics section off the screen, so the collapse
+    // applies even when nothing scored well enough to badge.
     function usenetResultList(results, cardFor) {
-        const matched = results.filter(
-            r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK');
-        if (!matched.length) {
-            return results.map(cardFor).join('');
-        }
+        const isMatch = r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK';
+        const matched = results.filter(isMatch);
+        const others = results.filter(r => !isMatch(r));
 
-        const others = results.filter(
-            r => r.decision !== 'ACCEPT' && r.decision !== 'FALLBACK');
-        let html = matched.map(cardFor).join('');
+        let html = matched.length
+            ? matched.map(cardFor).join('')
+            : '<div class="text-muted small mb-2">No confident match.</div>';
+
         if (others.length) {
             html += `
             <div class="text-center my-2">
                 <button class="btn btn-sm btn-outline-secondary" type="button"
                     onclick="toggleUsenetOthers(this)">
-                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false)}
+                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false, matched.length > 0)}
                 </button>
             </div>
-            <div id="usenetOtherResults" class="d-none" data-count="${others.length}">
+            <div id="usenetOtherResults" class="d-none" data-count="${others.length}"
+                data-has-match="${matched.length > 0 ? '1' : ''}">
                 ${others.map(cardFor).join('')}
             </div>`;
         }
         return html;
     }
 
-    function usenetOthersLabel(count, expanded) {
+    function usenetOthersLabel(count, expanded, hasMatch) {
         const noun = count === 1 ? 'result' : 'results';
-        return `${expanded ? 'Hide' : 'Show'} ${count} lower-scoring ${noun}`;
+        // "lower-scoring" only reads right when something better is shown above.
+        const qualifier = hasMatch ? 'lower-scoring ' : '';
+        return `${expanded ? 'Hide' : 'Show'} ${count} ${qualifier}${noun}`;
     }
 
     function toggleUsenetOthers(btn) {
@@ -1284,7 +1287,7 @@
         const hidden = el.classList.toggle('d-none');
         const count = Number(el.dataset.count) || 0;
         btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
-            usenetOthersLabel(count, !hidden);
+            usenetOthersLabel(count, !hidden, !!el.dataset.hasMatch);
     }
 
     async function grabUsenet(btn, nzbUrl) {

--- a/templates/series.html
+++ b/templates/series.html
@@ -301,7 +301,12 @@
                         {% set manual = manual_status.get(issue.number|string, {}) if manual_status else {} %}
                         {% set has_manual = manual.get('status') %}
                         {% set is_upcoming = issue.store_date and (issue.store_date|string) > today %}
-                        <tr data-issue-number="{{ issue.number }}"
+                        {# Year used to narrow GetComics/Usenet searches — the issue's own
+                           publication year, never the series start year (a wrong year now
+                           actively filters results). #}
+                        {% set issue_year = (issue.store_date|string)[:4] if issue.store_date
+                        else ((issue.cover_date|string)[:4] if issue.cover_date else '') %}
+                        <tr data-issue-number="{{ issue.number }}" data-issue-year="{{ issue_year }}"
                             class="{% if mapped_path %}{% if status.get('found') or has_manual == 'owned' %}table-success{% elif has_manual == 'skipped' %}table-warning{% elif is_upcoming %}table-info{% else %}table-danger{% endif %}{% endif %}">
                             {% if mapped_path %}
                             <td class="ps-3">
@@ -395,7 +400,8 @@
                                     <button class="btn btn-sm btn-outline-primary"
                                         data-series="{{ series.name }}"
                                         data-issue="{{ issue.number }}"
-                                        onclick="searchGetComics(this.dataset.series, this.dataset.issue)"
+                                        data-year="{{ issue_year }}"
+                                        onclick="searchGetComics(this.dataset.series, this.dataset.issue, this.dataset.year)"
                                         title="Search GetComics">
                                         <i class="bi bi-search"></i>
                                     </button>
@@ -1061,6 +1067,7 @@
     // GetComics search functionality
     let currentSearchSeries = '';
     let currentSearchIssue = '';
+    let currentSearchYear = '';
     let getcomicsModal = null;
 
     document.addEventListener('DOMContentLoaded', function () {
@@ -1070,19 +1077,32 @@
         }
     });
 
-    function searchGetComics(seriesName, issueNumber) {
+    function searchGetComics(seriesName, issueNumber, issueYear) {
         currentSearchSeries = seriesName;
         currentSearchIssue = issueNumber;
+        currentSearchYear = issueYear || '';
 
         // Prefer the first configured alias over the series title for the query
         const aliasName = getFirstAlias();
         const queryName = aliasName || seriesName;
 
-        const query = `${queryName} ${issueNumber}`;
+        // The issue's year narrows both sources — "Iron Man 8" matches every
+        // volume that ever had an #8, "Iron Man 8 2026" matches this one.
+        const query = [queryName, issueNumber, currentSearchYear]
+            .filter(part => part !== '' && part !== null && part !== undefined)
+            .join(' ');
         document.getElementById('getcomicsQuery').value = query;
 
         getcomicsModal.show();
         doGetComicsSearch();
+    }
+
+    // The query box is the source of truth for the year: seeded by
+    // searchGetComics(), but a user who edits or clears it widens/narrows
+    // GetComics and Usenet together.
+    function extractQueryYear(query) {
+        const m = String(query).trim().match(/(?:^|\s)((?:19|20)\d{2})$/);
+        return m ? m[1] : '';
     }
 
     function getFirstAlias() {
@@ -1094,6 +1114,9 @@
     async function doGetComicsSearch() {
         const query = document.getElementById('getcomicsQuery').value.trim();
         if (!query) return;
+
+        // Keep the Usenet year filter in step with what's in the box.
+        currentSearchYear = extractQueryYear(query);
 
         const resultsDiv = document.getElementById('getcomicsResults');
         resultsDiv.innerHTML = `
@@ -1133,7 +1156,8 @@
             }
             if (!data.results.length) return { html: '' };
 
-            const sorted = sortResultsGC(data.results, currentSearchSeries, currentSearchIssue);
+            const sorted = sortResultsGC(data.results, currentSearchSeries, currentSearchIssue,
+                currentSearchYear);
             const cards = sorted.map((r, idx) => `
             <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
                 <div class="card-body d-flex align-items-center gap-3 py-2">
@@ -1158,7 +1182,13 @@
             const resp = await fetch('/api/usenet/search', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ series: currentSearchSeries, issue: currentSearchIssue }),
+                body: JSON.stringify({
+                    series: currentSearchSeries,
+                    issue: currentSearchIssue,
+                    // Without a year every volume's #8 scores the same; with it,
+                    // wrong-year releases are penalized below the accept line.
+                    issue_year: currentSearchYear ? Number(currentSearchYear) : null,
+                }),
             });
             const data = await resp.json();
             const usenetFirst = !!data.usenet_first;
@@ -1247,7 +1277,7 @@
         }
     }
 
-    function sortResultsGC(results, seriesName, issueNumber) {
+    function sortResultsGC(results, seriesName, issueNumber, issueYear) {
         return results.map(r => {
             let score = 0;
             const title = r.title.toLowerCase();
@@ -1255,6 +1285,9 @@
 
             if (title.includes(series)) score += 10;
             if (title.includes(`#${issueNumber}`) || title.includes(` ${issueNumber} `) || title.endsWith(` ${issueNumber}`)) score += 5;
+            // A matching year separates this volume's issue from every reprint
+            // and reboot that shares the number.
+            if (issueYear && title.includes(String(issueYear))) score += 8;
 
             return { ...r, score };
         }).sort((a, b) => b.score - a.score);

--- a/templates/wanted.html
+++ b/templates/wanted.html
@@ -141,10 +141,16 @@
                                     {% endif %}
                                 </td>
                                 <td class="text-end pe-4">
+                                    {# The issue's own publication year narrows both sources —
+                                       never the series start year, since a wrong year now
+                                       filters results out. #}
+                                    {% set issue_year = (item.issue.store_date|string)[:4] if item.issue.store_date
+                                    else ((item.issue.cover_date|string)[:4] if item.issue.cover_date else '') %}
                                     <button class="btn btn-sm btn-outline-primary me-1"
                                         data-series="{{ item.series_name }}"
                                         data-issue="{{ item.issue.number }}"
-                                        onclick="searchGetComics(this.dataset.series, this.dataset.issue)"
+                                        data-year="{{ issue_year }}"
+                                        onclick="searchGetComics(this.dataset.series, this.dataset.issue, this.dataset.year)"
                                         title="Search GetComics">
                                         <i class="bi bi-search"></i>
                                     </button>
@@ -263,26 +269,43 @@
 <script>
     let currentSearchSeries = '';
     let currentSearchIssue = '';
+    let currentSearchYear = '';
     let getcomicsModal = null;
 
     document.addEventListener('DOMContentLoaded', function () {
         getcomicsModal = new bootstrap.Modal(document.getElementById('getcomicsModal'));
     });
 
-    function searchGetComics(seriesName, issueNumber) {
+    function searchGetComics(seriesName, issueNumber, issueYear) {
         currentSearchSeries = seriesName;
         currentSearchIssue = issueNumber;
+        currentSearchYear = issueYear || '';
 
-        const query = `${seriesName} ${issueNumber}`;
+        // The issue's year narrows both sources — "Iron Man 8" matches every
+        // volume that ever had an #8, "Iron Man 8 2026" matches this one.
+        const query = [seriesName, issueNumber, currentSearchYear]
+            .filter(part => part !== '' && part !== null && part !== undefined)
+            .join(' ');
         document.getElementById('getcomicsQuery').value = query;
 
         getcomicsModal.show();
         doGetComicsSearch();
     }
 
+    // The query box is the source of truth for the year: seeded by
+    // searchGetComics(), but a user who edits or clears it widens/narrows
+    // GetComics and Usenet together.
+    function extractQueryYear(query) {
+        const m = String(query).trim().match(/(?:^|\s)((?:19|20)\d{2})$/);
+        return m ? m[1] : '';
+    }
+
     async function doGetComicsSearch() {
         const query = document.getElementById('getcomicsQuery').value.trim();
         if (!query) return;
+
+        // Keep the Usenet year filter in step with what's in the box.
+        currentSearchYear = extractQueryYear(query);
 
         const resultsDiv = document.getElementById('getcomicsResults');
         resultsDiv.innerHTML = `
@@ -322,7 +345,8 @@
             }
             if (!data.results.length) return { html: '' };
 
-            const sorted = sortResults(data.results, currentSearchSeries, currentSearchIssue);
+            const sorted = sortResults(data.results, currentSearchSeries, currentSearchIssue,
+                currentSearchYear);
             const cards = sorted.map((r, idx) => `
             <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
                 <div class="card-body d-flex align-items-center gap-3 py-2">
@@ -347,7 +371,13 @@
             const resp = await fetch('/api/usenet/search', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ series: currentSearchSeries, issue: currentSearchIssue }),
+                body: JSON.stringify({
+                    series: currentSearchSeries,
+                    issue: currentSearchIssue,
+                    // Without a year every volume's #8 scores the same; with it,
+                    // wrong-year releases are penalized below the accept line.
+                    issue_year: currentSearchYear ? Number(currentSearchYear) : null,
+                }),
             });
             const data = await resp.json();
             const usenetFirst = !!data.usenet_first;
@@ -435,7 +465,7 @@
         }
     }
 
-    function sortResults(results, seriesName, issueNumber) {
+    function sortResults(results, seriesName, issueNumber, issueYear) {
         // Score results based on match quality
         return results.map(r => {
             let score = 0;
@@ -444,6 +474,9 @@
 
             if (title.includes(series)) score += 10;
             if (title.includes(`#${issueNumber}`) || title.includes(` ${issueNumber} `) || title.endsWith(` ${issueNumber}`)) score += 5;
+            // A matching year separates this volume's issue from every reprint
+            // and reboot that shares the number.
+            if (issueYear && title.includes(String(issueYear))) score += 8;
 
             return { ...r, score };
         }).sort((a, b) => b.score - a.score);

--- a/templates/wanted.html
+++ b/templates/wanted.html
@@ -406,7 +406,7 @@
             }
 
             const fmtSize = (b) => b ? (b / (1024 * 1024)).toFixed(0) + ' MB' : '';
-            const cards = data.results.map((r) => {
+            const usenetCard = (r) => {
                 const badge = r.decision === 'ACCEPT'
                     ? '<span class="badge bg-success ms-1">Match</span>'
                     : (r.decision === 'FALLBACK'
@@ -423,11 +423,57 @@
                     </button>
                 </div>
             </div>`;
-            }).join('');
-            return { html: header + clientNote + errNote + cards, usenetFirst };
+            };
+            return {
+                html: header + clientNote + errNote + usenetResultList(data.results, usenetCard),
+                usenetFirst,
+            };
         } catch (e) {
             return { html: `<div class="alert alert-danger">Usenet error: ${escapeHtml(e.message)}</div>`, usenetFirst: false };
         }
+    }
+
+    // Only badged results (Match/Pack) are shown up front; everything the
+    // scorer rejected — chiefly wrong-year releases of the same issue number —
+    // is hidden behind a toggle. If nothing scored well enough to badge, show
+    // the lot rather than an empty section.
+    function usenetResultList(results, cardFor) {
+        const matched = results.filter(
+            r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK');
+        if (!matched.length) {
+            return results.map(cardFor).join('');
+        }
+
+        const others = results.filter(
+            r => r.decision !== 'ACCEPT' && r.decision !== 'FALLBACK');
+        let html = matched.map(cardFor).join('');
+        if (others.length) {
+            html += `
+            <div class="text-center my-2">
+                <button class="btn btn-sm btn-outline-secondary" type="button"
+                    onclick="toggleUsenetOthers(this)">
+                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false)}
+                </button>
+            </div>
+            <div id="usenetOtherResults" class="d-none" data-count="${others.length}">
+                ${others.map(cardFor).join('')}
+            </div>`;
+        }
+        return html;
+    }
+
+    function usenetOthersLabel(count, expanded) {
+        const noun = count === 1 ? 'result' : 'results';
+        return `${expanded ? 'Hide' : 'Show'} ${count} lower-scoring ${noun}`;
+    }
+
+    function toggleUsenetOthers(btn) {
+        const el = document.getElementById('usenetOtherResults');
+        if (!el) return;
+        const hidden = el.classList.toggle('d-none');
+        const count = Number(el.dataset.count) || 0;
+        btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
+            usenetOthersLabel(count, !hidden);
     }
 
     async function grabUsenet(btn, nzbUrl) {

--- a/templates/wanted.html
+++ b/templates/wanted.html
@@ -433,38 +433,41 @@
         }
     }
 
-    // Only badged results (Match/Pack) are shown up front; everything the
-    // scorer rejected — chiefly wrong-year releases of the same issue number —
-    // is hidden behind a toggle. If nothing scored well enough to badge, show
-    // the lot rather than an empty section.
+    // Only badged results (Match/Pack) are shown up front; everything else —
+    // chiefly wrong-year releases of the same issue number — is hidden behind
+    // a toggle. Indexers can return 50+ hits for one issue, and an unfiltered
+    // list pushes the GetComics section off the screen, so the collapse
+    // applies even when nothing scored well enough to badge.
     function usenetResultList(results, cardFor) {
-        const matched = results.filter(
-            r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK');
-        if (!matched.length) {
-            return results.map(cardFor).join('');
-        }
+        const isMatch = r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK';
+        const matched = results.filter(isMatch);
+        const others = results.filter(r => !isMatch(r));
 
-        const others = results.filter(
-            r => r.decision !== 'ACCEPT' && r.decision !== 'FALLBACK');
-        let html = matched.map(cardFor).join('');
+        let html = matched.length
+            ? matched.map(cardFor).join('')
+            : '<div class="text-muted small mb-2">No confident match.</div>';
+
         if (others.length) {
             html += `
             <div class="text-center my-2">
                 <button class="btn btn-sm btn-outline-secondary" type="button"
                     onclick="toggleUsenetOthers(this)">
-                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false)}
+                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false, matched.length > 0)}
                 </button>
             </div>
-            <div id="usenetOtherResults" class="d-none" data-count="${others.length}">
+            <div id="usenetOtherResults" class="d-none" data-count="${others.length}"
+                data-has-match="${matched.length > 0 ? '1' : ''}">
                 ${others.map(cardFor).join('')}
             </div>`;
         }
         return html;
     }
 
-    function usenetOthersLabel(count, expanded) {
+    function usenetOthersLabel(count, expanded, hasMatch) {
         const noun = count === 1 ? 'result' : 'results';
-        return `${expanded ? 'Hide' : 'Show'} ${count} lower-scoring ${noun}`;
+        // "lower-scoring" only reads right when something better is shown above.
+        const qualifier = hasMatch ? 'lower-scoring ' : '';
+        return `${expanded ? 'Hide' : 'Show'} ${count} ${qualifier}${noun}`;
     }
 
     function toggleUsenetOthers(btn) {
@@ -473,7 +476,7 @@
         const hidden = el.classList.toggle('d-none');
         const count = Number(el.dataset.count) || 0;
         btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
-            usenetOthersLabel(count, !hidden);
+            usenetOthersLabel(count, !hidden, !!el.dataset.hasMatch);
     }
 
     async function grabUsenet(btn, nzbUrl) {

--- a/tests/mocked/test_usenet.py
+++ b/tests/mocked/test_usenet.py
@@ -158,6 +158,60 @@ class TestSearchAndScore:
         assert res["chosen"] is None
 
 
+class TestIssueYearSeparatesVolumes:
+    """The manual search UI now sends the issue's year (see series.html /
+    wanted.html). Without it every volume's #8 scored identically."""
+
+    TITLES = [
+        "Iron Man 008 (2026) (Digital) (Zone-Empire)",
+        "Iron Man 008 (2025-07) (c2c) (SHELL-HEAD)",
+        "Iron Man 008 (2021) (Digital) (Zone-Empire)",
+        "Iron Man 008 (1968) (digital) (Minutemen-Slayer)",
+        "Iron Man 2.0 008 (2011) (Digital) (Shadowcat-Empire)",
+    ]
+
+    def _results(self):
+        return [
+            NZBSearchResult(indexer_id=5, indexer_name="NZBgeek", title=t,
+                            nzb_url=f"https://x/{i}.nzb", size=100)
+            for i, t in enumerate(self.TITLES)
+        ]
+
+    @patch("models.indexers.get_indexer_impl")
+    @patch("core.database.get_enabled_indexers", return_value=[
+        {"id": 5, "name": "NZBgeek", "url": "https://x", "api_key": "k",
+         "categories": None, "enabled": True, "indexer_type": "newznab"},
+    ])
+    def test_without_year_every_volume_matches(self, mock_idx, mock_impl):
+        impl = MagicMock()
+        impl.search.return_value = self._results()
+        mock_impl.return_value = impl
+
+        res = un.search_usenet_for_issue("Iron Man", "8")
+        accepted = [r for r in res["all_results"] if r["decision"] == "ACCEPT"]
+        # The reported bug: reprints and reboots all badge as "Match".
+        assert len(accepted) > 1
+
+    @patch("models.indexers.get_indexer_impl")
+    @patch("core.database.get_enabled_indexers", return_value=[
+        {"id": 5, "name": "NZBgeek", "url": "https://x", "api_key": "k",
+         "categories": None, "enabled": True, "indexer_type": "newznab"},
+    ])
+    def test_year_leaves_only_the_right_volume(self, mock_idx, mock_impl):
+        impl = MagicMock()
+        impl.search.return_value = self._results()
+        mock_impl.return_value = impl
+
+        res = un.search_usenet_for_issue("Iron Man", "8", issue_year=2026)
+        accepted = [r for r in res["all_results"] if r["decision"] == "ACCEPT"]
+        assert [r["title"] for r in accepted] == [
+            "Iron Man 008 (2026) (Digital) (Zone-Empire)"
+        ]
+        # And it outscores every wrong-year release.
+        best = max(res["all_results"], key=lambda r: r["score"])
+        assert best["title"] == "Iron Man 008 (2026) (Digital) (Zone-Empire)"
+
+
 class TestTryDownloadForIssue:
 
     @patch("models.usenet.search_usenet_for_issue")

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -281,6 +281,39 @@ class TestUsenetDownloads:
         resp = client.post("/api/usenet/search", json={"issue": "1"})
         assert resp.status_code == 400
 
+    @patch("models.usenet.usenet_precedes_getcomics", return_value=False)
+    @patch("core.database.get_active_download_client", return_value=None)
+    @patch("core.database.get_enabled_indexers", return_value=[{"id": 1}])
+    @patch("models.usenet.search_usenet_for_issue", return_value={"all_results": []})
+    def test_search_passes_issue_year(self, mock_search, mock_idx, mock_client,
+                                      mock_first, client):
+        # Scoring compares the year numerically, so it must arrive as an int —
+        # a string would penalize every result, including the right one.
+        resp = client.post("/api/usenet/search",
+                           json={"series": "Iron Man", "issue": "8",
+                                 "issue_year": "2026"})
+        assert resp.status_code == 200
+        assert mock_search.call_args.kwargs["issue_year"] == 2026
+
+    @patch("models.usenet.usenet_precedes_getcomics", return_value=False)
+    @patch("core.database.get_active_download_client", return_value=None)
+    @patch("core.database.get_enabled_indexers", return_value=[{"id": 1}])
+    @patch("models.usenet.search_usenet_for_issue", return_value={"all_results": []})
+    def test_search_year_coercion(self, mock_search, mock_idx, mock_client,
+                                  mock_first, client):
+        for sent, expected in [
+            (2026, 2026),
+            ("2026-01-14", 2026),   # a store date, not just a year
+            ("", None),
+            (None, None),
+            ("not-a-year", None),
+            (1492, None),           # outside the plausible range
+        ]:
+            client.post("/api/usenet/search",
+                        json={"series": "Iron Man", "issue": "8",
+                              "issue_year": sent})
+            assert mock_search.call_args.kwargs["issue_year"] == expected, sent
+
     @patch("models.usenet.grab_nzb", return_value="dl-123")
     def test_grab(self, mock_grab, client):
         resp = client.post("/api/usenet/grab",

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -621,6 +621,63 @@ class TestSeriesBulkMonitored:
         mock_set.assert_called_once_with([], True)
 
 
+class TestSeriesPageSearchYear:
+    """Same on the series page: the row and its search button carry the
+    issue's publication year so both GetComics and Usenet can narrow."""
+
+    def test_row_and_button_carry_issue_year(self, app, client_with_data):
+        app.jinja_env.globals["generate_series_slug"] = (
+            lambda name, sid, volume=None: f"{sid}-slug"
+        )
+        resp = client_with_data.get("/series/batman-v2020-100")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # Seeded issues have store_date 2020-mm-10.
+        assert 'data-issue-year="2020"' in html
+        assert "searchGetComics(this.dataset.series, this.dataset.issue, this.dataset.year)" in html
+
+
+class TestWantedPage:
+    """The /wanted page seeds each search with the issue's own year — without
+    it "Iron Man 8" matches every volume that ever had an #8."""
+
+    @staticmethod
+    def _register_slug_global(app):
+        app.jinja_env.globals["generate_series_slug"] = (
+            lambda name, sid, volume=None: f"{sid}-slug"
+        )
+
+    def _seed_wanted(self, store_date="2026-01-14", cover_date="2026-03-01"):
+        from core.database import save_wanted_issues_for_series
+        save_wanted_issues_for_series(100, "Iron Man", 2020, [{
+            "id": 5001, "number": "8", "name": "Chapter Eight",
+            "store_date": store_date, "cover_date": cover_date, "image": None,
+        }])
+
+    def test_search_button_carries_issue_year(self, app, client_with_data):
+        self._register_slug_global(app)
+        self._seed_wanted()
+
+        html = client_with_data.get("/wanted").get_data(as_text=True)
+        assert 'data-year="2026"' in html
+        assert "searchGetComics(this.dataset.series, this.dataset.issue, this.dataset.year)" in html
+
+    def test_falls_back_to_cover_date(self, app, client_with_data):
+        self._register_slug_global(app)
+        self._seed_wanted(store_date=None, cover_date="2019-05-01")
+
+        html = client_with_data.get("/wanted").get_data(as_text=True)
+        assert 'data-year="2019"' in html
+
+    def test_no_dates_sends_no_year(self, app, client_with_data):
+        self._register_slug_global(app)
+        self._seed_wanted(store_date=None, cover_date=None)
+
+        html = client_with_data.get("/wanted").get_data(as_text=True)
+        # Better to search without a year than to guess the wrong one.
+        assert 'data-year=""' in html
+
+
 class TestPullListPage:
     """The /pull-list page must render with per-series collection status
     coloring and the status filter/legend controls."""


### PR DESCRIPTION
## What

`Iron Man 8` matches every volume that ever had an #8. `Iron Man 8 2026` matches the one you actually want. The series and wanted pages now seed the search with the issue's own publication year and pass it to both sources — and the Usenet section collapses everything that isn't a confident match, so an indexer returning 50+ hits no longer pushes the GetComics results off the screen.

## Changes

**Year in the search**
- `templates/series.html`, `templates/wanted.html` — each issue row carries its publication year (`store_date`, falling back to `cover_date`; never the series start year, since a wrong year now actively filters). `searchGetComics()` appends it to the query box and sends it to `/api/usenet/search` as `issue_year`.
- The query box stays the source of truth: `doGetComicsSearch()` re-reads the trailing year from it, so editing or clearing the box widens/narrows GetComics and Usenet together.
- `static/js/series.js` — the search button rebuilt by `refreshCollectionStatus()` reads the year off the row, so a refresh doesn't silently widen the search back out.
- `routes/download_clients.py` — coerce `issue_year` to an int. The route already accepted the field (the UI just never sent it), but scoring compares numerically (`int(y) != search.year`), so a string year would have penalized *every* result including the correct one.

**Collapsed Usenet results**

Only badged results (Match/Pack) render inline; the rest sit behind a toggle that flips to "Hide" when opened and keeps its best-first sort.

| Case | Shown up front | Toggle |
|---|---|---|
| 1 match + 52 others | the match | `Show 52 lower-scoring results` |
| 52 others, none badged | `No confident match.` | `Show 52 results` |
| All badged | all of them | none |

## Why the indexer query stays broad

The Usenet query is still `series + padded issue` — the year does its work in scoring, matching what nightly auto-download already does. Release titles carry the year in parens/brackets (`(2025-07)`, `[2026]`), so folding it into a strict newznab text match risks returning nothing at all.

Effect on the reported case: with `issue_year=2026`, `Iron Man 008 (2026)` gains +20 → 60 and stays ACCEPT; the 2025/2021/1968/`2.0 (2011)` releases lose 20 → 20, dropping below the accept threshold, losing the "Match" badge and collapsing out of view.

## Tests

- `tests/mocked/test_usenet.py::TestIssueYearSeparatesVolumes` — the reported titles, asserting many ACCEPTs without a year and exactly one with it, and that it outscores the rest.
- `tests/routes/test_series_routes.py` — `TestSeriesPageSearchYear` / `TestWantedPage` cover the rendered year attributes, the `cover_date` fallback, and the no-dates case. Neither page had a render test before.
- `tests/routes/test_download_clients_routes.py` — `issue_year` reaches the search as an int, plus coercion of a store date, empty, null, garbage, and an implausible year.

Full suite: **2948 passed, 6 skipped**.

The collapse branches have no JS test harness in this repo, so I verified them by running the functions directly against the reported result set (52 rejects → 0 inline; 1 match + 52 → 1 inline; all badged → no toggle; singular/plural and Hide labels).

## Note

The series and wanted pages each carry their own copy of the search-modal JS, so `buildUsenetSection`, `sortResults` and now the collapse helpers are duplicated in both. Extracting the modal into a shared `clu-search.js` would be a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
