### PR TITLE
Update Modals to Default to "Enter" Keyboard Control for Confirmation

### DIFF
--- a/static/js/clu-cbz-info.js
+++ b/static/js/clu-cbz-info.js
@@ -16,6 +16,8 @@
  * DOM contracts:
  *   #cbzInfoModal  (from modal_cbz_info.html)
  *   #cbzInfoContent, #cbzNavButtons, #cbzPrevBtn, #cbzNextBtn
+ *   #clearComicInfoConfirmModal  (same partial) – required before ComicInfo.xml
+ *   can be deleted; #clearComicInfoFileName, #confirmClearComicInfoBtn
  */
 (function () {
   'use strict';
@@ -288,6 +290,9 @@
   function _handleKeydown(e) {
     var modal = document.getElementById('cbzInfoModal');
     if (!modal || !modal.classList.contains('show')) return;
+    // Don't flip pages behind the clear-ComicInfo confirmation stacked on top
+    var confirmModal = document.getElementById('clearComicInfoConfirmModal');
+    if (confirmModal && confirmModal.classList.contains('show')) return;
     if (e.key === 'ArrowLeft') { CLU.cbzPagePrev(); }
     else if (e.key === 'ArrowRight' || e.code === 'Space') { e.preventDefault(); CLU.cbzPageNext(); }
   }
@@ -308,13 +313,36 @@
 
   // ── Clear ComicInfo.xml ───────────────────────────────────────────────────
 
-  function _clearComicInfoXml() {
+  /** Open the confirmation modal; the delete itself runs from its confirm button. */
+  function _promptClearComicInfoXml() {
     if (!_currentFilePath) {
       CLU.showError('No CBZ file is currently selected.');
       return;
     }
 
-    if (!confirm('Are you sure you want to delete ComicInfo.xml? This cannot be undone.')) return;
+    var el = document.getElementById('clearComicInfoConfirmModal');
+    if (!el) {
+      // The partial that owns the confirmation is missing — refuse rather than
+      // delete metadata unconfirmed.
+      console.error('#clearComicInfoConfirmModal not found; include partials/modal_cbz_info.html');
+      CLU.showError('Unable to confirm this deletion.');
+      return;
+    }
+
+    var nameEl = document.getElementById('clearComicInfoFileName');
+    if (nameEl) nameEl.textContent = _currentFilePath.split('/').pop();
+
+    var modal = bootstrap.Modal.getInstance(el);
+    if (!modal) modal = new bootstrap.Modal(el);
+    modal.show();
+  }
+
+  function _doClearComicInfoXml() {
+    if (!_currentFilePath) return;
+
+    var el = document.getElementById('clearComicInfoConfirmModal');
+    var modal = el && bootstrap.Modal.getInstance(el);
+    if (modal) modal.hide();
 
     fetch('/cbz-clear-comicinfo', {
       method: 'POST',
@@ -490,7 +518,7 @@
 
         // Attach clear button handler
         var clearBtn = document.getElementById('clearComicInfoBtn');
-        if (clearBtn) clearBtn.addEventListener('click', _clearComicInfoXml);
+        if (clearBtn) clearBtn.addEventListener('click', _promptClearComicInfoXml);
 
         // Load preview
         fetch('/cbz-preview?path=' + encodeURIComponent(filePath) + '&size=large')
@@ -582,6 +610,11 @@
         _resetPageViewer();
       });
     }
+
+    // Stacking on top of #cbzInfoModal (focus, body.modal-open) is handled
+    // generically in clu-utils.js.
+    var confirmBtn = document.getElementById('confirmClearComicInfoBtn');
+    if (confirmBtn) confirmBtn.addEventListener('click', _doClearComicInfoXml);
   });
 
 })();

--- a/static/js/clu-utils.js
+++ b/static/js/clu-utils.js
@@ -6,11 +6,15 @@
  *           CLU.showSuccess, CLU.showError, CLU.showProgressIndicator,
  *           CLU.hideProgressIndicator, CLU.updateProgress
  *
+ * Also installs page-wide modal behaviour — stacked-modal focus repair and the
+ * declarative Enter-to-confirm handler — see the bottom of this file.
+ *
  * DOM contracts (optional – functions degrade gracefully):
  *   - .toast-container          dynamic toasts are appended here
  *   - #successToast / #successToastBody   pre-built success toast
  *   - #errorToast   / #errorToastBody     pre-built error toast
  *   - #progress-container / #progress-bar / #progress-text
+ *   - [data-enter-confirm="<button id>"]  Enter inside clicks that button
  *
  * Must be loaded before any other clu-*.js module.
  */
@@ -276,5 +280,76 @@
       txt.textContent = 'Initializing...';
     }
   };
+
+  // ── Stacked modal focus ─────────────────────────────────────────────────
+  //
+  // Bootstrap 5.3's FocusTrap.activate() focuses the newly shown modal *before*
+  // removing the previous trap's focusin listener:
+  //
+  //     if (this._config.autofocus) this._config.trapElement.focus()
+  //     EventHandler.off(document, EVENT_KEY)
+  //
+  // So when modal B opens over modal A, A's still-active trap sees focus land
+  // outside itself and pulls it straight back. B ends up visible but unfocused,
+  // and keystrokes — including Enter-to-confirm below — go to A.
+  //
+  // By the time shown.bs.modal fires, activate() has finished and only B's trap
+  // is listening, so focusing here sticks.
+
+  document.addEventListener('shown.bs.modal', function (event) {
+    var modal = event.target;
+    if (modal && !modal.contains(document.activeElement)) modal.focus();
+  });
+
+  // The mirror image on the way out: Bootstrap unconditionally drops
+  // body.modal-open and blurs into nothing when any modal hides, even with
+  // another still open. Hand the page back to whatever is still showing.
+  document.addEventListener('hidden.bs.modal', function () {
+    var stillOpen = document.querySelector('.modal.show');
+    if (!stillOpen) return;
+    document.body.classList.add('modal-open');
+    if (!stillOpen.contains(document.activeElement)) stillOpen.focus();
+  });
+
+  // ── Enter-to-confirm ────────────────────────────────────────────────────
+  //
+  // Declarative keyboard confirmation for modals. Put
+  //   data-enter-confirm="<button id>"
+  // on a modal — or on any element inside one — and pressing Enter within
+  // that scope clicks the named button.
+  //
+  // Because closest() resolves to the nearest matching ancestor-or-self, the
+  // attribute on an inner element overrides the modal's. That is how the
+  // "create a new list" field in addToReadingListModal targets Create while
+  // the rest of the modal targets Add.
+  //
+  // We click the button rather than calling its handler directly, so all the
+  // existing wiring still applies: input validation, state stashed on the
+  // button's dataset, and disabled/hidden states.
+
+  document.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter') return;
+    if (event.isComposing || event.keyCode === 229) return;  // IME composition commit
+    if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
+
+    var target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+
+    // Skip elements the browser already activates on Enter, and those where
+    // Enter means "newline" rather than "confirm".
+    var tag = target.tagName;
+    if (tag === 'TEXTAREA' || tag === 'BUTTON' || tag === 'A') return;
+    if (target.isContentEditable) return;
+    if (tag === 'INPUT' && /^(button|submit|reset|checkbox|radio)$/i.test(target.type)) return;
+
+    var scope = target.closest('[data-enter-confirm]');
+    if (!scope) return;
+
+    var btn = document.getElementById(scope.getAttribute('data-enter-confirm'));
+    if (!btn || btn.disabled || btn.offsetParent === null) return;
+
+    event.preventDefault();
+    btn.click();
+  });
 
 })();

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -2190,9 +2190,8 @@ document.addEventListener('DOMContentLoaded', function () {
     setupDropEvents(destList, 'destination');
   }
 
-  // Add event listener for Update XML confirm button
-  const updateXmlBtn = document.getElementById('updateXmlConfirmBtn');
-  if (updateXmlBtn) updateXmlBtn.addEventListener('click', CLU.submitUpdateXml);
+  // #updateXmlConfirmBtn is wired by clu-update-xml.js, which owns the modal —
+  // binding it here too made every update submit twice.
 
   // Add event listener for Update XML field dropdown change
   const updateXmlFieldSelect = document.getElementById('updateXmlField');
@@ -2704,13 +2703,7 @@ if (confirmCreateFolderBtn) {
   confirmCreateFolderBtn.addEventListener('click', createFolder);
 }
 
-// Listen for "Enter" keypress inside input field (only if input exists)
-if (createFolderNameInput) createFolderNameInput.addEventListener('keypress', function (event) {
-  if (event.key === 'Enter') {
-    event.preventDefault(); // Prevent form submission if inside a form
-    createFolder();
-  }
-});
+// Enter key support comes from data-enter-confirm on #createFolderModal (clu-utils.js)
 
 
 function moveMultipleItems(filePaths, targetFolder, panel, itemsWithTypes = null) {
@@ -3318,15 +3311,7 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-// Add Enter key support for the text input (only if element exists)
-const textToRemoveEl = document.getElementById('textToRemove');
-if (textToRemoveEl) {
-  textToRemoveEl.addEventListener('keypress', function (e) {
-    if (e.key === 'Enter') {
-      previewCustomRename();
-    }
-  });
-}
+// Enter key support comes from data-enter-confirm on #customRenameModal (clu-utils.js)
 
 // ============================================================================
 // Series Rename Modal functionality
@@ -3548,15 +3533,7 @@ function executeRenameFiles() {
     });
 }
 
-// Add Enter key support for the series name input (only if element exists)
-const newSeriesNameEl = document.getElementById('newSeriesName');
-if (newSeriesNameEl) {
-  newSeriesNameEl.addEventListener('keypress', function (e) {
-    if (e.key === 'Enter') {
-      previewRenameFiles();
-    }
-  });
-}
+// Enter key support comes from data-enter-confirm on #renameFilesModal (clu-utils.js)
 
 // Search functionality
 let searchModal;

--- a/static/js/files_context_menu.js
+++ b/static/js/files_context_menu.js
@@ -147,13 +147,8 @@ function showFolderNamePrompt(filePaths, seriesInfo) {
   // Show modal
   modal.show();
 
-  // Handle Enter key in input
+  // Enter key support comes from data-enter-confirm on #folderNamePromptModal (clu-utils.js)
   const inputElement = document.getElementById('customFolderName');
-  inputElement.onkeypress = function(e) {
-    if (e.key === 'Enter') {
-      document.getElementById('confirmCustomFolderBtn').click();
-    }
-  };
 
   // Focus the input
   document.getElementById('folderNamePromptModal').addEventListener('shown.bs.modal', function () {

--- a/templates/files.html
+++ b/templates/files.html
@@ -103,46 +103,12 @@
 
   <!-- Toast Container -->
   {% include 'partials/toast_container.html' %}
-  <div class="position-fixed top-0 end-0 p-3" style="z-index: 1100;">
-    <!-- ComicInfo Clear Confirmation Toast -->
-    <div id="clearComicInfoConfirmToast" class="toast bg-warning" role="alert" aria-live="assertive" aria-atomic="true">
-      <div class="toast-header bg-warning">
-        <strong class="me-auto">Confirm Delete</strong>
-        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-      </div>
-      <div class="toast-body">
-        <p class="mb-2">Are you sure you want to delete ComicInfo.xml? This cannot be undone.</p>
-        <div class="d-flex gap-2">
-          <button type="button" class="btn btn-sm btn-danger" id="confirmClearComicInfoBtn">Delete</button>
-          <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="toast">Cancel</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- ComicInfo Clear Success Toast -->
-    <div id="clearComicInfoSuccessToast" class="toast bg-success text-white" role="alert" aria-live="assertive"
-      aria-atomic="true">
-      <div class="toast-header bg-success text-white">
-        <strong class="me-auto">Success</strong>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
-      </div>
-      <div class="toast-body">
-        ComicInfo.xml has been successfully deleted.
-      </div>
-    </div>
-
-    <!-- ComicInfo Clear Error Toast -->
-    <div id="clearComicInfoErrorToast" class="toast bg-danger text-white" role="alert" aria-live="assertive"
-      aria-atomic="true">
-      <div class="toast-header bg-danger text-white">
-        <strong class="me-auto">Error</strong>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
-      </div>
-      <div class="toast-body" id="clearComicInfoErrorBody">
-        Failed to delete ComicInfo.xml.
-      </div>
-    </div>
-  </div>
+  <!--
+    The ComicInfo clear flow lives in clu-cbz-info.js: it confirms through
+    #clearComicInfoConfirmModal (partials/modal_cbz_info.html) and reports via
+    CLU.showSuccess/CLU.showError. The hand-rolled toasts that used to sit here
+    were never wired to anything.
+  -->
 
 </div>
 
@@ -167,7 +133,7 @@
 
 <!-- Folder Name Prompt Modal for Mixed Series -->
 <div class="modal fade" id="folderNamePromptModal" tabindex="-1" aria-labelledby="folderNamePromptModalLabel"
-  aria-hidden="true">
+  aria-hidden="true" data-enter-confirm="confirmCustomFolderBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -201,7 +167,8 @@
 <!-- End of Folder Name Prompt Modal -->
 
 <!-- Combine Files Modal -->
-<div class="modal fade" id="combineFilesModal" tabindex="-1" aria-labelledby="combineFilesModalLabel" aria-hidden="true">
+<div class="modal fade" id="combineFilesModal" tabindex="-1" aria-labelledby="combineFilesModalLabel" aria-hidden="true"
+  data-enter-confirm="confirmCombineFilesBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -229,7 +196,8 @@
 <!-- End of Combine Files Modal -->
 
 <!-- Remove XML Confirmation Modal -->
-<div class="modal fade" id="removeXmlModal" tabindex="-1" aria-labelledby="removeXmlModalLabel" aria-hidden="true">
+<div class="modal fade" id="removeXmlModal" tabindex="-1" aria-labelledby="removeXmlModalLabel" aria-hidden="true"
+  data-enter-confirm="confirmRemoveXmlBtn">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
@@ -258,7 +226,8 @@
 <!-- End of Remove XML Modal -->
 
 <!-- Remove XML from Directory Confirmation Modal -->
-<div class="modal fade" id="removeXmlDirModal" tabindex="-1" aria-labelledby="removeXmlDirModalLabel" aria-hidden="true">
+<div class="modal fade" id="removeXmlDirModal" tabindex="-1" aria-labelledby="removeXmlDirModalLabel" aria-hidden="true"
+  data-enter-confirm="confirmRemoveXmlDirBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -284,7 +253,7 @@
 
 <!-- Smart Rename Preview Modal -->
 <div class="modal fade" id="smartRenamePreviewModal" tabindex="-1" aria-labelledby="smartRenamePreviewModalLabel"
-  aria-hidden="true">
+  aria-hidden="true" data-enter-confirm="smartRenameApplyBtn">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
@@ -328,7 +297,7 @@
 
 <!-- Create Folder Modal -->
 <div class="modal fade" id="createFolderModal" tabindex="-1" aria-labelledby="createFolderModalLabel"
-  aria-hidden="true">
+  aria-hidden="true" data-enter-confirm="confirmCreateFolderBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -353,8 +322,9 @@
 {% include 'partials/modal_cbz_info.html' %}
 
 <!-- Custom Remove Text from Filenames Modal -->
+<!-- Enter targets Preview, never Execute: the execute button stays a deliberate click. -->
 <div class="modal fade" id="customRenameModal" tabindex="-1" aria-labelledby="customRenameModalLabel"
-  aria-hidden="true">
+  aria-hidden="true" data-enter-confirm="previewRenameBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -395,7 +365,8 @@
 <!-- End of Custom Rename Modal -->
 
 <!-- Replace Text in Filenames Modal -->
-<div class="modal fade" id="replaceTextModal" tabindex="-1" aria-labelledby="replaceTextModalLabel" aria-hidden="true">
+<div class="modal fade" id="replaceTextModal" tabindex="-1" aria-labelledby="replaceTextModalLabel" aria-hidden="true"
+  data-enter-confirm="previewReplaceBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -445,7 +416,8 @@
 <!-- End of Replace Text Modal -->
 
 <!-- Rename Files Modal -->
-<div class="modal fade" id="renameFilesModal" tabindex="-1" aria-labelledby="renameFilesModalLabel" aria-hidden="true">
+<div class="modal fade" id="renameFilesModal" tabindex="-1" aria-labelledby="renameFilesModalLabel" aria-hidden="true"
+  data-enter-confirm="previewRenameFilesBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -614,7 +586,8 @@
 <!-- End of Missing File Check Results Modal -->
 
 <!-- ComicVine URL Modal -->
-<div class="modal fade" id="cvInfoModal" tabindex="-1" aria-labelledby="cvInfoModalLabel" aria-hidden="true">
+<div class="modal fade" id="cvInfoModal" tabindex="-1" aria-labelledby="cvInfoModalLabel" aria-hidden="true"
+  data-enter-confirm="cvInfoSaveBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -638,7 +611,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" onclick="saveCVInfo()">
+        <button type="button" class="btn btn-primary" id="cvInfoSaveBtn" onclick="saveCVInfo()">
           <i class="bi bi-save"></i> Save
         </button>
       </div>

--- a/templates/partials/modal_add_to_reading_list.html
+++ b/templates/partials/modal_add_to_reading_list.html
@@ -1,5 +1,5 @@
 <!-- Add to Reading List Modal -->
-<div class="modal fade" id="addToReadingListModal" tabindex="-1">
+<div class="modal fade" id="addToReadingListModal" tabindex="-1" data-enter-confirm="readingListPickerConfirmBtn">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
@@ -21,7 +21,9 @@
                     <div class="mb-3">
                         <label class="form-label fw-bold">Or create a new list</label>
                         <div class="input-group">
-                            <input type="text" class="form-control" id="readingListPickerNewName" placeholder="New list name...">
+                            <!-- Overrides the modal's Enter target: here Enter creates the list. -->
+                            <input type="text" class="form-control" id="readingListPickerNewName" placeholder="New list name..."
+                                   data-enter-confirm="readingListPickerCreateBtn">
                             <button class="btn btn-outline-success" type="button" id="readingListPickerCreateBtn">Create</button>
                         </div>
                     </div>

--- a/templates/partials/modal_cbz_info.html
+++ b/templates/partials/modal_cbz_info.html
@@ -31,3 +31,32 @@
     </div>
   </div>
 </div>
+
+<!-- Clear ComicInfo.xml confirmation – stacks on top of #cbzInfoModal, which stays open -->
+<div class="modal fade" id="clearComicInfoConfirmModal" tabindex="-1"
+  aria-labelledby="clearComicInfoConfirmModalLabel" aria-hidden="true"
+  data-enter-confirm="confirmClearComicInfoBtn">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title text-danger" id="clearComicInfoConfirmModalLabel">
+          <i class="bi bi-eraser me-2"></i>Delete ComicInfo.xml
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Delete ComicInfo.xml from <strong id="clearComicInfoFileName"></strong>?</p>
+        <div class="alert alert-warning mb-0">
+          <i class="bi bi-exclamation-triangle me-2"></i>This permanently removes the embedded
+          metadata from this file and cannot be undone.
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="confirmClearComicInfoBtn">
+          <i class="bi bi-eraser me-1"></i>Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/partials/modal_cbz_split.html
+++ b/templates/partials/modal_cbz_split.html
@@ -23,7 +23,8 @@
     overflow-wrap: anywhere;
   }
 </style>
-<div class="modal fade" id="splitCBZModal" tabindex="-1" aria-labelledby="splitCBZModalLabel" aria-hidden="true">
+<div class="modal fade" id="splitCBZModal" tabindex="-1" aria-labelledby="splitCBZModalLabel" aria-hidden="true"
+  data-enter-confirm="splitCommitBtn">
   <div class="modal-dialog modal-fullscreen">
     <div class="modal-content">
       <div class="modal-header">

--- a/templates/partials/modal_metadata_select.html
+++ b/templates/partials/modal_metadata_select.html
@@ -63,7 +63,8 @@
             <li><strong>Year:</strong> <span id="cvParsedYear"></span></li>
           </ul>
         </div>
-        <div class="mb-3" id="cvRefineSearchRow">
+        <!-- Scoped to the refine row only — Enter in #cvFilterInput below must stay inert. -->
+        <div class="mb-3" id="cvRefineSearchRow" data-enter-confirm="cvRefineSearchBtn">
           <div class="input-group">
             <input type="text" class="form-control" id="cvRefineSearchInput" placeholder="Refine search term...">
             <button class="btn btn-outline-primary" type="button" id="cvRefineSearchBtn">
@@ -139,7 +140,8 @@
 <!-- End of Manga Series Selection Modal -->
 
 <!-- Refine Search Modal -->
-<div class="modal fade" id="refineSearchModal" tabindex="-1" aria-labelledby="refineSearchModalLabel" aria-hidden="true">
+<div class="modal fade" id="refineSearchModal" tabindex="-1" aria-labelledby="refineSearchModalLabel" aria-hidden="true"
+  data-enter-confirm="refineSearchBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/templates/partials/modal_update_xml.html
+++ b/templates/partials/modal_update_xml.html
@@ -1,5 +1,6 @@
 <!-- Update XML Modal – shared partial (clu-update-xml.js) -->
-<div class="modal fade" id="updateXmlModal" tabindex="-1" aria-labelledby="updateXmlModalLabel" aria-hidden="true">
+<div class="modal fade" id="updateXmlModal" tabindex="-1" aria-labelledby="updateXmlModalLabel" aria-hidden="true"
+  data-enter-confirm="updateXmlConfirmBtn">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/tests/routes/test_collection_routes.py
+++ b/tests/routes/test_collection_routes.py
@@ -12,6 +12,61 @@ class TestFilesPage:
         resp = client.get("/files")
         assert resp.status_code == 200
 
+    @patch("routes.collection.config")
+    def test_files_page_modals_confirm_on_enter(self, mock_config, client):
+        """Confirmation modals opt into Enter-to-confirm via data-enter-confirm.
+
+        The attribute names a button id; clu-utils.js clicks that button when
+        Enter is pressed inside the annotated scope.
+        """
+        mock_config.get.side_effect = lambda s, k, fallback="": fallback
+        html = client.get("/files").get_data(as_text=True)
+
+        for button_id in (
+            "confirmCustomFolderBtn",
+            "confirmCombineFilesBtn",
+            "confirmRemoveXmlBtn",
+            "confirmRemoveXmlDirBtn",
+            "smartRenameApplyBtn",
+            "confirmCreateFolderBtn",
+            "cvInfoSaveBtn",
+            "updateXmlConfirmBtn",
+        ):
+            assert f'data-enter-confirm="{button_id}"' in html
+            assert f'id="{button_id}"' in html
+
+    @patch("routes.collection.config")
+    def test_files_page_clear_comicinfo_confirms_via_modal(self, mock_config, client):
+        """Clearing ComicInfo.xml confirms through a modal, not a native confirm().
+
+        The modal ships with partials/modal_cbz_info.html so every page that can
+        open the CBZ info viewer can also confirm the delete.
+        """
+        mock_config.get.side_effect = lambda s, k, fallback="": fallback
+        html = client.get("/files").get_data(as_text=True)
+
+        assert 'id="clearComicInfoConfirmModal"' in html
+        assert 'id="confirmClearComicInfoBtn"' in html
+        assert 'id="clearComicInfoFileName"' in html
+        assert 'data-enter-confirm="confirmClearComicInfoBtn"' in html
+
+    @patch("routes.collection.config")
+    def test_files_page_bulk_rename_enter_targets_preview(self, mock_config, client):
+        """Enter must never fire a bulk rename -- it stops at Preview.
+
+        The Execute buttons in these two-stage modals stay a deliberate click.
+        """
+        mock_config.get.side_effect = lambda s, k, fallback="": fallback
+        html = client.get("/files").get_data(as_text=True)
+
+        for preview_id, execute_id in (
+            ("previewRenameBtn", "executeRenameBtn"),
+            ("previewReplaceBtn", "executeReplaceBtn"),
+            ("previewRenameFilesBtn", "executeRenameFilesBtn"),
+        ):
+            assert f'data-enter-confirm="{preview_id}"' in html
+            assert f'data-enter-confirm="{execute_id}"' not in html
+
 
 class TestCollectionPage:
 


### PR DESCRIPTION
## Why

Two things prompted this:

1. On the File Manager, modals could only be completed with the mouse. `templates/files.html` has no `<form>` elements, so Enter did nothing in any modal without a hand-written handler — e.g. typing a Comic Vine Volume ID in `#cvInfoModal` and pressing Enter did nothing.
2. Clearing ComicInfo.xml used a native `confirm()`, which `CLAUDE.md` prohibits.

## Enter-to-confirm

The few modals that already supported Enter used three incompatible idioms: an input-level `keypress` listener, an `.onkeypress` assignment re-set on every open, and modal-level `keydown` delegation. All of it is replaced by one delegated listener in `static/js/clu-utils.js`, driven declaratively from the templates:

```html
<div class="modal fade" id="cvInfoModal" ... data-enter-confirm="cvInfoSaveBtn">
```

It **clicks the button** rather than calling its handler, so existing wiring survives untouched — `saveCVInfo()`'s empty/numeric validation, the directory path stashed on `#confirmRemoveXmlDirBtn.dataset`, and `disabled`/hidden button states.

Because `closest()` resolves to the nearest ancestor-or-self, the attribute on an inner element overrides the modal's. That is how the "create a new list" field in Add to Reading List targets **Create** while the rest of the modal targets **Add**, and how the ComicVine refine row is scoped so Enter in the adjacent live-filter box stays inert.

Guards skip textareas, buttons, links, `contenteditable`, modifier combos, and IME composition commits.

**Covered:** 10 modals in `files.html` plus 5 in shared partials (Update XML, Split CBZ, Refine Search, ComicVine refine row, Add to Reading List) — the partials also render on collection/series pages, so the improvement applies there too.

**Not covered, deliberately:** `#searchModal` already has working Enter with debounce cancellation and is a search, not a confirmation.

### Enter can't fire a bulk rename

The two-stage rename modals point at their **Preview** button. Their Execute buttons are `display:none` until a preview renders, and the hidden-button guard makes them unreachable by keyboard — so a bulk directory rename stays a deliberate click. A test asserts `data-enter-confirm="executeRenameBtn"` never appears.

## ComicInfo.xml confirmation

`confirm()` in `clu-cbz-info.js` is replaced by `#clearComicInfoConfirmModal`, which names the specific file and warns the metadata loss is permanent. It ships in `partials/modal_cbz_info.html`, so all six pages that can open the CBZ viewer can also confirm the delete. If the partial is ever missing, the code refuses rather than deleting unconfirmed.

The three hand-rolled `clearComicInfo*` toasts in `files.html` were wired to nothing and are removed — that flow already reported through `CLU.showSuccess`/`CLU.showError`.

## Two Bootstrap 5.3 stacked-modal bugs

The confirmation stacks over `#cbzInfoModal`, which surfaced two bugs worth fixing generically — `clu-cbz-crop.js:154` stacks a modal too:

- **`FocusTrap.activate()` focuses the new modal *before* removing the previous trap's `focusin` listener**, so the open modal's still-active trap yanks focus back. The confirmation rendered visible but unfocused, and Enter went to the modal underneath. Fixed by re-focusing on `shown.bs.modal`, once `activate()` has finished and only the new trap is listening. No-op for non-stacked modals, and it can't fight modals that focus their own input on open (element listeners fire before document listeners while bubbling).
- **Hiding any modal unconditionally drops `body.modal-open` and leaves focus nowhere**, even with another modal still open — so cancelling the confirmation left the viewer scrollable-behind and unfocused. Fixed on `hidden.bs.modal`.

## Drive-by fix

`#updateXmlConfirmBtn` had click listeners in **both** `files.js` and `clu-update-xml.js`, so every Update XML submitted twice. Removed the `files.js` copy — `clu-update-xml.js` owns that modal. Latent before, but trivially reachable once Enter also triggers the click.

## Testing

Three route tests added to `tests/routes/test_collection_routes.py` asserting the attributes render, the Execute buttons stay unbound, and the confirmation modal is present. The repo has no JS test runner, so the JS itself is covered only by `node --check` (clean).

Full suite: **2951 passed, 6 skipped** (POSIX-only chmod tests).

Manual browser verification has **not** been run — worth a click-through of: Enter in `#cvInfoModal` (including blank/non-numeric, which should still toast and stay open), Enter twice in a rename modal (should refresh the preview, never rename), and the eraser → confirm → Escape path on a CBZ with metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
