### PR TITLE
Give each user their own theme and dashboard layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import (
     jsonify,
     url_for,
     flash,
+    g,
 )
 from werkzeug.routing import IntegerConverter
 import subprocess
@@ -228,7 +229,12 @@ if not _db_ok:
     )
 
 # Migrate custom rename settings from config.ini to user_preferences DB (one-time)
-from core.database import get_user_preference, set_user_preference
+from core.database import (
+    get_user_preference,
+    set_user_preference,
+    get_user_setting_override,
+    delete_user_setting,
+)
 
 if get_user_preference("custom_rename_pattern") is None:
     _ini_pattern = config.get("SETTINGS", "CUSTOM_RENAME_PATTERN", fallback="")
@@ -4140,20 +4146,52 @@ def update_index_on_create(path):
         app_logger.error(f"Failed to update index on create {path}: {e}")
 
 
-# Bootswatch themes that ship a dark palette. Setting data-bs-theme="dark" for
-# these activates Bootstrap 5.3's dark helper variables (emphasis/tertiary-bg/etc.),
-# which the themes otherwise leave at light-mode defaults at :root.
-DARK_BOOTSWATCH_THEMES = {"cyborg", "darkly", "slate", "solar", "superhero", "vapor"}
+# Canonical theme catalog now lives in core/themes.py so routes/ can import it
+# too. Re-bound here because other modules already read app.DARK_BOOTSWATCH_THEMES.
+from core.themes import BOOTSWATCH_THEMES, DARK_BOOTSWATCH_THEMES  # noqa: E402
+
+
+def _resolve_request_theme():
+    """The theme for this request: personal override, else the site default.
+
+    ``app.config["BOOTSTRAP_THEME"]`` is the site default (loaded at startup by
+    core.config.load_flask_config and kept live by /api/config/styling), so the
+    middle link of the fallback chain costs no query — only an identified user
+    with an override triggers a lookup, and that is one indexed PK hit.
+
+    Memoized on ``g`` because a single render can call the context processor
+    more than once. routes/auth.py's teardown clears the memo; without that,
+    pytest-flask's shared app context would leak one user's theme into another
+    user's request.
+    """
+    memo = getattr(g, "_clu_theme", None)
+    if memo is not None:
+        return memo
+
+    theme = None
+    try:
+        user = getattr(g, "current_user", None)
+        if user:
+            theme = get_user_setting_override("bootstrap_theme", user_id=user["id"])
+    except Exception:
+        # This runs on every render, including error pages — a DB hiccup here
+        # must degrade to the site default, not break the whole app.
+        theme = None
+
+    theme = theme or app.config.get("BOOTSTRAP_THEME", "default")
+    g._clu_theme = theme
+    return theme
 
 
 @app.context_processor
 def inject_global_vars():
-    theme = app.config.get("BOOTSTRAP_THEME", "default")
+    theme = _resolve_request_theme()
     return {
         "monitor": os.getenv("MONITOR", "no"),
         "version": __version__,
         "bootstrap_theme": theme,
         "theme_is_dark": theme in DARK_BOOTSWATCH_THEMES,
+        "bootswatch_themes": BOOTSWATCH_THEMES,
     }
 
 
@@ -7093,6 +7131,14 @@ def save_styling_config():
             category="personalization",
         )
         app.config["BOOTSTRAP_THEME"] = data.get("bootstrapTheme", "default")
+        # Setting the site default also resets the owner to follow it. Without
+        # this, an owner who had picked a personal theme on /account would set
+        # the default here and see nothing change, because their own override
+        # still wins.
+        try:
+            delete_user_setting("bootstrap_theme")
+        except Exception as e:
+            app_logger.debug(f"Could not clear own theme override: {e}")
         return jsonify({"success": True, "message": "Styling settings saved"})
     except Exception as e:
         app_logger.error(f"Error saving styling config: {e}")
@@ -7109,34 +7155,21 @@ def save_dashboard_config():
         if not data:
             return jsonify({"success": False, "error": "No data provided"}), 400
 
-        valid_ids = {
-            "favorites",
-            "want_to_read",
-            "continue_reading",
-            "on_the_stack",
-            "discover",
-            "recently_added",
-            "library",
-        }
+        from routes.collection import sanitize_dashboard_payload
 
-        # Validate and sanitize order
-        raw_order = data.get("dashboardOrder", [])
-        if isinstance(raw_order, str):
-            raw_order = [s.strip() for s in raw_order.split(",") if s.strip()]
-        order = [s for s in raw_order if s in valid_ids]
-        # Append any missing sections at the end to prevent data loss
-        for sid in valid_ids:
-            if sid not in order:
-                order.append(sid)
-
-        # Validate hidden list
-        raw_hidden = data.get("dashboardHidden", [])
-        if isinstance(raw_hidden, str):
-            raw_hidden = [s.strip() for s in raw_hidden.split(",") if s.strip()]
-        hidden = [s for s in raw_hidden if s in valid_ids]
+        order, hidden = sanitize_dashboard_payload(
+            data.get("dashboardOrder", []), data.get("dashboardHidden", [])
+        )
 
         set_user_preference("dashboard_order", order, category="dashboard")
         set_user_preference("dashboard_hidden", hidden, category="dashboard")
+        # See save_styling_config: setting the site default resets the caller to
+        # follow it, so /config doesn't look broken to an owner with overrides.
+        try:
+            delete_user_setting("dashboard_order")
+            delete_user_setting("dashboard_hidden")
+        except Exception as e:
+            app_logger.debug(f"Could not clear own dashboard override: {e}")
 
         return jsonify({"success": True, "message": "Dashboard settings saved"})
     except Exception as e:
@@ -7413,7 +7446,7 @@ def config_page():
     settings = config["SETTINGS"] if "SETTINGS" in config else {}
 
     from core.database import get_user_preference, get_provider_credentials
-    from routes.collection import get_dashboard_order
+    from routes.collection import dashboard_section_meta, site_default_dashboard_order
 
     # Load credential display values from DB if available
     try:
@@ -7513,8 +7546,12 @@ def config_page():
         rec_provider=get_user_preference("rec_provider", default="gemini"),
         rec_api_key=get_user_preference("rec_api_key", default=""),
         rec_model=get_user_preference("rec_model", default="gemini-2.0-flash"),
-        dashboard_order=get_dashboard_order(),
+        # The SITE DEFAULT, not this owner's personal layout — read the global
+        # preference directly rather than via get_dashboard_order(), which now
+        # resolves the caller's override first.
+        dashboard_order=site_default_dashboard_order(),
         dashboard_hidden=get_user_preference("dashboard_hidden", default=[]),
+        dashboard_section_meta=dashboard_section_meta(),
     )
 
 

--- a/core/database.py
+++ b/core/database.py
@@ -1316,6 +1316,21 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id)"
         )
 
+        # Per-user overrides of the settings in user_preferences (which, despite
+        # its name, is a single global key/value store). A missing row means
+        # "follow the site default" — that is why this needs no backfill. See
+        # get_user_setting() for the resolution order.
+        # No FK to users, for the same reason as user_favorite_publishers below.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS user_settings (
+                user_id    INTEGER   NOT NULL,
+                key        TEXT      NOT NULL,
+                value      TEXT      NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (user_id, key)
+            )
+        """)
+
         # publishers is a SHARED metadata table, so a per-user "favorite" flag
         # can't live on it — this join table carries the per-user state instead.
         # No FK to users (matches the other personal-data tables): favorites are
@@ -7416,6 +7431,124 @@ def set_user_preference(key, value, category="general"):
 
     except Exception as e:
         app_logger.error(f"Failed to save user preference '{key}': {e}")
+        return False
+
+
+# =============================================================================
+# Per-user settings (personal overrides of the global user_preferences values)
+# =============================================================================
+#
+# user_preferences is a single global key/value store. user_settings layers a
+# per-user override on top of it, so the same key resolves as:
+#
+#     user_settings[user_id][key]  ->  user_preferences[key]  ->  default
+#          personal override            owner's site default
+#
+# Deleting the personal row is how "use the site default" is expressed; there is
+# no sentinel value. Values are JSON-encoded exactly as in user_preferences so a
+# value is byte-compatible between the two tables — the same caller reads either.
+
+
+_UNSET = object()
+
+
+def get_user_setting_override(key, user_id=None, default=None):
+    """Return this user's personal override for ``key``, without falling back.
+
+    Use this (not get_user_setting) when you need to distinguish "the user chose
+    this" from "the user is following the site default" — the settings UI shows
+    that distinction, and the theme context processor uses it to skip a second
+    lookup on the hot path.
+    """
+    try:
+        import json
+
+        conn = get_db_connection()
+        if not conn:
+            return default
+
+        c = conn.cursor()
+        c.execute(
+            "SELECT value FROM user_settings WHERE user_id = ? AND key = ?",
+            (_resolve_user_id(user_id), key),
+        )
+        row = c.fetchone()
+        conn.close()
+
+        if row:
+            return json.loads(row["value"])
+        return default
+
+    except Exception as e:
+        app_logger.error(f"Failed to get user setting override '{key}': {e}")
+        return default
+
+
+def get_user_setting(key, default=None, user_id=None):
+    """Resolve ``key`` for a user: personal override, else site default, else
+    ``default``.
+
+    ``user_id`` defaults to the request's user (see _resolve_user_id), which in
+    implicit-owner mode is the owner — single-user installs keep one coherent
+    identity.
+
+    A corrupt/undecodable personal row falls through to the global value rather
+    than to ``default``. This is deliberately unlike get_user_preference (which
+    returns its default on any error): a broken override must not mask the
+    owner's site default.
+    """
+    override = get_user_setting_override(key, user_id=user_id, default=_UNSET)
+    if override is not _UNSET:
+        return override
+    return get_user_preference(key, default=default)
+
+
+def set_user_setting(key, value, user_id=None):
+    """Store a personal override for ``key``. Returns True on success."""
+    try:
+        import json
+
+        conn = get_db_connection()
+        if not conn:
+            return False
+
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT OR REPLACE INTO user_settings (user_id, key, value, updated_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+        """,
+            (_resolve_user_id(user_id), key, json.dumps(value)),
+        )
+
+        conn.commit()
+        conn.close()
+        return True
+
+    except Exception as e:
+        app_logger.error(f"Failed to save user setting '{key}': {e}")
+        return False
+
+
+def delete_user_setting(key, user_id=None):
+    """Drop a personal override so the user follows the site default again."""
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return False
+
+        c = conn.cursor()
+        c.execute(
+            "DELETE FROM user_settings WHERE user_id = ? AND key = ?",
+            (_resolve_user_id(user_id), key),
+        )
+
+        conn.commit()
+        conn.close()
+        return True
+
+    except Exception as e:
+        app_logger.error(f"Failed to delete user setting '{key}': {e}")
         return False
 
 

--- a/core/themes.py
+++ b/core/themes.py
@@ -1,0 +1,69 @@
+"""Bootswatch theme catalog.
+
+Single source of truth for the themes offered in the UI. Lives in ``core`` so
+both ``app.py`` (context processor, site default) and ``routes/auth.py``
+(per-user override validation) can import it — ``routes`` cannot import
+``app.py`` without a circular import.
+"""
+
+# Bootswatch themes that ship a dark palette. Setting data-bs-theme="dark" for
+# these activates Bootstrap 5.3's dark helper variables (emphasis/tertiary-bg/
+# etc.), which the themes otherwise leave at light-mode defaults at :root.
+DARK_BOOTSWATCH_THEMES = {"cyborg", "darkly", "slate", "solar", "superhero", "vapor"}
+
+# Theme ids in the order they are offered. "default" is stock Bootstrap (no
+# Bootswatch stylesheet). Labels are derived below so the "(Dark)" suffix can
+# never drift from DARK_BOOTSWATCH_THEMES again — it previously did, with the
+# picker labelling quartz "(Dark)" while the rendering set omitted it.
+THEME_ORDER = (
+    "default",
+    "brite",
+    "cerulean",
+    "cosmo",
+    "cyborg",
+    "darkly",
+    "flatly",
+    "journal",
+    "litera",
+    "lumen",
+    "lux",
+    "materia",
+    "minty",
+    "morph",
+    "pulse",
+    "quartz",
+    "sandstone",
+    "simplex",
+    "sketchy",
+    "slate",
+    "solar",
+    "spacelab",
+    "superhero",
+    "united",
+    "vapor",
+    "yeti",
+    "zephyr",
+)
+
+_LABEL_OVERRIDES = {"default": "Default (Bootstrap)"}
+
+
+def _label(theme_id):
+    base = _LABEL_OVERRIDES.get(theme_id, theme_id.title())
+    return f"{base} (Dark)" if theme_id in DARK_BOOTSWATCH_THEMES else base
+
+
+# [(id, label), ...] — what the theme <select> renders.
+BOOTSWATCH_THEMES = [(t, _label(t)) for t in THEME_ORDER]
+
+THEME_IDS = frozenset(THEME_ORDER)
+
+
+def is_valid_theme(theme_id):
+    """True if ``theme_id`` is a theme we actually offer."""
+    return theme_id in THEME_IDS
+
+
+def is_dark_theme(theme_id):
+    """True if ``theme_id`` needs data-bs-theme="dark"."""
+    return theme_id in DARK_BOOTSWATCH_THEMES

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -33,10 +33,16 @@ from core.auth import (
 from core.database import (
     create_api_token,
     delete_api_token,
+    delete_user_setting,
+    get_user_preference,
+    get_user_setting,
+    get_user_setting_override,
     list_api_tokens,
+    set_user_setting,
     update_last_login,
     verify_password,
 )
+from core.themes import BOOTSWATCH_THEMES, is_valid_theme
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -92,8 +98,13 @@ def _reset_request_identity(exc=None):
     (a logged-out session still reads as authenticated; a second user's write is
     attributed to the first). Popping it here guarantees every request resolves
     its own identity from its own session.
+
+    ``_clu_theme`` (app.py:_resolve_request_theme) is memoized the same way and
+    derives from the same identity, so it has to be cleared here for the same
+    reason — otherwise one user's theme renders on another user's page.
     """
     g.pop("current_user", None)
+    g.pop("_clu_theme", None)
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
@@ -140,8 +151,103 @@ def logout():
 
 @auth_bp.route("/account")
 def account():
-    """Self-service account page (currently: personal API tokens)."""
-    return render_template("account.html")
+    """Self-service account page: appearance, dashboard layout, API tokens.
+
+    Initial state is rendered server-side (as /config does) rather than fetched,
+    so the panes don't flicker and there's no extra GET route to secure.
+    """
+    from routes.collection import (
+        DEFAULT_DASHBOARD_ORDER,
+        dashboard_section_meta,
+        get_dashboard_order,
+    )
+
+    site_theme = get_user_preference("bootstrap_theme", default="default") or "default"
+    theme_override = get_user_setting_override("bootstrap_theme")
+
+    return render_template(
+        "account.html",
+        # Passed explicitly rather than relying on app.py's context processor, so
+        # this page renders standalone (the route tests build their own app).
+        bootswatch_themes=BOOTSWATCH_THEMES,
+        # Appearance
+        account_theme=theme_override or site_theme,
+        theme_is_override=theme_override is not None,
+        site_theme=site_theme,
+        # Dashboard layout
+        dashboard_order=get_dashboard_order(),
+        dashboard_hidden=get_user_setting("dashboard_hidden", default=[]) or [],
+        dashboard_is_override=get_user_setting_override("dashboard_order") is not None,
+        dashboard_section_meta=dashboard_section_meta(),
+        default_dashboard_order=DEFAULT_DASHBOARD_ORDER,
+    )
+
+
+# Per-user personalization. These MUST stay under "/api/account/" — that prefix
+# is what core.auth._READER_WRITE_PREFIXES matches to let a Reader POST to their
+# own data. Renaming them to e.g. /api/settings/* would 403 every reader.
+# tests/routes/test_rbac.py pins this.
+
+
+@auth_bp.route("/api/account/appearance", methods=["POST"])
+def account_save_appearance():
+    """Save (or clear) the current user's personal theme override."""
+    user = current_user()
+    if user is None:
+        return jsonify({"error": "unauthorized"}), 401
+
+    body = request.get_json(silent=True) or {}
+
+    if body.get("useSiteDefault"):
+        delete_user_setting("bootstrap_theme", user_id=user["id"])
+        site = get_user_preference("bootstrap_theme", default="default") or "default"
+        return jsonify({"success": True, "theme": site, "override": False})
+
+    theme = (body.get("bootstrapTheme") or "").strip()
+    if not is_valid_theme(theme):
+        return jsonify({"success": False, "error": "Unknown theme"}), 400
+
+    # Deliberately does NOT touch app.config["BOOTSTRAP_THEME"] — that is the
+    # site default, which only the owner changes via /api/config/styling.
+    if not set_user_setting("bootstrap_theme", theme, user_id=user["id"]):
+        return jsonify({"success": False, "error": "Could not save theme"}), 500
+    return jsonify({"success": True, "theme": theme, "override": True})
+
+
+@auth_bp.route("/api/account/dashboard", methods=["POST"])
+def account_save_dashboard():
+    """Save (or clear) the current user's personal dashboard layout."""
+    from routes.collection import get_dashboard_order, sanitize_dashboard_payload
+
+    user = current_user()
+    if user is None:
+        return jsonify({"error": "unauthorized"}), 401
+
+    body = request.get_json(silent=True) or {}
+
+    if body.get("useSiteDefault"):
+        delete_user_setting("dashboard_order", user_id=user["id"])
+        delete_user_setting("dashboard_hidden", user_id=user["id"])
+        return jsonify({
+            "success": True,
+            "override": False,
+            "dashboardOrder": get_dashboard_order(user_id=user["id"]),
+            "dashboardHidden": get_user_setting(
+                "dashboard_hidden", default=[], user_id=user["id"]
+            ) or [],
+        })
+
+    order, hidden = sanitize_dashboard_payload(
+        body.get("dashboardOrder", []), body.get("dashboardHidden", [])
+    )
+    set_user_setting("dashboard_order", order, user_id=user["id"])
+    set_user_setting("dashboard_hidden", hidden, user_id=user["id"])
+    return jsonify({
+        "success": True,
+        "override": True,
+        "dashboardOrder": order,
+        "dashboardHidden": hidden,
+    })
 
 
 @auth_bp.route("/api/account/tokens", methods=["GET"])

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -33,7 +33,8 @@ from core.auth import (
 from core.database import (
     get_directory_children, get_path_counts_batch, get_recent_files,
     invalidate_browse_cache, add_file_index_entry, delete_file_index_entry,
-    search_file_index, get_user_preference, get_files_recursive_paged
+    search_file_index, get_user_preference, get_files_recursive_paged,
+    get_user_setting
 )
 
 collection_bp = Blueprint('collection', __name__)
@@ -81,6 +82,10 @@ DASHBOARD_SECTION_DEFS = {
         'id': 'discover',
         'title': 'Discover',
         'icon': 'bi-stars text-warning',
+        # Longer name for the layout editor, where "Discover" alone doesn't
+        # convey that this section is the recommendations feed.
+        'settings_label': 'Discover / Recommendations',
+        'settings_note': 'Also requires Recommendations enabled',
     },
     'recently_added': {
         'id': 'recently_added',
@@ -100,10 +105,79 @@ DASHBOARD_SECTION_DEFS = {
 
 DEFAULT_DASHBOARD_ORDER = ['favorites', 'want_to_read', 'continue_reading', 'on_the_stack', 'discover', 'recently_added', 'library']
 
+VALID_DASHBOARD_IDS = frozenset(DASHBOARD_SECTION_DEFS)
 
-def get_dashboard_order():
-    """Return the stored dashboard order with any missing sections appended."""
-    order = get_user_preference('dashboard_order', default=DEFAULT_DASHBOARD_ORDER)
+
+def dashboard_section_meta():
+    """Section id -> display metadata for the layout editor.
+
+    Derived from DASHBOARD_SECTION_DEFS so the editor can't drift from the
+    sections the dashboard actually renders.
+    """
+    return {
+        sid: {
+            'name': defn.get('settings_label') or defn['title'],
+            'icon': defn['icon'],
+            'note': defn.get('settings_note'),
+        }
+        for sid, defn in DASHBOARD_SECTION_DEFS.items()
+    }
+
+
+def sanitize_dashboard_payload(raw_order, raw_hidden):
+    """Validate a dashboard order/hidden payload from the client.
+
+    Accepts either a list or a comma-separated string for each. Unknown ids are
+    dropped; sections missing from the order are appended so a client that
+    posts a stale list can't silently lose a newly-added section.
+
+    Returns ``(order, hidden)``.
+    """
+    if isinstance(raw_order, str):
+        raw_order = [s.strip() for s in raw_order.split(',') if s.strip()]
+    order = [s for s in (raw_order or []) if s in VALID_DASHBOARD_IDS]
+    # Append in DEFAULT_DASHBOARD_ORDER order, not set order, so the result is
+    # deterministic (and therefore testable).
+    for sid in DEFAULT_DASHBOARD_ORDER:
+        if sid not in order:
+            order.append(sid)
+
+    if isinstance(raw_hidden, str):
+        raw_hidden = [s.strip() for s in raw_hidden.split(',') if s.strip()]
+    hidden = [s for s in (raw_hidden or []) if s in VALID_DASHBOARD_IDS]
+
+    return order, hidden
+
+
+def site_default_dashboard_order():
+    """The owner-set site default order, ignoring any personal override.
+
+    /config edits the site default, so it must render this rather than
+    get_dashboard_order(), which resolves the caller's own override first.
+    """
+    order = get_user_preference('dashboard_order', default=None)
+    if not isinstance(order, list):
+        order = []
+    order = [s for s in order if s in VALID_DASHBOARD_IDS]
+    for section_id in DEFAULT_DASHBOARD_ORDER:
+        if section_id not in order:
+            order.append(section_id)
+    return order
+
+
+def get_dashboard_order(user_id=None):
+    """Return the dashboard order for a user, with missing sections appended.
+
+    Resolves the user's personal override first, then the owner-set site
+    default, then DEFAULT_DASHBOARD_ORDER.
+    """
+    # list(...) matters: the fallback would otherwise hand back the module-level
+    # DEFAULT_DASHBOARD_ORDER object, which the backfill below appends to.
+    order = get_user_setting(
+        'dashboard_order', default=list(DEFAULT_DASHBOARD_ORDER), user_id=user_id
+    )
+    if not isinstance(order, list):
+        order = list(DEFAULT_DASHBOARD_ORDER)
     # Backfill any sections added after the user last saved
     for section_id in DEFAULT_DASHBOARD_ORDER:
         if section_id not in order:
@@ -111,10 +185,13 @@ def get_dashboard_order():
     return order
 
 
-def get_dashboard_sections():
-    """Build ordered list of visible dashboard sections from user preferences."""
-    order = get_dashboard_order()
-    hidden = set(get_user_preference('dashboard_hidden', default=[]))
+def get_dashboard_sections(user_id=None):
+    """Build the ordered list of visible dashboard sections for a user."""
+    order = get_dashboard_order(user_id)
+    hidden = set(get_user_setting('dashboard_hidden', default=[], user_id=user_id) or [])
+    # rec_enabled stays GLOBAL: it gates an owner-configured AI service holding a
+    # shared API key, not a display preference. A user who just wants Discover
+    # gone hides it via dashboard_hidden.
     rec_enabled = get_user_preference('rec_enabled', default=True)
 
     sections = []

--- a/static/js/clu-personalization.js
+++ b/static/js/clu-personalization.js
@@ -1,0 +1,156 @@
+/**
+ * Shared personalization widgets: the Bootswatch theme picker preview and the
+ * dashboard layout editor.
+ *
+ * Used by both the owner-only site defaults on /config and the per-user
+ * overrides on /account, so element ids are passed in rather than hardcoded —
+ * the two pages must be able to render these side by side without colliding.
+ *
+ * These helpers only render and read the DOM. Saving stays in the page, because
+ * the two pages post to different endpoints (/api/config/* vs /api/account/*).
+ */
+(function (global) {
+  'use strict';
+
+  const CLU = (global.CLU = global.CLU || {});
+
+  // ---------------------------------------------------------------------------
+  // Theme picker preview
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Wire a theme <select> to its thumbnail + name preview.
+   * @param {{selectId: string, imgId: string, nameId: string}} opts
+   */
+  CLU.initThemePreview = function (opts) {
+    const select = document.getElementById(opts.selectId);
+    if (!select) return;
+
+    function update() {
+      const img = document.getElementById(opts.imgId);
+      const name = document.getElementById(opts.nameId);
+      if (!img || !name) return;
+
+      const theme = select.value;
+      const label = select.options[select.selectedIndex].text;
+
+      img.src = 'https://bootswatch.com/' + theme + '/thumbnail.png';
+      // Drop the "(Dark)" suffix — the preview image already shows that.
+      name.textContent = label.replace(' (Dark)', '');
+    }
+
+    select.addEventListener('change', update);
+    update();
+  };
+
+  // ---------------------------------------------------------------------------
+  // Dashboard layout editor
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Turn a <ul> of section <li>s into a reorderable list: numbered badges,
+   * up/down buttons, and HTML5 drag-and-drop. Idempotent — safe to re-run.
+   * @param {string} listId
+   */
+  function renderDashboardList(listId) {
+    const list = document.getElementById(listId);
+    if (!list) return;
+
+    const items = Array.from(list.children);
+    list.innerHTML = '';
+
+    items.forEach(function (item, idx) {
+      const oldBtnGroup = item.querySelector('.dashboard-btn-group');
+      if (oldBtnGroup) oldBtnGroup.remove();
+
+      let badge = item.querySelector('.dashboard-order-badge');
+      if (!badge) {
+        badge = document.createElement('span');
+        badge.className = 'badge bg-secondary me-2 dashboard-order-badge';
+        item
+          .querySelector('div')
+          .insertBefore(badge, item.querySelector('.form-check-input'));
+      }
+      badge.textContent = idx + 1;
+
+      const btnGroup = document.createElement('div');
+      btnGroup.className = 'dashboard-btn-group';
+      if (idx > 0) {
+        const upBtn = document.createElement('button');
+        upBtn.type = 'button';
+        upBtn.className = 'btn btn-sm btn-outline-secondary me-1';
+        upBtn.title = 'Move up';
+        upBtn.innerHTML = '<i class="bi bi-arrow-up"></i>';
+        upBtn.onclick = function () { moveDashboardSection(listId, idx, idx - 1); };
+        btnGroup.appendChild(upBtn);
+      }
+      if (idx < items.length - 1) {
+        const downBtn = document.createElement('button');
+        downBtn.type = 'button';
+        downBtn.className = 'btn btn-sm btn-outline-secondary';
+        downBtn.title = 'Move down';
+        downBtn.innerHTML = '<i class="bi bi-arrow-down"></i>';
+        downBtn.onclick = function () { moveDashboardSection(listId, idx, idx + 1); };
+        btnGroup.appendChild(downBtn);
+      }
+      item.appendChild(btnGroup);
+
+      item.draggable = true;
+      item.addEventListener('dragstart', function (e) {
+        e.dataTransfer.setData('text/plain', idx);
+        item.classList.add('opacity-50');
+      });
+      item.addEventListener('dragend', function () {
+        item.classList.remove('opacity-50');
+      });
+      item.addEventListener('dragover', function (e) {
+        e.preventDefault();
+        item.classList.add('border-primary');
+      });
+      item.addEventListener('dragleave', function () {
+        item.classList.remove('border-primary');
+      });
+      item.addEventListener('drop', function (e) {
+        e.preventDefault();
+        item.classList.remove('border-primary');
+        const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+        moveDashboardSection(listId, fromIdx, idx);
+      });
+
+      list.appendChild(item);
+    });
+  }
+
+  function moveDashboardSection(listId, fromIdx, toIdx) {
+    const list = document.getElementById(listId);
+    if (!list) return;
+    const items = Array.from(list.children);
+    const [moved] = items.splice(fromIdx, 1);
+    items.splice(toIdx, 0, moved);
+    list.innerHTML = '';
+    items.forEach(function (item) { list.appendChild(item); });
+    renderDashboardList(listId);
+  }
+
+  /** Render/refresh the editor for the given list. */
+  CLU.initDashboardEditor = function (opts) {
+    renderDashboardList(typeof opts === 'string' ? opts : opts.listId);
+  };
+
+  /**
+   * Read the current selection out of the DOM.
+   * @returns {{order: string[], hidden: string[]}}
+   */
+  CLU.readDashboardSelection = function (listId) {
+    const order = [];
+    const hidden = [];
+    document.querySelectorAll('#' + listId + ' li').forEach(function (item) {
+      const id = item.dataset.sectionId;
+      if (!id) return;
+      order.push(id);
+      const check = item.querySelector('.dashboard-visible-check');
+      if (check && !check.checked) hidden.push(id);
+    });
+    return { order: order, hidden: hidden };
+  };
+})(window);

--- a/templates/account.html
+++ b/templates/account.html
@@ -3,14 +3,119 @@
 {% block title %}CLU: My Account{% endblock %}
 
 {% block content %}
-<div class="container py-4" id="account-app" style="max-width: 720px;">
+<div class="container py-4" id="account-app" style="max-width: 960px;">
   <div class="d-flex align-items-center mb-3">
     <h2 class="mb-0"><i class="bi bi-person-badge me-2"></i>My Account</h2>
+    {% if g.get('current_user') %}
+    <span class="badge bg-secondary ms-3 align-self-center">
+      {{ g.current_user.display_name or g.current_user.username }}
+      &middot; {{ g.current_user.role|title }}
+    </span>
+    {% endif %}
   </div>
+  <p class="text-muted">
+    These settings apply to you only. Site-wide defaults are set by the Store Owner.
+  </p>
 
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <h5 class="card-title mb-1"><i class="bi bi-key me-2"></i>API Tokens</h5>
+  {% include 'partials/toast_container.html' %}
+
+  <ul class="nav nav-tabs" id="accountTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="appearance-tab" data-bs-toggle="tab" data-bs-target="#appearance"
+        type="button" role="tab" aria-controls="appearance" aria-selected="true">
+        <i class="bi bi-palette me-1"></i>Appearance
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="dashboard-tab" data-bs-toggle="tab" data-bs-target="#dashboard"
+        type="button" role="tab" aria-controls="dashboard" aria-selected="false">
+        <i class="bi bi-layout-text-window-reverse me-1"></i>Dashboard Layout
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="tokens-tab" data-bs-toggle="tab" data-bs-target="#tokens"
+        type="button" role="tab" aria-controls="tokens" aria-selected="false">
+        <i class="bi bi-key me-1"></i>API Tokens
+      </button>
+    </li>
+  </ul>
+
+  <div class="tab-content border border-top-0 rounded-bottom p-4" id="accountTabsContent">
+
+    <!-- ── Appearance ───────────────────────────────────────────────────── -->
+    <div class="tab-pane fade show active" id="appearance" role="tabpanel" aria-labelledby="appearance-tab">
+      <div class="d-flex justify-content-between align-items-start mb-2">
+        <div>
+          <h5 class="mb-1">Theme</h5>
+          <p class="text-muted small mb-0">
+            Choose how CLU looks for you. Themes provided by
+            <a href="https://bootswatch.com/" target="_blank">Bootswatch</a>.
+          </p>
+        </div>
+        <span class="badge {{ 'bg-primary' if theme_is_override else 'bg-secondary' }}" id="themeStateBadge">
+          {{ 'Custom' if theme_is_override else 'Following site default' }}
+        </span>
+      </div>
+
+      {% with select_id='accountTheme',
+              img_id='accountThemePreviewImg',
+              name_id='accountThemePreviewName',
+              selected_theme=account_theme,
+              help_text='Applies to your account only. Dark themes are marked.',
+              preview_note='Save to apply this theme.' %}
+      {% include 'partials/theme_picker.html' %}
+      {% endwith %}
+
+      <div class="mt-3 d-flex gap-2">
+        <button type="button" class="btn btn-primary" id="saveThemeBtn" onclick="saveTheme()">
+          <i class="bi bi-floppy me-1"></i>Save Theme
+        </button>
+        <button type="button" class="btn btn-outline-secondary" id="resetThemeBtn" onclick="resetTheme()">
+          <i class="bi bi-arrow-counterclockwise me-1"></i>Use site default
+          <span class="text-muted">({{ site_theme|title }})</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- ── Dashboard Layout ─────────────────────────────────────────────── -->
+    <div class="tab-pane fade" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab">
+      <div class="d-flex justify-content-between align-items-start mb-2">
+        <div>
+          <h5 class="mb-1">Dashboard Layout</h5>
+          <p class="text-muted small mb-0">
+            Which sections appear on your home page, and in what order. Drag a row, or use the arrows.
+          </p>
+        </div>
+        <span class="badge {{ 'bg-primary' if dashboard_is_override else 'bg-secondary' }}" id="dashboardStateBadge">
+          {{ 'Custom' if dashboard_is_override else 'Following site default' }}
+        </span>
+      </div>
+
+      {% with list_id='accountDashboardList',
+              order=dashboard_order,
+              hidden=dashboard_hidden,
+              section_meta=dashboard_section_meta %}
+      {% include 'partials/dashboard_layout_editor.html' %}
+      {% endwith %}
+
+      <div class="alert alert-info mt-3 mb-0">
+        <i class="bi bi-info-circle me-1"></i>
+        Changes take effect on your home page after saving.
+      </div>
+
+      <div class="mt-3 d-flex gap-2">
+        <button type="button" class="btn btn-primary" id="saveDashboardBtn" onclick="saveDashboard()">
+          <i class="bi bi-floppy me-1"></i>Save Layout
+        </button>
+        <button type="button" class="btn btn-outline-secondary" id="resetDashboardBtn" onclick="resetDashboard()">
+          <i class="bi bi-arrow-counterclockwise me-1"></i>Use site default
+        </button>
+      </div>
+    </div>
+
+    <!-- ── API Tokens ───────────────────────────────────────────────────── -->
+    <div class="tab-pane fade" id="tokens" role="tabpanel" aria-labelledby="tokens-tab">
+      <h5 class="mb-1">API Tokens</h5>
       <p class="text-muted small mb-3">
         Personal bearer tokens for API/reader clients. A token acts as you and has
         your access level. Send it as <code>Authorization: Bearer &lt;token&gt;</code>.
@@ -44,16 +149,132 @@
     </div>
   </div>
 </div>
+
+<!-- Token revoke confirmation. Purpose-built rather than CLU.showDeleteConfirmation,
+     whose contract is file-shaped (path/size/-> /api/delete-file). -->
+<div class="modal fade" id="revokeTokenModal" tabindex="-1" aria-labelledby="revokeTokenLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="revokeTokenLabel">
+          <i class="bi bi-exclamation-triangle text-warning me-2"></i>Revoke token?
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-1">
+          Revoke <strong id="revokeTokenName"></strong>?
+        </p>
+        <p class="text-muted small mb-0">Any client using it will immediately lose access.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="confirmRevokeBtn">Revoke</button>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
 {{ super() }}
+<script src="{{ url_for('static', filename='js/clu-utils.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-personalization.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script>
+  const SITE_THEME = {{ site_theme | tojson }};
+
   function esc(s) {
     return String(s).replace(/[&<>"']/g, c => ({
       "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
     }[c]));
   }
+
+  function setBadge(id, isOverride) {
+    const badge = document.getElementById(id);
+    if (!badge) return;
+    badge.textContent = isOverride ? "Custom" : "Following site default";
+    badge.classList.toggle("bg-primary", isOverride);
+    badge.classList.toggle("bg-secondary", !isOverride);
+  }
+
+  // Run an async save behind a button spinner, reporting via toast.
+  async function withButton(btnId, successMsg, fn) {
+    const btn = document.getElementById(btnId);
+    const originalHtml = btn.innerHTML;
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
+    try {
+      const result = await fn();
+      if (result && result.success) {
+        CLU.showSuccess(successMsg);
+        return result;
+      }
+      CLU.showError((result && result.error) || "Failed to save.");
+      return null;
+    } catch (e) {
+      CLU.showError("Failed to save: " + e.message);
+      return null;
+    } finally {
+      btn.disabled = false;
+      btn.innerHTML = originalHtml;
+    }
+  }
+
+  async function postJSON(url, payload) {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    return await resp.json().catch(() => ({ success: false, error: "Bad response" }));
+  }
+
+  // ── Appearance ────────────────────────────────────────────────────────────
+
+  async function saveTheme() {
+    const theme = document.getElementById("accountTheme").value;
+    const result = await withButton("saveThemeBtn", "Theme saved. Reloading…", () =>
+      postJSON("/api/account/appearance", { bootstrapTheme: theme }));
+    if (result) {
+      setBadge("themeStateBadge", true);
+      // The theme is applied server-side in <head>, so it only takes effect on
+      // the next render.
+      setTimeout(() => window.location.reload(), 600);
+    }
+  }
+
+  async function resetTheme() {
+    const result = await withButton("resetThemeBtn", "Following the site default. Reloading…", () =>
+      postJSON("/api/account/appearance", { useSiteDefault: true }));
+    if (result) {
+      setBadge("themeStateBadge", false);
+      document.getElementById("accountTheme").value = SITE_THEME;
+      setTimeout(() => window.location.reload(), 600);
+    }
+  }
+
+  // ── Dashboard layout ──────────────────────────────────────────────────────
+
+  async function saveDashboard() {
+    const sel = CLU.readDashboardSelection("accountDashboardList");
+    const result = await withButton("saveDashboardBtn", "Dashboard layout saved.", () =>
+      postJSON("/api/account/dashboard", {
+        dashboardOrder: sel.order,
+        dashboardHidden: sel.hidden,
+      }));
+    if (result) setBadge("dashboardStateBadge", true);
+  }
+
+  async function resetDashboard() {
+    const result = await withButton("resetDashboardBtn", "Following the site default. Reloading…", () =>
+      postJSON("/api/account/dashboard", { useSiteDefault: true }));
+    if (result) {
+      setBadge("dashboardStateBadge", false);
+      setTimeout(() => window.location.reload(), 600);
+    }
+  }
+
+  // ── API tokens ────────────────────────────────────────────────────────────
 
   function alertMsg(msg) {
     document.getElementById("account-alert").innerHTML =
@@ -75,7 +296,8 @@
           <span>${esc(t.name || "(unnamed)")}
             <span class="text-muted">· ${t.last_used_at ? "last used " + esc(t.last_used_at) : "never used"}</span>
           </span>
-          <button class="btn btn-sm btn-outline-danger py-0" onclick="revokeToken(${t.id})">Revoke</button>
+          <button class="btn btn-sm btn-outline-danger py-0"
+                  onclick="askRevokeToken(${t.id}, '${esc(t.name || "(unnamed)")}')">Revoke</button>
         </div>`).join("");
     } catch (e) {
       box.innerHTML = "<span class='text-danger'>Failed to load tokens.</span>";
@@ -105,17 +327,50 @@
     navigator.clipboard.writeText(val).catch(() => {});
   }
 
+  let _pendingRevokeId = null;
+
+  function askRevokeToken(tokenId, tokenName) {
+    _pendingRevokeId = tokenId;
+    document.getElementById("revokeTokenName").textContent = tokenName;
+    bootstrap.Modal.getOrCreateInstance(document.getElementById("revokeTokenModal")).show();
+  }
+
   async function revokeToken(tokenId) {
-    if (!confirm("Revoke this token? Any client using it will lose access.")) return;
     const resp = await fetch(`/api/account/tokens/${tokenId}`, { method: "DELETE" });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok || !data.success) {
       alertMsg(data.error || "Failed to revoke token.");
       return;
     }
+    CLU.showSuccess("Token revoked.");
     loadTokens();
   }
 
-  document.addEventListener("DOMContentLoaded", loadTokens);
+  // ── Init ──────────────────────────────────────────────────────────────────
+
+  document.addEventListener("DOMContentLoaded", function () {
+    CLU.initThemePreview({
+      selectId: "accountTheme",
+      imgId: "accountThemePreviewImg",
+      nameId: "accountThemePreviewName",
+    });
+    CLU.initDashboardEditor("accountDashboardList");
+    loadTokens();
+
+    document.getElementById("confirmRevokeBtn").addEventListener("click", function () {
+      bootstrap.Modal.getOrCreateInstance(document.getElementById("revokeTokenModal")).hide();
+      if (_pendingRevokeId !== null) {
+        revokeToken(_pendingRevokeId);
+        _pendingRevokeId = null;
+      }
+    });
+
+    // Deep links: /account#tokens, #dashboard, #appearance (used by the header menu).
+    const hash = window.location.hash.replace("#", "");
+    if (hash) {
+      const trigger = document.querySelector(`#accountTabs [data-bs-target="#${hash}"]`);
+      if (trigger) bootstrap.Tab.getOrCreateInstance(trigger).show();
+    }
+  });
 </script>
 {% endblock %}

--- a/templates/config.html
+++ b/templates/config.html
@@ -66,7 +66,7 @@
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="personalization-tab" data-bs-toggle="tab" data-bs-target="#personalization"
                     type="button" role="tab" aria-controls="personalization"
-                    aria-selected="false">Personalization</button>
+                    aria-selected="false">Personalization (Site Defaults)</button>
             </li>
         </ul>
 
@@ -1465,127 +1465,47 @@
             <!-- ========================================== -->
             <div class="tab-pane fade" id="personalization" role="tabpanel" aria-labelledby="personalization-tab">
 
-                <!-- Theme Selection -->
+                <!-- Theme Selection (site default) -->
                 <div class="container p-4 border rounded shadow-sm mb-4">
-                    <h4>Theme Selection</h4>
-                    <p class="text-muted">Choose a Bootstrap theme for the application. Themes provided by <a
-                            href="https://bootswatch.com/" target="_blank">Bootswatch</a>.</p>
+                    <h4>Default Theme</h4>
+                    <p class="text-muted">
+                        The theme for users who haven't picked their own. Themes provided by
+                        <a href="https://bootswatch.com/" target="_blank">Bootswatch</a>.
+                        To change only your own theme, go to
+                        <a href="{{ url_for('auth.account') }}#appearance">My Account &rarr; Appearance</a>.
+                    </p>
 
-                    <div class="row">
-                        <div class="col-md-6">
-                            <label for="bootstrapTheme" class="form-label">Bootstrap Theme:</label>
-                            <select class="form-select" id="bootstrapTheme" name="bootstrapTheme">
-                                <option value="default" {% if bootstrapTheme=='default' %}selected{% endif %}>Default
-                                    (Bootstrap)</option>
-                                <option value="brite" {% if bootstrapTheme=='brite' %}selected{% endif %}>Brite
-                                </option>
-                                <option value="cerulean" {% if bootstrapTheme=='cerulean' %}selected{% endif %}>Cerulean
-                                </option>
-                                <option value="cosmo" {% if bootstrapTheme=='cosmo' %}selected{% endif %}>Cosmo</option>
-                                <option value="cyborg" {% if bootstrapTheme=='cyborg' %}selected{% endif %}>Cyborg
-                                    (Dark)</option>
-                                <option value="darkly" {% if bootstrapTheme=='darkly' %}selected{% endif %}>Darkly
-                                    (Dark)</option>
-                                <option value="flatly" {% if bootstrapTheme=='flatly' %}selected{% endif %}>Flatly
-                                </option>
-                                <option value="journal" {% if bootstrapTheme=='journal' %}selected{% endif %}>Journal
-                                </option>
-                                <option value="litera" {% if bootstrapTheme=='litera' %}selected{% endif %}>Litera
-                                </option>
-                                <option value="lumen" {% if bootstrapTheme=='lumen' %}selected{% endif %}>Lumen</option>
-                                <option value="lux" {% if bootstrapTheme=='lux' %}selected{% endif %}>Lux</option>
-                                <option value="materia" {% if bootstrapTheme=='materia' %}selected{% endif %}>Materia
-                                </option>
-                                <option value="minty" {% if bootstrapTheme=='minty' %}selected{% endif %}>Minty</option>
-                                <option value="morph" {% if bootstrapTheme=='morph' %}selected{% endif %}>Morph</option>
-                                <option value="pulse" {% if bootstrapTheme=='pulse' %}selected{% endif %}>Pulse</option>
-                                <option value="quartz" {% if bootstrapTheme=='quartz' %}selected{% endif %}>Quartz
-                                    (Dark)</option>
-                                <option value="sandstone" {% if bootstrapTheme=='sandstone' %}selected{% endif %}>
-                                    Sandstone</option>
-                                <option value="simplex" {% if bootstrapTheme=='simplex' %}selected{% endif %}>Simplex
-                                </option>
-                                <option value="sketchy" {% if bootstrapTheme=='sketchy' %}selected{% endif %}>Sketchy
-                                </option>
-                                <option value="slate" {% if bootstrapTheme=='slate' %}selected{% endif %}>Slate (Dark)
-                                </option>
-                                <option value="solar" {% if bootstrapTheme=='solar' %}selected{% endif %}>Solar (Dark)
-                                </option>
-                                <option value="spacelab" {% if bootstrapTheme=='spacelab' %}selected{% endif %}>Spacelab
-                                </option>
-                                <option value="superhero" {% if bootstrapTheme=='superhero' %}selected{% endif %}>
-                                    Superhero (Dark)</option>
-                                <option value="united" {% if bootstrapTheme=='united' %}selected{% endif %}>United
-                                </option>
-                                <option value="vapor" {% if bootstrapTheme=='vapor' %}selected{% endif %}>Vapor (Dark)
-                                </option>
-                                <option value="yeti" {% if bootstrapTheme=='yeti' %}selected{% endif %}>Yeti</option>
-                                <option value="zephyr" {% if bootstrapTheme=='zephyr' %}selected{% endif %}>Zephyr
-                                </option>
-                            </select>
-                            <small class="form-text text-muted">
-                                Select a theme to change the look and feel of the application. Dark themes are marked.
-                            </small>
-                        </div>
-                        <div class="col-md-6">
-                            <label class="form-label">Theme Preview:</label>
-                            <div class="border rounded p-2 text-center">
-                                <img id="themePreviewImg"
-                                    src="https://bootswatch.com/{{ bootstrapTheme|default('default') }}/thumbnail.png"
-                                    alt="Theme preview" class="img-fluid rounded" style="max-height: 200px;"
-                                    onerror="this.src='/static/images/default.png'">
-                                <div class="mt-2">
-                                    <strong id="themePreviewName">{{ bootstrapTheme|default('default')|title }}</strong>
-                                    <br><small class="text-muted">Save settings to apply this theme.</small>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    {% with select_id='bootstrapTheme',
+                            selected_theme=bootstrapTheme|default('default'),
+                            preview_note='Save settings to apply this theme.' %}
+                    {% include 'partials/theme_picker.html' %}
+                    {% endwith %}
                 </div>
 
                 <!-- Save Button - Styling -->
                 <div class="mb-3 text-center">
                     <button type="button" class="btn btn-primary" onclick="saveStylingSettings()">
-                        <i class="bi bi-floppy"></i> Save Styling Settings
+                        <i class="bi bi-floppy"></i> Save Default Theme
                     </button>
                 </div>
 
                 <hr>
 
-                <!-- Dashboard Layout -->
+                <!-- Dashboard Layout (site default) -->
                 <div class="container p-4 border rounded shadow-sm mb-4">
-                    <h4><i class="bi bi-layout-text-window-reverse me-2"></i>Dashboard Layout</h4>
-                    <p class="text-muted">Configure which sections appear on your collection dashboard and their display
-                        order.</p>
+                    <h4><i class="bi bi-layout-text-window-reverse me-2"></i>Default Dashboard Layout</h4>
+                    <p class="text-muted">
+                        Which sections appear on the collection dashboard, and in what order, for users who
+                        haven't set their own. To change only your own layout, go to
+                        <a href="{{ url_for('auth.account') }}#dashboard">My Account &rarr; Dashboard Layout</a>.
+                    </p>
 
-                    {% set sections_meta = {
-                    'favorites': {'name': 'Favorite Collections', 'icon': 'bi-bookmark-heart-fill text-danger'},
-                    'want_to_read': {'name': 'Want to Read', 'icon': 'bi-bookmark-star-fill text-warning'},
-                    'continue_reading': {'name': 'Continue Reading', 'icon': 'bi-book-half text-info'},
-                    'on_the_stack': {'name': 'On the Stack', 'icon': 'bi-layers-fill text-success'},
-                    'discover': {'name': 'Discover / Recommendations', 'icon': 'bi-stars text-warning'},
-                    'recently_added': {'name': 'Recently Added', 'icon': 'bi-clock-history text-primary'},
-                    'library': {'name': 'Library', 'icon': 'bi-collection-fill text-primary'}
-                    } %}
-                    <ul class="list-group" id="dashboardSectionsList" style="max-width: 600px;">
-                        {% for section_id in dashboard_order %}
-                        {% if section_id in sections_meta %}
-                        {% set meta = sections_meta[section_id] %}
-                        <li class="list-group-item d-flex justify-content-between align-items-center"
-                            data-section-id="{{ section_id }}">
-                            <div class="d-flex align-items-center">
-                                <input type="checkbox" class="form-check-input dashboard-visible-check me-3" {{ '' if
-                                    section_id in dashboard_hidden else 'checked' }}>
-                                <i class="bi {{ meta.icon }} me-2"></i>
-                                <strong>{{ meta.name }}</strong>
-                                {% if section_id == 'discover' %}
-                                <small class="text-muted ms-2">(Also requires Recommendations enabled)</small>
-                                {% endif %}
-                            </div>
-                        </li>
-                        {% endif %}
-                        {% endfor %}
-                    </ul>
+                    {% with list_id='dashboardSectionsList',
+                            order=dashboard_order,
+                            hidden=dashboard_hidden,
+                            section_meta=dashboard_section_meta %}
+                    {% include 'partials/dashboard_layout_editor.html' %}
+                    {% endwith %}
 
                     <div class="alert alert-info mt-2 mb-0">
                         <i class="bi bi-info-circle me-1"></i>
@@ -1734,6 +1654,7 @@
 {{ super() }}
 <script src="{{ url_for('static', filename='js/clu-utils.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-streaming.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-personalization.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/database_panel.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script>
     // Toast notification system for config.html
@@ -2128,77 +2049,10 @@
         }
     }
 
-    // Dashboard section list with up/down arrows
-    function renderDashboardList() {
-        const list = document.getElementById('dashboardSectionsList');
-        const items = Array.from(list.children);
-        list.innerHTML = '';
-        items.forEach((item, idx) => {
-            // Remove old arrow buttons
-            const oldBtnGroup = item.querySelector('.dashboard-btn-group');
-            if (oldBtnGroup) oldBtnGroup.remove();
-
-            // Update badge number
-            let badge = item.querySelector('.dashboard-order-badge');
-            if (!badge) {
-                badge = document.createElement('span');
-                badge.className = 'badge bg-secondary me-2 dashboard-order-badge';
-                item.querySelector('div').insertBefore(badge, item.querySelector('.form-check-input'));
-            }
-            badge.textContent = idx + 1;
-
-            const btnGroup = document.createElement('div');
-            btnGroup.className = 'dashboard-btn-group';
-            if (idx > 0) {
-                const upBtn = document.createElement('button');
-                upBtn.type = 'button';
-                upBtn.className = 'btn btn-sm btn-outline-secondary me-1';
-                upBtn.innerHTML = '<i class="bi bi-arrow-up"></i>';
-                upBtn.onclick = () => moveDashboardSection(idx, idx - 1);
-                btnGroup.appendChild(upBtn);
-            }
-            if (idx < items.length - 1) {
-                const downBtn = document.createElement('button');
-                downBtn.type = 'button';
-                downBtn.className = 'btn btn-sm btn-outline-secondary';
-                downBtn.innerHTML = '<i class="bi bi-arrow-down"></i>';
-                downBtn.onclick = () => moveDashboardSection(idx, idx + 1);
-                btnGroup.appendChild(downBtn);
-            }
-            item.appendChild(btnGroup);
-
-            // Drag events
-            item.draggable = true;
-            item.addEventListener('dragstart', (e) => {
-                e.dataTransfer.setData('text/plain', idx);
-                item.classList.add('opacity-50');
-            });
-            item.addEventListener('dragend', () => item.classList.remove('opacity-50'));
-            item.addEventListener('dragover', (e) => { e.preventDefault(); item.classList.add('border-primary'); });
-            item.addEventListener('dragleave', () => item.classList.remove('border-primary'));
-            item.addEventListener('drop', (e) => {
-                e.preventDefault();
-                item.classList.remove('border-primary');
-                const fromIdx = parseInt(e.dataTransfer.getData('text/plain'));
-                moveDashboardSection(fromIdx, idx);
-            });
-
-            list.appendChild(item);
-        });
-    }
-
-    function moveDashboardSection(fromIdx, toIdx) {
-        const list = document.getElementById('dashboardSectionsList');
-        const items = Array.from(list.children);
-        const [moved] = items.splice(fromIdx, 1);
-        items.splice(toIdx, 0, moved);
-        list.innerHTML = '';
-        items.forEach(item => list.appendChild(item));
-        renderDashboardList();
-    }
-
-    // Initialize the dashboard list on load
-    renderDashboardList();
+    // Dashboard reorder/drag-drop lives in static/js/clu-personalization.js so
+    // /account can reuse it. Rendered immediately (not on DOMContentLoaded) to
+    // match where this script runs in the page.
+    CLU.initDashboardEditor('dashboardSectionsList');
 
     async function saveDashboardSettings() {
         const btn = document.getElementById('saveDashboardBtn');
@@ -2206,20 +2060,10 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
 
-        const items = Array.from(document.querySelectorAll('#dashboardSectionsList li'));
-        const order = [];
-        const hidden = [];
-        items.forEach(item => {
-            const id = item.dataset.sectionId;
-            order.push(id);
-            if (!item.querySelector('.dashboard-visible-check').checked) {
-                hidden.push(id);
-            }
-        });
-
+        const sel = CLU.readDashboardSelection('dashboardSectionsList');
         const data = {
-            dashboardOrder: order,
-            dashboardHidden: hidden
+            dashboardOrder: sel.order,
+            dashboardHidden: sel.hidden
         };
 
         try {
@@ -2951,34 +2795,13 @@
         }
     }
 
-    // Theme Preview Functions
-    function initializeThemePreview() {
-        const themeSelect = document.getElementById('bootstrapTheme');
-        if (themeSelect) {
-            themeSelect.addEventListener('change', updateThemePreview);
-        }
-    }
-
-    function updateThemePreview() {
-        const themeSelect = document.getElementById('bootstrapTheme');
-        const previewImg = document.getElementById('themePreviewImg');
-        const previewName = document.getElementById('themePreviewName');
-
-        if (!themeSelect || !previewImg || !previewName) return;
-
-        const theme = themeSelect.value;
-        const themeName = themeSelect.options[themeSelect.selectedIndex].text;
-
-        // Update thumbnail image
-        previewImg.src = `https://bootswatch.com/${theme}/thumbnail.png`;
-
-        // Update theme name (remove "(Dark)" suffix for display)
-        previewName.textContent = themeName.replace(' (Dark)', '');
-    }
-
-    // Initialize theme preview on page load
+    // Theme preview lives in static/js/clu-personalization.js (shared with /account).
     document.addEventListener('DOMContentLoaded', function () {
-        initializeThemePreview();
+        CLU.initThemePreview({
+            selectId: 'bootstrapTheme',
+            imgId: 'themePreviewImg',
+            nameId: 'themePreviewName'
+        });
     });
 </script>
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -167,6 +167,40 @@
             Insights
           </a>
         </li>
+        {# Signed-in identity. Gated on session.user_id rather than g.current_user:
+           in implicit-owner mode current_user resolves to the owner even though
+           nobody logged in, and "signed in as owner" would be misleading there.
+           The g.get() half is defensive — a session pointing at a deleted user
+           would otherwise 500 every page. #}
+        {% if session.get('user_id') and g.get('current_user') %}
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="userMenu" role="button"
+            data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="bi bi-person-circle me-1"></i>
+            <span class="text-truncate" style="max-width: 12rem;">{{ g.current_user.display_name or
+              g.current_user.username }}</span>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userMenu">
+            <li>
+              <a href="{{ url_for('auth.account') }}"
+                class="dropdown-item {% if current_page == url_for('auth.account') %}active{% endif %}">
+                <i class="bi bi-person-badge me-2"></i>My Account
+              </a>
+            </li>
+            <li>
+              <a href="{{ url_for('auth.account') }}#tokens" class="dropdown-item">
+                <i class="bi bi-key me-2"></i>API Tokens
+              </a>
+            </li>
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <a href="{{ url_for('auth.logout') }}" class="dropdown-item text-danger">
+                <i class="bi bi-box-arrow-right me-2"></i>Logout
+              </a>
+            </li>
+          </ul>
+        </li>
+        {% endif %}
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle {% if current_page in [url_for('config_page'), url_for('schedules_page'), url_for('logs_page')] %}active{% endif %}"
             href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -209,21 +243,18 @@
               </a>
             </li>
             {% endif %}
-            {% if session.get('authenticated') %}
             <li><hr class="dropdown-divider"></li>
-            <li>
-              <a href="{{ url_for('auth.logout') }}" class="dropdown-item text-danger">
-                <i class="bi bi-box-arrow-right me-2"></i>Logout
-              </a>
-            </li>
-            {% endif %}
-            <li><hr class="dropdown-divider"></li>
+            {# Logout and My Account live in the user dropdown above — but that
+               dropdown is hidden in implicit-owner mode, so keep an entry point
+               to /account here for exactly that case. #}
+            {% if not session.get('user_id') %}
             <li>
               <a href="{{ url_for('auth.account') }}"
                 class="dropdown-item {% if current_page == url_for('auth.account') %}active{% endif %}">
-                <i class="bi bi-key me-2"></i>API Tokens
+                <i class="bi bi-person-badge me-2"></i>My Account
               </a>
             </li>
+            {% endif %}
             <li>
               <a href="/api/v1/docs"
                 class="dropdown-item {% if current_page == '/api/v1/docs' %}active{% endif %}">

--- a/templates/partials/dashboard_layout_editor.html
+++ b/templates/partials/dashboard_layout_editor.html
@@ -1,0 +1,33 @@
+{# Reorderable dashboard-section list with per-section visibility checkboxes.
+
+   Shared by /config (site default) and /account (per-user override).
+
+   Order and visibility are read straight out of the DOM by
+   CLU.readDashboardSelection() — the <li>s carry data-section-id and a
+   .dashboard-visible-check, and there are deliberately no name= attributes.
+
+   Params (pass via {% with %}):
+     list_id         id for the <ul>                       (default: dashboardSectionsList)
+     order           list of section ids, in display order
+     hidden          list of section ids that are unchecked
+     section_meta    id -> {name, icon, note} from routes.collection.dashboard_section_meta()
+#}
+{% set _list_id = list_id|default('dashboardSectionsList') %}
+<ul class="list-group" id="{{ _list_id }}" style="max-width: 600px;">
+    {% for section_id in order %}
+    {% if section_id in section_meta %}
+    {% set meta = section_meta[section_id] %}
+    <li class="list-group-item d-flex justify-content-between align-items-center" data-section-id="{{ section_id }}">
+        <div class="d-flex align-items-center">
+            <input type="checkbox" class="form-check-input dashboard-visible-check me-3" {{ '' if section_id in hidden
+                else 'checked' }}>
+            <i class="bi {{ meta.icon }} me-2"></i>
+            <strong>{{ meta.name }}</strong>
+            {% if meta.note %}
+            <small class="text-muted ms-2">({{ meta.note }})</small>
+            {% endif %}
+        </div>
+    </li>
+    {% endif %}
+    {% endfor %}
+</ul>

--- a/templates/partials/theme_picker.html
+++ b/templates/partials/theme_picker.html
@@ -1,0 +1,44 @@
+{# Bootswatch theme <select> + live thumbnail preview.
+
+   Shared by /config (site default) and /account (per-user override), so every
+   element id is parameterised — the two pages must not collide.
+
+   Params (pass via {% with %}):
+     select_id      id for the <select>            (default: bootstrapTheme)
+     img_id         id for the preview <img>       (default: themePreviewImg)
+     name_id        id for the preview label       (default: themePreviewName)
+     selected_theme currently-selected theme id    (default: 'default')
+     help_text      small print under the select
+     preview_note   small print under the preview name
+
+   Options come from the `bootswatch_themes` context variable (core/themes.py),
+   so the list and its "(Dark)" labels live in exactly one place.
+#}
+{% set _select_id = select_id|default('bootstrapTheme') %}
+{% set _img_id = img_id|default('themePreviewImg') %}
+{% set _name_id = name_id|default('themePreviewName') %}
+{% set _selected = selected_theme|default('default') %}
+<div class="row">
+    <div class="col-md-6">
+        <label for="{{ _select_id }}" class="form-label">Bootstrap Theme:</label>
+        <select class="form-select" id="{{ _select_id }}" name="{{ _select_id }}">
+            {% for theme_id, theme_label in bootswatch_themes %}
+            <option value="{{ theme_id }}" {% if _selected == theme_id %}selected{% endif %}>{{ theme_label }}</option>
+            {% endfor %}
+        </select>
+        <small class="form-text text-muted">
+            {{ help_text|default('Select a theme to change the look and feel of the application. Dark themes are marked.') }}
+        </small>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Theme Preview:</label>
+        <div class="border rounded p-2 text-center">
+            <img id="{{ _img_id }}" src="https://bootswatch.com/{{ _selected }}/thumbnail.png" alt="Theme preview"
+                class="img-fluid rounded" style="max-height: 200px;" onerror="this.src='/static/images/default.png'">
+            <div class="mt-2">
+                <strong id="{{ _name_id }}">{{ _selected|title }}</strong>
+                <br><small class="text-muted">{{ preview_note|default('Save settings to apply this theme.') }}</small>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -48,6 +48,7 @@ class TestTablesExist:
         "to_read",
         "stats_cache",
         "user_preferences",
+        "user_settings",
         "reading_positions",
         "publishers",
         "series",

--- a/tests/integration/test_user_settings.py
+++ b/tests/integration/test_user_settings.py
@@ -1,0 +1,216 @@
+"""Per-user settings: the user_settings override layer over user_preferences.
+
+Resolution order under test:
+
+    user_settings[user_id][key]  ->  user_preferences[key]  ->  default
+         personal override           owner-set site default
+"""
+import json
+
+import pytest
+
+from core.database import (
+    delete_user_setting,
+    get_user_preference,
+    get_user_setting,
+    get_user_setting_override,
+    set_user_preference,
+    set_user_setting,
+)
+
+
+class TestFallbackChain:
+    """get_user_setting resolves override -> global -> default."""
+
+    def test_neither_set_returns_default(self, db_connection):
+        assert get_user_setting("bootstrap_theme", default="default", user_id=1) == "default"
+
+    def test_global_only_returns_global(self, db_connection):
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        assert get_user_setting("bootstrap_theme", default="default", user_id=1) == "flatly"
+
+    def test_override_wins_over_global(self, db_connection):
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        set_user_setting("bootstrap_theme", "darkly", user_id=1)
+        assert get_user_setting("bootstrap_theme", default="default", user_id=1) == "darkly"
+
+    def test_corrupt_override_falls_through_to_global(self, db_connection):
+        """A broken personal row must not mask the owner's site default.
+
+        This is deliberately unlike get_user_preference, which returns its
+        ``default`` on any error.
+        """
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        db_connection.execute(
+            "INSERT OR REPLACE INTO user_settings (user_id, key, value) VALUES (?, ?, ?)",
+            (1, "bootstrap_theme", "{not valid json"),
+        )
+        db_connection.commit()
+
+        assert get_user_setting("bootstrap_theme", default="default", user_id=1) == "flatly"
+
+    def test_falsy_override_is_respected(self, db_connection):
+        """An override of False/0/[] is a real choice, not "unset"."""
+        set_user_preference("dashboard_hidden", ["library"], category="dashboard")
+        set_user_setting("dashboard_hidden", [], user_id=1)
+        assert get_user_setting("dashboard_hidden", default=None, user_id=1) == []
+
+
+class TestOverrideAccessor:
+    """get_user_setting_override never falls back."""
+
+    def test_returns_none_when_only_global_exists(self, db_connection):
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        assert get_user_setting_override("bootstrap_theme", user_id=1) is None
+
+    def test_returns_the_override(self, db_connection):
+        set_user_setting("bootstrap_theme", "darkly", user_id=1)
+        assert get_user_setting_override("bootstrap_theme", user_id=1) == "darkly"
+
+
+class TestIsolation:
+    """Overrides are per user."""
+
+    def test_users_do_not_see_each_other(self, db_connection):
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        set_user_setting("bootstrap_theme", "darkly", user_id=1)
+        set_user_setting("bootstrap_theme", "cyborg", user_id=2)
+
+        assert get_user_setting("bootstrap_theme", user_id=1) == "darkly"
+        assert get_user_setting("bootstrap_theme", user_id=2) == "cyborg"
+        # A third user with no override still follows the site default.
+        assert get_user_setting("bootstrap_theme", user_id=3) == "flatly"
+
+    def test_delete_only_affects_one_user(self, db_connection):
+        set_user_setting("bootstrap_theme", "darkly", user_id=1)
+        set_user_setting("bootstrap_theme", "cyborg", user_id=2)
+
+        delete_user_setting("bootstrap_theme", user_id=1)
+
+        assert get_user_setting_override("bootstrap_theme", user_id=1) is None
+        assert get_user_setting_override("bootstrap_theme", user_id=2) == "cyborg"
+
+
+class TestDelete:
+
+    def test_delete_reverts_to_global(self, db_connection):
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        set_user_setting("bootstrap_theme", "darkly", user_id=1)
+        assert get_user_setting("bootstrap_theme", user_id=1) == "darkly"
+
+        delete_user_setting("bootstrap_theme", user_id=1)
+        assert get_user_setting("bootstrap_theme", user_id=1) == "flatly"
+
+    def test_delete_missing_row_is_a_noop(self, db_connection):
+        assert delete_user_setting("never_set", user_id=1) is True
+
+
+class TestRoundTrip:
+
+    @pytest.mark.parametrize("value", [
+        "darkly",
+        ["favorites", "library"],
+        {"a": 1, "b": [2, 3]},
+        True,
+        0,
+        None,
+    ])
+    def test_json_round_trip(self, db_connection, value):
+        set_user_setting("some_key", value, user_id=7)
+        assert get_user_setting_override("some_key", user_id=7) == value
+
+    def test_encoding_matches_user_preferences(self, db_connection):
+        """Both tables must JSON-encode identically — the same caller reads either."""
+        set_user_preference("shared_key", {"x": [1, 2]}, category="general")
+        set_user_setting("shared_key", {"x": [1, 2]}, user_id=1)
+
+        pref = db_connection.execute(
+            "SELECT value FROM user_preferences WHERE key = 'shared_key'"
+        ).fetchone()["value"]
+        setting = db_connection.execute(
+            "SELECT value FROM user_settings WHERE user_id = 1 AND key = 'shared_key'"
+        ).fetchone()["value"]
+
+        assert pref == setting
+        assert json.loads(setting) == {"x": [1, 2]}
+
+    def test_set_overwrites(self, db_connection):
+        set_user_setting("bootstrap_theme", "darkly", user_id=1)
+        set_user_setting("bootstrap_theme", "lux", user_id=1)
+        assert get_user_setting_override("bootstrap_theme", user_id=1) == "lux"
+        rows = db_connection.execute(
+            "SELECT COUNT(*) c FROM user_settings WHERE user_id = 1 AND key = 'bootstrap_theme'"
+        ).fetchone()["c"]
+        assert rows == 1
+
+
+class TestDashboardResolution:
+    """routes.collection resolves dashboard layout through the same chain."""
+
+    def test_order_falls_back_and_backfills(self, db_connection):
+        from routes.collection import DEFAULT_DASHBOARD_ORDER, get_dashboard_order
+
+        # A stale saved order missing a newer section still yields every section.
+        set_user_setting("dashboard_order", ["library", "favorites"], user_id=1)
+        order = get_dashboard_order(user_id=1)
+
+        assert order[:2] == ["library", "favorites"]
+        assert set(order) == set(DEFAULT_DASHBOARD_ORDER)
+
+    def test_default_order_is_not_mutated_by_backfill(self, db_connection):
+        """The fallback must hand back a copy, not the module-level list."""
+        from routes.collection import DEFAULT_DASHBOARD_ORDER, get_dashboard_order
+
+        before = list(DEFAULT_DASHBOARD_ORDER)
+        get_dashboard_order(user_id=1)
+        get_dashboard_order(user_id=2)
+        assert DEFAULT_DASHBOARD_ORDER == before
+
+    def test_site_default_ignores_personal_override(self, db_connection):
+        from routes.collection import site_default_dashboard_order
+
+        set_user_preference("dashboard_order", ["library", "favorites"], category="dashboard")
+        set_user_setting("dashboard_order", ["discover", "library"], user_id=1)
+
+        assert site_default_dashboard_order()[:2] == ["library", "favorites"]
+
+    def test_sections_respect_per_user_hidden(self, db_connection):
+        from routes.collection import get_dashboard_sections
+
+        set_user_setting("dashboard_hidden", ["library"], user_id=1)
+        set_user_setting("dashboard_hidden", [], user_id=2)
+
+        ids_1 = [s["id"] for s in get_dashboard_sections(user_id=1)]
+        ids_2 = [s["id"] for s in get_dashboard_sections(user_id=2)]
+
+        assert "library" not in ids_1
+        assert "library" in ids_2
+
+
+class TestSanitizeDashboardPayload:
+
+    def test_drops_unknown_and_backfills_deterministically(self, db_connection):
+        from routes.collection import DEFAULT_DASHBOARD_ORDER, sanitize_dashboard_payload
+
+        order, hidden = sanitize_dashboard_payload(["library", "bogus"], ["nope", "discover"])
+
+        assert order[0] == "library"
+        assert "bogus" not in order
+        assert set(order) == set(DEFAULT_DASHBOARD_ORDER)
+        # Backfill order follows DEFAULT_DASHBOARD_ORDER, not set iteration.
+        assert order[1:] == [s for s in DEFAULT_DASHBOARD_ORDER if s != "library"]
+        assert hidden == ["discover"]
+
+    def test_accepts_comma_separated_strings(self, db_connection):
+        from routes.collection import sanitize_dashboard_payload
+
+        order, hidden = sanitize_dashboard_payload("library, favorites", "discover")
+        assert order[:2] == ["library", "favorites"]
+        assert hidden == ["discover"]
+
+    def test_empty_payload_yields_full_default_order(self, db_connection):
+        from routes.collection import DEFAULT_DASHBOARD_ORDER, sanitize_dashboard_payload
+
+        order, hidden = sanitize_dashboard_payload([], [])
+        assert order == list(DEFAULT_DASHBOARD_ORDER)
+        assert hidden == []

--- a/tests/routes/test_account_settings.py
+++ b/tests/routes/test_account_settings.py
@@ -1,0 +1,299 @@
+"""Per-user personalization on /account.
+
+Covers the two self-service endpoints (/api/account/appearance, /api/account/
+dashboard), the override -> site-default fallback as it reaches the rendered
+page, and the implicit-owner (no-login) path.
+"""
+import pytest
+
+from core.database import (
+    create_user,
+    get_user_preference,
+    get_user_setting_override,
+    set_user_preference,
+    set_user_setting,
+)
+
+
+def _login(client, username, password):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def _uid(username):
+    from core.database import get_user_by_username
+    return get_user_by_username(username)["id"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-user: real login, real RBAC
+# ---------------------------------------------------------------------------
+class TestMultiUser:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        create_user("reader2", password="reader2pass", role="reader")
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        yield
+
+    # -- Appearance --------------------------------------------------------
+
+    def test_reader_can_save_own_theme(self, client):
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/account/appearance", json={"bootstrapTheme": "darkly"})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        assert get_user_setting_override("bootstrap_theme", user_id=_uid("reader")) == "darkly"
+
+    def test_saving_own_theme_leaves_site_default_alone(self, client):
+        _login(client, "reader", "readerpass")
+        client.post("/api/account/appearance", json={"bootstrapTheme": "darkly"})
+
+        assert get_user_preference("bootstrap_theme") == "flatly"
+
+    def test_one_users_theme_does_not_affect_another(self, client):
+        _login(client, "reader", "readerpass")
+        client.post("/api/account/appearance", json={"bootstrapTheme": "darkly"})
+
+        assert get_user_setting_override("bootstrap_theme", user_id=_uid("reader2")) is None
+
+    def test_unknown_theme_rejected_and_not_stored(self, client):
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/account/appearance", json={"bootstrapTheme": "not-a-theme"})
+
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+        assert get_user_setting_override("bootstrap_theme", user_id=_uid("reader")) is None
+
+    def test_use_site_default_clears_override(self, client):
+        _login(client, "reader", "readerpass")
+        client.post("/api/account/appearance", json={"bootstrapTheme": "darkly"})
+
+        resp = client.post("/api/account/appearance", json={"useSiteDefault": True})
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["override"] is False
+        assert body["theme"] == "flatly"
+        assert get_user_setting_override("bootstrap_theme", user_id=_uid("reader")) is None
+
+    # -- Dashboard ---------------------------------------------------------
+
+    def test_reader_can_save_own_dashboard(self, client):
+        from routes.collection import DEFAULT_DASHBOARD_ORDER
+
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/account/dashboard", json={
+            "dashboardOrder": ["library", "favorites"],
+            "dashboardHidden": ["discover"],
+        })
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["dashboardOrder"][:2] == ["library", "favorites"]
+        # Sections missing from the payload are backfilled, never dropped.
+        assert set(body["dashboardOrder"]) == set(DEFAULT_DASHBOARD_ORDER)
+        assert body["dashboardHidden"] == ["discover"]
+
+    def test_dashboard_junk_ids_are_dropped(self, client):
+        _login(client, "reader", "readerpass")
+        resp = client.post("/api/account/dashboard", json={
+            "dashboardOrder": ["library", "../etc/passwd", "bogus"],
+            "dashboardHidden": ["also-bogus"],
+        })
+
+        body = resp.get_json()
+        assert "../etc/passwd" not in body["dashboardOrder"]
+        assert "bogus" not in body["dashboardOrder"]
+        assert body["dashboardHidden"] == []
+
+    def test_dashboard_is_per_user(self, client):
+        _login(client, "reader", "readerpass")
+        client.post("/api/account/dashboard", json={
+            "dashboardOrder": ["library"], "dashboardHidden": ["favorites"],
+        })
+
+        assert get_user_setting_override("dashboard_hidden", user_id=_uid("reader")) == ["favorites"]
+        assert get_user_setting_override("dashboard_hidden", user_id=_uid("reader2")) is None
+
+    def test_dashboard_use_site_default_clears_both_keys(self, client):
+        _login(client, "reader", "readerpass")
+        client.post("/api/account/dashboard", json={
+            "dashboardOrder": ["library"], "dashboardHidden": ["favorites"],
+        })
+
+        resp = client.post("/api/account/dashboard", json={"useSiteDefault": True})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["override"] is False
+        uid = _uid("reader")
+        assert get_user_setting_override("dashboard_order", user_id=uid) is None
+        assert get_user_setting_override("dashboard_hidden", user_id=uid) is None
+
+    # -- Page render -------------------------------------------------------
+
+    def test_account_page_renders_all_three_panes(self, client):
+        _login(client, "reader", "readerpass")
+        html = client.get("/account").get_data(as_text=True)
+
+        assert client.get("/account").status_code == 200
+        assert 'id="appearance"' in html
+        assert 'id="dashboard"' in html
+        assert 'id="tokens"' in html
+
+    def test_account_page_shows_following_site_default(self, client):
+        _login(client, "reader", "readerpass")
+        html = client.get("/account").get_data(as_text=True)
+        assert "Following site default" in html
+
+    def test_account_page_shows_custom_once_overridden(self, client):
+        _login(client, "reader", "readerpass")
+
+        before = client.get("/account").get_data(as_text=True)
+        assert 'id="themeStateBadge"' in before
+        assert "Following site default" in before
+
+        client.post("/api/account/appearance", json={"bootstrapTheme": "darkly"})
+        after = client.get("/account").get_data(as_text=True)
+
+        # The appearance badge flips to Custom; the dashboard one does not.
+        assert after.count("Following site default") == before.count("Following site default") - 1
+        assert after.count("Custom") == before.count("Custom") + 1
+
+    def test_account_page_uses_no_native_dialogs(self, client):
+        """CLAUDE.md forbids alert()/confirm()/prompt() — token revoke uses a modal."""
+        _login(client, "reader", "readerpass")
+        html = client.get("/account").get_data(as_text=True)
+
+        assert "confirm(" not in html
+        assert "prompt(" not in html
+        assert "revokeTokenModal" in html
+
+    def test_theme_select_is_populated(self, client):
+        _login(client, "reader", "readerpass")
+        html = client.get("/account").get_data(as_text=True)
+
+        assert 'id="accountTheme"' in html
+        assert 'value="darkly"' in html
+        assert "Darkly (Dark)" in html
+
+    def test_unauthenticated_gets_401(self, client):
+        assert client.post("/api/account/appearance", json={"bootstrapTheme": "darkly"}).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Header identity
+# ---------------------------------------------------------------------------
+class TestHeaderIdentity:
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        yield
+
+    def test_username_and_logout_shown_when_logged_in(self, client):
+        _login(client, "reader", "readerpass")
+        # A page other than /account, so "My Account" here can only come from
+        # the header rather than the page's own heading.
+        html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert 'id="userMenu"' in html
+        assert "bi-person-circle" in html
+        assert ">reader<" in html
+        assert "/logout" in html
+        assert "My Account" in html
+
+    def test_logout_is_not_in_the_gear_menu(self, client):
+        """Logout moved into the user dropdown; the gear must not duplicate it."""
+        _login(client, "reader", "readerpass")
+        html = client.get("/reading-lists").get_data(as_text=True)
+        assert html.count("/logout") == 1
+
+
+class TestImplicitOwnerHeader:
+    @pytest.fixture(autouse=True)
+    def _single_user(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        yield
+
+    def test_no_username_chip_without_login(self, client):
+        """Single-user installs never logged in — "signed in as owner" would lie."""
+        html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert 'id="userMenu"' not in html
+        assert "/logout" not in html
+        # ...but /account must still be reachable, via the gear menu.
+        assert "My Account" in html
+        assert "/account" in html
+
+    def test_account_page_loads_without_a_session(self, client):
+        assert client.get("/account").status_code == 200
+
+    def test_settings_save_without_a_session(self, client):
+        assert client.post(
+            "/api/account/appearance", json={"bootstrapTheme": "darkly"}
+        ).status_code == 200
+        assert client.post(
+            "/api/account/dashboard", json={"dashboardOrder": ["library"]}
+        ).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Theme resolution reaching the rendered page
+# ---------------------------------------------------------------------------
+class TestRenderedTheme:
+    """The context processor lives in app.py, which route tests can't import.
+
+    These exercise the same resolution helper the processor calls, so the chain
+    (override -> app.config site default) is still pinned.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _users(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("reader", password="readerpass", role="reader")
+        set_user_preference("bootstrap_theme", "flatly", category="personalization")
+        yield
+
+    def test_override_selected_in_the_picker(self, client):
+        set_user_setting("bootstrap_theme", "cyborg", user_id=_uid("reader"))
+        _login(client, "reader", "readerpass")
+        html = client.get("/account").get_data(as_text=True)
+
+        assert '<option value="cyborg" selected>' in html
+
+    def test_site_default_selected_without_an_override(self, client):
+        _login(client, "reader", "readerpass")
+        html = client.get("/account").get_data(as_text=True)
+
+        assert '<option value="flatly" selected>' in html
+
+
+# ---------------------------------------------------------------------------
+# Owner shadowing: saving the site default resets the owner's own override
+# ---------------------------------------------------------------------------
+class TestOwnerShadowing:
+
+    def test_site_default_save_clears_callers_override(self, db_connection):
+        """Without this, an owner with a personal theme sets the site default on
+        /config and sees nothing change, because their override still wins."""
+        from core.database import delete_user_setting
+
+        create_user("owner", password="ownerpass", role="owner")
+        uid = _uid("owner")
+        set_user_setting("bootstrap_theme", "darkly", user_id=uid)
+
+        # What app.py:save_styling_config does after writing the global pref.
+        set_user_preference("bootstrap_theme", "lux", category="personalization")
+        delete_user_setting("bootstrap_theme", user_id=uid)
+
+        assert get_user_setting_override("bootstrap_theme", user_id=uid) is None

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -60,6 +60,11 @@ class TestRolePolicy:
         ("GET", "/api/account/tokens", "reader"),
         ("POST", "/api/account/tokens", "reader"),
         ("DELETE", "/api/account/tokens/5", "reader"),
+        # Per-user personalization. These live under /api/account/ precisely so
+        # _READER_WRITE_PREFIXES classifies them as reader-writable; a rename to
+        # e.g. /api/settings/* would silently 403 every Reader.
+        ("POST", "/api/account/appearance", "reader"),
+        ("POST", "/api/account/dashboard", "reader"),
         ("GET", "/config", "owner"),
         ("POST", "/api/config/file-processing", "owner"),
         ("GET", "/api/database/stats", "owner"),

--- a/tests/unit/test_themes.py
+++ b/tests/unit/test_themes.py
@@ -1,0 +1,143 @@
+"""Theme catalog + the shared personalization partials.
+
+The partials are rendered by both /config (site defaults) and /account (per-user
+overrides). /config lives in app.py and isn't reachable from the route tests, so
+these cover the shared markup directly.
+"""
+import os
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from core.themes import (
+    BOOTSWATCH_THEMES,
+    DARK_BOOTSWATCH_THEMES,
+    THEME_IDS,
+    THEME_ORDER,
+    is_dark_theme,
+    is_valid_theme,
+)
+
+TEMPLATE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "templates",
+)
+
+
+@pytest.fixture
+def env():
+    return Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+
+
+class TestThemeCatalog:
+
+    def test_ids_are_unique(self):
+        assert len(THEME_ORDER) == len(set(THEME_ORDER))
+
+    def test_default_is_first(self):
+        assert THEME_ORDER[0] == "default"
+        assert BOOTSWATCH_THEMES[0] == ("default", "Default (Bootstrap)")
+
+    def test_every_dark_theme_is_offered(self):
+        """A dark theme not in the picker could never be selected."""
+        assert DARK_BOOTSWATCH_THEMES <= THEME_IDS
+
+    def test_dark_labels_match_the_dark_set(self):
+        """The label suffix is derived, so it can't drift from the set again."""
+        for theme_id, label in BOOTSWATCH_THEMES:
+            assert label.endswith(" (Dark)") == (theme_id in DARK_BOOTSWATCH_THEMES), theme_id
+
+    def test_validators(self):
+        assert is_valid_theme("darkly")
+        assert is_valid_theme("default")
+        assert not is_valid_theme("not-a-theme")
+        assert not is_valid_theme("")
+        assert is_dark_theme("cyborg")
+        assert not is_dark_theme("flatly")
+
+
+class TestThemePickerPartial:
+
+    def _render(self, env, **kwargs):
+        kwargs.setdefault("bootswatch_themes", BOOTSWATCH_THEMES)
+        return env.get_template("partials/theme_picker.html").render(**kwargs)
+
+    def test_renders_every_theme(self, env):
+        html = self._render(env, selected_theme="default")
+        assert html.count("<option") == len(BOOTSWATCH_THEMES)
+
+    def test_marks_the_selected_theme(self, env):
+        html = self._render(env, selected_theme="cyborg")
+        assert '<option value="cyborg" selected>Cyborg (Dark)</option>' in html
+        assert '<option value="flatly" selected>' not in html
+
+    def test_element_ids_are_parameterised(self, env):
+        """/config and /account render this on different pages; ids must not collide."""
+        html = self._render(
+            env, select_id="accountTheme", img_id="accountImg", name_id="accountName",
+            selected_theme="lux",
+        )
+        assert 'id="accountTheme"' in html
+        assert 'id="accountImg"' in html
+        assert 'id="accountName"' in html
+        assert 'id="bootstrapTheme"' not in html
+
+    def test_defaults_to_config_ids(self, env):
+        html = self._render(env, selected_theme="default")
+        assert 'id="bootstrapTheme"' in html
+        assert 'id="themePreviewImg"' in html
+        assert 'id="themePreviewName"' in html
+
+
+class TestDashboardEditorPartial:
+
+    def _render(self, env, **kwargs):
+        from routes.collection import DEFAULT_DASHBOARD_ORDER, dashboard_section_meta
+
+        kwargs.setdefault("order", DEFAULT_DASHBOARD_ORDER)
+        kwargs.setdefault("hidden", [])
+        kwargs.setdefault("section_meta", dashboard_section_meta())
+        return env.get_template("partials/dashboard_layout_editor.html").render(**kwargs)
+
+    def test_renders_one_row_per_section(self, env):
+        from routes.collection import DEFAULT_DASHBOARD_ORDER
+
+        html = self._render(env)
+        assert html.count("<li") == len(DEFAULT_DASHBOARD_ORDER)
+        for section_id in DEFAULT_DASHBOARD_ORDER:
+            assert f'data-section-id="{section_id}"' in html
+
+    def test_hidden_sections_are_unchecked(self, env):
+        html = self._render(env, hidden=["library"])
+
+        library_row = html.split('data-section-id="library"')[1].split("</li>")[0]
+        favorites_row = html.split('data-section-id="favorites"')[1].split("</li>")[0]
+
+        assert "checked" not in library_row
+        assert "checked" in favorites_row
+
+    def test_uses_the_settings_label_for_discover(self, env):
+        html = self._render(env)
+        assert "Discover / Recommendations" in html
+        assert "Also requires Recommendations enabled" in html
+
+    def test_respects_the_given_order(self, env):
+        html = self._render(env, order=["library", "favorites"])
+        assert html.index('data-section-id="library"') < html.index('data-section-id="favorites"')
+
+    def test_list_id_is_parameterised(self, env):
+        html = self._render(env, list_id="accountDashboardList")
+        assert 'id="accountDashboardList"' in html
+        assert 'id="dashboardSectionsList"' not in html
+
+
+class TestDashboardSectionMeta:
+
+    def test_covers_every_section(self):
+        from routes.collection import DASHBOARD_SECTION_DEFS, dashboard_section_meta
+
+        meta = dashboard_section_meta()
+        assert set(meta) == set(DASHBOARD_SECTION_DEFS)
+        for entry in meta.values():
+            assert entry["name"]
+            assert entry["icon"]


### PR DESCRIPTION
## Why

Roles landed before per-user preferences did. Two settings that are inherently personal — the Bootswatch theme and the dashboard section layout — were global and editable only by the owner on `/config`:

- `user_preferences` is a flat `key TEXT PRIMARY KEY` store with **no `user_id`**, so every preference is app-wide.
- `/config` is owner-only via `_OWNER_PREFIXES`.

So a reader couldn't choose their own theme, and hiding "Discover" from the dashboard hid it for everybody. Nothing in the UI showed who you were signed in as, either — logout was buried in the gear dropdown.

## What

**Storage.** New `user_settings(user_id, key, value)` table (composite PK, no FK to `users`, matching the other personal-data tables). Resolution:

```
user_settings[user_id][key]  ->  user_preferences[key]  ->  default
     personal override            owner-set site default
```

A missing row *means* "follow the site default", so there is **no data migration** and existing installs are unchanged.

**My Account.** `/account` becomes three tabs — Appearance / Dashboard Layout / API Tokens — deep-linkable via `#appearance` / `#dashboard` / `#tokens`. Each new pane shows a **Custom** vs **Following site default** badge and a **Use site default** button, so the override state is never invisible.

**Site defaults.** `/config`'s Personalization tab keeps the same controls, recaptioned as site defaults and cross-linked to `/account`. Its savers also clear the caller's own override — otherwise an owner who'd picked a personal theme would set the default and see nothing happen.

**Header.** A person-icon dropdown (My Account / API Tokens / Logout) sits left of the gear, gated on `session.user_id`. Single-user installs where nobody logged in look exactly as before — "signed in as owner" would be misleading — and the gear keeps a My Account entry for that case. Logout moves out of the gear into the new menu.

## Notes for review

- **`/api/account/` is load-bearing.** `_READER_WRITE_PREFIXES` matches that literal prefix, so the new endpoints give readers write access with no change to `core/auth.py`. Anything named `/api/settings/*` would silently 403 every reader — this is the known reader-403 bug class, so `test_rbac.py` pins both routes.
- **`app.config["BOOTSTRAP_THEME"]` keeps its meaning** — the *site default*. That's what makes the chain cheap: the middle link needs no query, and only an identified user with an override triggers one indexed PK lookup. `inject_global_vars` memoizes on `g` and falls back through `try/except`, because it runs on every render including error pages.
- **`g._clu_theme` is popped in `_reset_request_identity`** alongside `current_user`. Without it, pytest-flask's shared app context leaks one user's theme into another user's request.
- **`rec_enabled` stays global** — it gates an owner-configured AI service holding a shared API key, not a display preference. A user who just wants Discover gone hides it via `dashboard_hidden`.
- `/config` renders `site_default_dashboard_order()`, not the per-user resolver, so editing the default can't accidentally edit the owner's own override.

## Drive-by fixes in the same files

- Native `confirm()` on token revoke → Bootstrap modal (CLAUDE.md forbids `alert`/`confirm`/`prompt`).
- The theme picker and dashboard editor become two Jinja partials plus `static/js/clu-personalization.js`, instead of ~250 lines of markup and hand-rolled drag-drop JS duplicated across two pages. The `sections_meta` Jinja dict in `config.html` was a third copy of `DASHBOARD_SECTION_DEFS` and is gone.
- Dashboard backfill iterated a *set*, so appended sections landed in nondeterministic order — now follows `DEFAULT_DASHBOARD_ORDER`.
- `quartz` was labelled "(Dark)" in the picker but absent from `DARK_BOOTSWATCH_THEMES`, so it rendered light. Labels are now derived from the set, so they can't drift again.

## Testing

`pytest`: **3126 passed, 6 skipped, 0 failed** (baseline 3059; +67 new in `test_user_settings.py`, `test_account_settings.py`, `test_themes.py`).

Route tests stub `/config`, so `config.html` was additionally rendered end to end against a **real two-user database**: `/config` and `/account` both 200 for the owner; a reader saved a theme, got `bootswatch/darkly` on `/`, and the owner's render was unaffected; reset returned them to the site default. `test_themes.py` covers the shared partials directly, since `/config` isn't reachable from the route-test app.

## Out of scope

`app.py:8223, 8248, 8301, 8324` still read the theme from the deprecated `config.ini` value rather than the DB. Pre-existing and untouched here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
