### PR TITLE
Share provider clients, pace both APIs, and map via ComicVine

### DIFF
--- a/app.py
+++ b/app.py
@@ -562,7 +562,10 @@ def scheduled_series_sync():
                     lambda: api.series(series_id),
                     f"fetching series info for {series_id}",
                 )
-                time.sleep(3)  # Rate limit: 20 calls/min on Metron API
+                # No sleep here: metron._api_call already paces every request
+                # through the shared sliding-window limiter, retuned from the
+                # rate-limit headers Metron returns. A fixed sleep on top just
+                # added dead time per series without adding protection.
                 if not series_info:
                     fail_count += 1
                     continue
@@ -605,7 +608,7 @@ def scheduled_series_sync():
                 app_logger.info(f"Fetching updates for series {series_id}...")
                 all_issues_result = metron.get_all_issues_for_series(api, series_id)
                 all_issues = list(all_issues_result) if all_issues_result else []
-                time.sleep(3)  # Rate limit: 20 calls/min on Metron API
+                # Paced by metron._api_call -- see the note above.
 
                 # 4. Save and Cleanup
                 save_issues_bulk(all_issues, series_id)

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -131,15 +131,26 @@ def _resolve_series_via_providers(cvinfo_path: str, library_id: Optional[int]):
 
 
 def _build_comicvine_series_dict(api_key: str, cv_id: int) -> Optional[Dict]:
-    """Fetch a CV volume and shape it for `write_series_json`."""
-    try:
-        from simyan.comicvine import Comicvine  # type: ignore
-    except ImportError:
+    """Fetch a CV volume and shape it for `write_series_json`.
+
+    Goes through ``models.comicvine`` rather than constructing a Simyan client
+    here: that gets the process-shared client (so this doesn't leak a limiter
+    thread and SQLite connections per call), the browser User-Agent Cloudflare
+    wants, cache paths that don't depend on ``$HOME``, and the shared rate-limit
+    budget. Constructing one locally also passed ``cache=None``, which Simyan
+    3.x doesn't accept -- so this fallback raised TypeError into the
+    catch-all below and silently never worked.
+    """
+    from models import comicvine as cv_module
+
+    if not cv_module.is_simyan_available():
         app_logger.warning("smart_rename: simyan not installed; cannot use ComicVine fallback")
         return None
     try:
-        cv = Comicvine(api_key=api_key, cache=None)
-        volume = cv.get_volume(cv_id)
+        cv = cv_module.get_cv_client(api_key)
+        volume = cv_module._cv_call_with_retry(
+            lambda: cv.get_volume(cv_id), f"smart_rename volume {cv_id}"
+        )
         if not volume:
             return None
         publisher = getattr(volume, "publisher", None)
@@ -160,6 +171,15 @@ def _build_comicvine_series_dict(api_key: str, cv_id: int) -> Optional[Dict]:
             "status": None,
             "image": image_url,
         }
+    except (AttributeError, TypeError) as e:
+        # A Simyan API change (renamed method, changed signature) is a bug we
+        # need to see, not something to swallow -- that is exactly how the
+        # cache=None breakage stayed hidden. Log it loudly.
+        app_logger.error(
+            f"smart_rename: ComicVine client API mismatch fetching {cv_id} "
+            f"(simyan version change?): {e}"
+        )
+        return None
     except Exception as e:
         app_logger.error(f"smart_rename: ComicVine volume fetch failed for {cv_id}: {e}")
         return None

--- a/core/database.py
+++ b/core/database.py
@@ -11286,6 +11286,7 @@ def save_provider_credentials(provider_type: str, credentials: dict) -> bool:
         )
         conn.commit()
         conn.close()
+        invalidate_provider_client_caches()
         app_logger.info(f"Saved credentials for provider: {provider_type}")
         return True
     except Exception as e:
@@ -11293,6 +11294,34 @@ def save_provider_credentials(provider_type: str, credentials: dict) -> bool:
             f"Failed to save provider credentials for {provider_type}: {e}"
         )
         return False
+
+
+def invalidate_provider_client_caches() -> None:
+    """Drop cached provider instances and API clients after a credential change.
+
+    Provider instances and the Simyan/mokkari clients they hold are cached per
+    credential set for the life of the process, so without this a saved key
+    keeps being ignored in favour of the old one. Best-effort and never fatal:
+    a failure here costs a stale client, not a failed save.
+    """
+    try:
+        from models.providers import invalidate_provider_cache
+
+        invalidate_provider_cache()
+    except Exception as e:
+        app_logger.warning(f"Could not clear provider instance cache: {e}")
+    try:
+        from models.comicvine import invalidate_cv_client_cache
+
+        invalidate_cv_client_cache()
+    except Exception as e:
+        app_logger.warning(f"Could not clear ComicVine client cache: {e}")
+    try:
+        from models.metron import invalidate_session_cache
+
+        invalidate_session_cache()
+    except Exception as e:
+        app_logger.warning(f"Could not clear Metron session cache: {e}")
 
 
 def get_provider_credentials(provider_type: str) -> Optional[dict]:
@@ -11425,6 +11454,7 @@ def delete_provider_credentials(provider_type: str) -> bool:
         )
         conn.commit()
         conn.close()
+        invalidate_provider_client_caches()
         app_logger.info(f"Deleted credentials for provider: {provider_type}")
         return True
     except Exception as e:

--- a/core/memory_utils.py
+++ b/core/memory_utils.py
@@ -14,21 +14,45 @@ from core.app_logging import app_logger
 import tracemalloc
 
 
+def _threshold_from_env(name, default):
+    """Read a positive MB threshold from the environment, else ``default``."""
+    try:
+        value = int(os.environ.get(name, default))
+    except (ValueError, TypeError):
+        return default
+    return value if value > 0 else default
+
+
 class MemoryMonitor:
     """
     Memory monitoring and management utility.
     """
-    
-    def __init__(self, threshold_mb=1500, cleanup_threshold_mb=1000):
+
+    def __init__(self, threshold_mb=None, cleanup_threshold_mb=None):
         """
         Initialize memory monitor.
 
         Args:
-            threshold_mb: Memory threshold in MB to trigger warnings
-            cleanup_threshold_mb: Memory threshold in MB to trigger cleanup
+            threshold_mb: Memory threshold in MB to trigger warnings. Defaults to
+                MEMORY_THRESHOLD_MB, or 1500.
+            cleanup_threshold_mb: Memory threshold in MB to trigger cleanup.
+                Defaults to MEMORY_CLEANUP_THRESHOLD_MB, or 1000.
+
+        The thresholds are configurable because the warning re-fires every poll
+        (60s) for as long as RSS stays above it, so a deployment whose normal
+        working set is legitimately larger than the default would otherwise fill
+        its logs with a warning it can do nothing about.
         """
-        self.threshold_mb = threshold_mb
-        self.cleanup_threshold_mb = cleanup_threshold_mb
+        self.threshold_mb = (
+            _threshold_from_env("MEMORY_THRESHOLD_MB", 1500)
+            if threshold_mb is None
+            else threshold_mb
+        )
+        self.cleanup_threshold_mb = (
+            _threshold_from_env("MEMORY_CLEANUP_THRESHOLD_MB", 1000)
+            if cleanup_threshold_mb is None
+            else cleanup_threshold_mb
+        )
         self.process = psutil.Process()
         self.monitoring = False
         self.monitor_thread = None

--- a/helpers/provider_cache.py
+++ b/helpers/provider_cache.py
@@ -1,0 +1,49 @@
+"""Writable on-disk cache locations for the third-party provider clients.
+
+Both Simyan (ComicVine) and Mokkari (Metron) keep SQLite files -- Simyan for its
+HTTP cache and rate-limit buckets, Mokkari for its response cache. Both default
+to ``$HOME/.cache``, which doesn't exist for the container's non-root user and
+can't be created by it (issue #396), so CLU resolves the location itself.
+
+Kept in one place so the two providers can't drift apart: a permissions fix for
+one is a permissions fix for both, and their cache files sit side by side.
+"""
+
+import os
+import tempfile
+
+from core.app_logging import app_logger
+
+
+def provider_cache_dir(name: str) -> str:
+    """Return a writable directory for provider ``name``'s cache files.
+
+    Mirrors Simyan's own resolution order (``$XDG_CACHE_HOME`` first, then a
+    CLU-owned location under ``CONFIG_DIR``), falling back to a temp dir if the
+    preferred location isn't writable.
+
+    ``CONFIG_DIR`` is used rather than ``CACHE_DIR`` because the latter only
+    exists as ``app.config["CACHE_DIR"]``; these clients are built from daemon
+    threads with no Flask app context. ``CONFIG_DIR`` is a module constant and
+    is already a mounted volume in Docker.
+
+    Args:
+        name: Leaf directory name, e.g. ``"simyan"`` or ``"mokkari"``.
+
+    Returns:
+        Path to an existing, writable directory.
+    """
+    from core.config import CONFIG_DIR
+
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.join(CONFIG_DIR, ".cache")
+    target = os.path.join(base, name)
+    try:
+        os.makedirs(target, exist_ok=True)
+        return target
+    except OSError:
+        fallback = os.path.join(tempfile.gettempdir(), f"clu-{name}")
+        os.makedirs(fallback, exist_ok=True)
+        app_logger.warning(
+            f"Provider cache dir {target} not writable; using {fallback}"
+        )
+        return fallback

--- a/helpers/rate_limit.py
+++ b/helpers/rate_limit.py
@@ -1,0 +1,120 @@
+"""Process-wide request pacing for the third-party metadata providers.
+
+CLU reaches Metron and ComicVine from several places at once -- background
+sweeps, bulk-metadata jobs, the wanted-cache refresh and live web requests --
+so pacing has to be shared across threads or the providers' burst limits get
+tripped by the aggregate rather than by any one caller.
+
+The limiter here is the *outer* gate: it trips before the provider libraries'
+own limits so the wait happens somewhere we control and log. It does not
+replace Simyan's or Metron's own protection.
+"""
+
+import threading
+import time
+from collections import deque
+from typing import Dict, Optional
+
+
+class SlidingWindowRateLimiter:
+    """Caps outgoing requests to `max_requests` per `window_seconds`, process-wide.
+
+    Blocking by default: ``acquire()`` sleeps the calling thread until a slot
+    frees up rather than raising, so retry/error-handling logic above it doesn't
+    need to change.
+    """
+
+    def __init__(self, max_requests: int, window_seconds: float):
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._timestamps: deque = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self, timeout: Optional[float] = None) -> bool:
+        """Take a slot, waiting for one if necessary.
+
+        Args:
+            timeout: Longest to wait, in seconds. ``None`` waits indefinitely,
+                which is right for background jobs. Interactive callers must
+                pass a bound: a limiter with an hour-long window would
+                otherwise park a Flask request thread for most of an hour,
+                turning a visible rate-limit error into a hung spinner.
+
+        Returns:
+            True if a slot was taken, False if ``timeout`` elapsed first. On
+            False the caller has *not* consumed a slot.
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                while (
+                    self._timestamps
+                    and now - self._timestamps[0] >= self._window_seconds
+                ):
+                    self._timestamps.popleft()
+                if len(self._timestamps) < self._max_requests:
+                    self._timestamps.append(now)
+                    return True
+                wait = self._window_seconds - (now - self._timestamps[0])
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or wait > remaining:
+                    return False
+            if wait > 0:
+                time.sleep(wait)
+
+    def retune(self, max_requests: int, window_seconds: Optional[float] = None) -> None:
+        """Adjust the budget in place, keeping the observed request history.
+
+        Used when a provider reports its real limit in response headers, so we
+        can stop guessing without discarding what has already been sent.
+        """
+        with self._lock:
+            self._max_requests = max(1, int(max_requests))
+            if window_seconds is not None:
+                self._window_seconds = float(window_seconds)
+
+    @property
+    def max_requests(self) -> int:
+        with self._lock:
+            return self._max_requests
+
+    @property
+    def window_seconds(self) -> float:
+        with self._lock:
+            return self._window_seconds
+
+    def reset(self) -> None:
+        with self._lock:
+            self._timestamps.clear()
+
+
+_LIMITERS: Dict[str, SlidingWindowRateLimiter] = {}
+_LIMITERS_LOCK = threading.Lock()
+
+
+def get_limiter(
+    name: str, max_requests: int, window_seconds: float
+) -> SlidingWindowRateLimiter:
+    """Return the shared limiter called ``name``, creating it on first use.
+
+    ``max_requests``/``window_seconds`` only apply when the limiter is first
+    created; later callers get the existing one so every caller in the process
+    draws on the same budget. Use :meth:`SlidingWindowRateLimiter.retune` to
+    change an existing limiter's budget.
+    """
+    with _LIMITERS_LOCK:
+        limiter = _LIMITERS.get(name)
+        if limiter is None:
+            limiter = SlidingWindowRateLimiter(max_requests, window_seconds)
+            _LIMITERS[name] = limiter
+        return limiter
+
+
+def reset_all_limiters() -> None:
+    """Clear every shared limiter's window (used by tests)."""
+    with _LIMITERS_LOCK:
+        limiters = list(_LIMITERS.values())
+    for limiter in limiters:
+        limiter.reset()

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -11,16 +11,26 @@ from typing import Optional, Dict, List, Any
 import os
 import shutil
 import re
-import tempfile
+import threading
 import time
 from pathlib import Path
 from cbz_ops.rename import rename_comic_from_metadata
+from helpers.rate_limit import get_limiter
 
 try:
     from simyan.comicvine import Comicvine, ComicvineResource
     SIMYAN_AVAILABLE = True
 except ImportError:
     SIMYAN_AVAILABLE = False
+
+# Simyan's typed rate-limit error, when this version exposes one. Guarded
+# because simyan may be absent entirely, and the module has been renamed across
+# releases -- _is_rate_limit_error falls back to message matching either way.
+try:
+    from simyan.errors import RateLimitError as _SimyanRateLimitError
+    _RATE_LIMIT_ERROR_TYPES = (_SimyanRateLimitError,)
+except ImportError:
+    _RATE_LIMIT_ERROR_TYPES = ()
 
 
 def _get_cv_request_timeout() -> int:
@@ -43,23 +53,12 @@ def _cv_cache_dir() -> str:
 
     Simyan 3.x always caches and defaults to ``$HOME/.cache``, which doesn't exist
     for the container's non-root user and can't be created by it (issue #396).
-    Mirrors Simyan's own resolution order, falling back to a temp dir if the
-    preferred location isn't writable.
+    Shares its resolution with Mokkari's cache via ``helpers.provider_cache`` so
+    the two can't drift apart.
     """
-    from core.config import CONFIG_DIR
+    from helpers.provider_cache import provider_cache_dir
 
-    base = os.environ.get("XDG_CACHE_HOME") or os.path.join(CONFIG_DIR, ".cache")
-    target = os.path.join(base, "simyan")
-    try:
-        os.makedirs(target, exist_ok=True)
-        return target
-    except OSError:
-        fallback = os.path.join(tempfile.gettempdir(), "clu-simyan")
-        os.makedirs(fallback, exist_ok=True)
-        app_logger.warning(
-            f"ComicVine cache dir {target} not writable; using {fallback}"
-        )
-        return fallback
+    return provider_cache_dir("simyan")
 
 
 def _make_cv_client(api_key: str):
@@ -81,13 +80,17 @@ def _make_cv_client(api_key: str):
     Both ``cache_path`` and ``ratelimit_path`` must be passed: each defaults to
     ``get_cache_root() / ...``, which creates a directory under ``$HOME``. Passing
     both short-circuits that and keeps the client independent of ``$HOME``.
+
+    Prefer :func:`get_cv_client` over calling this directly — every client owns a
+    background limiter thread and SQLite connections that are never released.
     """
     from models.providers.base import DEFAULT_PROVIDER_USER_AGENT
 
     # Modern Simyan: no `cache` kwarg, native `user_agent` support.
+    client = None
     try:
         cache_dir = Path(_cv_cache_dir())
-        return Comicvine(
+        client = Comicvine(
             api_key=api_key,
             timeout=CV_REQUEST_TIMEOUT,
             user_agent=DEFAULT_PROVIDER_USER_AGENT,
@@ -97,13 +100,114 @@ def _make_cv_client(api_key: str):
     except TypeError:
         pass
 
-    # Legacy Simyan: takes `cache`, no `user_agent` — patch the session afterwards.
-    client = Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
+    if client is None:
+        # Legacy Simyan: takes `cache`, no `user_agent` — patch the session after.
+        client = Comicvine(api_key=api_key, cache=None, timeout=CV_REQUEST_TIMEOUT)
+        try:
+            client._session.headers.update(
+                {"User-Agent": DEFAULT_PROVIDER_USER_AGENT}
+            )
+        except Exception:
+            pass
+
+    _apply_max_delay(client)
+    return client
+
+
+def _cv_max_delay() -> float:
+    """Longest a request may wait inside Simyan's own rate limiter.
+
+    Simyan builds its session with ``max_delay=timeout * 2`` (40s by default).
+    Once the client is shared process-wide its ``per_hour=200`` bucket actually
+    engages, and a saturated bucket makes ``LimiterMixin.send`` raise rather
+    than wait past ``max_delay``. Raising the ceiling lets a long sweep ride out
+    a full bucket instead of failing. Never unbounded — a live web request must
+    not hang forever. Overridable via ``COMICVINE_MAX_DELAY``.
+    """
     try:
-        client._session.headers.update({"User-Agent": DEFAULT_PROVIDER_USER_AGENT})
+        return max(0.0, float(os.environ.get("COMICVINE_MAX_DELAY", "60")))
+    except (ValueError, TypeError):
+        return 60.0
+
+
+def _apply_max_delay(client) -> None:
+    """Best-effort ``max_delay`` bump on a Simyan client's limiter session."""
+    try:
+        client._session.max_delay = _cv_max_delay()
     except Exception:
         pass
-    return client
+
+
+# ---------------------------------------------------------------------------
+# Shared client cache
+#
+# Every Simyan client is a CachedLimiterSession: constructing one spins up a
+# background pyrate_limiter Leaker thread plus SQLite connections for the HTTP
+# cache and the rate-limit bucket, and nothing ever releases them. Building one
+# per call (which every function here used to do) leaked a thread and two
+# connections per series during a library sweep, and left N independent buckets
+# racing each other past ComicVine's limit -- the "Slow down cowboy" rejections.
+#
+# One shared client per key fixes both: Simyan's own per_second/per_hour budget
+# finally accumulates real state, and the thread/connection count stays flat.
+# Mirrors models.metron._SESSION_CACHE.
+# ---------------------------------------------------------------------------
+
+_CV_CLIENT_CACHE: Dict[str, Any] = {}
+_CV_CLIENT_CACHE_LOCK = threading.Lock()
+
+
+def get_cv_client(api_key: str):
+    """Return the process-shared Simyan client for ``api_key``.
+
+    Clients are cached and reused across calls and threads. A shared
+    ``CachedLimiterSession`` is safe to use concurrently: Simyan writes
+    ``headers``/``params`` once at construction and only reads them afterwards,
+    urllib3's pool manager is thread-safe, ``requests_cache`` keeps thread-local
+    connections, and ``pyrate_limiter``'s SQLite bucket guards itself with a
+    lock. One shared bucket is strictly safer than the racing per-call buckets
+    it replaces.
+    """
+    with _CV_CLIENT_CACHE_LOCK:
+        client = _CV_CLIENT_CACHE.get(api_key)
+        if client is not None:
+            return client
+
+    client = _make_cv_client(api_key)
+
+    with _CV_CLIENT_CACHE_LOCK:
+        # Another thread may have raced us for the same key; keep whichever won
+        # so only one is ever cached, and close the loser's session so its
+        # Leaker thread doesn't outlive it.
+        winner = _CV_CLIENT_CACHE.setdefault(api_key, client)
+    if winner is not client:
+        _close_cv_client(client)
+    return winner
+
+
+def _close_cv_client(client) -> None:
+    """Release a Simyan client's limiter thread, cache and connection pool.
+
+    ``LimiterMixin.close()`` is what stops the background Leaker thread and
+    closes the SQLite buckets; without it, dropping a client from the cache
+    leaks exactly what the cache exists to prevent.
+    """
+    try:
+        client._session.close()
+    except Exception:
+        pass
+
+
+def invalidate_cv_client_cache() -> None:
+    """Drop all cached ComicVine clients, closing their sessions.
+
+    Used when the API key changes and by tests for isolation.
+    """
+    with _CV_CLIENT_CACHE_LOCK:
+        clients = list(_CV_CLIENT_CACHE.values())
+        _CV_CLIENT_CACHE.clear()
+    for client in clients:
+        _close_cv_client(client)
 
 
 def _cv_retry_config():
@@ -127,24 +231,103 @@ def _cv_retry_config():
 def _is_rate_limit_error(exc) -> bool:
     """True when a Simyan/ComicVine error is a rate-limit rejection.
 
-    ComicVine returns the status text "Rate limit exceeded. Slow down cowboy.",
-    which Simyan surfaces as a ServiceError. Match on the message so we stay
-    robust to Simyan's exception class names changing across versions.
+    Three shapes have to be recognised:
+
+    * ComicVine's own status text "Rate limit exceeded. Slow down cowboy.",
+      which Simyan surfaces as a ServiceError. Matched on the message so we stay
+      robust to Simyan's exception class names changing across versions.
+    * Simyan's typed ``RateLimitError`` (HTTP 429/420).
+    * Simyan's own rate limiter refusing to wait any longer. That raises
+      ``requests.exceptions.Timeout("Rate limit not cleared within max_delay=…")``,
+      which ``Comicvine._get_request`` re-raises as the far less specific
+      ``ServiceError("Service took too long to respond")``. The original is
+      still on ``__cause__``, so walk the chain rather than matching that
+      message directly — a genuine network timeout must stay a hard error.
     """
-    return 'rate limit' in str(exc).lower()
+    seen = set()
+    current = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if 'rate limit' in str(current).lower():
+            return True
+        if _RATE_LIMIT_ERROR_TYPES and isinstance(current, _RATE_LIMIT_ERROR_TYPES):
+            return True
+        current = current.__cause__
+    return False
 
 
-def _cv_call_with_retry(fn, description: str):
-    """Run a Simyan operation, retrying on ComicVine rate-limit errors.
+# ComicVine allows roughly 200 requests per resource per hour. Sit under that
+# so this limiter trips *before* Simyan's own per_hour bucket does: then the
+# wait happens here, where it's logged and bounded, instead of surfacing as a
+# hard error from deep inside the HTTP session. The headroom also covers the
+# handful of paths that reach ComicVine outside _cv_call_with_retry.
+_CV_SAFE_HOURLY = 180
+_CV_RATE_WINDOW_SECONDS = 3600.0
 
-    ComicVine throttles burst traffic aggressively ("Slow down cowboy"). A
-    single throttle shouldn't make the bulk-metadata flow fail over to a
-    lower-quality provider (GCD), so we back off and re-attempt a few times
-    before letting the error propagate. Non-rate-limit errors raise immediately.
+
+def _cv_hourly_limit() -> int:
+    try:
+        return max(1, int(os.environ.get("COMICVINE_RATE_LIMIT_PER_HOUR", "180")))
+    except (ValueError, TypeError):
+        return _CV_SAFE_HOURLY
+
+
+_comicvine_rate_limiter = get_limiter(
+    "comicvine", _cv_hourly_limit(), _CV_RATE_WINDOW_SECONDS
+)
+
+# How long a live web request will wait for a throttle slot before giving up on
+# it and letting the reactive retry path handle the call. A user-facing search
+# must not park a request thread behind an hour-long window.
+_CV_INTERACTIVE_ACQUIRE_TIMEOUT = 5.0
+
+
+def _cv_acquire_timeout(blocking: Optional[bool]) -> Optional[float]:
+    """How long this caller may wait for a throttle slot.
+
+    Auto-detects by default rather than making every call site declare itself:
+    inside a Flask request we're on a worker thread a user is waiting on, so
+    wait only briefly; anywhere else (sweeps, bulk jobs, the scheduler) we're on
+    a daemon thread that should wait as long as the budget requires.
+    """
+    if blocking is None:
+        try:
+            from flask import has_request_context
+
+            blocking = not has_request_context()
+        except Exception:
+            blocking = True
+    return None if blocking else _CV_INTERACTIVE_ACQUIRE_TIMEOUT
+
+
+def _cv_call_with_retry(fn, description: str, blocking: Optional[bool] = None):
+    """Run a Simyan operation under the shared throttle, retrying on rate limits.
+
+    Two layers, because ComicVine throttles burst traffic aggressively
+    ("Slow down cowboy"):
+
+    * Proactively, every attempt takes a slot from the process-wide limiter, so
+      concurrent sweeps and web requests share one budget instead of racing.
+    * Reactively, a throttle that still gets through is backed off and retried
+      a few times -- a single rejection shouldn't make the bulk-metadata flow
+      fail over to a lower-quality provider (GCD).
+
+    Non-rate-limit errors raise immediately.
+
+    Args:
+        blocking: Wait indefinitely for a throttle slot. Defaults to
+            auto-detection (see :func:`_cv_acquire_timeout`); pass explicitly
+            only to override that.
     """
     retries, backoff = _cv_retry_config()
+    timeout = _cv_acquire_timeout(blocking)
     attempt = 0
     while True:
+        if not _comicvine_rate_limiter.acquire(timeout=timeout):
+            app_logger.info(
+                f"ComicVine throttle saturated for {description}; proceeding "
+                "without a slot so the request isn't held"
+            )
         try:
             return fn()
         except Exception as e:
@@ -211,11 +394,17 @@ def fetch_cv_arcs(api_key, search=None):
         return []
 
     try:
-        cv = _make_cv_client(api_key)
+        cv = get_cv_client(api_key)
         if search:
-            arcs = cv.search(resource=ComicvineResource.STORY_ARC, query=search)
+            arcs = _cv_call_with_retry(
+                lambda: cv.search(resource=ComicvineResource.STORY_ARC, query=search),
+                f"story arc search '{search}'",
+            )
         else:
-            arcs = cv.list_story_arcs(max_results=500)
+            arcs = _cv_call_with_retry(
+                lambda: cv.list_story_arcs(max_results=500),
+                "story arc list",
+            )
 
         if not arcs:
             return []
@@ -256,8 +445,10 @@ def fetch_cv_arc_detail(api_key, arc_id):
         return None
 
     try:
-        cv = _make_cv_client(api_key)
-        arc = cv.get_story_arc(arc_id)
+        cv = get_cv_client(api_key)
+        arc = _cv_call_with_retry(
+            lambda: cv.get_story_arc(arc_id), f"story arc detail {arc_id}"
+        )
         if not arc:
             return None
 
@@ -299,12 +490,17 @@ def fetch_cv_arc_issues(api_key, arc_id):
         if not detail or not detail.get('issues'):
             return []
 
-        cv = _make_cv_client(api_key)
+        cv = get_cv_client(api_key)
         resolved = []
 
+        # One request per issue in the arc, so this loop alone can exhaust the
+        # hourly budget -- it has to go through the throttle like everything else.
         for i, entry in enumerate(detail['issues']):
             try:
-                issue = cv.get_issue(entry['id'])
+                issue = _cv_call_with_retry(
+                    lambda eid=entry['id']: cv.get_issue(eid),
+                    f"arc {arc_id} issue {entry['id']}",
+                )
                 if not issue:
                     continue
 
@@ -368,7 +564,7 @@ def search_volumes(api_key: str, series_name: str, year: Optional[int] = None) -
         app_logger.info(f"Searching ComicVine for volume: '{series_name}' (year: {year})")
 
         # Initialize ComicVine API client
-        cv = _make_cv_client(api_key)
+        cv = get_cv_client(api_key)
 
         # Search for volumes using fuzzy search. Retry on rate-limit so a burst
         # throttle doesn't force a premature failover to a lesser provider.
@@ -458,7 +654,7 @@ def get_issue_by_number(api_key: str, volume_id: int, issue_number: str, year: O
         app_logger.info(f"Searching for issue #{issue_number} in volume {volume_id} (year: {year})")
 
         # Initialize ComicVine API client
-        cv = _make_cv_client(api_key)
+        cv = get_cv_client(api_key)
 
         # Get issues from the volume
         # Build filter string
@@ -1159,7 +1355,7 @@ def get_volume_details(api_key: str, volume_id: int) -> Dict[str, Any]:
 
     try:
         app_logger.info(f"Fetching volume details for volume ID: {volume_id}")
-        cv = _make_cv_client(api_key)
+        cv = get_cv_client(api_key)
         volume = _cv_call_with_retry(
             lambda: cv.get_volume(volume_id),
             f"volume details {volume_id}",
@@ -1214,7 +1410,7 @@ def get_all_issues_for_volume(api_key: str, volume_id: int) -> List[Dict[str, An
         app_logger.warning("Simyan library not available for volume issue listing")
         return []
 
-    cv = _make_cv_client(api_key)
+    cv = get_cv_client(api_key)
     issues: List[Dict[str, Any]] = []
     seen_ids = set()
     offset = 0

--- a/models/comicvine_source.py
+++ b/models/comicvine_source.py
@@ -1,0 +1,130 @@
+"""Unified access to ComicVine data from whichever source is configured.
+
+CLU can reach ComicVine two ways: the web API (Simyan, needs
+``COMICVINE_API_KEY``) or a user-supplied local SQLite dump (needs
+``database_path``). Callers that just want "the volume" or "the issues"
+shouldn't have to know which is set up, and the library sweep in particular
+must not be gated on the API key alone -- a user with only the local dump was
+previously treated as having no ComicVine at all.
+
+**Local first, API fallback.** The dump costs no requests and no rate-limit
+budget, and the per-volume issue listing is the single most expensive call in a
+sweep (one full pagination per series). A volume the dump doesn't know about
+falls through to the API, so coverage is the union of both. The trade-off: for
+a volume that *is* in the dump, recently published issues won't appear until the
+dump is refreshed.
+
+Metron remains the preferred provider overall -- this is only consulted once a
+sidecar's ComicVine id has failed to resolve to a Metron series.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from core.app_logging import app_logger
+
+
+def _local_available() -> bool:
+    """True when a usable local ComicVine SQLite dump is configured."""
+    try:
+        from models import comicvine_sqlite as cv_sqlite
+
+        return bool(
+            cv_sqlite.check_database_status().get("cv_sqlite_available", False)
+        )
+    except Exception:
+        return False
+
+
+def _api_key(app=None) -> Optional[str]:
+    """The ComicVine API key, or None (tolerates a missing app context)."""
+    try:
+        from models import comicvine
+
+        return comicvine.get_cv_api_key(app)
+    except Exception:
+        return None
+
+
+def is_available(app=None) -> bool:
+    """True when ComicVine data can be read from either source.
+
+    This is the gate for ComicVine-sourced mapping. Checking the API key alone
+    silently disabled ComicVine for local-dump-only users.
+    """
+    return _local_available() or bool(_api_key(app))
+
+
+def describe(app=None) -> str:
+    """Human-readable summary of the configured sources, for logs."""
+    parts = []
+    if _local_available():
+        parts.append("local DB")
+    if _api_key(app):
+        parts.append("API")
+    return " + ".join(parts) if parts else "none"
+
+
+def get_volume_details(cv_id: int, app=None) -> Dict[str, Any]:
+    """Volume metadata for a ComicVine volume id, from whichever source has it.
+
+    Returns ``{}`` when neither source can answer, so callers can fall back to
+    sidecar-derived data.
+    """
+    if _local_available():
+        try:
+            from models import comicvine_sqlite as cv_sqlite
+
+            details = cv_sqlite.get_volume_details(cv_id)
+            if details and details.get("name"):
+                return dict(details)
+        except Exception as e:
+            app_logger.warning(
+                f"ComicVine local DB volume {cv_id} lookup failed: {e}"
+            )
+
+    key = _api_key(app)
+    if key:
+        try:
+            from models import comicvine
+
+            return comicvine.get_volume_details(key, cv_id) or {}
+        except Exception as e:
+            app_logger.warning(f"ComicVine API volume {cv_id} fetch failed: {e}")
+
+    return {}
+
+
+def get_all_issues_for_volume(cv_id: int, app=None) -> List[Dict[str, Any]]:
+    """Every issue in a ComicVine volume, from whichever source has it.
+
+    Both sources return the same record shape (ids offset into the ComicVine
+    range), so callers can treat them interchangeably.
+    """
+    if _local_available():
+        try:
+            from models import comicvine_sqlite as cv_sqlite
+
+            issues = cv_sqlite.get_all_issues_for_volume(cv_id)
+            if issues:
+                app_logger.info(
+                    f"ComicVine local DB returned {len(issues)} issues for "
+                    f"volume {cv_id}"
+                )
+                return issues
+        except Exception as e:
+            app_logger.warning(
+                f"ComicVine local DB issue list for volume {cv_id} failed: {e}"
+            )
+
+    key = _api_key(app)
+    if key:
+        try:
+            from models import comicvine
+
+            return comicvine.get_all_issues_for_volume(key, cv_id) or []
+        except Exception as e:
+            app_logger.warning(
+                f"ComicVine API issue list for volume {cv_id} failed: {e}"
+            )
+
+    return []

--- a/models/comicvine_sqlite.py
+++ b/models/comicvine_sqlite.py
@@ -246,6 +246,65 @@ def get_volume_details(volume_id: int) -> Optional[Dict[str, Any]]:
         conn.close()
 
 
+def get_all_issues_for_volume(volume_id: int) -> List[Dict[str, Any]]:
+    """Every issue in a volume, shaped like ``comicvine.get_all_issues_for_volume``.
+
+    Lightweight records for ``save_issues_bulk`` / collection matching -- issue
+    number and dates, not per-issue credits. The ``id`` is offset into the
+    ComicVine range so it can't collide with a Metron issue id, matching the API
+    path exactly, so callers can use either source interchangeably.
+
+    This is the local equivalent of the API's paginated per-volume fetch, which
+    is the single most expensive call in a library sweep (one full pagination
+    per series). Answering it from the dump costs no requests and no rate-limit
+    budget.
+    """
+    from helpers.comicvine_ids import COMICVINE_SERIES_ID_OFFSET
+
+    conn = get_connection()
+    if not conn:
+        return []
+    try:
+        cursor = conn.cursor()
+        # Only columns the rest of this module already relies on -- a dump
+        # missing an optional column (site_detail_url) would otherwise make the
+        # whole query raise and silently return no issues at all.
+        cursor.execute(
+            "SELECT i.id, i.name, i.issue_number, i.cover_date, i.store_date,"
+            "       i.image_url"
+            " FROM cv_issue i"
+            " WHERE i.volume_id = ?",
+            (int(volume_id),),
+        )
+        rows = cursor.fetchall()
+    except (sqlite3.Error, ValueError) as e:
+        app_logger.error(f"ComicVine SQLite get_all_issues_for_volume failed: {e}")
+        return []
+    finally:
+        conn.close()
+
+    issues: List[Dict[str, Any]] = []
+    seen = set()
+    for row in rows:
+        iid = row.get("id")
+        if iid is None or iid in seen:
+            continue
+        seen.add(iid)
+        issues.append({
+            "id": COMICVINE_SERIES_ID_OFFSET + int(iid),
+            "cv_id": iid,
+            "number": row.get("issue_number"),
+            "name": row.get("name"),
+            "cover_date": row.get("cover_date") or None,
+            "store_date": row.get("store_date") or None,
+            "image": row.get("image_url") or None,
+            # Synthesised rather than read from the dump: 4000 is ComicVine's
+            # issue resource prefix (4050 is volumes).
+            "resource_url": f"https://comicvine.gamespot.com/issue/4000-{iid}/",
+        })
+    return issues
+
+
 def get_issue_by_number(volume_id: int, issue_number: str, year: Optional[int] = None) -> Optional[Dict[str, Any]]:
     """Look up an issue within a volume and build the intermediate issue_data dict.
 

--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -27,6 +27,7 @@ Reuses existing parsers/writers rather than re-implementing them:
 ``core.database.save_series_mapping``.
 """
 
+import gc
 import os
 import re
 import threading
@@ -39,11 +40,17 @@ from helpers.comicvine_ids import (
     is_comicvine_series_id,
     make_comicvine_series_id,
 )
-from models import metron, comicvine
+from models import metron, comicvine, comicvine_source
 from models.series_json import read_series_json, write_series_json
 
 COMIC_EXTENSIONS = (".cbz", ".cbr", ".zip", ".rar")
 SIDECAR_NAMES = {"series.json", "cvinfo"}
+
+# How often the library sweep nudges the collector. A sweep over thousands of
+# series churns huge short-lived object graphs without ever tripping the
+# generational thresholds, and core.memory_utils only collects once every five
+# minutes.
+_GC_EVERY_N_SERIES = 50
 
 # A leaf folder like ``v2017`` / ``v2`` is a *volume* marker, not a series name
 # (Mylar lays libraries out as ``<publisher>/<series>/v<year>/``). Mirrors the
@@ -111,8 +118,16 @@ def _count_comics(folder):
         return 0
 
 
-def _resolve_identity(folder, api, cv_api_key=None):
-    """Resolve a candidate folder to a Metron series id via the sidecar cascade.
+def _resolve_identity(folder, api, cv_available=False):
+    """Resolve a candidate folder to a series id via the sidecar cascade.
+
+    Metron is the preferred provider and is always tried first; ComicVine is
+    only consulted once a sidecar's ComicVine id has failed to resolve there.
+
+    ``cv_available`` means ComicVine is reachable by *either* the web API or a
+    local SQLite dump (see ``models.comicvine_source``). It used to be the API
+    key alone, which silently disabled ComicVine mapping for anyone running only
+    the local dump.
 
     Returns a candidate dict, or None if the folder has no sidecar at all.
     On success ``metron_id`` is set and ``reason`` is None; when a sidecar is
@@ -172,18 +187,19 @@ def _resolve_identity(folder, api, cv_api_key=None):
             if mid:
                 return _candidate(mid, "comicvine_id")
         # Not in Metron (or no Metron API). Fall back to a ComicVine-sourced
-        # identity when the ComicVine API is enabled — cvinfo/series.json are
+        # identity when ComicVine is configured at all — cvinfo/series.json are
         # natively ComicVine, so this is the original, not an edge case.
-        if cv_api_key:
-            return _candidate(make_comicvine_series_id(cv_id), "comicvine_api")
+        if cv_available:
+            return _candidate(make_comicvine_series_id(cv_id), "comicvine")
         if api:
             return _candidate(
                 None, "comicvine_id",
-                f"ComicVine ID {cv_id} not in Metron; enable the ComicVine API to map it",
+                f"ComicVine ID {cv_id} not in Metron; enable ComicVine "
+                "(API key or local DB) to map it",
             )
         return _candidate(
             None, "comicvine_id",
-            "Not resolvable: no Metron match and ComicVine API not enabled",
+            "Not resolvable: no Metron match and ComicVine not enabled",
         )
 
     return _candidate(None, "sidecar", "Sidecar has no Metron or ComicVine ID")
@@ -212,15 +228,16 @@ def _find_candidate_folders(roots):
     return folders
 
 
-def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
+def scan_library_for_automap(api=None, cv_available=None, progress_cb=None):
     """Scan library roots and classify sidecar folders into auto/review/skipped.
 
     Args:
         api: Optional Metron API client. Without it, only steps 1-2 (direct
             Metron id) can resolve.
-        cv_api_key: Optional ComicVine API key. When set, sidecars carrying a
-            ComicVine id that isn't in Metron resolve to a ComicVine-sourced
-            series instead of being skipped.
+        cv_available: Whether ComicVine can be read (web API key or local SQLite
+            dump). When true, sidecars carrying a ComicVine id that isn't in
+            Metron resolve to a ComicVine-sourced series instead of being
+            skipped. Defaults to detecting it via ``models.comicvine_source``.
         progress_cb: Optional callable(current, total, folder_or_None).
 
     Returns:
@@ -231,6 +248,13 @@ def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
         single bad sidecar can never discard the whole run's work.
     """
     from core.database import get_all_mapped_series
+
+    if cv_available is None:
+        cv_available = comicvine_source.is_available()
+    app_logger.info(
+        f"automap: scanning with Metron {'on' if api else 'off'}, "
+        f"ComicVine sources: {comicvine_source.describe()}"
+    )
 
     roots = get_library_roots()
     mapped_rows = get_all_mapped_series()
@@ -262,7 +286,7 @@ def scan_library_for_automap(api=None, cv_api_key=None, progress_cb=None):
             if nfolder in mapped_paths:
                 continue  # already tracked -- leave it alone
 
-            ident = _resolve_identity(folder, api, cv_api_key=cv_api_key)
+            ident = _resolve_identity(folder, api, cv_available=cv_available)
             if ident is None:
                 # Every candidate folder was flagged because it holds a sidecar
                 # file, so resolving to nothing means that sidecar (typically a
@@ -323,14 +347,6 @@ def get_library_roots():
     return _roots()
 
 
-def _safe_cv_key():
-    """Return the ComicVine API key, or None (tolerates missing app context)."""
-    try:
-        return comicvine.get_cv_api_key()
-    except Exception:
-        return None
-
-
 def _strip_html(text):
     """Reduce a ComicVine HTML description to plain text."""
     if not text:
@@ -342,20 +358,21 @@ def _strip_html(text):
 
 
 def _fetch_comicvine_series_dict(series_id, fallback):
-    """Build a series payload from the ComicVine API for an offset (cv) id.
+    """Build a series payload from ComicVine for an offset (cv) id.
+
+    Reads from whichever ComicVine source is configured -- local SQLite dump
+    first, then the web API.
 
     Returns ``(series_dict, authoritative)`` where ``authoritative`` is True only
     when ComicVine actually returned a named volume (so the name/metadata is
     trustworthy, not a folder-derived guess).
     """
     cv_id = cv_id_from_series_id(series_id)
-    details = {}
-    key = _safe_cv_key()
-    if key:
-        try:
-            details = comicvine.get_volume_details(key, cv_id) or {}
-        except Exception as e:
-            app_logger.warning(f"automap: ComicVine volume {cv_id} fetch failed: {e}")
+    try:
+        details = comicvine_source.get_volume_details(cv_id) or {}
+    except Exception as e:
+        app_logger.warning(f"automap: ComicVine volume {cv_id} fetch failed: {e}")
+        details = {}
 
     authoritative = bool(details.get("name"))
     name = details.get("name") or fallback.get("series_name") or f"ComicVine {cv_id}"
@@ -628,6 +645,10 @@ def _sync_and_match(api, series_id):
             _maybe_default_monitor_off(series_id, series_info, match_status)
     except Exception as e:
         app_logger.warning(f"automap: sync+match failed for {series_id}: {e}")
+    # No explicit cleanup needed here: this series' issue graph lives in this
+    # frame's locals and is released when the function returns. (The scan job's
+    # payload does need dropping by hand -- that frame stays alive for the whole
+    # post-scan tail. See _run_scan_job_inner.)
 
 
 def _sync_comicvine_issues(series_id):
@@ -638,13 +659,15 @@ def _sync_comicvine_issues(series_id):
         update_series_sync_time,
     )
 
-    key = _safe_cv_key()
-    if not key:
+    if not comicvine_source.is_available():
         app_logger.info(
-            f"automap: ComicVine API not available; cannot sync issues for {series_id}"
+            f"automap: ComicVine not configured (no API key or local DB); "
+            f"cannot sync issues for {series_id}"
         )
         return
-    cv_issues = comicvine.get_all_issues_for_volume(key, cv_id_from_series_id(series_id))
+    cv_issues = comicvine_source.get_all_issues_for_volume(
+        cv_id_from_series_id(series_id)
+    )
     if not cv_issues:
         return
     delete_issues_for_series(series_id)
@@ -684,6 +707,9 @@ def match_unmatched_mapped_series(api, force=False, progress_cb=None):
         invalidate_collection_status_for_series,
     )
 
+    # Keep only what the loop below uses. Retaining the full DB row for every
+    # mapped series held the whole library's rows alive for the duration of a
+    # sweep that already has plenty to allocate.
     worklist = []
     for row in get_all_mapped_series():
         series_id = row.get("id")
@@ -691,7 +717,7 @@ def match_unmatched_mapped_series(api, force=False, progress_cb=None):
             continue
         if not force and get_collection_status_for_series(series_id):
             continue  # already matched — leave it (and its Metron budget) alone
-        worklist.append(row)
+        worklist.append((series_id, row.get("name")))
 
     if not worklist:
         return 0
@@ -699,8 +725,8 @@ def match_unmatched_mapped_series(api, force=False, progress_cb=None):
     label = "Re-matching library to issues" if force else "Matching library to issues"
     op_id = register_operation("match", label, total=len(worklist))
     try:
-        for index, row in enumerate(worklist):
-            name = row.get("name") or f"Series {row.get('id')}"
+        for index, (series_id, series_name) in enumerate(worklist):
+            name = series_name or f"Series {series_id}"
             update_operation(op_id, current=index, detail=name)
             if progress_cb:
                 progress_cb(index, len(worklist), name)
@@ -710,8 +736,14 @@ def match_unmatched_mapped_series(api, force=False, progress_cb=None):
                 # and never deletes, so rows for issues that no longer exist would
                 # survive — and a series whose folder has since disappeared returns
                 # early from _sync_and_match, keeping its poisoned rows forever.
-                invalidate_collection_status_for_series(row["id"])
-            _sync_and_match(api, row["id"])
+                invalidate_collection_status_for_series(series_id)
+            _sync_and_match(api, series_id)
+            # A long sweep never trips the generational thresholds on its own --
+            # the background monitor only collects once every five minutes --
+            # so nudge it periodically rather than letting garbage accumulate
+            # across thousands of series.
+            if (index + 1) % _GC_EVERY_N_SERIES == 0:
+                gc.collect()
         complete_operation(op_id)
     except Exception:
         complete_operation(op_id, error=True)
@@ -823,6 +855,12 @@ def apply_and_sync(items, api=None):
 _jobs = {}
 _jobs_lock = threading.Lock()
 _JOB_TTL = 900  # keep finished jobs 15 min for the UI to fetch
+# A whole-library scan can produce a review/skipped entry per folder. Keeping
+# every one pinned the entire scan result in memory until the *next* job started
+# -- forever, if the user closed the tab -- and asked the browser to render tens
+# of thousands of rows. Cap what we retain and report the true totals alongside.
+_JOB_LIST_CAP = 500
+_MAX_FINISHED_JOBS = 5  # backstop if the TTL sweep is ever bypassed
 
 
 def _prune_jobs_locked():
@@ -834,6 +872,25 @@ def _prune_jobs_locked():
         and (now - job.get("finished_at", now)) > _JOB_TTL
     ]:
         del _jobs[op_id]
+
+    finished = [
+        (job.get("finished_at", 0), oid)
+        for oid, job in _jobs.items()
+        if job["status"] in ("done", "error")
+    ]
+    if len(finished) > _MAX_FINISHED_JOBS:
+        finished.sort()
+        for _, op_id in finished[: len(finished) - _MAX_FINISHED_JOBS]:
+            del _jobs[op_id]
+
+
+def _cap_list(items):
+    """Return (capped_items, total, truncated) for a job result list."""
+    items = items or []
+    total = len(items)
+    if total <= _JOB_LIST_CAP:
+        return items, total, False
+    return items[:_JOB_LIST_CAP], total, True
 
 
 def _update_job(op_id, **fields):
@@ -853,7 +910,7 @@ def _run_scan_job(op_id, app):
 def _run_scan_job_inner(op_id, app):
     try:
         api = metron.get_flask_api(app)
-        cv_api_key = comicvine.get_cv_api_key(app)
+        cv_available = comicvine_source.is_available(app)
 
         def progress(current, total, folder):
             _update_job(
@@ -864,17 +921,32 @@ def _run_scan_job_inner(op_id, app):
             )
 
         scan = scan_library_for_automap(
-            api=api, cv_api_key=cv_api_key, progress_cb=progress
+            api=api, cv_available=cv_available, progress_cb=progress
         )
         _update_job(op_id, detail="Applying matches...")
         applied = apply_automap(scan["auto"], api=api)
 
+        review, review_total, review_truncated = _cap_list(scan["review"])
+        skipped, skipped_total, skipped_truncated = _cap_list(scan["skipped"])
+        errors, errors_total, errors_truncated = _cap_list(scan["errors"])
+        if review_truncated or skipped_truncated or errors_truncated:
+            app_logger.info(
+                f"automap: scan job {op_id} result lists capped at {_JOB_LIST_CAP} "
+                f"(review {review_total}, skipped {skipped_total}, errors {errors_total})"
+            )
+
         result = {
             "applied": applied["applied"],
             "applied_failed": applied["failed"],
-            "review": scan["review"],
-            "skipped": scan["skipped"],
-            "errors": scan["errors"],
+            "review": review,
+            "review_total": review_total,
+            "review_truncated": review_truncated,
+            "skipped": skipped,
+            "skipped_total": skipped_total,
+            "skipped_truncated": skipped_truncated,
+            "errors": errors,
+            "errors_total": errors_total,
+            "errors_truncated": errors_truncated,
             "total_candidates": scan["total_candidates"],
         }
         with _jobs_lock:
@@ -902,6 +974,15 @@ def _run_scan_job_inner(op_id, app):
     # earlier scan that hit the API rate limit, then sync + match every mapped
     # series that isn't matched yet, so the Pull List / Wanted lists reflect
     # owned vs missing without opening each one.
+    # Drop the whole-library scan payload before the tail: the tail is the
+    # longest phase of the operation, and holding these here kept every
+    # candidate folder's data alive for its entire duration on top of whatever
+    # the sweep itself allocates. The retained copy lives in _jobs.
+    scan = None
+    applied = None
+    result = None
+    review = skipped = errors = None
+
     try:
         repair_volume_named_series(api)
         match_unmatched_mapped_series(api)

--- a/models/metron.py
+++ b/models/metron.py
@@ -4,16 +4,18 @@ Metron API integration for comic metadata retrieval using Mokkari library.
 
 from core.app_logging import app_logger
 from typing import Optional, Dict, Any, List, Tuple
+import os
 import re
 import threading
 import time
-from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from core.version import __version__
 
 import requests as requests_lib
 import requests.exceptions as requests_exceptions
+from helpers.rate_limit import SlidingWindowRateLimiter, get_limiter
 from mokkari.session import Session as MokkariSession
+from mokkari.sqlite_cache import SqliteCache
 from mokkari.exceptions import ApiError, RateLimitError
 from mokkari.schemas.collection import ScrobbleRequest
 
@@ -39,50 +41,240 @@ _DAILY_RATE_LIMIT_THRESHOLD = (
 _SESSION_CACHE: Dict[Tuple[str, str], MokkariSession] = {}
 _SESSION_CACHE_LOCK = threading.Lock()
 
+
+def _metron_cache_expire_days() -> int:
+    """Days a cached Metron response stays valid (``METRON_CACHE_EXPIRE_DAYS``).
+
+    Deliberately short. ``scheduled_series_sync`` decides whether to do the
+    expensive issue fetch by comparing the API's ``issue_count`` against the
+    local count, so a cached series response means that decision runs on stale
+    data and a newly published issue can be missed for one cycle. One day keeps
+    that bounded while still collapsing a whole library sweep -- which re-reads
+    the same series and issue endpoints from ``_sync_and_match``, the scan tail,
+    the re-match job and the wanted-cache refresh -- down to one request each.
+
+    Never ``None``: mokkari treats a falsy ``expire`` as "never expire".
+    """
+    try:
+        days = int(os.environ.get("METRON_CACHE_EXPIRE_DAYS", "1"))
+    except (ValueError, TypeError):
+        return 1
+    return max(1, days)
+
+
+def _metron_cache() -> Optional[SqliteCache]:
+    """Build mokkari's response cache, or ``None`` if it can't be created.
+
+    ``Session._get`` consults the cache *before* dispatching, so a hit costs
+    neither an HTTP request nor a rate-limit slot -- the cheapest reduction in
+    Metron quota burn available to us.
+
+    Caveat worth knowing when reading this code: mokkari's ``SqliteCache.get()``
+    never checks the ``expire`` column. Expiry is only ever applied by
+    ``cleanup()``, which mokkari itself runs just once, in ``__init__``. With a
+    process-shared, long-lived Session the effective TTL is therefore
+    ``expire + process uptime``, which is why ``invalidate_session_cache()``
+    also calls ``cleanup()`` and why the default expiry is kept small.
+    """
+    try:
+        from helpers.provider_cache import provider_cache_dir
+
+        return SqliteCache(
+            db_name=os.path.join(provider_cache_dir("mokkari"), "mokkari_cache.db"),
+            expire=_metron_cache_expire_days(),
+        )
+    except Exception as e:
+        # A read-only volume must degrade to "uncached", never to "no Metron".
+        app_logger.warning(f"Metron response cache unavailable, continuing uncached: {e}")
+        return None
+
+
 _BURST_WINDOW_SECONDS = 60.0
 _SAFE_BURST_LIMIT = 15  # stay under Metron's 20/min burst limit for headroom
 
 
-class _SlidingWindowRateLimiter:
-    """Caps outgoing requests to `max_requests` per `window_seconds`, process-wide.
+# Re-exported so existing callers (and tests) keep importing it from here.
+_SlidingWindowRateLimiter = SlidingWindowRateLimiter
 
-    Blocking (not rejecting): acquire() sleeps the calling thread until a slot
-    frees up rather than raising, so existing retry/error-handling logic above
-    it doesn't need to change.
+_metron_rate_limiter = get_limiter(
+    "metron", _SAFE_BURST_LIMIT, _BURST_WINDOW_SECONDS
+)
+
+# Longest we'll pause waiting for the per-minute burst window to roll over.
+# The window is 60s, so this is a guard against a bad/skewed reset header
+# parking a thread, not a normal-path value.
+_MAX_BURST_WAIT_SECONDS = 90.0
+
+
+def _as_aware(dt):
+    """Coerce a datetime to UTC-aware, or None. mokkari returns tz-aware values;
+    comparing one against a naive ``datetime.now()`` raises."""
+    if not isinstance(dt, datetime):
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+class _MetronPacer:
+    """Paces Metron requests from the limits Metron itself reports.
+
+    mokkari parses ``X-RateLimit-*`` into ``session.rate_limit_status`` but its
+    own pre-emptive check is advisory -- its docstring says callers must cap
+    their own concurrency. So we read the same headers and do the capping here.
+
+    Two windows matter, and they need opposite responses:
+
+    * **burst** (per-minute, same for everyone). Short. Worth waiting out.
+    * **sustained** (daily, varies by donor tier). Hours away. Waiting is
+      pointless -- and worse, mokkari reports ``retry_after`` as
+      ``max(burst_wait, sustained_wait)``, so an exhausted daily quota surfaced
+      as a 59.5s wait that sat just under the "this must be the daily cap"
+      threshold and got retried 3x *per series*, for every series in a sweep.
+      That is the log in the bug report. Once the daily window is known to be
+      empty we stop calling until it resets.
     """
 
-    def __init__(self, max_requests: int, window_seconds: float):
-        self._max_requests = max_requests
-        self._window_seconds = window_seconds
-        self._timestamps: deque = deque()
+    def __init__(self, limiter):
+        self._limiter = limiter
         self._lock = threading.Lock()
+        self._sustained_until = None
+        self._burst_until = None
 
-    def acquire(self) -> None:
-        while True:
+    def before(self) -> bool:
+        """Take a slot. Returns False when the daily quota is spent."""
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            sustained_until = self._sustained_until
+            burst_until = self._burst_until
+            if burst_until is not None and now >= burst_until:
+                self._burst_until = None
+                burst_until = None
+
+        if sustained_until is not None:
+            if now < sustained_until:
+                return False
             with self._lock:
-                now = time.monotonic()
-                while self._timestamps and now - self._timestamps[0] >= self._window_seconds:
-                    self._timestamps.popleft()
-                if len(self._timestamps) < self._max_requests:
-                    self._timestamps.append(now)
-                    return
-                wait = self._window_seconds - (now - self._timestamps[0])
+                self._sustained_until = None
+            app_logger.info("Metron daily rate limit window has reset; resuming")
+
+        if burst_until is not None:
+            wait = min((burst_until - now).total_seconds(), _MAX_BURST_WAIT_SECONDS)
             if wait > 0:
+                app_logger.info(
+                    f"Metron burst window exhausted; waiting {wait:.1f}s for reset"
+                )
                 time.sleep(wait)
+            with self._lock:
+                self._burst_until = None
+
+        self._limiter.acquire()
+        return True
+
+    def observe(self, session) -> None:
+        """Update pacing from the rate-limit headers on the last response.
+
+        Every field is ``None`` until the first response completes, and Metron
+        may not report a given window at all, so each branch has to fall back to
+        the configured defaults rather than assume a number is present.
+        """
+        status = getattr(session, "rate_limit_status", None)
+        if status is None:
+            return
+        try:
+            self._observe_burst(getattr(status, "burst", None))
+            self._observe_sustained(getattr(status, "sustained", None))
+        except Exception as e:  # never let telemetry break a worker thread
+            app_logger.debug(f"Metron rate-limit header parse skipped: {e}")
+
+    def _observe_burst(self, burst) -> None:
+        if burst is None:
+            return
+        limit = getattr(burst, "limit", None)
+        if isinstance(limit, int) and limit > 0:
+            # Stop guessing at 15/min once Metron tells us the real number.
+            self._limiter.retune(max(1, int(limit * 0.8)), _BURST_WINDOW_SECONDS)
+
+        remaining = getattr(burst, "remaining", None)
+        reset = _as_aware(getattr(burst, "reset", None))
+        if (
+            isinstance(remaining, int)
+            and remaining <= 1
+            and reset is not None
+            and reset > datetime.now(timezone.utc)
+        ):
+            with self._lock:
+                self._burst_until = reset
+
+    def _observe_sustained(self, sustained) -> None:
+        if sustained is None:
+            return
+        remaining = getattr(sustained, "remaining", None)
+        reset = _as_aware(getattr(sustained, "reset", None))
+        if not (isinstance(remaining, int) and remaining <= 0):
+            return
+        if reset is None or reset <= datetime.now(timezone.utc):
+            return
+        with self._lock:
+            already_latched = self._sustained_until is not None
+            self._sustained_until = reset
+        if not already_latched:
+            app_logger.warning(
+                f"Metron daily rate limit exhausted; pausing Metron calls until "
+                f"{reset.isoformat()}"
+            )
+
+    def daily_limit_reached(self) -> bool:
+        """True when the last response said the daily quota is spent."""
+        with self._lock:
+            until = self._sustained_until
+        return until is not None and datetime.now(timezone.utc) < until
+
+    def latch_daily_limit(self, seconds: float, context: str) -> None:
+        """Record a daily-cap rejection reported via ``retry_after``."""
+        reset = datetime.now(timezone.utc) + timedelta(seconds=max(0.0, seconds))
+        with self._lock:
+            already_latched = self._sustained_until is not None
+            self._sustained_until = reset
+        if not already_latched:
+            app_logger.warning(
+                f"Metron daily rate limit exceeded {context}; pausing Metron "
+                f"calls until {reset.isoformat()}"
+            )
 
     def reset(self) -> None:
         with self._lock:
-            self._timestamps.clear()
+            self._sustained_until = None
+            self._burst_until = None
+        self._limiter.retune(_SAFE_BURST_LIMIT, _BURST_WINDOW_SECONDS)
+        self._limiter.reset()
 
 
-_metron_rate_limiter = _SlidingWindowRateLimiter(_SAFE_BURST_LIMIT, _BURST_WINDOW_SECONDS)
+_metron_pacer = _MetronPacer(_metron_rate_limiter)
+
+
+def _cached_sessions() -> List[MokkariSession]:
+    with _SESSION_CACHE_LOCK:
+        return list(_SESSION_CACHE.values())
 
 
 def invalidate_session_cache() -> None:
-    """Clear the cached Metron sessions and rate-limiter window (used by tests)."""
+    """Clear the cached Metron sessions and rate-limiter window (used by tests).
+
+    Also runs each session's cache ``cleanup()``. mokkari only expires rows in
+    ``SqliteCache.__init__``, so on a long-lived shared session this is the only
+    thing that ever drops stale responses before the process restarts.
+    """
     with _SESSION_CACHE_LOCK:
+        sessions = list(_SESSION_CACHE.values())
         _SESSION_CACHE.clear()
-    _metron_rate_limiter.reset()
+    for session in sessions:
+        cache = getattr(session, "cache", None)
+        if cache is None:
+            continue
+        try:
+            cache.cleanup()
+        except Exception:
+            pass
+    _metron_pacer.reset()
 
 
 def _handle_rate_limit(e: "RateLimitError", attempt: int, context: str) -> bool:
@@ -93,10 +285,21 @@ def _handle_rate_limit(e: "RateLimitError", attempt: int, context: str) -> bool:
     """
     wait = e.retry_after if e.retry_after else _RATE_LIMIT_DEFAULT_WAIT
     if e.retry_after and e.retry_after > _DAILY_RATE_LIMIT_THRESHOLD:
+        _metron_pacer.latch_daily_limit(e.retry_after, context)
+        return False
+
+    # mokkari reports retry_after as max(burst_wait, sustained_wait), so a spent
+    # daily quota can arrive as a sub-threshold wait (observed: 59.5s) and get
+    # retried three times per series for a whole sweep. The headers say which
+    # window it really is -- trust them over the magnitude.
+    for session in _cached_sessions():
+        _metron_pacer.observe(session)
+    if _metron_pacer.daily_limit_reached():
         app_logger.info(
-            f"Metron daily rate limit exceeded {context}: retry_after={e.retry_after}s, giving up"
+            f"Metron daily rate limit reached {context}: giving up without retrying"
         )
         return False
+
     if attempt < _RATE_LIMIT_MAX_RETRIES - 1:
         app_logger.info(
             f"Metron rate limit hit {context}: waiting {wait}s before retry "
@@ -115,17 +318,31 @@ def _handle_rate_limit(e: "RateLimitError", attempt: int, context: str) -> bool:
 
 
 def _api_call(fn, context: str, default=None):
-    """Call fn() with rate-limit retry and standard error handling."""
+    """Call fn() paced by the shared limiter, with rate-limit retry.
+
+    Returns ``default`` immediately while Metron's daily quota is spent rather
+    than sleeping: a sweep of 800 series must not sit through 800 x 3 x 60s of
+    waits that can't succeed. Callers already tolerate ``default`` -- it's the
+    same contract as an ApiError.
+    """
     for attempt in range(_RATE_LIMIT_MAX_RETRIES):
-        _metron_rate_limiter.acquire()
+        if not _metron_pacer.before():
+            app_logger.debug(
+                f"Metron daily rate limit active; skipping {context}"
+            )
+            return default
         try:
-            return fn()
+            result = fn()
         except RateLimitError as e:
             if not _handle_rate_limit(e, attempt, context):
                 return default
         except ApiError as e:
             app_logger.error(f"Metron API error {context}: {e}")
             return default
+        else:
+            for session in _cached_sessions():
+                _metron_pacer.observe(session)
+            return result
     return default
 
 
@@ -174,7 +391,10 @@ def get_api(username: str, password: str):
 
     try:
         session = MokkariSession(
-            username=username, passwd=password, user_agent=CLU_USER_AGENT
+            username=username,
+            passwd=password,
+            user_agent=CLU_USER_AGENT,
+            cache=_metron_cache(),
         )
     except ApiError as e:
         app_logger.error(f"Metron API error initializing session: {e}")
@@ -305,7 +525,11 @@ def get_series_id_by_comicvine_id(api, cv_series_id: int) -> Optional[int]:
             series_id = results[0].id
             app_logger.info(f"Found Metron series {series_id} for CV ID {cv_series_id}")
             return series_id
-        app_logger.warning(f"No Metron series found for ComicVine ID {cv_series_id}")
+        # Informational, not a problem: Metron simply doesn't carry every
+        # ComicVine volume, and callers (the library sweep in particular) fall
+        # through to a ComicVine-sourced identity. Logging this at WARNING made
+        # a routine cascade step look like a failure.
+        app_logger.info(f"No Metron series found for ComicVine ID {cv_series_id}")
         return None
 
     return _api_call(_call, f"looking up CV ID {cv_series_id}")

--- a/models/providers/__init__.py
+++ b/models/providers/__init__.py
@@ -17,7 +17,8 @@ Usage:
     provider = get_provider(ProviderType.METRON, credentials)
     results = provider.search_series("Batman", 2020)
 """
-from typing import Dict, Type, List, Optional
+import threading
+from typing import Any, Dict, Tuple, Type, List, Optional
 
 from .base import (
     BaseProvider,
@@ -48,12 +49,48 @@ def register_provider(provider_class: Type[BaseProvider]) -> Type[BaseProvider]:
     return provider_class
 
 
+# Cache of live provider instances, keyed by type + credentials.
+#
+# Provider instances are cheap objects wrapped around expensive clients: the
+# ComicVine adapter memoises a Simyan client (a background limiter thread plus
+# SQLite connections), the Metron one a mokkari Session, Bedetheque a requests
+# Session. Building a provider per call -- which core.bulk_metadata does once
+# per FILE -- meant rebuilding those clients thousands of times a job and never
+# releasing them. Caching the instance is what makes _instantiate_provider free.
+#
+# Safe to share: the only per-instance mutable state across all providers is
+# those lazily-created clients, which is exactly what we want reused. The
+# SQLite-backed providers open their connections per call, never on self.
+_PROVIDER_INSTANCE_CACHE: Dict[Tuple[ProviderType, Tuple], BaseProvider] = {}
+_PROVIDER_INSTANCE_LOCK = threading.Lock()
+
+
+def _credentials_key(credentials: Optional[ProviderCredentials]) -> Tuple:
+    """Hashable identity for a credential set.
+
+    ``ProviderCredentials`` is a mutable dataclass and so unhashable;
+    ``to_dict()`` already drops ``None`` fields, which makes it the natural
+    canonical form.
+    """
+    if credentials is None:
+        return ()
+    try:
+        return tuple(sorted(credentials.to_dict().items()))
+    except Exception:
+        # Un-canonicalisable credentials simply don't get cached.
+        return (id(credentials),)
+
+
 def get_provider(
     provider_type: ProviderType,
     credentials: Optional[ProviderCredentials] = None
 ) -> BaseProvider:
     """
-    Factory function to create a provider instance.
+    Factory function to get a provider instance.
+
+    Instances are cached and reused per (provider type, credentials) so the
+    expensive API clients they hold are built once per process rather than once
+    per call. Use :func:`invalidate_provider_cache` after credentials change.
 
     Args:
         provider_type: The type of provider to create
@@ -67,7 +104,29 @@ def get_provider(
     """
     if provider_type not in _PROVIDER_REGISTRY:
         raise ValueError(f"Unknown provider type: {provider_type.value}")
-    return _PROVIDER_REGISTRY[provider_type](credentials)
+
+    cache_key = (provider_type, _credentials_key(credentials))
+    with _PROVIDER_INSTANCE_LOCK:
+        provider = _PROVIDER_INSTANCE_CACHE.get(cache_key)
+        if provider is not None:
+            return provider
+
+    provider = _PROVIDER_REGISTRY[provider_type](credentials)
+
+    with _PROVIDER_INSTANCE_LOCK:
+        # Another thread may have raced us; keep whichever won so callers all
+        # share one instance and one underlying client.
+        return _PROVIDER_INSTANCE_CACHE.setdefault(cache_key, provider)
+
+
+def invalidate_provider_cache() -> None:
+    """Drop all cached provider instances.
+
+    Call after provider credentials change -- otherwise a stale instance keeps
+    serving the old key. Also used by tests for isolation.
+    """
+    with _PROVIDER_INSTANCE_LOCK:
+        _PROVIDER_INSTANCE_CACHE.clear()
 
 
 def get_provider_by_name(
@@ -117,7 +176,8 @@ def get_available_providers() -> List[Dict]:
             "name": p.display_name,
             "requires_auth": p.requires_auth,
             "auth_fields": p.auth_fields,
-            "rate_limit": p.rate_limit
+            "rate_limit": p.rate_limit,
+            "rate_limit_window_seconds": p.rate_limit_window_seconds
         }
         for p in _PROVIDER_REGISTRY.values()
     ]
@@ -175,6 +235,7 @@ __all__ = [
     'register_provider',
     'get_provider',
     'get_provider_by_name',
+    'invalidate_provider_cache',
     'get_registered_providers',
     'get_available_providers',
     'is_provider_registered',

--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -230,8 +230,16 @@ class BaseProvider(ABC):
     requires_auth: bool = True
     auth_fields: List[str] = []  # e.g., ["api_key"] or ["username", "password"]
 
-    # Default rate limit (requests per minute)
+    # Advertised rate limit: `rate_limit` requests per `rate_limit_window_seconds`.
+    # The window is explicit because providers don't agree on one -- ComicVine
+    # publishes an hourly budget, Metron and AniList per-minute ones -- and a bare
+    # number under a "per minute" comment was silently wrong for ComicVine.
+    #
+    # This pair is descriptive metadata for the settings UI. Enforcement lives
+    # with each provider's own client (models.comicvine._cv_call_with_retry,
+    # models.metron._api_call), which is where the shared limiters are applied.
     rate_limit: int = 30
+    rate_limit_window_seconds: int = 60
 
     def __init__(self, credentials: Optional[ProviderCredentials] = None):
         """
@@ -327,5 +335,6 @@ class BaseProvider(ABC):
             "name": self.display_name,
             "requires_auth": self.requires_auth,
             "auth_fields": self.auth_fields,
-            "rate_limit": self.rate_limit
+            "rate_limit": self.rate_limit,
+            "rate_limit_window_seconds": self.rate_limit_window_seconds
         }

--- a/models/providers/comicvine_provider.py
+++ b/models/providers/comicvine_provider.py
@@ -19,6 +19,7 @@ class ComicVineProvider(BaseProvider):
     requires_auth = True
     auth_fields = ["api_key"]
     rate_limit = 200  # ComicVine allows ~200 requests per resource per hour
+    rate_limit_window_seconds = 3600
 
     def __init__(self, credentials: Optional[ProviderCredentials] = None):
         super().__init__(credentials)
@@ -38,9 +39,10 @@ class ComicVineProvider(BaseProvider):
                 app_logger.warning("Simyan library not available")
                 return None
 
-            # Reuse the timeout-bounded factory so adapter calls (get_issues,
-            # get_issue, test_connection) can't stall a worker indefinitely.
-            self._cv = cv_module._make_cv_client(self.credentials.api_key)
+            # Reuse the process-shared, timeout-bounded client so adapter calls
+            # (get_issues, get_issue, test_connection) can't stall a worker
+            # indefinitely and share one rate-limit budget with the rest of CLU.
+            self._cv = cv_module.get_cv_client(self.credentials.api_key)
             return self._cv
         except Exception as e:
             app_logger.error(f"Failed to initialize ComicVine client: {e}")

--- a/routes/series.py
+++ b/routes/series.py
@@ -1474,18 +1474,22 @@ def _sync_comicvine_series(series_id):
     """Refresh a ComicVine-sourced series' issue list, then re-match the collection."""
     from core.database import clear_wanted_cache_for_series
     from helpers.comicvine_ids import cv_id_from_series_id
-    from models import comicvine as cv_mod
+    from models import comicvine_source
 
-    key = cv_mod.get_cv_api_key()
-    if not key:
-        return jsonify({"error": "ComicVine API not configured"}), 500
+    # Either source will do -- the local SQLite dump answers this without
+    # spending any API budget, and falls through to the web API when the dump
+    # doesn't know the volume.
+    if not comicvine_source.is_available():
+        return jsonify(
+            {"error": "ComicVine not configured (no API key or local DB)"}
+        ), 500
 
     try:
         series_mapping = get_series_by_id(series_id)
         mapped_path = series_mapping.get("mapped_path") if series_mapping else None
 
-        cv_issues = cv_mod.get_all_issues_for_volume(
-            key, cv_id_from_series_id(series_id)
+        cv_issues = comicvine_source.get_all_issues_for_volume(
+            cv_id_from_series_id(series_id)
         )
         delete_issues_for_series(series_id)
         save_issues_bulk(cv_issues, series_id)

--- a/templates/pull_list.html
+++ b/templates/pull_list.html
@@ -320,6 +320,7 @@
                         </div>
                         <p class="text-muted small mb-2">These folders resolved to a series that is already
                             mapped elsewhere, or two folders point at the same series. Pick the ones to map.</p>
+                        <div id="automapReviewNote"></div>
                         <div class="table-responsive mb-3">
                             <table class="table table-sm align-middle">
                                 <thead class="table-light">
@@ -472,9 +473,16 @@
             }
 
             const applied = result.applied || 0;
-            const reviewN = (result.review || []).length;
-            const skippedN = (result.skipped || []).length;
-            const errorN = (result.errors || []).length;
+            // *_total is the true count; the list itself is capped so a big
+            // library doesn't pin the whole scan in memory or render tens of
+            // thousands of rows. Fall back to the list length for older jobs.
+            const reviewN = result.review_total ?? (result.review || []).length;
+            const skippedN = result.skipped_total ?? (result.skipped || []).length;
+            const errorN = result.errors_total ?? (result.errors || []).length;
+
+            const shownNote = (list, total, truncated) => truncated
+                ? `<div class="small text-muted mb-2">Showing the first ${list.length} of ${total}.</div>`
+                : '';
             document.getElementById('automapSummary').innerHTML =
                 `<strong>Mapped ${applied}</strong> series automatically from `
                 + `${result.total_candidates || 0} folder(s) with sidecar files. `
@@ -490,7 +498,8 @@
             const errWrap = document.getElementById('automapErrorsWrap');
             if (errors.length) {
                 document.getElementById('automapErrorsList').innerHTML =
-                    '<ul class="list-group list-group-flush small">' + errors.map(it => `
+                    shownNote(errors, errorN, result.errors_truncated)
+                    + '<ul class="list-group list-group-flush small">' + errors.map(it => `
                         <li class="list-group-item px-0 bg-transparent">
                             <span class="text-danger">${esc(it.folder)}</span>
                             — ${esc(it.reason)}
@@ -505,6 +514,8 @@
             const reviewWrap = document.getElementById('automapReviewWrap');
             const body = document.getElementById('automapReviewBody');
             if (reviewItems.length) {
+                document.getElementById('automapReviewNote').innerHTML =
+                    shownNote(reviewItems, reviewN, result.review_truncated);
                 body.innerHTML = reviewItems.map((it, i) => `
                     <tr>
                         <td><input class="form-check-input automap-review-cb" type="checkbox" data-idx="${i}"></td>
@@ -522,9 +533,10 @@
             const skipped = result.skipped || [];
             const skWrap = document.getElementById('automapSkippedWrap');
             if (skipped.length) {
-                document.getElementById('automapSkippedCount').textContent = `${skipped.length} skipped (reason)`;
+                document.getElementById('automapSkippedCount').textContent = `${skippedN} skipped (reason)`;
                 document.getElementById('automapSkippedList').innerHTML =
-                    '<ul class="list-group list-group-flush small">' + skipped.map(it => `
+                    shownNote(skipped, skippedN, result.skipped_truncated)
+                    + '<ul class="list-group list-group-flush small">' + skipped.map(it => `
                         <li class="list-group-item px-0">
                             <span class="text-muted">${esc(it.folder)}</span>
                             — ${esc(it.reason)}

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -34,6 +34,48 @@ def _reset_metron_session_cache():
 
 
 # ---------------------------------------------------------------------------
+# Reset the module-level ComicVine (Simyan) client cache between tests. Beyond
+# isolation this matters for resources: each cached client owns a background
+# limiter thread and SQLite connections, and invalidating closes them.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_cv_client_cache():
+    from models.comicvine import invalidate_cv_client_cache
+    invalidate_cv_client_cache()
+    yield
+    invalidate_cv_client_cache()
+
+
+# ---------------------------------------------------------------------------
+# Clear the shared provider rate limiters between tests. They are process-wide
+# by design, so without this one test's requests eat the next one's budget and
+# a later test blocks on a window it never filled.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_provider_rate_limiters():
+    from helpers.rate_limit import reset_all_limiters
+    reset_all_limiters()
+    yield
+    reset_all_limiters()
+
+
+# ---------------------------------------------------------------------------
+# Drop cached provider instances between tests -- they're keyed by credentials
+# and shared process-wide, so without this a test inherits the neighbour's
+# instance (and its mocked client).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_provider_instance_cache():
+    from models.providers import invalidate_provider_cache
+    invalidate_provider_cache()
+    yield
+    invalidate_provider_cache()
+
+
+# ---------------------------------------------------------------------------
 # Common credential fixtures
 # ---------------------------------------------------------------------------
 

--- a/tests/mocked/test_comicvine_model.py
+++ b/tests/mocked/test_comicvine_model.py
@@ -1,4 +1,6 @@
 """Tests for models/comicvine.py -- mocked Simyan library."""
+import threading
+
 import pytest
 from unittest.mock import patch, MagicMock
 from tests.mocked.conftest import make_mock_cv_volume, make_mock_cv_issue
@@ -9,6 +11,239 @@ class TestIsSimyanAvailable:
     def test_returns_bool(self):
         from models.comicvine import is_simyan_available
         assert isinstance(is_simyan_available(), bool)
+
+
+class TestClientCache:
+    """Every Simyan client is a CachedLimiterSession, and constructing one
+    starts a background pyrate_limiter Leaker thread plus SQLite connections
+    for the HTTP cache and the rate-limit bucket -- none of which are ever
+    released. Building one per call leaked a thread and two connections per
+    series during a library sweep (observed: 4.6GB RSS), and left N independent
+    buckets racing past ComicVine's limit ("Slow down cowboy"). The client must
+    be shared."""
+
+    def test_same_key_returns_same_client_and_builds_once(self):
+        import models.comicvine as cv
+
+        with patch.object(cv, "_make_cv_client") as mock_make:
+            mock_make.side_effect = lambda key: MagicMock(name=f"client-{key}")
+            first = cv.get_cv_client("KEY")
+            second = cv.get_cv_client("KEY")
+
+        assert first is second
+        assert mock_make.call_count == 1
+
+    def test_different_keys_get_different_clients(self):
+        import models.comicvine as cv
+
+        with patch.object(cv, "_make_cv_client") as mock_make:
+            mock_make.side_effect = lambda key: MagicMock(name=f"client-{key}")
+            a = cv.get_cv_client("KEY-A")
+            b = cv.get_cv_client("KEY-B")
+
+        assert a is not b
+
+    def test_invalidate_closes_sessions_and_forces_rebuild(self):
+        """Dropping a client without closing it leaks exactly what the cache
+        exists to prevent -- LimiterMixin.close() stops the Leaker thread."""
+        import models.comicvine as cv
+
+        first = MagicMock(name="first")
+        second = MagicMock(name="second")
+        with patch.object(cv, "_make_cv_client", side_effect=[first, second]):
+            assert cv.get_cv_client("KEY") is first
+            cv.invalidate_cv_client_cache()
+            first._session.close.assert_called_once()
+            assert cv.get_cv_client("KEY") is second
+
+    def test_concurrent_callers_share_one_client(self):
+        """Background sweeps, the wanted-cache refresh and live web requests can
+        all reach for a client at once."""
+        import models.comicvine as cv
+
+        built = []
+        start = threading.Barrier(8)
+
+        def build(key):
+            client = MagicMock(name=f"client-{len(built)}")
+            built.append(client)
+            return client
+
+        results = []
+        results_lock = threading.Lock()
+
+        def worker():
+            start.wait()
+            client = cv.get_cv_client("KEY")
+            with results_lock:
+                results.append(client)
+
+        with patch.object(cv, "_make_cv_client", side_effect=build):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(results) == 8
+        assert all(c is results[0] for c in results)
+        # Losers of the race must have had their session closed, or their
+        # Leaker threads outlive them.
+        for client in built:
+            if client is not results[0]:
+                client._session.close.assert_called_once()
+
+
+class TestMaxDelay:
+    """Once the client is shared, Simyan's own per_hour=200 bucket finally
+    engages -- and a saturated bucket raises instead of waiting past
+    max_delay (default timeout*2 = 40s). Raise the ceiling, but never to
+    unbounded: a live web request must not hang forever."""
+
+    def test_default_max_delay_applied_to_session(self, monkeypatch):
+        import models.comicvine as cv
+
+        monkeypatch.delenv("COMICVINE_MAX_DELAY", raising=False)
+        with patch.object(cv, "Comicvine", create=True) as mock_cv:
+            client = cv._make_cv_client("KEY")
+
+        assert client._session.max_delay == 60.0
+
+    def test_env_override_honoured(self, monkeypatch):
+        import models.comicvine as cv
+
+        monkeypatch.setenv("COMICVINE_MAX_DELAY", "120")
+        with patch.object(cv, "Comicvine", create=True):
+            client = cv._make_cv_client("KEY")
+
+        assert client._session.max_delay == 120.0
+
+    def test_garbage_env_falls_back_to_default(self, monkeypatch):
+        import models.comicvine as cv
+
+        monkeypatch.setenv("COMICVINE_MAX_DELAY", "not-a-number")
+        assert cv._cv_max_delay() == 60.0
+
+
+class TestProactiveThrottle:
+    """Reactive backoff alone means we only slow down after ComicVine has
+    already rejected us. Every call must take a slot from the shared budget
+    first, so concurrent sweeps and web requests pace each other."""
+
+    def test_every_attempt_takes_a_slot(self):
+        import models.comicvine as cv
+
+        with patch.object(cv._comicvine_rate_limiter, "acquire", return_value=True) as acq:
+            cv._cv_call_with_retry(lambda: "ok", "test")
+
+        assert acq.call_count == 1
+
+    @patch("models.comicvine.time.sleep")
+    @patch("models.comicvine._cv_retry_config", return_value=(2, 0.0))
+    def test_retries_also_take_a_slot(self, mock_cfg, mock_sleep):
+        import models.comicvine as cv
+
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise Exception("Rate limit exceeded. Slow down cowboy.")
+            return "ok"
+
+        with patch.object(cv._comicvine_rate_limiter, "acquire", return_value=True) as acq:
+            assert cv._cv_call_with_retry(flaky, "test") == "ok"
+
+        assert acq.call_count == 3
+
+    def test_background_callers_wait_indefinitely(self):
+        """A sweep on a daemon thread should ride out the budget, not skip it."""
+        import models.comicvine as cv
+
+        with patch.object(cv._comicvine_rate_limiter, "acquire", return_value=True) as acq:
+            cv._cv_call_with_retry(lambda: "ok", "test", blocking=True)
+
+        assert acq.call_args.kwargs["timeout"] is None
+
+    def test_interactive_callers_use_a_bounded_wait(self):
+        import models.comicvine as cv
+
+        with patch.object(cv._comicvine_rate_limiter, "acquire", return_value=True) as acq:
+            cv._cv_call_with_retry(lambda: "ok", "test", blocking=False)
+
+        timeout = acq.call_args.kwargs["timeout"]
+        assert timeout is not None and timeout > 0
+
+    def test_saturated_throttle_still_lets_an_interactive_call_through(self):
+        """Better a slow answer than a held request thread -- the reactive
+        retry below still covers the call."""
+        import models.comicvine as cv
+
+        with patch.object(cv._comicvine_rate_limiter, "acquire", return_value=False):
+            assert cv._cv_call_with_retry(lambda: "ok", "test", blocking=False) == "ok"
+
+    def test_defaults_to_blocking_outside_a_request_context(self):
+        import models.comicvine as cv
+
+        with patch.object(cv._comicvine_rate_limiter, "acquire", return_value=True) as acq:
+            cv._cv_call_with_retry(lambda: "ok", "test")
+
+        assert acq.call_args.kwargs["timeout"] is None
+
+    def test_defaults_to_bounded_wait_inside_a_request_context(self):
+        """Auto-detected so no call site has to declare itself: a live web
+        request is a thread a user is waiting on."""
+        import models.comicvine as cv
+
+        with patch("flask.has_request_context", return_value=True):
+            with patch.object(
+                cv._comicvine_rate_limiter, "acquire", return_value=True
+            ) as acq:
+                cv._cv_call_with_retry(lambda: "ok", "test")
+
+        assert acq.call_args.kwargs["timeout"] is not None
+
+    def test_hourly_limit_sits_below_comicvines_own_budget(self):
+        """The shared limiter has to trip before Simyan's per_hour=200 bucket,
+        so the wait lands somewhere we log and bound."""
+        import models.comicvine as cv
+
+        assert cv._cv_hourly_limit() < 200
+
+
+class TestRateLimitDetectionThroughCause:
+    """Simyan's limiter raises Timeout("Rate limit not cleared within
+    max_delay=..."), but Comicvine._get_request re-raises it as the far less
+    specific ServiceError("Service took too long to respond"). Matching only the
+    outer message would turn a throttle into a hard failure and drop the volume."""
+
+    def test_detects_rate_limit_on_cause_chain(self):
+        from models.comicvine import _is_rate_limit_error
+
+        cause = Exception("Rate limit not cleared within max_delay=60s")
+        outer = Exception("Service took too long to respond")
+        outer.__cause__ = cause
+
+        assert _is_rate_limit_error(outer)
+
+    def test_genuine_network_timeout_is_not_a_rate_limit(self):
+        """A real read timeout must stay a hard error, not be retried as a
+        throttle."""
+        from models.comicvine import _is_rate_limit_error
+
+        cause = Exception("HTTPSConnectionPool(host='comicvine.gamespot.com'): Read timed out")
+        outer = Exception("Service took too long to respond")
+        outer.__cause__ = cause
+
+        assert not _is_rate_limit_error(outer)
+
+    def test_survives_a_self_referential_cause_chain(self):
+        from models.comicvine import _is_rate_limit_error
+
+        exc = Exception("boom")
+        exc.__cause__ = exc
+
+        assert not _is_rate_limit_error(exc)
 
 
 class TestRateLimitRetry:

--- a/tests/mocked/test_comicvine_provider.py
+++ b/tests/mocked/test_comicvine_provider.py
@@ -35,24 +35,28 @@ class TestComicVineProviderInit:
         assert p._get_client() is None
 
     @patch("models.comicvine.is_simyan_available", return_value=True)
-    @patch("models.comicvine._make_cv_client")
-    def test_client_built_via_timeout_bounded_factory(
-        self, mock_make, mock_avail, comicvine_creds
+    @patch("models.comicvine.get_cv_client")
+    def test_client_built_via_shared_timeout_bounded_factory(
+        self, mock_get, mock_avail, comicvine_creds
     ):
-        """The adapter must build its Simyan client through the timeout-bounded
-        factory — otherwise get_issues/get_issue/test_connection can hang a
-        worker indefinitely on a slow ComicVine (regression: 'Applying…' stuck).
+        """The adapter must take its Simyan client from the shared accessor.
+
+        Two reasons: the factory behind it is timeout-bounded, so get_issues /
+        get_issue / test_connection can't hang a worker on a slow ComicVine
+        (regression: 'Applying…' stuck); and sharing means the adapter draws on
+        the same rate-limit budget as the rest of CLU rather than spinning up
+        its own limiter thread and bucket per instance.
         """
         from models.providers.comicvine_provider import ComicVineProvider
 
         sentinel = MagicMock()
-        mock_make.return_value = sentinel
+        mock_get.return_value = sentinel
 
         p = ComicVineProvider(credentials=comicvine_creds)
         client = p._get_client()
 
         assert client is sentinel
-        mock_make.assert_called_once_with(comicvine_creds.api_key)
+        mock_get.assert_called_once_with(comicvine_creds.api_key)
 
 
 class TestMakeCvClientUserAgent:

--- a/tests/mocked/test_comicvine_source.py
+++ b/tests/mocked/test_comicvine_source.py
@@ -1,0 +1,165 @@
+"""Tests for models/comicvine_source.py -- local-DB-first ComicVine access.
+
+Metron stays the preferred provider overall; this module is only consulted once
+a sidecar's ComicVine id has failed to resolve to a Metron series. Between the
+two ComicVine sources the local dump wins: it costs no requests and no
+rate-limit budget, and the per-volume issue listing is the most expensive call
+in a library sweep.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from models import comicvine_source
+
+
+@pytest.fixture
+def no_local(monkeypatch):
+    monkeypatch.setattr(comicvine_source, "_local_available", lambda: False)
+
+
+@pytest.fixture
+def no_api(monkeypatch):
+    monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: None)
+
+
+class TestIsAvailable:
+    """Gating ComicVine mapping on the API key alone silently disabled it for
+    anyone running only the local dump."""
+
+    def test_available_with_local_db_only(self, no_api, monkeypatch):
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        assert comicvine_source.is_available() is True
+
+    def test_available_with_api_key_only(self, no_local, monkeypatch):
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+        assert comicvine_source.is_available() is True
+
+    def test_unavailable_with_neither(self, no_local, no_api):
+        assert comicvine_source.is_available() is False
+
+    def test_describe_names_the_configured_sources(self, monkeypatch):
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+        assert comicvine_source.describe() == "local DB + API"
+
+    def test_describe_when_nothing_configured(self, no_local, no_api):
+        assert comicvine_source.describe() == "none"
+
+
+class TestGetAllIssuesForVolume:
+
+    def test_prefers_the_local_db(self, monkeypatch):
+        """The dump answers without spending any API budget."""
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine_sqlite.get_all_issues_for_volume",
+                   return_value=[{"id": 1}]) as local, \
+             patch("models.comicvine.get_all_issues_for_volume") as api:
+            result = comicvine_source.get_all_issues_for_volume(4050)
+
+        assert result == [{"id": 1}]
+        local.assert_called_once_with(4050)
+        api.assert_not_called()
+
+    def test_falls_through_to_the_api_when_the_dump_lacks_the_volume(self, monkeypatch):
+        """Coverage is the union of both sources, not just the dump's."""
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine_sqlite.get_all_issues_for_volume",
+                   return_value=[]), \
+             patch("models.comicvine.get_all_issues_for_volume",
+                   return_value=[{"id": 2}]) as api:
+            result = comicvine_source.get_all_issues_for_volume(4050)
+
+        assert result == [{"id": 2}]
+        api.assert_called_once_with("KEY", 4050)
+
+    def test_local_db_error_falls_through_to_the_api(self, monkeypatch):
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine_sqlite.get_all_issues_for_volume",
+                   side_effect=RuntimeError("db locked")), \
+             patch("models.comicvine.get_all_issues_for_volume",
+                   return_value=[{"id": 3}]):
+            assert comicvine_source.get_all_issues_for_volume(4050) == [{"id": 3}]
+
+    def test_uses_the_api_when_there_is_no_local_db(self, no_local, monkeypatch):
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine.get_all_issues_for_volume",
+                   return_value=[{"id": 4}]) as api:
+            assert comicvine_source.get_all_issues_for_volume(4050) == [{"id": 4}]
+
+        api.assert_called_once_with("KEY", 4050)
+
+    def test_returns_empty_with_no_source(self, no_local, no_api):
+        assert comicvine_source.get_all_issues_for_volume(4050) == []
+
+    def test_api_failure_returns_empty_rather_than_raising(self, no_local, monkeypatch):
+        """Callers fall back to sidecar data; an exception here would abort a
+        whole sweep."""
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine.get_all_issues_for_volume",
+                   side_effect=RuntimeError("rate limited")):
+            assert comicvine_source.get_all_issues_for_volume(4050) == []
+
+
+class TestGetVolumeDetails:
+
+    def test_prefers_the_local_db(self, monkeypatch):
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine_sqlite.get_volume_details",
+                   return_value={"name": "Batman"}), \
+             patch("models.comicvine.get_volume_details") as api:
+            assert comicvine_source.get_volume_details(4050)["name"] == "Batman"
+
+        api.assert_not_called()
+
+    def test_unnamed_local_row_falls_through_to_the_api(self, monkeypatch):
+        """A row with no name isn't authoritative -- callers use `name` to decide
+        whether to trust the metadata over a folder-derived guess."""
+        monkeypatch.setattr(comicvine_source, "_local_available", lambda: True)
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: "KEY")
+
+        with patch("models.comicvine_sqlite.get_volume_details",
+                   return_value={"name": None}), \
+             patch("models.comicvine.get_volume_details",
+                   return_value={"name": "Batman"}) as api:
+            assert comicvine_source.get_volume_details(4050)["name"] == "Batman"
+
+        api.assert_called_once_with("KEY", 4050)
+
+    def test_returns_empty_dict_with_no_source(self, no_local, no_api):
+        assert comicvine_source.get_volume_details(4050) == {}
+
+
+class TestAgainstTheRealLocalDatabase:
+    """End-to-end through the real SQLite fixture, not mocks."""
+
+    def test_reads_issues_from_the_configured_dump(
+        self, comicvine_sqlite_configured, monkeypatch
+    ):
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: None)
+
+        assert comicvine_source.is_available() is True
+        issues = comicvine_source.get_all_issues_for_volume(4050)
+
+        assert len(issues) == 1
+        assert issues[0]["number"] == "1"
+
+    def test_reads_volume_details_from_the_configured_dump(
+        self, comicvine_sqlite_configured, monkeypatch
+    ):
+        monkeypatch.setattr(comicvine_source, "_api_key", lambda app=None: None)
+
+        details = comicvine_source.get_volume_details(4050)
+
+        assert details["name"] == "Batman"
+        assert details["publisher_name"] == "DC Comics"

--- a/tests/mocked/test_comicvine_sqlite_model.py
+++ b/tests/mocked/test_comicvine_sqlite_model.py
@@ -172,3 +172,47 @@ class TestGetIssueMetadata:
                                     source_label=SOURCE_LABEL)
         actual = {k: v for k, v in get_issue_metadata(4050, "1").items() if k != '_image_url'}
         assert actual == expected
+
+
+class TestGetAllIssuesForVolume:
+    """The local equivalent of the API's paginated per-volume fetch -- the single
+    most expensive call in a library sweep. Shape must match
+    comicvine.get_all_issues_for_volume exactly so callers can use either."""
+
+    def test_returns_issues_in_the_api_shape(self, comicvine_sqlite_configured):
+        from helpers.comicvine_ids import COMICVINE_SERIES_ID_OFFSET
+        from models.comicvine_sqlite import get_all_issues_for_volume
+
+        issues = get_all_issues_for_volume(4050)
+
+        assert len(issues) == 1
+        issue = issues[0]
+        assert issue["cv_id"] == 500
+        # Offset so a ComicVine issue id can't collide with a Metron one.
+        assert issue["id"] == COMICVINE_SERIES_ID_OFFSET + 500
+        assert issue["number"] == "1"
+        assert issue["name"] == "The Beginning"
+        assert issue["cover_date"] == "2016-06-01"
+        assert issue["store_date"] == "2016-05-15"
+        assert issue["image"] == "https://example.com/issue1.jpg"
+        assert "4000-500" in issue["resource_url"]
+
+    def test_key_set_matches_the_api_path(self, comicvine_sqlite_configured):
+        """Callers save these straight to the issues cache, so a missing key
+        would silently degrade matching."""
+        from models.comicvine_sqlite import get_all_issues_for_volume
+
+        issue = get_all_issues_for_volume(4050)[0]
+
+        assert set(issue) == {
+            "id", "cv_id", "number", "name", "cover_date", "store_date",
+            "image", "resource_url",
+        }
+
+    def test_unknown_volume_returns_empty(self, comicvine_sqlite_configured):
+        from models.comicvine_sqlite import get_all_issues_for_volume
+        assert get_all_issues_for_volume(999999) == []
+
+    def test_returns_empty_when_unconfigured(self, not_configured):
+        from models.comicvine_sqlite import get_all_issues_for_volume
+        assert get_all_issues_for_volume(4050) == []

--- a/tests/mocked/test_cv_sync_guards.py
+++ b/tests/mocked/test_cv_sync_guards.py
@@ -77,7 +77,7 @@ def test_get_all_issues_for_volume(monkeypatch):
 
     cv = MagicMock()
     cv.list_issues.return_value = [issue(500, "1"), issue(501, "2")]
-    monkeypatch.setattr(comicvine, "_make_cv_client", lambda key: cv)
+    monkeypatch.setattr(comicvine, "get_cv_client", lambda key: cv)
 
     issues = comicvine.get_all_issues_for_volume("key", 18705)
     assert len(issues) == 2

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -1,6 +1,7 @@
 """Tests for models/library_automap.py -- sidecar-based auto-mapping."""
 import json
 import os
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -74,9 +75,9 @@ class TestResolveIdentity:
         folder = _make_folder(
             tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
         )
-        ident = library_automap._resolve_identity(folder, api=None, cv_api_key=None)
+        ident = library_automap._resolve_identity(folder, api=None, cv_available=False)
         assert ident["metron_id"] is None
-        assert "comicvine api not enabled" in ident["reason"].lower()
+        assert "comicvine not enabled" in ident["reason"].lower()
 
     def test_comicid_not_found_on_metron(self, tmp_path):
         folder = _make_folder(
@@ -84,7 +85,7 @@ class TestResolveIdentity:
         )
         api = MagicMock()
         api.series_list.return_value = []
-        ident = library_automap._resolve_identity(folder, api=api, cv_api_key=None)
+        ident = library_automap._resolve_identity(folder, api=api, cv_available=False)
         assert ident["metron_id"] is None
         assert "not in metron" in ident["reason"].lower()
 
@@ -180,10 +181,10 @@ class TestScan:
                            series_json={"name": "Broken", "metron_id": 999})
         real_resolve = library_automap._resolve_identity
 
-        def flaky_resolve(folder, api, cv_api_key=None):
+        def flaky_resolve(folder, api, cv_available=False):
             if library_automap._norm(folder) == library_automap._norm(bad):
                 raise ValueError("corrupt sidecar")
-            return real_resolve(folder, api, cv_api_key=cv_api_key)
+            return real_resolve(folder, api, cv_available=cv_available)
 
         p_roots, p_map = self._patch_roots_and_mapping([str(tmp_path)], [])
         with p_roots, p_map, \
@@ -262,22 +263,22 @@ class TestApply:
         assert len(result["failed"]) == 1
 
 class TestComicVineResolution:
-    def test_cv_only_resolves_with_cv_key(self, tmp_path):
+    def test_cv_only_resolves_when_comicvine_available(self, tmp_path):
         folder = _make_folder(
             tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
         )
-        ident = library_automap._resolve_identity(folder, api=None, cv_api_key="key")
+        ident = library_automap._resolve_identity(folder, api=None, cv_available=True)
         assert ident["metron_id"] == make_comicvine_series_id(18705)
-        assert ident["source"] == "comicvine_api"
+        assert ident["source"] == "comicvine"
         assert ident["cv_id"] == 18705
 
-    def test_cv_only_skipped_without_key(self, tmp_path):
+    def test_cv_only_skipped_when_comicvine_unavailable(self, tmp_path):
         folder = _make_folder(
             tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
         )
-        ident = library_automap._resolve_identity(folder, api=None, cv_api_key=None)
+        ident = library_automap._resolve_identity(folder, api=None, cv_available=False)
         assert ident["metron_id"] is None
-        assert "ComicVine API not enabled" in ident["reason"]
+        assert "ComicVine not enabled" in ident["reason"]
 
     def test_prefers_metron_over_comicvine(self, tmp_path):
         folder = _make_folder(
@@ -287,7 +288,7 @@ class TestComicVineResolution:
         result = MagicMock()
         result.id = 999
         api.series_list.return_value = [result]
-        ident = library_automap._resolve_identity(folder, api=api, cv_api_key="key")
+        ident = library_automap._resolve_identity(folder, api=api, cv_available=True)
         assert ident["metron_id"] == 999
         assert ident["source"] == "comicvine_id"
 
@@ -990,3 +991,232 @@ class TestCollectionStatusRebuild:
             library_automap.start_collection_status_rebuild(MagicMock())
         T.assert_called_once()
         assert T.call_args.kwargs["daemon"] is True
+
+
+class TestScanResultRetention:
+    """A whole-library scan's review/skipped/errors lists are held in the module
+    job store until the *next* job starts -- forever if the user closes the tab.
+    Cap what's retained, but report the true totals so nothing looks complete
+    when it isn't."""
+
+    def _seed_job(self, op_id):
+        library_automap._jobs[op_id] = {
+            "id": op_id, "status": "running", "current": 0, "total": 2,
+            "detail": "", "result": None, "error": None,
+        }
+
+    def _run(self, op_id, scan_result):
+        with patch.object(library_automap.metron, "get_flask_api", return_value=None), \
+             patch.object(library_automap.comicvine, "get_cv_api_key", return_value=None), \
+             patch.object(library_automap, "scan_library_for_automap",
+                          return_value=scan_result), \
+             patch.object(library_automap, "apply_automap",
+                          return_value={"applied": 0, "failed": [], "applied_ids": []}), \
+             patch.object(library_automap, "repair_volume_named_series"), \
+             patch.object(library_automap, "match_unmatched_mapped_series"):
+            library_automap._run_scan_job_inner(op_id, app=MagicMock())
+        return library_automap._jobs[op_id]["result"]
+
+    def test_caps_long_lists_and_reports_true_totals(self):
+        op_id = "test-cap"
+        self._seed_job(op_id)
+        cap = library_automap._JOB_LIST_CAP
+        oversize = [{"folder": f"/data/S{i}", "reason": "dupe"} for i in range(cap + 250)]
+        try:
+            result = self._run(op_id, {
+                "auto": [], "review": oversize, "skipped": oversize,
+                "errors": oversize, "total_candidates": len(oversize),
+            })
+            for key in ("review", "skipped", "errors"):
+                assert len(result[key]) == cap
+                assert result[f"{key}_total"] == cap + 250
+                assert result[f"{key}_truncated"] is True
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_short_lists_are_untouched_and_not_flagged(self):
+        op_id = "test-nocap"
+        self._seed_job(op_id)
+        items = [{"folder": "/data/A", "reason": "dupe"}]
+        try:
+            result = self._run(op_id, {
+                "auto": [], "review": items, "skipped": [], "errors": [],
+                "total_candidates": 1,
+            })
+            assert result["review"] == items
+            assert result["review_total"] == 1
+            assert result["review_truncated"] is False
+            assert result["skipped_total"] == 0
+            assert result["errors_truncated"] is False
+        finally:
+            library_automap._jobs.pop(op_id, None)
+
+    def test_prune_hard_caps_finished_jobs(self):
+        """Backstop in case the TTL sweep is ever bypassed."""
+        saved = dict(library_automap._jobs)
+        library_automap._jobs.clear()
+        try:
+            now = time.time()
+            for i in range(library_automap._MAX_FINISHED_JOBS + 4):
+                # Recent enough that the TTL sweep leaves them alone, so this
+                # exercises the hard cap rather than the TTL.
+                library_automap._jobs[f"job-{i}"] = {
+                    "id": f"job-{i}", "status": "done", "finished_at": now + i,
+                    "result": {}, "error": None,
+                }
+            library_automap._prune_jobs_locked()
+
+            assert len(library_automap._jobs) == library_automap._MAX_FINISHED_JOBS
+            # The newest survive.
+            assert "job-8" in library_automap._jobs
+            assert "job-0" not in library_automap._jobs
+        finally:
+            library_automap._jobs.clear()
+            library_automap._jobs.update(saved)
+
+    def test_prune_keeps_running_jobs(self):
+        saved = dict(library_automap._jobs)
+        library_automap._jobs.clear()
+        try:
+            library_automap._jobs["live"] = {
+                "id": "live", "status": "running", "result": None, "error": None,
+            }
+            now = time.time()
+            for i in range(library_automap._MAX_FINISHED_JOBS + 3):
+                library_automap._jobs[f"job-{i}"] = {
+                    "id": f"job-{i}", "status": "done", "finished_at": now + i,
+                    "result": {}, "error": None,
+                }
+            library_automap._prune_jobs_locked()
+
+            assert "live" in library_automap._jobs
+        finally:
+            library_automap._jobs.clear()
+            library_automap._jobs.update(saved)
+
+
+class TestSweepMemoryHygiene:
+
+    def test_worklist_does_not_retain_full_db_rows(self):
+        """Holding every mapped series' full row for the length of a sweep is
+        pure overhead -- only the id and name are used."""
+        rows = [
+            {"id": 1, "name": "Batman", "payload": "x" * 64},
+            {"id": 2, "name": "Saga", "payload": "y" * 64},
+        ]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch.object(library_automap, "_sync_and_match") as sm:
+            n = library_automap.match_unmatched_mapped_series(api=None)
+
+        assert n == 2
+        assert [c.args[1] for c in sm.call_args_list] == [1, 2]
+
+    def test_falls_back_to_series_id_when_name_missing(self):
+        seen = []
+        rows = [{"id": 42}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch.object(library_automap, "_sync_and_match"):
+            library_automap.match_unmatched_mapped_series(
+                api=None, progress_cb=lambda c, t, n: seen.append(n)
+            )
+
+        assert seen == ["Series 42"]
+
+    def test_collects_periodically_during_a_long_sweep(self):
+        """A long sweep never trips the generational thresholds on its own and
+        the background monitor only collects once every five minutes."""
+        every = library_automap._GC_EVERY_N_SERIES
+        # ids start at 1 -- a 0 id is falsy and gets filtered out of the worklist.
+        rows = [{"id": i, "name": f"S{i}"} for i in range(1, every * 2 + 1)]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch.object(library_automap, "_sync_and_match"), \
+             patch.object(library_automap.gc, "collect") as collect:
+            library_automap.match_unmatched_mapped_series(api=None)
+
+        assert collect.call_count == 2
+
+    def test_no_collection_for_a_short_sweep(self):
+        rows = [{"id": 1, "name": "Batman"}]
+        with patch("core.database.get_all_mapped_series", return_value=rows), \
+             patch("core.database.get_collection_status_for_series", return_value=None), \
+             patch.object(library_automap, "_sync_and_match"), \
+             patch.object(library_automap.gc, "collect") as collect:
+            library_automap.match_unmatched_mapped_series(api=None)
+
+        collect.assert_not_called()
+
+
+class TestComicVineSourceIndependence:
+    """ComicVine mapping used to be gated on the API key alone, so a user
+    running only the local ComicVine dump had every ComicVine-id sidecar
+    skipped. Either source must enable it."""
+
+    def test_resolves_with_local_db_and_no_api_key(self, tmp_path):
+        folder = _make_folder(
+            tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705},
+        )
+        with patch("models.comicvine_source._local_available", return_value=True), \
+             patch("models.comicvine_source._api_key", return_value=None):
+            available = library_automap.comicvine_source.is_available()
+            ident = library_automap._resolve_identity(
+                folder, api=None, cv_available=available
+            )
+
+        assert available is True
+        assert ident["metron_id"] == make_comicvine_series_id(18705)
+        assert ident["source"] == "comicvine"
+
+    def test_scan_detects_the_source_when_not_told(self, tmp_path):
+        """scan_library_for_automap defaults cv_available rather than requiring
+        the caller to know which source is configured."""
+        _make_folder(tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705})
+        with patch.object(library_automap, "get_library_roots",
+                          return_value=[str(tmp_path)]), \
+             patch("core.database.get_all_mapped_series", return_value=[]), \
+             patch("models.comicvine_source._local_available", return_value=True), \
+             patch("models.comicvine_source._api_key", return_value=None):
+            result = library_automap.scan_library_for_automap(api=None)
+
+        assert len(result["auto"]) == 1
+        assert result["auto"][0]["metron_id"] == make_comicvine_series_id(18705)
+
+    def test_scan_skips_comicvine_ids_when_no_source_configured(self, tmp_path):
+        _make_folder(tmp_path, "Saga", series_json={"name": "Saga", "comicid": 18705})
+        with patch.object(library_automap, "get_library_roots",
+                          return_value=[str(tmp_path)]), \
+             patch("core.database.get_all_mapped_series", return_value=[]), \
+             patch("models.comicvine_source._local_available", return_value=False), \
+             patch("models.comicvine_source._api_key", return_value=None):
+            result = library_automap.scan_library_for_automap(api=None)
+
+        assert not result["auto"]
+        assert len(result["skipped"]) == 1
+
+    def test_issue_sync_uses_the_local_db_without_an_api_key(self):
+        """The per-volume issue fetch is the most expensive call in a sweep;
+        answering it from the dump spends no API budget at all."""
+        cv_issues = [{"id": 1, "cv_id": 500, "number": "1"}]
+        with patch("models.comicvine_source._local_available", return_value=True), \
+             patch("models.comicvine_source._api_key", return_value=None), \
+             patch("models.comicvine_sqlite.get_all_issues_for_volume",
+                   return_value=cv_issues) as local, \
+             patch("models.comicvine.get_all_issues_for_volume") as api, \
+             patch("core.database.delete_issues_for_series"), \
+             patch("core.database.save_issues_bulk") as save, \
+             patch("core.database.update_series_sync_time"):
+            library_automap._sync_comicvine_issues(make_comicvine_series_id(18705))
+
+        local.assert_called_once_with(18705)
+        api.assert_not_called()
+        assert save.call_args.args[0] == cv_issues
+
+    def test_issue_sync_no_ops_without_any_comicvine_source(self):
+        with patch("models.comicvine_source._local_available", return_value=False), \
+             patch("models.comicvine_source._api_key", return_value=None), \
+             patch("core.database.save_issues_bulk") as save:
+            library_automap._sync_comicvine_issues(make_comicvine_series_id(18705))
+
+        save.assert_not_called()

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -1,7 +1,13 @@
 """Tests for models/metron.py -- mocked Mokkari API."""
 import time
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
+
+from mokkari.exceptions import RateLimitError
+
 from tests.mocked.conftest import make_mock_series, make_mock_issue
 
 
@@ -43,6 +49,91 @@ class TestGetApi:
         second = get_api("user2", "pass2")
         assert first is not second
         assert mock_session_class.call_count == 2
+
+
+class TestSessionCache:
+    """mokkari consults its cache before dispatching, so a hit costs neither an
+    HTTP request nor a rate-limit slot. A library sweep re-reads the same series
+    and issue endpoints from several code paths, so this is the cheapest
+    reduction in Metron quota burn available."""
+
+    @patch("models.metron.MokkariSession")
+    def test_session_gets_a_cache(self, mock_session_class, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        monkeypatch.delenv("METRON_CACHE_EXPIRE_DAYS", raising=False)
+        from models.metron import get_api
+
+        mock_session_class.return_value = MagicMock()
+        get_api("user", "pass")
+
+        _, kwargs = mock_session_class.call_args
+        cache = kwargs.get("cache")
+        assert cache is not None
+        assert cache.expire == 1
+        assert str(tmp_path / "mokkari") in cache.con.execute(
+            "PRAGMA database_list"
+        ).fetchone()[2]
+
+    @patch("models.metron.MokkariSession")
+    def test_expiry_env_override(self, mock_session_class, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        monkeypatch.setenv("METRON_CACHE_EXPIRE_DAYS", "7")
+        from models.metron import get_api
+
+        mock_session_class.return_value = MagicMock()
+        get_api("user", "pass")
+
+        _, kwargs = mock_session_class.call_args
+        assert kwargs["cache"].expire == 7
+
+    def test_expiry_never_falsy(self, monkeypatch):
+        """mokkari treats a falsy expire as 'never expire' -- a cache that never
+        drops a row would pin stale metadata forever."""
+        from models.metron import _metron_cache_expire_days
+
+        monkeypatch.setenv("METRON_CACHE_EXPIRE_DAYS", "0")
+        assert _metron_cache_expire_days() >= 1
+        monkeypatch.setenv("METRON_CACHE_EXPIRE_DAYS", "garbage")
+        assert _metron_cache_expire_days() >= 1
+
+    @patch("models.metron.MokkariSession")
+    @patch("models.metron.SqliteCache", side_effect=OSError(30, "Read-only file system"))
+    def test_unwritable_cache_degrades_to_uncached_not_to_no_metron(
+        self, mock_cache, mock_session_class
+    ):
+        from models.metron import get_api
+
+        mock_session_class.return_value = MagicMock()
+        api = get_api("user", "pass")
+
+        assert api is not None
+        _, kwargs = mock_session_class.call_args
+        assert kwargs["cache"] is None
+
+    @patch("models.metron.MokkariSession")
+    def test_invalidate_runs_cache_cleanup(self, mock_session_class):
+        """mokkari only expires rows in SqliteCache.__init__, so on a long-lived
+        shared session this is the only thing that ever drops stale responses."""
+        from models.metron import get_api, invalidate_session_cache
+
+        session = MagicMock()
+        mock_session_class.return_value = session
+        get_api("user", "pass")
+
+        invalidate_session_cache()
+
+        session.cache.cleanup.assert_called_once()
+
+    @patch("models.metron.MokkariSession")
+    def test_invalidate_survives_a_session_without_a_cache(self, mock_session_class):
+        from models.metron import get_api, invalidate_session_cache
+
+        session = MagicMock()
+        session.cache = None
+        mock_session_class.return_value = session
+        get_api("user", "pass")
+
+        invalidate_session_cache()  # must not raise
 
 
 class TestIsConnectionError:
@@ -508,6 +599,178 @@ class TestSlidingWindowRateLimiter:
             result = _api_call(lambda: "ok", "test context")
         assert result == "ok"
         mock_acquire.assert_called_once()
+
+
+def _window(limit=None, remaining=None, reset=None):
+    return SimpleNamespace(limit=limit, remaining=remaining, reset=reset)
+
+
+def _status(burst=None, sustained=None):
+    return SimpleNamespace(
+        burst=burst or _window(), sustained=sustained or _window()
+    )
+
+
+class TestAdaptivePacing:
+    """mokkari parses the X-RateLimit-* headers but its own pre-emptive check is
+    advisory -- its docstring says callers must cap their own concurrency. These
+    tests pin the capping we do from those headers."""
+
+    def test_retunes_the_window_from_the_reported_burst_limit(self):
+        from models.metron import _metron_pacer, _metron_rate_limiter
+
+        session = MagicMock()
+        session.rate_limit_status = _status(burst=_window(limit=20, remaining=19))
+
+        _metron_pacer.observe(session)
+
+        assert _metron_rate_limiter.max_requests == 16  # 80% of 20
+
+    def test_missing_headers_leave_the_default_budget_alone(self):
+        """Every field is None until the first response completes; a TypeError
+        here would kill a daemon thread."""
+        from models.metron import _metron_pacer, _metron_rate_limiter
+
+        before = _metron_rate_limiter.max_requests
+        session = MagicMock()
+        session.rate_limit_status = _status()
+
+        _metron_pacer.observe(session)  # must not raise
+
+        assert _metron_rate_limiter.max_requests == before
+
+    def test_session_without_rate_limit_status_is_ignored(self):
+        from models.metron import _metron_pacer
+
+        session = MagicMock()
+        session.rate_limit_status = None
+
+        _metron_pacer.observe(session)  # must not raise
+
+    def test_naive_reset_datetime_does_not_explode(self):
+        """mokkari returns tz-aware datetimes; comparing one against a naive
+        now() raises. Guard both ways."""
+        from models.metron import _metron_pacer
+
+        session = MagicMock()
+        session.rate_limit_status = _status(
+            sustained=_window(
+                limit=100, remaining=0, reset=datetime.now() + timedelta(hours=2)
+            )
+        )
+
+        _metron_pacer.observe(session)  # must not raise
+
+    def test_exhausted_daily_quota_skips_the_call_without_sleeping(self):
+        """The regression test for the reported log: a spent daily quota was
+        surfacing as a 59.5s wait retried 3x per series, for every series in a
+        sweep. It must now short-circuit."""
+        from models.metron import _api_call, _metron_pacer
+
+        session = MagicMock()
+        session.rate_limit_status = _status(
+            sustained=_window(
+                limit=100,
+                remaining=0,
+                reset=datetime.now(timezone.utc) + timedelta(hours=2),
+            )
+        )
+        _metron_pacer.observe(session)
+
+        called = {"n": 0}
+
+        def fn():
+            called["n"] += 1
+            return "ok"
+
+        with patch("models.metron.time.sleep") as mock_sleep:
+            result = _api_call(fn, "test context", default="fallback")
+
+        assert result == "fallback"
+        assert called["n"] == 0
+        mock_sleep.assert_not_called()
+
+    def test_calls_resume_once_the_daily_window_has_reset(self):
+        from models.metron import _api_call, _metron_pacer
+
+        session = MagicMock()
+        session.rate_limit_status = _status(
+            sustained=_window(
+                limit=100,
+                remaining=0,
+                reset=datetime.now(timezone.utc) + timedelta(milliseconds=50),
+            )
+        )
+        _metron_pacer.observe(session)
+        assert _metron_pacer.daily_limit_reached() is True
+
+        time.sleep(0.1)
+
+        assert _metron_pacer.daily_limit_reached() is False
+        assert _api_call(lambda: "ok", "test context") == "ok"
+
+    def test_sub_threshold_retry_after_gives_up_on_the_first_attempt(self):
+        """mokkari reports retry_after as max(burst_wait, sustained_wait), so a
+        spent daily quota can arrive as 59.5s -- just under the old 60s 'this is
+        the daily cap' threshold. The headers say which window it really is."""
+        from models.metron import _api_call, invalidate_session_cache
+        import models.metron as metron
+
+        session = MagicMock()
+        session.rate_limit_status = _status(
+            sustained=_window(
+                limit=100,
+                remaining=0,
+                reset=datetime.now(timezone.utc) + timedelta(hours=2),
+            )
+        )
+        with metron._SESSION_CACHE_LOCK:
+            metron._SESSION_CACHE[("u", "p")] = session
+
+        calls = {"n": 0}
+
+        def fn():
+            calls["n"] += 1
+            raise RateLimitError("slow down", retry_after=59.5)
+
+        with patch("models.metron.time.sleep") as mock_sleep:
+            result = _api_call(fn, "test context", default="fallback")
+
+        assert result == "fallback"
+        assert calls["n"] == 1  # not 3
+        mock_sleep.assert_not_called()
+
+    def test_invalidate_clears_the_daily_latch(self):
+        """A wrongly-latched window would silently disable Metron for hours."""
+        from models.metron import _metron_pacer, invalidate_session_cache
+
+        session = MagicMock()
+        session.rate_limit_status = _status(
+            sustained=_window(
+                limit=100,
+                remaining=0,
+                reset=datetime.now(timezone.utc) + timedelta(hours=2),
+            )
+        )
+        _metron_pacer.observe(session)
+        assert _metron_pacer.daily_limit_reached() is True
+
+        invalidate_session_cache()
+
+        assert _metron_pacer.daily_limit_reached() is False
+
+    def test_successful_call_observes_the_headers(self):
+        from models.metron import _api_call, _metron_rate_limiter
+        import models.metron as metron
+
+        session = MagicMock()
+        session.rate_limit_status = _status(burst=_window(limit=40, remaining=39))
+        with metron._SESSION_CACHE_LOCK:
+            metron._SESSION_CACHE[("u", "p")] = session
+
+        assert _api_call(lambda: "ok", "test context") == "ok"
+
+        assert _metron_rate_limiter.max_requests == 32  # 80% of 40
 
 
 class TestGetReleases:

--- a/tests/routes/test_pull_list_automap.py
+++ b/tests/routes/test_pull_list_automap.py
@@ -57,6 +57,26 @@ class TestScanStatusRoute:
         assert data["status"] == "done"
         assert data["result"]["errors"][0]["folder"] == "/data/Broken"
 
+    def test_done_job_passes_through_truncation_fields(self, client):
+        # A whole-library scan's lists are capped so the job store doesn't pin
+        # them all in memory; the UI needs the true totals to say so.
+        job = {
+            "status": "done", "current": 900, "total": 900, "detail": "",
+            "result": {
+                "applied": 400, "total_candidates": 900,
+                "review": [{"folder": "/data/A"}], "review_total": 700,
+                "review_truncated": True,
+                "skipped": [], "skipped_total": 0, "skipped_truncated": False,
+                "errors": [], "errors_total": 0, "errors_truncated": False,
+            },
+        }
+        with patch("models.library_automap.get_scan_job", return_value=job):
+            resp = client.get("/api/pull-list/scan/status?op_id=x")
+        data = resp.get_json()
+        assert data["result"]["review_total"] == 700
+        assert data["result"]["review_truncated"] is True
+        assert len(data["result"]["review"]) == 1
+
     def test_error_job_returns_error(self, client):
         job = {"status": "error", "current": 0, "total": 0, "detail": "", "error": "boom"}
         with patch("models.library_automap.get_scan_job", return_value=job):

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -951,3 +951,43 @@ class TestGetSeriesAliasesPersistence:
         assert updated == 0
         # Reading back must surface the alias via the canonical alias table.
         assert "2000ad" in get_series_aliases("2000 AD")
+
+
+class TestSyncComicVineSeries:
+    """POST /api/sync/series/<id> for a ComicVine-sourced id. It used to require
+    a ComicVine API key, so a user running only the local ComicVine dump could
+    not sync at all."""
+
+    def _cv_series_id(self):
+        from helpers.comicvine_ids import make_comicvine_series_id
+        return make_comicvine_series_id(18705)
+
+    def test_syncs_from_the_local_db_without_an_api_key(self, client):
+        cv_issues = [
+            {"id": 1, "cv_id": 500, "number": "1", "name": "One",
+             "cover_date": "2016-06-01", "store_date": None,
+             "image": None, "resource_url": None},
+        ]
+        with patch("models.comicvine_source._local_available", return_value=True), \
+             patch("models.comicvine_source._api_key", return_value=None), \
+             patch("models.comicvine_sqlite.get_all_issues_for_volume",
+                   return_value=cv_issues), \
+             patch("routes.series.get_series_by_id", return_value={"id": 1, "name": "Saga"}), \
+             patch("routes.series.delete_issues_for_series"), \
+             patch("routes.series.save_issues_bulk"), \
+             patch("routes.series.update_series_sync_time"), \
+             patch("core.database.clear_wanted_cache_for_series"):
+            resp = client.post(f"/api/sync/series/{self._cv_series_id()}")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["issue_count"] == 1
+
+    def test_errors_only_when_no_comicvine_source_at_all(self, client):
+        with patch("models.comicvine_source._local_available", return_value=False), \
+             patch("models.comicvine_source._api_key", return_value=None):
+            resp = client.post(f"/api/sync/series/{self._cv_series_id()}")
+
+        assert resp.status_code == 500
+        assert "ComicVine not configured" in resp.get_json()["error"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for unit tests.
+
+The provider layer keeps process-wide caches -- provider instances, the Simyan
+client, the shared rate limiters -- which are exactly what makes a library sweep
+affordable, and exactly what leaks state between tests. Reset them per test.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_instance_cache():
+    from models.providers import invalidate_provider_cache
+    invalidate_provider_cache()
+    yield
+    invalidate_provider_cache()
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_rate_limiters():
+    from helpers.rate_limit import reset_all_limiters
+    reset_all_limiters()
+    yield
+    reset_all_limiters()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cv_client_cache():
+    from models.comicvine import invalidate_cv_client_cache
+    invalidate_cv_client_cache()
+    yield
+    invalidate_cv_client_cache()

--- a/tests/unit/test_memory_utils.py
+++ b/tests/unit/test_memory_utils.py
@@ -1,0 +1,61 @@
+"""Tests for core.memory_utils threshold configuration.
+
+The high-memory warning re-fires on every poll (60s) for as long as RSS stays
+above the threshold, so a deployment whose normal working set is legitimately
+larger than the default would fill its logs with a warning it can do nothing
+about. The thresholds have to be tunable.
+"""
+import pytest
+
+from core.memory_utils import MemoryMonitor, _threshold_from_env
+
+
+class TestThresholdFromEnv:
+
+    def test_returns_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("MEMORY_THRESHOLD_MB", raising=False)
+        assert _threshold_from_env("MEMORY_THRESHOLD_MB", 1500) == 1500
+
+    def test_reads_the_environment(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_THRESHOLD_MB", "4096")
+        assert _threshold_from_env("MEMORY_THRESHOLD_MB", 1500) == 4096
+
+    def test_garbage_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_THRESHOLD_MB", "lots")
+        assert _threshold_from_env("MEMORY_THRESHOLD_MB", 1500) == 1500
+
+    def test_non_positive_falls_back_to_default(self, monkeypatch):
+        """A zero threshold would warn on every single poll forever."""
+        monkeypatch.setenv("MEMORY_THRESHOLD_MB", "0")
+        assert _threshold_from_env("MEMORY_THRESHOLD_MB", 1500) == 1500
+        monkeypatch.setenv("MEMORY_THRESHOLD_MB", "-5")
+        assert _threshold_from_env("MEMORY_THRESHOLD_MB", 1500) == 1500
+
+
+class TestMemoryMonitorThresholds:
+
+    def test_defaults_preserved(self, monkeypatch):
+        monkeypatch.delenv("MEMORY_THRESHOLD_MB", raising=False)
+        monkeypatch.delenv("MEMORY_CLEANUP_THRESHOLD_MB", raising=False)
+
+        monitor = MemoryMonitor()
+
+        assert monitor.threshold_mb == 1500
+        assert monitor.cleanup_threshold_mb == 1000
+
+    def test_env_overrides_both(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_THRESHOLD_MB", "3000")
+        monkeypatch.setenv("MEMORY_CLEANUP_THRESHOLD_MB", "2500")
+
+        monitor = MemoryMonitor()
+
+        assert monitor.threshold_mb == 3000
+        assert monitor.cleanup_threshold_mb == 2500
+
+    def test_explicit_arguments_win_over_env(self, monkeypatch):
+        monkeypatch.setenv("MEMORY_THRESHOLD_MB", "3000")
+
+        monitor = MemoryMonitor(threshold_mb=800, cleanup_threshold_mb=400)
+
+        assert monitor.threshold_mb == 800
+        assert monitor.cleanup_threshold_mb == 400

--- a/tests/unit/test_provider_cache.py
+++ b/tests/unit/test_provider_cache.py
@@ -1,0 +1,64 @@
+"""Tests for helpers.provider_cache -- writable cache locations for provider clients.
+
+Simyan and Mokkari both default their SQLite files to ``$HOME/.cache``, which the
+container's non-root user can neither reach nor create (issue #396). These tests
+pin the resolution order and the fallback that keeps a provider working when the
+preferred location is unwritable.
+"""
+import os
+
+import pytest
+
+from helpers.provider_cache import provider_cache_dir
+
+
+class TestProviderCacheDir:
+
+    def test_honours_xdg_cache_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+        result = provider_cache_dir("simyan")
+
+        assert result == str(tmp_path / "simyan")
+
+    def test_creates_the_directory(self, tmp_path, monkeypatch):
+        """Neither Simyan nor Mokkari creates parent dirs itself."""
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+        result = provider_cache_dir("mokkari")
+
+        assert os.path.isdir(result)
+
+    def test_leaf_name_separates_providers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+        assert provider_cache_dir("simyan") != provider_cache_dir("mokkari")
+
+    def test_falls_back_to_tempdir_when_unwritable(self, monkeypatch):
+        """An unwritable config dir must not take the provider down with it."""
+        import helpers.provider_cache as pc
+
+        real_makedirs = os.makedirs
+
+        def fake_makedirs(path, *args, **kwargs):
+            if "clu-mokkari" not in str(path):
+                raise OSError(13, "Permission denied")
+            return real_makedirs(path, *args, **kwargs)
+
+        monkeypatch.setenv("XDG_CACHE_HOME", "/nonexistent-unwritable")
+        monkeypatch.setattr(pc.os, "makedirs", fake_makedirs)
+
+        result = provider_cache_dir("mokkari")
+
+        assert "clu-mokkari" in result
+        assert os.path.isdir(result)
+
+    def test_falls_back_to_config_dir_without_xdg(self, tmp_path, monkeypatch):
+        import core.config
+
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setattr(core.config, "CONFIG_DIR", str(tmp_path))
+
+        result = provider_cache_dir("simyan")
+
+        assert result == str(tmp_path / ".cache" / "simyan")

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -55,6 +55,104 @@ class TestGetProvider:
             get_provider("nonexistent")
 
 
+class TestProviderInstanceCache:
+    """Provider instances wrap expensive clients -- the ComicVine adapter holds
+    a Simyan client (background limiter thread + SQLite connections), Metron a
+    mokkari Session. core.bulk_metadata builds a provider once per FILE, so
+    without caching a 3000-file job rebuilt those clients 3000 times and never
+    released any of them."""
+
+    def test_same_type_and_credentials_share_one_instance(self):
+        from models.providers import get_provider
+
+        creds = ProviderCredentials(username="user", password="pass")
+        first = get_provider(ProviderType.METRON, credentials=creds)
+        second = get_provider(
+            ProviderType.METRON,
+            credentials=ProviderCredentials(username="user", password="pass"),
+        )
+
+        assert first is second
+
+    def test_different_credentials_get_different_instances(self):
+        from models.providers import get_provider
+
+        a = get_provider(
+            ProviderType.METRON,
+            credentials=ProviderCredentials(username="a", password="pass"),
+        )
+        b = get_provider(
+            ProviderType.METRON,
+            credentials=ProviderCredentials(username="b", password="pass"),
+        )
+
+        assert a is not b
+
+    def test_no_credentials_is_distinct_from_credentialled(self):
+        from models.providers import get_provider
+
+        anon = get_provider(ProviderType.METRON)
+        creds = get_provider(
+            ProviderType.METRON,
+            credentials=ProviderCredentials(username="user", password="pass"),
+        )
+
+        assert anon is not creds
+        assert anon.credentials is None
+
+    def test_different_types_get_different_instances(self):
+        from models.providers import get_provider
+
+        assert get_provider(ProviderType.METRON) is not get_provider(
+            ProviderType.COMICVINE
+        )
+
+    def test_invalidate_forces_reconstruction(self):
+        """A saved API key that keeps being ignored in favour of the old one is
+        the failure this prevents."""
+        from models.providers import get_provider, invalidate_provider_cache
+
+        creds = ProviderCredentials(api_key="key")
+        first = get_provider(ProviderType.COMICVINE, credentials=creds)
+
+        invalidate_provider_cache()
+
+        assert get_provider(ProviderType.COMICVINE, credentials=creds) is not first
+
+    def test_concurrent_callers_share_one_instance(self):
+        import threading
+
+        from models.providers import get_provider
+
+        results = []
+        results_lock = threading.Lock()
+        start = threading.Barrier(8)
+
+        def worker():
+            start.wait()
+            provider = get_provider(
+                ProviderType.COMICVINE,
+                credentials=ProviderCredentials(api_key="key"),
+            )
+            with results_lock:
+                results.append(provider)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 8
+        assert all(p is results[0] for p in results)
+
+    def test_unknown_type_still_raises_before_touching_the_cache(self):
+        from models.providers import get_provider
+
+        with pytest.raises((ValueError, AttributeError)):
+            get_provider("nonexistent")
+
+
 class TestGetProviderByName:
 
     def test_by_name_metron(self):

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,161 @@
+"""Tests for helpers.rate_limit -- shared process-wide provider pacing.
+
+CLU reaches Metron and ComicVine from background sweeps, bulk jobs, the
+wanted-cache refresh and live web requests at once, so the budget has to be
+shared across threads or the aggregate trips the provider's burst limit even
+when no single caller does.
+"""
+import threading
+import time
+
+import pytest
+
+from helpers.rate_limit import (
+    SlidingWindowRateLimiter,
+    get_limiter,
+    reset_all_limiters,
+)
+
+
+class TestSlidingWindowAcquire:
+
+    def test_allows_up_to_the_budget_without_waiting(self):
+        limiter = SlidingWindowRateLimiter(3, 60.0)
+
+        started = time.monotonic()
+        assert all(limiter.acquire() for _ in range(3))
+
+        assert time.monotonic() - started < 0.5
+
+    def test_blocks_once_the_window_is_full(self):
+        limiter = SlidingWindowRateLimiter(2, 0.2)
+        limiter.acquire()
+        limiter.acquire()
+
+        started = time.monotonic()
+        assert limiter.acquire() is True
+
+        assert time.monotonic() - started >= 0.1
+
+    def test_reset_clears_the_window(self):
+        limiter = SlidingWindowRateLimiter(1, 60.0)
+        limiter.acquire()
+
+        limiter.reset()
+
+        started = time.monotonic()
+        assert limiter.acquire() is True
+        assert time.monotonic() - started < 0.5
+
+
+class TestAcquireTimeout:
+    """A limiter with an hour-long window would park a Flask worker for most of
+    an hour, turning a visible rate-limit error into a hung page. Interactive
+    callers must be able to give up."""
+
+    def test_returns_false_immediately_when_it_cannot_be_served(self):
+        limiter = SlidingWindowRateLimiter(1, 3600.0)
+        limiter.acquire()
+
+        started = time.monotonic()
+        assert limiter.acquire(timeout=0) is False
+
+        assert time.monotonic() - started < 0.5
+
+    def test_a_refused_acquire_does_not_consume_a_slot(self):
+        limiter = SlidingWindowRateLimiter(1, 0.2)
+        limiter.acquire()
+
+        assert limiter.acquire(timeout=0) is False
+        time.sleep(0.25)
+        # The window has rolled over; exactly one slot should be free.
+        assert limiter.acquire(timeout=0) is True
+        assert limiter.acquire(timeout=0) is False
+
+    def test_waits_up_to_the_timeout_then_succeeds(self):
+        limiter = SlidingWindowRateLimiter(1, 0.2)
+        limiter.acquire()
+
+        assert limiter.acquire(timeout=5.0) is True
+
+    def test_timeout_none_waits_indefinitely(self):
+        limiter = SlidingWindowRateLimiter(1, 0.2)
+        limiter.acquire()
+
+        assert limiter.acquire(timeout=None) is True
+
+
+class TestRetune:
+    """Providers report their real limit in response headers; we should stop
+    guessing without discarding what has already been sent."""
+
+    def test_changes_the_budget_in_place(self):
+        limiter = SlidingWindowRateLimiter(1, 3600.0)
+        limiter.acquire()
+        assert limiter.acquire(timeout=0) is False
+
+        limiter.retune(5)
+
+        assert limiter.max_requests == 5
+        assert limiter.acquire(timeout=0) is True
+
+    def test_never_drops_below_one(self):
+        limiter = SlidingWindowRateLimiter(10, 60.0)
+        limiter.retune(0)
+        assert limiter.max_requests == 1
+
+    def test_window_optional(self):
+        limiter = SlidingWindowRateLimiter(10, 60.0)
+        limiter.retune(20)
+        assert limiter.window_seconds == 60.0
+        limiter.retune(20, 30.0)
+        assert limiter.window_seconds == 30.0
+
+
+class TestGetLimiter:
+
+    def test_same_name_returns_the_same_instance(self):
+        a = get_limiter("test-provider", 5, 60.0)
+        b = get_limiter("test-provider", 999, 1.0)
+
+        assert a is b
+        # Later callers must not silently widen an existing budget.
+        assert a.max_requests == 5
+
+    def test_different_names_are_independent(self):
+        a = get_limiter("test-provider-a", 5, 60.0)
+        b = get_limiter("test-provider-b", 5, 60.0)
+
+        assert a is not b
+
+    def test_reset_all_clears_every_window(self):
+        limiter = get_limiter("test-reset-all", 1, 3600.0)
+        limiter.acquire()
+        assert limiter.acquire(timeout=0) is False
+
+        reset_all_limiters()
+
+        assert limiter.acquire(timeout=0) is True
+
+
+class TestConcurrency:
+
+    def test_never_admits_more_than_the_budget(self):
+        limiter = SlidingWindowRateLimiter(5, 3600.0)
+        granted = []
+        granted_lock = threading.Lock()
+        start = threading.Barrier(20)
+
+        def worker():
+            start.wait()
+            if limiter.acquire(timeout=0):
+                with granted_lock:
+                    granted.append(1)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(granted) == 5

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -568,3 +568,91 @@ class TestApplySmartRename:
         summary = apply_smart_rename(plan)
         assert summary["renamed"] == 0
         assert summary["skipped"] >= 1
+
+
+class TestBuildComicvineSeriesDict:
+    """Regression cover for a fallback that never worked: this built its own
+    Simyan client with `cache=None`, which Simyan 3.x rejects with TypeError,
+    and the bare `except Exception` swallowed it."""
+
+    def _volume(self):
+        return SimpleNamespace(
+            name="Batman",
+            start_year=2016,
+            publisher=SimpleNamespace(name="DC Comics"),
+            image=SimpleNamespace(original_url="http://img/batman.jpg"),
+            issue_count=85,
+            description="The Dark Knight.",
+        )
+
+    def test_maps_a_volume_to_the_series_json_shape(self):
+        import cbz_ops.smart_rename as sr
+
+        cv = MagicMock()
+        cv.get_volume.return_value = self._volume()
+        with patch("models.comicvine.is_simyan_available", return_value=True), \
+             patch("models.comicvine.get_cv_client", return_value=cv):
+            result = sr._build_comicvine_series_dict("KEY", 4050)
+
+        assert result["name"] == "Batman"
+        assert result["year_began"] == 2016
+        assert result["publisher"] == "DC Comics"
+        assert result["issue_count"] == 85
+        assert result["image"] == "http://img/batman.jpg"
+        assert result["cv_id"] == 4050
+
+    def test_uses_the_shared_client_and_never_passes_cache(self):
+        """The exact bug: a locally-built Comicvine(cache=None) raises TypeError
+        on Simyan 3.x, so the ComicVine fallback silently did nothing."""
+        import cbz_ops.smart_rename as sr
+        import models.comicvine as cv_module
+
+        cv = MagicMock()
+        cv.get_volume.return_value = self._volume()
+        with patch("models.comicvine.is_simyan_available", return_value=True), \
+             patch("models.comicvine.get_cv_client", return_value=cv) as get_client, \
+             patch.object(cv_module, "Comicvine", create=True) as raw_ctor:
+            sr._build_comicvine_series_dict("KEY", 4050)
+
+        get_client.assert_called_once_with("KEY")
+        raw_ctor.assert_not_called()
+
+    def test_goes_through_the_shared_throttle(self):
+        import cbz_ops.smart_rename as sr
+
+        cv = MagicMock()
+        cv.get_volume.return_value = self._volume()
+        with patch("models.comicvine.is_simyan_available", return_value=True), \
+             patch("models.comicvine.get_cv_client", return_value=cv), \
+             patch("models.comicvine._cv_call_with_retry",
+                   side_effect=lambda fn, desc: fn()) as retry:
+            sr._build_comicvine_series_dict("KEY", 4050)
+
+        retry.assert_called_once()
+
+    def test_missing_volume_returns_none(self):
+        import cbz_ops.smart_rename as sr
+
+        cv = MagicMock()
+        cv.get_volume.return_value = None
+        with patch("models.comicvine.is_simyan_available", return_value=True), \
+             patch("models.comicvine.get_cv_client", return_value=cv):
+            assert sr._build_comicvine_series_dict("KEY", 4050) is None
+
+    def test_simyan_unavailable_returns_none(self):
+        import cbz_ops.smart_rename as sr
+
+        with patch("models.comicvine.is_simyan_available", return_value=False), \
+             patch("models.comicvine.get_cv_client") as get_client:
+            assert sr._build_comicvine_series_dict("KEY", 4050) is None
+
+        get_client.assert_not_called()
+
+    def test_api_error_returns_none_without_raising(self):
+        import cbz_ops.smart_rename as sr
+
+        cv = MagicMock()
+        cv.get_volume.side_effect = RuntimeError("ComicVine down")
+        with patch("models.comicvine.is_simyan_available", return_value=True), \
+             patch("models.comicvine.get_cv_client", return_value=cv):
+            assert sr._build_comicvine_series_dict("KEY", 4050) is None


### PR DESCRIPTION
## Problem

A Pull List scan on a large library tripped both providers' rate limits and pushed RSS to 4.6GB:

```
ERROR   - Error fetching issues for ComicVine volume 145744: Rate limit exceeded.  Slow down cowboy.
INFO    - Metron rate limit hit getting series 14885: waiting 59.564542s before retry (attempt 1/3)
WARNING - High memory usage: 4646.1MB (threshold: 1500MB)
```

`/api/pull-list/import` is DB-only. The traffic comes from `match_unmatched_mapped_series`, reached from the scan tail, the re-match job and the startup rebuild.

## Root cause

`_make_cv_client()` built a **brand-new Simyan client on every call** — once per series, and once per *file* during bulk metadata. Each is a `CachedLimiterSession`: constructing one opens two SQLite connections and starts a background `pyrate_limiter` `Leaker` thread. `LimiterMixin.close()` exists to release all of it; CLU never called it.

Measured directly:

| | live SQLite conns | RSS |
|---|---|---|
| 50× `_make_cv_client` (old) | **100** | +15MB |
| 50× `get_cv_client` (new) | **2** | +0.2MB |

The same defect caused the rate limiting: Simyan already configures `per_second=1, per_hour=200`, but N independent SQLite buckets doing non-atomic count-then-insert race each other into over-admission. One shared client fixes both symptoms.

## Rate limiting and memory

- **Share the Simyan client** process-wide, mirroring Metron's session cache. `invalidate_cv_client_cache()` calls `_session.close()` — that's what actually stops the Leaker thread.
- **Handle the failure mode a *working* limiter creates.** A saturated limiter raises `Timeout("Rate limit not cleared…")`, which `simyan/comicvine.py:187` re-raises as `ServiceError("Service took too long to respond")`. `_is_rate_limit_error` now walks `__cause__`; without this, sharing the client trades throttling for hard failure. `max_delay` raised to 60s (`COMICVINE_MAX_DELAY`), never unbounded.
- **Give mokkari a `SqliteCache`** — it accepts one, CLU passed none. 1-day expiry (`METRON_CACHE_EXPIRE_DAYS`). A hit costs neither a request nor a rate-limit slot. Note mokkari only expires rows in `SqliteCache.__init__`, so `invalidate_session_cache()` also runs `cleanup()`.
- **Shared limiter** in `helpers/rate_limit.py`, used by both providers, plus a proactive ComicVine throttle at 180/hour so it trips *before* Simyan's own bucket. Background jobs wait indefinitely; live web requests wait 5s, auto-detected via `flask.has_request_context()` rather than threading a flag through every signature.
- **Adaptive Metron pacing** from its own `X-RateLimit-*` headers. An exhausted daily quota was arriving as a 59.5s `retry_after` — just under the 60s "this is the daily cap" threshold — and being retried 3× *per series* for a whole sweep. It now short-circuits. Also drops the two redundant `time.sleep(3)` calls in `app.py`.
- **Provider instances cached** by (type, credentials), with invalidation wired into credential save/delete.
- **Memory**: scan-result lists capped at 500 with true totals surfaced to the UI, scan payload dropped before the long post-scan tail, finished jobs hard-capped, periodic `gc.collect()` during a sweep, and `MEMORY_THRESHOLD_MB` / `MEMORY_CLEANUP_THRESHOLD_MB` now configurable.

## ComicVine mapping

Everything ComicVine was gated on `get_cv_api_key()`. The **local ComicVine provider authenticates with `database_path`**, so ComicVine mapping was entirely disabled for local-dump-only users.

- New `models/comicvine_source.py` gates on **either** source and reads the **local dump first, web API second** — the dump costs no requests, and the per-volume issue listing is the most expensive call in a sweep. Coverage is the union of both.
- New `comicvine_sqlite.get_all_issues_for_volume()` returns the same record shape as the API path (ids offset into the ComicVine range) so callers can't tell the sources apart.
- **Metron precedence is unchanged** — still tried first, ComicVine only on a miss. That miss now logs at INFO; it's a routine cascade step, not a failure.

## Also fixed

`cbz_ops/smart_rename.py` built `Comicvine(cache=None)` directly. Simyan 3.x has no `cache` kwarg, so that raised `TypeError` into a bare `except` — the ComicVine fallback had **never** worked.

## Behaviour changes to be aware of

1. A saturated budget now **waits** instead of erroring, so a big sweep takes longer but completes. Live web requests are exempt.
2. **Staleness trade-off**: for a volume that *is* in the local ComicVine dump, newly published issues won't appear in Wanted until the dump is refreshed. Volumes absent from it still hit the API and stay current.
3. The three sweep entry points remain unserialized by design — the limiters are process-wide, so concurrent sweeps queue against one shared budget rather than multiplying the request rate.

## Testing

`pytest`: **3059 passed, 6 skipped** (up 27 tests; the 6 skips are POSIX-only permission tests). New/updated coverage for the client cache and its concurrency, `__cause__`-chain rate-limit detection, the mokkari cache, the shared limiter's timeout semantics, adaptive Metron pacing (including a direct regression test for the 59.5s retry loop), provider instance caching, scan-result truncation, and ComicVine mapping from a local dump with no API key.

Leak check: 50 shared-client acquisitions hold 2 SQLite connections vs 100 for the old path, and `_close_cv_client` drops them to 0.

## Deliberately left as follow-ups

`models/providers/comicvine_provider.py:get_issues()` has no pagination, so volumes over 500 issues are silently truncated. Real bug, but fixing it *increases* API calls — better landed once these changes are proven. Same for the `core/bulk_metadata.py` and `app.py:directory_cache` retention issues, which are on different code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
