### PR TITLE
Add DC++ (AirDC++) as a third download source

### DIFF
--- a/app.py
+++ b/app.py
@@ -970,13 +970,12 @@ def scheduled_getcomics_download(dry_run=False):
         download_count = 0
         search_count = 0
 
-        # Usenet source wiring (PR 2). When Usenet is enabled and a client +
-        # indexer are configured, it either precedes GetComics (tried first,
-        # skipping GetComics on a hit) or acts as a fallback when GetComics
-        # finds nothing. Evaluated once per run.
-        from models import usenet as usenet_mod
-        usenet_on = usenet_mod.usenet_enabled_and_configured()
-        usenet_first = usenet_on and usenet_mod.usenet_precedes_getcomics()
+        # External source wiring (Usenet, DC++). Each enabled+configured source
+        # either precedes GetComics (tried first, skipping GetComics on a hit)
+        # or acts as a fallback when GetComics finds nothing, according to the
+        # user's Source Priority. Evaluated once per run.
+        from models.download_sources import split_around_getcomics
+        pre_sources, post_sources = split_around_getcomics()
 
         # Get all mapped series
         mapped_series = get_all_mapped_series()
@@ -1105,10 +1104,11 @@ def scheduled_getcomics_download(dry_run=False):
                     except Exception:
                         pass  # Proactive refresh is best-effort
 
-                    # Usenet first: try indexers before GetComics; on a hit, submit
-                    # to the client and skip GetComics for this issue.
-                    if usenet_on and usenet_first:
-                        u = usenet_mod.try_download_for_issue(
+                    # Higher-priority sources first: try each before GetComics
+                    # and, on a hit, skip GetComics for this issue.
+                    handled_by_pre_source = False
+                    for src_name, src_label, src_try in pre_sources:
+                        u = src_try(
                             series_name, issue_num,
                             issue_year=issue_year,
                             series_volume=series_volume,
@@ -1125,23 +1125,27 @@ def scheduled_getcomics_download(dry_run=False):
                                 "issue_year": issue_year,
                                 "series_volume": series_volume,
                                 "search_context": search_context,
-                                "source": "usenet",
+                                "source": src_name,
                                 "best_accept": u.get("chosen"),
                                 "best_fallback": None,
                                 "all_results": u.get("all_results", []),
                                 "status": "match_found",
                             })
-                            continue
+                            handled_by_pre_source = True
+                            break
                         if not dry_run and u.get("submitted"):
                             download_count += 1
                             app_logger.info(
-                                f"Submitted Usenet download for {series_name} #{issue_num}: "
-                                f"{u['chosen']['filename']} {search_context}"
+                                f"Submitted {src_label} download for {series_name} "
+                                f"#{issue_num}: {u['chosen']['filename']} {search_context}"
                             )
-                            continue
+                            handled_by_pre_source = True
+                            break
+                    if handled_by_pre_source:
+                        continue
 
                     # Track queue count so we can tell whether GetComics queued
-                    # anything for this issue (used by the Usenet fallback below).
+                    # anything for this issue (used by the fallback sources below).
                     gc_count_before = download_count
 
                     results = search_getcomics_for_issue(
@@ -1422,25 +1426,27 @@ def scheduled_getcomics_download(dry_run=False):
                                 "status": "no_match",
                             })
 
-                    # Usenet fallback: GetComics queued nothing for this issue, so
-                    # try the indexers before moving on to the next issue.
-                    if (usenet_on and not usenet_first and not dry_run
-                            and download_count == gc_count_before):
-                        u = usenet_mod.try_download_for_issue(
-                            series_name, issue_num,
-                            issue_year=issue_year,
-                            series_volume=series_volume,
-                            series_year=series_year,
-                            publisher_name=publisher_name,
-                            search_variants=search_variants,
-                            series_aliases=series_aliases,
-                        )
-                        if u.get("submitted"):
-                            download_count += 1
-                            app_logger.info(
-                                f"Submitted Usenet fallback for {series_name} #{issue_num}: "
-                                f"{u['chosen']['filename']} {search_context}"
+                    # Fallback sources: GetComics queued nothing for this issue,
+                    # so try each lower-priority source before moving on.
+                    if not dry_run and download_count == gc_count_before:
+                        for src_name, src_label, src_try in post_sources:
+                            u = src_try(
+                                series_name, issue_num,
+                                issue_year=issue_year,
+                                series_volume=series_volume,
+                                series_year=series_year,
+                                publisher_name=publisher_name,
+                                search_variants=search_variants,
+                                series_aliases=series_aliases,
                             )
+                            if u.get("submitted"):
+                                download_count += 1
+                                app_logger.info(
+                                    f"Submitted {src_label} fallback for {series_name} "
+                                    f"#{issue_num}: {u['chosen']['filename']} "
+                                    f"{search_context}"
+                                )
+                                break
                 except Exception as issue_err:
                     app_logger.error(
                         f"GetComics auto-download: skipping {series_name} "

--- a/core/auth.py
+++ b/core/auth.py
@@ -357,6 +357,7 @@ _CLERK_PREFIXES = (
     "/api/download-clients",
     "/api/indexers",
     "/api/usenet",
+    "/api/dcpp",
     "/api/pull-list",
     "/api/bulk-metadata",
     "/api/source-wall",

--- a/core/database.py
+++ b/core/database.py
@@ -971,12 +971,15 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_library_providers_library ON library_providers(library_id)"
         )
 
-        # Create download_clients table (encrypted Usenet client config).
-        # One row per client type; is_active picks the single live client.
+        # Create download_clients table (encrypted download client config).
+        # One row per client type; is_active picks the live client *within a
+        # client_group* ('usenet' for SABnzbd/NZBGet, 'dcpp' for AirDC++), so a
+        # Usenet client and a DC++ client can be active at the same time.
         c.execute("""
             CREATE TABLE IF NOT EXISTS download_clients (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 client_type TEXT NOT NULL UNIQUE,
+                client_group TEXT NOT NULL DEFAULT 'usenet',
                 config_encrypted BLOB NOT NULL,
                 config_nonce BLOB NOT NULL,
                 is_active INTEGER DEFAULT 0,
@@ -986,6 +989,16 @@ def init_db():
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
+
+        # Migration: pre-DC++ databases have no client_group. The 'usenet'
+        # default backfills the existing SABnzbd/NZBGet rows correctly.
+        c.execute("PRAGMA table_info(download_clients)")
+        dc_columns = [col[1] for col in c.fetchall()]
+        if "client_group" not in dc_columns:
+            c.execute(
+                "ALTER TABLE download_clients "
+                "ADD COLUMN client_group TEXT NOT NULL DEFAULT 'usenet'"
+            )
 
         # Create indexers table (id-keyed, priority-ordered list of indexers).
         c.execute("""
@@ -11649,8 +11662,15 @@ def register_provider_configured(provider_type: str, is_valid: bool = True) -> b
 # =============================================================================
 
 
-def save_download_client_config(client_type: str, config: dict) -> bool:
-    """Save encrypted download-client config (INSERT or UPDATE by client_type)."""
+def save_download_client_config(
+    client_type: str, config: dict, client_group: str = "usenet"
+) -> bool:
+    """Save encrypted download-client config (INSERT or UPDATE by client_type).
+
+    ``client_group`` ('usenet' / 'dcpp') scopes which clients compete for the
+    single active slot; it defaults to 'usenet' so existing callers are
+    unaffected.
+    """
     try:
         from models.providers.crypto import encrypt_credentials, is_crypto_available
 
@@ -11664,14 +11684,16 @@ def save_download_client_config(client_type: str, config: dict) -> bool:
         conn = get_db_connection()
         conn.execute(
             """
-            INSERT INTO download_clients (client_type, config_encrypted, config_nonce, updated_at)
-            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            INSERT INTO download_clients
+                (client_type, client_group, config_encrypted, config_nonce, updated_at)
+            VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
             ON CONFLICT(client_type) DO UPDATE SET
+                client_group = excluded.client_group,
                 config_encrypted = excluded.config_encrypted,
                 config_nonce = excluded.config_nonce,
                 updated_at = CURRENT_TIMESTAMP
         """,
-            (client_type, ciphertext, nonce),
+            (client_type, client_group, ciphertext, nonce),
         )
         conn.commit()
         conn.close()
@@ -11730,7 +11752,7 @@ def get_all_download_clients_status() -> list:
     try:
         conn = get_db_connection()
         rows = conn.execute("""
-            SELECT client_type, is_active, is_valid, last_tested, updated_at
+            SELECT client_type, client_group, is_active, is_valid, last_tested, updated_at
             FROM download_clients
             ORDER BY client_type
         """).fetchall()
@@ -11762,30 +11784,53 @@ def update_download_client_validity(client_type: str, is_valid: bool) -> bool:
 
 
 def set_active_download_client(client_type: str) -> bool:
-    """Mark one client active, clearing is_active on all others (single-active)."""
+    """Mark one client active, clearing is_active on its group-mates only.
+
+    Single-active is scoped to the client's own ``client_group``: activating
+    AirDC++ must not deactivate SABnzbd, because DC++ and Usenet are separate
+    download sources that can both be live.
+    """
     try:
         conn = get_db_connection()
-        conn.execute("UPDATE download_clients SET is_active = 0")
+        row = conn.execute(
+            "SELECT client_group FROM download_clients WHERE client_type = ?",
+            (client_type,),
+        ).fetchone()
+        if not row:
+            conn.close()
+            app_logger.error(
+                f"Cannot activate unconfigured download client: {client_type}"
+            )
+            return False
+        group = row["client_group"] or "usenet"
+        conn.execute(
+            "UPDATE download_clients SET is_active = 0 WHERE client_group = ?",
+            (group,),
+        )
         conn.execute(
             "UPDATE download_clients SET is_active = 1 WHERE client_type = ?",
             (client_type,),
         )
         conn.commit()
         conn.close()
-        app_logger.info(f"Set active download client: {client_type}")
+        app_logger.info(f"Set active {group} download client: {client_type}")
         return True
     except Exception as e:
         app_logger.error(f"Failed to set active download client {client_type}: {e}")
         return False
 
 
-def get_active_download_client() -> Optional[dict]:
-    """Return {client_type, config} for the active client (PR 2 entry point)."""
+def get_active_download_client(client_group: str = "usenet") -> Optional[dict]:
+    """Return {client_type, config} for the active client in a client group."""
     try:
         conn = get_db_connection()
-        row = conn.execute("""
-            SELECT client_type FROM download_clients WHERE is_active = 1 LIMIT 1
-        """).fetchone()
+        row = conn.execute(
+            """
+            SELECT client_type FROM download_clients
+            WHERE is_active = 1 AND client_group = ? LIMIT 1
+        """,
+            (client_group,),
+        ).fetchone()
         conn.close()
         if not row:
             return None

--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -41,6 +41,10 @@ _ACTIVE_POLL_INTERVAL = 5
 # inside the window while still bounding how long CLU holds the pairing.
 _TOKEN_TTL = 900
 
+# A result page this full means the hub truncated the list, so a narrower
+# follow-up search is worth its cost. Mirrors the client's result page size.
+_TRUNCATED_RESULT_COUNT = 250
+
 # In-memory tracking of queued DC++ bundles, keyed by our download_id.
 # Mirrors models.usenet.usenet_downloads so the status page renders both with
 # the same code.
@@ -145,7 +149,6 @@ def search_dcpp_for_issue(
     ``chosen`` ((result, score) or None), ``tier``, ``best_accept``,
     ``best_fallback``, ``all_results`` (scored dicts) and ``errors``.
     """
-    from models.download_sources import build_queries
     from models.getcomics import score_getcomics_result, accept_result
 
     empty = {
@@ -161,12 +164,26 @@ def search_dcpp_for_issue(
     if client is None:
         return {**empty, "errors": ["No active DC++ client"]}
 
-    queries = build_queries(series_name, issue_num)
+    # One search on the series name, not a query per zero-padding variant.
+    #
+    # Usenet can afford `build_queries`' 2-/3-digit variants because a Newznab
+    # call is a fast HTTP request. A hub search is not: AirDC++ paces searches
+    # to respect hub flood limits, so each one costs tens of seconds, and three
+    # per issue would both crawl and hammer the hub. Searching the series alone
+    # returns every issue of it in one go — "83", "083" and "#83" all included
+    # — and the scorer below picks the right one, which is more robust than
+    # guessing the padding anyway.
+    queries = [series_name.strip()]
 
     raw_results = []
     errors = []
     seen = set()
-    for q in queries:
+    tried = set()
+    while queries:
+        q = queries.pop(0)
+        if not q or q in tried:
+            continue
+        tried.add(q)
         try:
             instance_id, results = client.search(q)
         except Exception as e:
@@ -177,6 +194,13 @@ def search_dcpp_for_issue(
             if getattr(client, "last_error", None):
                 errors.append(client.last_error)
             continue
+
+        # A full page means the hub had more to say than it could return. Only
+        # then is a second, narrower search worth its cost — a prolific series
+        # can bury the wanted issue past the page limit.
+        if len(results) >= _TRUNCATED_RESULT_COUNT and str(issue_num or "").isdigit():
+            queries.append(f"{series_name.strip()} {str(int(issue_num)).zfill(3)}")
+
         for r in results:
             # De-dupe on TTH (the content hash) so the same file offered by
             # several users, or matched by several query variants, appears once.
@@ -187,7 +211,7 @@ def search_dcpp_for_issue(
             raw_results.append((instance_id, r))
 
     app_logger.info(
-        f"DC++ search {series_name} #{issue_num}: tried {queries} -> "
+        f"DC++ search {series_name} #{issue_num}: tried {sorted(tried)} -> "
         f"{len(raw_results)} unique result(s)"
         + (f"; errors: {errors}" if errors else "")
     )

--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -36,9 +36,10 @@ _POLL_INTERVAL = 15
 # hammering AirDC++.
 _ACTIVE_POLL_INTERVAL = 5
 
-# How long a manual search result stays grabbable. AirDC++ expires idle search
-# instances on its own; this only bounds how long CLU holds the pairing.
-_TOKEN_TTL = 300
+# How long a manual search result stays grabbable. AirDC++ reports
+# expires_in = 1800000ms (30 min) for a search instance, so this sits well
+# inside the window while still bounding how long CLU holds the pairing.
+_TOKEN_TTL = 900
 
 # In-memory tracking of queued DC++ bundles, keyed by our download_id.
 # Mirrors models.usenet.usenet_downloads so the status page renders both with
@@ -356,6 +357,8 @@ def grab_dcpp(result_token, filename, series=None, issue=None):
             "stage": "Queued",
             "bytes_total": entry.get("size"),
             "bytes_downloaded": None,
+            # Filled in by the poller from the bundle's target path.
+            "target": None,
         }
     app_logger.info(
         f"Queued DC++ download for {filename} (bundle={result.client_id})"
@@ -405,46 +408,58 @@ def _poll_loop():
             continue
         idle_rounds = 0
 
-        statuses = _statuses()
-        for download_id, job in pending.items():
-            status = statuses.get(str(job["client_id"]))
-            if status is None:
-                continue  # not yet visible in the queue
-            if status.status == "complete":
-                imported = _import_completed(status.storage_path, job["filename"])
-                _set_status(download_id, "complete" if imported else "complete_no_move",
-                            percent=100)
-            elif status.status == "failed":
-                _set_status(download_id, "failed", error="Download failed at client")
-            else:
-                _update_progress(download_id, status)
+        try:
+            client = _active_client()
+        except Exception as e:
+            app_logger.error(f"DC++ poll: could not build client: {e}")
+            client = None
+
+        if client is not None:
+            for download_id, job in pending.items():
+                _poll_one(client, download_id, job)
 
         time.sleep(_ACTIVE_POLL_INTERVAL)
 
 
-def _statuses():
-    """Return {client_id: DownloadStatus} for the active DC++ client, or {}.
-
-    Merges the in-progress queue with finished bundles; finished wins so a
-    completed bundle is not masked by a stale queue entry.
-    """
+def _poll_one(client, download_id, job):
+    """Advance a single tracked bundle by one poll."""
     try:
-        client = _active_client()
-        if client is None:
-            return {}
-        merged = {}
-        for q in client.get_queue():
-            merged[q.client_id] = q
-        for h in client.get_history():
-            merged[h.client_id] = h
-        return merged
+        state, status = client.get_bundle_state(job["client_id"])
     except Exception as e:
-        app_logger.error(f"DC++ status fetch failed: {e}")
-        return {}
+        app_logger.error(f"DC++ status fetch failed for {job['filename']}: {e}")
+        return
+
+    if state == "error":
+        return  # transient; try again next round
+
+    if state == "gone":
+        # AirDC++ no longer holds the bundle. With "remove finished bundles"
+        # enabled that is the *only* signal a download completed, so treat it
+        # as done and import from the target we cached while it was running.
+        # A user who cancelled by hand lands here too; the import simply finds
+        # nothing and the job records complete_no_move.
+        imported = _import_completed(job.get("target"), job["filename"])
+        _set_status(download_id, "complete" if imported else "complete_no_move",
+                    percent=100)
+        return
+
+    if status.status == "complete":
+        imported = _import_completed(status.storage_path, job["filename"])
+        _set_status(download_id, "complete" if imported else "complete_no_move",
+                    percent=100)
+    elif status.status == "failed":
+        _set_status(download_id, "failed", error="Download failed at client")
+    else:
+        _update_progress(download_id, status)
 
 
 def _update_progress(download_id, status):
-    """Cache live percent/stage/bytes from a DownloadStatus onto a job."""
+    """Cache live percent/stage/bytes from a DownloadStatus onto a job.
+
+    ``target`` is cached too: once AirDC++ drops a finished bundle from the
+    queue there is nothing left to ask where the file landed, so the last
+    value seen while it was running is what the WATCH import has to use.
+    """
     with _jobs_lock:
         job = dcpp_downloads.get(download_id)
         if job is None:
@@ -453,6 +468,8 @@ def _update_progress(download_id, status):
         job["stage"] = status.stage
         job["bytes_total"] = status.bytes_total
         job["bytes_downloaded"] = status.bytes_downloaded
+        if status.storage_path:
+            job["target"] = status.storage_path
 
 
 def _set_status(download_id, status, error=None, percent=None):

--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -223,8 +223,25 @@ def search_dcpp_for_issue(
 
     for instance_id, r in raw_results:
         title = r.get("name") or ""
+        scored_title, file_volume = _normalize_hub_title(title, series_name)
+
+        # Normalizing drops the vN token, so the scorer can no longer catch a
+        # volume mismatch — do it here instead, before anything else.
+        if (series_volume and file_volume
+                and int(file_volume) != int(series_volume)):
+            scored.append({
+                "title": title,
+                "result_token": _store_token(instance_id, r),
+                "size": r.get("size"),
+                "users": r.get("users"),
+                "tth": r.get("tth"),
+                "score": 0,
+                "decision": "REJECT",
+            })
+            continue
+
         score, is_range, series_match, issue_matched = score_getcomics_result(
-            title, series_name, issue_num, issue_year,
+            scored_title, series_name, issue_num, issue_year,
             accept_variants=search_variants,
             series_volume=series_volume,
             volume_year=series_year,
@@ -268,6 +285,62 @@ def search_dcpp_for_issue(
         "all_results": scored,
         "errors": errors,
     }
+
+
+def _normalize_hub_title(name, series_name):
+    """Reshape a DC++ hub filename into the form the scorer understands.
+
+    Hub back-catalogues are commonly named ``196103 Strange Tales v1 083.cbz``
+    — a ``YYYYMM`` date prefix and a ``vN`` volume token. The shared scorer
+    (``models.getcomics``) expects a scene-style ``Series 083 (1961)``: with
+    the date in front the series no longer starts the title and matching fails
+    outright, and ``v1 083`` defeats issue extraction. Neither shape ever
+    reaches GetComics or Usenet, so the fix lives here rather than in the
+    shared scorer.
+
+    Returns ``(title, volume)`` where ``volume`` is the ``vN`` the filename
+    declared (or None). The caller uses it to reject a wrong volume, since
+    stripping the token removes the scorer's own chance to notice.
+
+    Anything that doesn't match the pattern is returned untouched.
+    """
+    import re
+
+    base = str(name or "").strip()
+    series = str(series_name or "").strip()
+    if not base or not series:
+        return base, None
+
+    # Drop a container extension — the scorer scores a bare title higher.
+    base = re.sub(r"\.(cbz|cbr|cbt|pdf|zip|rar)$", "", base, flags=re.IGNORECASE)
+
+    year = None
+    m = re.match(r"^(\d{2,6})\s+(.*)$", base)
+    # Only strip a leading number when the series name follows it. Otherwise a
+    # series that legitimately opens with digits ("100 Bullets 001") would be
+    # decapitated into "Bullets 001".
+    if m and m.group(2).lower().startswith(series.lower()):
+        prefix, remainder = m.group(1), m.group(2)
+        if len(prefix) == 6 and 1900 <= int(prefix[:4]) <= 2100 \
+                and 1 <= int(prefix[4:]) <= 12:
+            year = prefix[:4]          # YYYYMM cover date
+        elif len(prefix) == 4 and 1900 <= int(prefix) <= 2100:
+            year = prefix              # YYYY
+        # A short run (e.g. "07 ") is a sequence number — drop it, no year.
+        base = remainder
+
+    # "v1 083" -> "083": the volume token sits between series and issue and
+    # stops the issue being read. Captured so the caller can still compare it.
+    volume = None
+    vm = re.search(r"\bv(\d{1,3})\b(?=\s*\d)", base)
+    if vm:
+        volume = int(vm.group(1))
+        base = (base[:vm.start()] + base[vm.end():]).replace("  ", " ").strip()
+
+    if year and not re.search(r"\((?:19|20)\d{2}\)", base):
+        base = f"{base} ({year})"
+
+    return base, volume
 
 
 def _make_filename(series_name, issue_num, chosen, tier) -> str:

--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -1,0 +1,478 @@
+"""
+DC++ download orchestration.
+
+The DC++ counterpart to ``models/usenet.py``: search the user's AirDC++ hubs
+for a wanted issue, score the hits with the existing GetComics scorer, queue
+the winner in AirDC++, and — once the bundle finishes — move the comic
+file(s) into the WATCH folder so the existing monitor pipeline imports them.
+
+Two things differ from Usenet and drive the design here:
+
+* **There are no indexers.** DC++ hubs are configured inside AirDC++ itself,
+  so being "configured" means only that DC++ is an enabled source with an
+  active client — there is no ``indexers`` table involvement.
+* **Results are only addressable while their search instance lives.** AirDC++
+  identifies a hit as ``(instance_id, result_id)``, so a manual search
+  followed by the user clicking Download — two separate HTTP requests to CLU
+  — needs the pairing kept somewhere. :data:`_result_tokens` is that cache:
+  an opaque token per result, expiring after :data:`_TOKEN_TTL`. Unattended
+  auto-download resolves its token in-process immediately and never depends
+  on the TTL.
+
+This module never touches ``api.py``. Completed files are landed in WATCH via
+the movers in ``models/usenet.py`` (protocol-agnostic, and already carrying
+the ``match_parent_permissions`` normalization) and the folder monitor takes
+over from there.
+"""
+import threading
+import time
+import uuid
+
+from core.app_logging import app_logger
+
+# How often the completion poller runs while idle (winding down before exit).
+_POLL_INTERVAL = 15
+# Faster cadence while jobs are active, so cached progress stays fresh without
+# hammering AirDC++.
+_ACTIVE_POLL_INTERVAL = 5
+
+# How long a manual search result stays grabbable. AirDC++ expires idle search
+# instances on its own; this only bounds how long CLU holds the pairing.
+_TOKEN_TTL = 300
+
+# In-memory tracking of queued DC++ bundles, keyed by our download_id.
+# Mirrors models.usenet.usenet_downloads so the status page renders both with
+# the same code.
+dcpp_downloads: dict = {}
+_jobs_lock = threading.Lock()
+_poller_thread = None
+_poller_lock = threading.Lock()
+
+# token -> {instance_id, result_id, name, size, expires}
+_result_tokens: dict = {}
+_tokens_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def dcpp_enabled_and_configured() -> bool:
+    """True if DC++ is an enabled source AND a DC++ client is active.
+
+    Deliberately does not check indexers — DC++ hubs live inside AirDC++.
+    """
+    from models.download_sources import source_enabled
+
+    if not source_enabled("dcpp"):
+        return False
+    try:
+        from core.database import get_active_download_client
+
+        return bool(get_active_download_client(client_group="dcpp"))
+    except Exception:
+        return False
+
+
+def _active_client():
+    """Return the active DC++ client instance, or None."""
+    from core.database import get_active_download_client
+    from models.download_clients import (
+        DownloadClientConfig,
+        get_download_client_by_name,
+    )
+
+    active = get_active_download_client(client_group="dcpp")
+    if not active:
+        return None
+    return get_download_client_by_name(
+        active["client_type"], DownloadClientConfig.from_dict(active["config"] or {})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search-result token cache
+# ---------------------------------------------------------------------------
+
+def _prune_tokens(now=None):
+    """Drop expired tokens so the cache cannot grow without bound."""
+    now = now if now is not None else time.time()
+    with _tokens_lock:
+        for token in [t for t, v in _result_tokens.items() if v["expires"] <= now]:
+            del _result_tokens[token]
+
+
+def _store_token(instance_id, result) -> str:
+    """Cache one (instance, result) pairing and return its opaque token."""
+    token = str(uuid.uuid4())
+    with _tokens_lock:
+        _result_tokens[token] = {
+            "instance_id": instance_id,
+            "result_id": result["result_id"],
+            "name": result.get("name"),
+            "size": result.get("size"),
+            "expires": time.time() + _TOKEN_TTL,
+        }
+    return token
+
+
+def _resolve_token(token):
+    """Return the cached pairing for a token, or None if unknown/expired."""
+    _prune_tokens()
+    with _tokens_lock:
+        entry = _result_tokens.get(token)
+        return dict(entry) if entry else None
+
+
+# ---------------------------------------------------------------------------
+# Search + scoring
+# ---------------------------------------------------------------------------
+
+def search_dcpp_for_issue(
+    series_name,
+    issue_num,
+    issue_year=None,
+    series_volume=None,
+    series_year=None,
+    publisher_name=None,
+    search_variants=None,
+    series_aliases=None,
+):
+    """Search the active client's hubs for an issue and score the results.
+
+    Returns the same shape as ``models.usenet.search_usenet_for_issue``:
+    ``chosen`` ((result, score) or None), ``tier``, ``best_accept``,
+    ``best_fallback``, ``all_results`` (scored dicts) and ``errors``.
+    """
+    from models.download_sources import build_queries
+    from models.getcomics import score_getcomics_result, accept_result
+
+    empty = {
+        "chosen": None, "tier": None, "best_accept": None,
+        "best_fallback": None, "all_results": [], "errors": [],
+    }
+
+    try:
+        client = _active_client()
+    except Exception as e:
+        app_logger.error(f"DC++ search: could not build client: {e}")
+        return {**empty, "errors": [str(e)]}
+    if client is None:
+        return {**empty, "errors": ["No active DC++ client"]}
+
+    queries = build_queries(series_name, issue_num)
+
+    raw_results = []
+    errors = []
+    seen = set()
+    for q in queries:
+        try:
+            instance_id, results = client.search(q)
+        except Exception as e:
+            app_logger.error(f"DC++ search failed for '{q}': {e}")
+            errors.append(str(e))
+            continue
+        if not instance_id:
+            if getattr(client, "last_error", None):
+                errors.append(client.last_error)
+            continue
+        for r in results:
+            # De-dupe on TTH (the content hash) so the same file offered by
+            # several users, or matched by several query variants, appears once.
+            key = r.get("tth") or f"{instance_id}:{r['result_id']}"
+            if key in seen:
+                continue
+            seen.add(key)
+            raw_results.append((instance_id, r))
+
+    app_logger.info(
+        f"DC++ search {series_name} #{issue_num}: tried {queries} -> "
+        f"{len(raw_results)} unique result(s)"
+        + (f"; errors: {errors}" if errors else "")
+    )
+
+    best_accept = None
+    best_fallback = None
+    single_found = False
+    scored = []
+
+    for instance_id, r in raw_results:
+        title = r.get("name") or ""
+        score, is_range, series_match, issue_matched = score_getcomics_result(
+            title, series_name, issue_num, issue_year,
+            accept_variants=search_variants,
+            series_volume=series_volume,
+            volume_year=series_year,
+            publisher_name=publisher_name,
+            series_aliases=series_aliases,
+            return_issue_matched=True,
+        )
+        decision = accept_result(
+            score, is_range, series_match, single_issue_found=single_found
+        )
+        # Same guard as Usenet: DC++ filenames rarely carry a '#' issue marker,
+        # so a wrong single issue can clear the threshold on series+year alone.
+        # Only auto-accept when the target issue was positively confirmed.
+        if decision == "ACCEPT" and not issue_matched:
+            decision = "REJECT"
+
+        token = _store_token(instance_id, r)
+        entry = {
+            "title": title,
+            "result_token": token,
+            "size": r.get("size"),
+            "users": r.get("users"),
+            "tth": r.get("tth"),
+            "score": score,
+            "decision": decision,
+        }
+        scored.append(entry)
+        if decision == "ACCEPT":
+            if best_accept is None or score > best_accept[1]:
+                best_accept = (entry, score)
+            single_found = True
+        elif decision == "FALLBACK" and best_fallback is None:
+            best_fallback = (entry, score)
+
+    chosen = best_accept or best_fallback
+    return {
+        "chosen": chosen,
+        "tier": "direct match" if best_accept else ("range fallback" if best_fallback else None),
+        "best_accept": best_accept,
+        "best_fallback": best_fallback,
+        "all_results": scored,
+        "errors": errors,
+    }
+
+
+def _make_filename(series_name, issue_num, chosen, tier) -> str:
+    """Build the destination filename (range packs keep the release title)."""
+    if tier == "range fallback":
+        raw = chosen.get("title") or f"{series_name} {issue_num}"
+    else:
+        raw = f"{series_name} {issue_num}"
+    return raw.replace("/", "-").replace("\\", "-").replace("#", "").strip() + ".cbz"
+
+
+def try_download_for_issue(
+    series_name,
+    issue_num,
+    *,
+    issue_year=None,
+    series_volume=None,
+    series_year=None,
+    publisher_name=None,
+    search_variants=None,
+    series_aliases=None,
+    dry_run=False,
+):
+    """Search DC++ for an issue and (unless dry_run) queue the best match.
+
+    Signature and return contract match
+    ``models.usenet.try_download_for_issue`` so the auto-download loop can
+    treat every non-GetComics source uniformly.
+    """
+    res = search_dcpp_for_issue(
+        series_name, issue_num,
+        issue_year=issue_year,
+        series_volume=series_volume,
+        series_year=series_year,
+        publisher_name=publisher_name,
+        search_variants=search_variants,
+        series_aliases=series_aliases,
+    )
+    out = {
+        "source": "dcpp",
+        "chosen": None,
+        "submitted": False,
+        "download_id": None,
+        "all_results": res["all_results"],
+        "status": "no_results" if not res["all_results"] else "no_match",
+    }
+    chosen = res["chosen"]
+    if not chosen:
+        return out
+
+    entry, score = chosen
+    filename = _make_filename(series_name, issue_num, entry, res["tier"])
+    out["chosen"] = {
+        "title": entry["title"],
+        "result_token": entry["result_token"],
+        "size": entry.get("size"),
+        "score": score,
+        "tier": res["tier"],
+        "filename": filename,
+    }
+    out["status"] = "match_found"
+    if dry_run:
+        return out
+
+    download_id = grab_dcpp(
+        entry["result_token"], filename, series=series_name, issue=issue_num
+    )
+    out["submitted"] = bool(download_id)
+    out["download_id"] = download_id
+    out["status"] = "submitted" if download_id else "submit_failed"
+    return out
+
+
+def grab_dcpp(result_token, filename, series=None, issue=None):
+    """Queue a previously-searched DC++ result and start tracking it.
+
+    Returns the tracking ``download_id`` on success, or None on failure.
+    """
+    entry = _resolve_token(result_token)
+    if not entry:
+        app_logger.warning(
+            "DC++ grab: search result expired — re-run the search and try again"
+        )
+        return None
+
+    try:
+        client = _active_client()
+    except Exception as e:
+        app_logger.error(f"DC++ grab: could not build client: {e}")
+        return None
+    if client is None:
+        app_logger.warning("DC++ grab requested but no active DC++ client")
+        return None
+
+    result = client.download_result(entry["instance_id"], entry["result_id"])
+    if not result.success:
+        app_logger.error(f"DC++ grab failed: {result.error}")
+        return None
+
+    download_id = str(uuid.uuid4())
+    with _jobs_lock:
+        dcpp_downloads[download_id] = {
+            "client_type": client.client_type.value,
+            "client_id": result.client_id,
+            "filename": filename,
+            "status": "downloading",
+            "error": None,
+            "series": series,
+            "issue": issue,
+            "percent": 0,
+            "stage": "Queued",
+            "bytes_total": entry.get("size"),
+            "bytes_downloaded": None,
+        }
+    app_logger.info(
+        f"Queued DC++ download for {filename} (bundle={result.client_id})"
+    )
+    _ensure_poller()
+    return download_id
+
+
+def get_dcpp_downloads() -> list:
+    """Return a snapshot of tracked DC++ downloads (for status display)."""
+    with _jobs_lock:
+        return [dict(download_id=k, **v) for k, v in dcpp_downloads.items()]
+
+
+# ---------------------------------------------------------------------------
+# Completion polling
+# ---------------------------------------------------------------------------
+
+def _ensure_poller():
+    """Start the completion poller thread if it isn't already running."""
+    global _poller_thread
+    with _poller_lock:
+        if _poller_thread is not None and _poller_thread.is_alive():
+            return
+        _poller_thread = threading.Thread(
+            target=_poll_loop, name="dcpp-poller", daemon=True
+        )
+        _poller_thread.start()
+
+
+def _pending_jobs():
+    with _jobs_lock:
+        return {k: dict(v) for k, v in dcpp_downloads.items()
+                if v["status"] == "downloading"}
+
+
+def _poll_loop():
+    """Poll AirDC++ until all tracked bundles reach a terminal state."""
+    idle_rounds = 0
+    while True:
+        pending = _pending_jobs()
+        if not pending:
+            idle_rounds += 1
+            if idle_rounds >= 2:
+                return
+            time.sleep(_POLL_INTERVAL)
+            continue
+        idle_rounds = 0
+
+        statuses = _statuses()
+        for download_id, job in pending.items():
+            status = statuses.get(str(job["client_id"]))
+            if status is None:
+                continue  # not yet visible in the queue
+            if status.status == "complete":
+                imported = _import_completed(status.storage_path, job["filename"])
+                _set_status(download_id, "complete" if imported else "complete_no_move",
+                            percent=100)
+            elif status.status == "failed":
+                _set_status(download_id, "failed", error="Download failed at client")
+            else:
+                _update_progress(download_id, status)
+
+        time.sleep(_ACTIVE_POLL_INTERVAL)
+
+
+def _statuses():
+    """Return {client_id: DownloadStatus} for the active DC++ client, or {}.
+
+    Merges the in-progress queue with finished bundles; finished wins so a
+    completed bundle is not masked by a stale queue entry.
+    """
+    try:
+        client = _active_client()
+        if client is None:
+            return {}
+        merged = {}
+        for q in client.get_queue():
+            merged[q.client_id] = q
+        for h in client.get_history():
+            merged[h.client_id] = h
+        return merged
+    except Exception as e:
+        app_logger.error(f"DC++ status fetch failed: {e}")
+        return {}
+
+
+def _update_progress(download_id, status):
+    """Cache live percent/stage/bytes from a DownloadStatus onto a job."""
+    with _jobs_lock:
+        job = dcpp_downloads.get(download_id)
+        if job is None:
+            return
+        job["percent"] = status.percent
+        job["stage"] = status.stage
+        job["bytes_total"] = status.bytes_total
+        job["bytes_downloaded"] = status.bytes_downloaded
+
+
+def _set_status(download_id, status, error=None, percent=None):
+    with _jobs_lock:
+        job = dcpp_downloads.get(download_id)
+        if job is not None:
+            job["status"] = status
+            job["error"] = error
+            if percent is not None:
+                job["percent"] = percent
+
+
+def _import_completed(storage_path, filename) -> bool:
+    """Move completed comic file(s) into WATCH.
+
+    Delegates to the Usenet mover — landing a finished file in WATCH is
+    protocol-agnostic, and that implementation already normalizes permissions
+    via ``match_parent_permissions``. Keeping one copy means DC++ and Usenet
+    can never drift on how files enter the pipeline.
+    """
+    from models.usenet import _import_completed as _shared_import
+
+    return _shared_import(storage_path, filename, source="DC++")

--- a/models/download_clients/__init__.py
+++ b/models/download_clients/__init__.py
@@ -74,9 +74,19 @@ def get_available_download_clients() -> List[Dict]:
             "name": c.display_name,
             "config_fields": c.config_fields,
             "requires_auth": c.requires_auth,
+            "client_group": c.client_group,
         }
         for c in _DOWNLOAD_CLIENT_REGISTRY.values()
     ]
+
+
+def get_client_group(name: str) -> str:
+    """Return the client_group for a client type name ('usenet' if unknown)."""
+    try:
+        client_class = _DOWNLOAD_CLIENT_REGISTRY.get(ClientType(name.lower()))
+    except ValueError:
+        return "usenet"
+    return getattr(client_class, "client_group", "usenet") if client_class else "usenet"
 
 
 def get_download_client_class(
@@ -94,6 +104,7 @@ def is_download_client_registered(client_type: ClientType) -> bool:
 # Import client implementations to register them (triggers @register_download_client)
 from .sabnzbd_client import SABnzbdClient
 from .nzbget_client import NZBGetClient
+from .airdcpp_client import AirDCPPClient
 
 
 __all__ = [
@@ -108,9 +119,11 @@ __all__ = [
     "get_download_client",
     "get_download_client_by_name",
     "get_available_download_clients",
+    "get_client_group",
     "get_download_client_class",
     "is_download_client_registered",
     # Client implementations
     "SABnzbdClient",
     "NZBGetClient",
+    "AirDCPPClient",
 ]

--- a/models/download_clients/airdcpp_client.py
+++ b/models/download_clients/airdcpp_client.py
@@ -136,10 +136,14 @@ class AirDCPPClient(BaseDownloadClient):
         cfg = self.config
         return (cfg.username or "", cfg.password or "") if cfg else ("", "")
 
-    def _request(self, method: str, path: str, **kwargs):
+    def _request(self, method: str, path: str, allow_missing: bool = False, **kwargs):
         """Issue an authenticated request; return the Response or None.
 
         Sets ``self.last_error`` on failure so callers can surface a reason.
+        With ``allow_missing``, a 404 is returned to the caller instead of
+        being treated as an error — AirDC++ answers a poll for a bundle it no
+        longer holds with ``404 {"message": "Bundle <id> was not found"}``,
+        which is meaningful rather than broken.
         """
         import requests
 
@@ -167,6 +171,8 @@ class AirDCPPClient(BaseDownloadClient):
         if resp.status_code == 401:
             self.last_error = "Authentication failed — check the username/password"
             return None
+        if resp.status_code == 404 and allow_missing:
+            return resp
         if resp.status_code >= 400:
             self.last_error = f"HTTP {resp.status_code} from {url}"
             return None
@@ -229,6 +235,7 @@ class AirDCPPClient(BaseDownloadClient):
         """
         self.last_error = None
 
+        # The instance id comes back as a number (e.g. 5); the URLs need a str.
         created = self._json(self._request("POST", "/search"))
         if not isinstance(created, dict) or created.get("id") in (None, ""):
             self.last_error = self.last_error or "AirDC++ did not return a search instance"
@@ -340,14 +347,16 @@ class AirDCPPClient(BaseDownloadClient):
 
     @staticmethod
     def _bundle_to_status(b: dict) -> DownloadStatus:
-        """Map one AirDC++ bundle to a unified DownloadStatus."""
+        """Map one AirDC++ bundle to a unified DownloadStatus.
+
+        ``size`` and ``downloaded_bytes`` come back as floats (27964355.0),
+        and ``id`` as an int, so both are coerced. Note ``status.downloaded``
+        is a *boolean* flag, not a byte count — it must never be used as a
+        progress fallback.
+        """
         status = b.get("status") or {}
         total = _to_int(b.get("size"))
-        # downloaded_bytes lives at the top level; older builds nest it under
-        # status.downloaded.
         downloaded = _to_int(b.get("downloaded_bytes"))
-        if downloaded is None:
-            downloaded = _to_int(status.get("downloaded"))
 
         return DownloadStatus(
             client_id=str(b.get("id") or ""),
@@ -374,10 +383,11 @@ class AirDCPPClient(BaseDownloadClient):
             return []
 
     def get_history(self) -> List[DownloadStatus]:
-        """Return finished (completed or failed) bundles.
+        """Return finished (completed or failed) bundles still in the queue.
 
-        AirDC++ keeps finished bundles in the same queue listing until they are
-        removed, so both views come from one call, split on the status flags.
+        AirDC++ can be configured to drop finished bundles from the queue, in
+        which case this is legitimately empty. Completion is therefore tracked
+        per bundle via :meth:`get_bundle_state`, not by diffing this list.
         """
         try:
             return [
@@ -390,12 +400,37 @@ class AirDCPPClient(BaseDownloadClient):
             app_logger.error(f"AirDC++ get_history failed: {e}")
             return []
 
+    def get_bundle_state(self, client_id: str):
+        """Poll one bundle by id. Returns ``(state, DownloadStatus | None)``.
+
+        ``state`` is one of:
+
+        ``"found"``  the bundle exists; the status carries live progress.
+        ``"gone"``   AirDC++ 404s for it. Either it finished and was removed
+                     from the queue (AirDC++ can be set to do that, and then
+                     a completed bundle is never observable any other way) or
+                     the user removed it by hand. The caller decides.
+        ``"error"``  the client was unreachable — say nothing, try later.
+
+        Polling by id rather than scanning the queue listing matters: a real
+        queue can be longer than one page, and a paged scan would lose sight
+        of a tracked bundle sitting past the end of it.
+        """
+        resp = self._request("GET", f"/queue/bundles/{client_id}", allow_missing=True)
+        if resp is None:
+            return "error", None
+        if resp.status_code == 404:
+            return "gone", None
+        data = self._json(resp)
+        if not isinstance(data, dict):
+            return "error", None
+        return "found", self._bundle_to_status(data)
+
     def get_status(self, client_id: str) -> Optional[DownloadStatus]:
-        """Return the status of a single bundle by id."""
+        """Return the status of a single bundle by id, or None if absent."""
         try:
-            for b in self._bundles():
-                if isinstance(b, dict) and str(b.get("id") or "") == str(client_id):
-                    return self._bundle_to_status(b)
+            state, status = self.get_bundle_state(client_id)
+            return status if state == "found" else None
         except Exception as e:
             app_logger.error(f"AirDC++ get_status failed: {e}")
-        return None
+            return None

--- a/models/download_clients/airdcpp_client.py
+++ b/models/download_clients/airdcpp_client.py
@@ -1,0 +1,401 @@
+"""
+AirDC++ Download Client Adapter (DC++ / Direct Connect).
+
+Talks to an AirDC++ Web Client over its JSON REST API (``/api/v1``) using
+HTTP Basic auth. DC++ itself has no remote API; AirDC++ Web Client is the
+headless client that exposes one, so it is what CLU connects to — the same
+way it connects to SABnzbd/NZBGet for Usenet.
+
+Searching is a three-step asynchronous flow, unlike the Usenet clients:
+
+    POST /search                          -> create a search instance
+    POST /search/{id}/hub_search          -> run the query on the hubs
+    GET  /search/{id}/results/{start}/{n} -> collect what the hubs returned
+
+Results are only addressable as ``(instance_id, result_id)``, so queueing a
+result means posting back to the same instance:
+
+    POST /search/{id}/results/{result_id}/download
+
+Progress for queued items comes from ``GET /queue/bundles/{start}/{n}``.
+
+API reference: https://airdcpp.docs.apiary.io/
+
+Field names below follow the published API docs. Every read is defensive
+(``.get`` with fallbacks) so an AirDC++ version that renames or drops a
+field degrades to "no progress shown" rather than raising inside the poller.
+"""
+import time
+from typing import List, Optional, Tuple
+
+from core.app_logging import app_logger
+from .base import BaseDownloadClient, ClientType, DownloadStatus, NZBSubmitResult
+from . import register_download_client
+
+# Short timeout so a wrong host/port fails fast instead of hanging the UI.
+_TIMEOUT = 10
+
+# Hubs answer a search asynchronously. Poll the result list until it stops
+# growing (or the budget runs out) rather than sleeping a flat interval, so a
+# fast hub returns quickly and a slow one still gets a chance.
+_SEARCH_WAIT_TOTAL = 8.0
+_SEARCH_POLL_INTERVAL = 1.0
+
+# How many results/bundles to pull per listing call.
+_PAGE_SIZE = 100
+
+# Restrict hub searches to comic files. DC++ shares hold these directly, and
+# without the filter a bare series name returns mostly unrelated media. This
+# also means directory (whole-run) hits are not returned — CLU wants single
+# issues, and a directory download on DC++ is rarely what the user intended.
+_COMIC_EXTENSIONS = ["cbz", "cbr", "cbt", "pdf"]
+
+
+def _normalize_airdcpp_status(status: dict) -> str:
+    """Map an AirDC++ bundle status object to complete/failed/downloading.
+
+    The boolean flags are authoritative; the ``id`` string is only consulted
+    when they are absent.
+    """
+    status = status or {}
+    if status.get("failed"):
+        return "failed"
+    if status.get("completed"):
+        return "complete"
+
+    sid = str(status.get("id") or "").lower()
+    if sid in ("download_failed", "failed", "validation_error", "shared_failed"):
+        return "failed"
+    if sid in ("completed", "finished", "shared", "downloaded"):
+        return "complete"
+    return "downloading"
+
+
+def _to_int(val) -> Optional[int]:
+    """Parse a value to int, or None if not numeric."""
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _percent(downloaded, total) -> Optional[float]:
+    """Percentage complete from byte counts, or None when unknown."""
+    d, t = _to_int(downloaded), _to_int(total)
+    if d is None or not t:
+        return None
+    return max(0.0, min(100.0, (d / t) * 100.0))
+
+
+def _result_type(raw) -> str:
+    """Extract a result's type, which may be a string or a {id: ...} object."""
+    if isinstance(raw, dict):
+        return str(raw.get("id") or raw.get("str") or "")
+    return str(raw or "")
+
+
+def _user_count(raw) -> Optional[int]:
+    """Extract the number of users sharing a result.
+
+    AirDC++ reports this as a plain count on some versions and as a
+    ``{"user": ..., "count": N}`` object on others.
+    """
+    if isinstance(raw, dict):
+        return _to_int(raw.get("count"))
+    return _to_int(raw)
+
+
+@register_download_client
+class AirDCPPClient(BaseDownloadClient):
+    """AirDC++ Web Client adapter using the /api/v1 REST API."""
+
+    client_type = ClientType.AIRDCPP
+    display_name = "AirDC++"
+    requires_auth = True
+    client_group = "dcpp"
+    config_fields = [
+        "host",
+        "port",
+        "username",
+        "password",
+        "use_ssl",
+        "url_base",
+        "target_directory",
+        "hub_urls",
+    ]
+
+    # ------------------------------------------------------------------
+    # Request plumbing
+    # ------------------------------------------------------------------
+
+    def _api_url(self, path: str) -> str:
+        """Build a full ``/api/v1`` URL for a path like ``/hubs``."""
+        return f"{self._base_url()}/api/v1{path}"
+
+    def _auth(self):
+        cfg = self.config
+        return (cfg.username or "", cfg.password or "") if cfg else ("", "")
+
+    def _request(self, method: str, path: str, **kwargs):
+        """Issue an authenticated request; return the Response or None.
+
+        Sets ``self.last_error`` on failure so callers can surface a reason.
+        """
+        import requests
+
+        url = self._api_url(path)
+        try:
+            resp = requests.request(
+                method, url, auth=self._auth(), timeout=kwargs.pop("timeout", _TIMEOUT),
+                **kwargs
+            )
+        except requests.exceptions.ConnectionError:
+            self.last_error = (
+                f"Could not connect to {url} — check the host/port are reachable "
+                f"from the CLU container (localhost inside Docker is the container "
+                f"itself, not your homeserver)"
+            )
+            return None
+        except requests.exceptions.Timeout:
+            self.last_error = f"Timed out connecting to {url}"
+            return None
+        except Exception as e:
+            self.last_error = str(e)
+            app_logger.error(f"AirDC++ request to {url} failed: {e}")
+            return None
+
+        if resp.status_code == 401:
+            self.last_error = "Authentication failed — check the username/password"
+            return None
+        if resp.status_code >= 400:
+            self.last_error = f"HTTP {resp.status_code} from {url}"
+            return None
+        return resp
+
+    @staticmethod
+    def _json(resp):
+        """Parse a JSON body, returning None when the body is not JSON."""
+        if resp is None:
+            return None
+        if not resp.content:
+            return {}
+        try:
+            return resp.json()
+        except ValueError:
+            return None
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    def test_connection(self) -> bool:
+        """Verify the AirDC++ Web Client is reachable and credentials work.
+
+        Queries ``/hubs``, which requires a valid session and returns a list
+        (possibly empty, if the user has no hubs connected yet).
+        """
+        self.last_error = None
+        cfg = self.config
+        if not cfg or not cfg.username or not cfg.password:
+            self.last_error = "Username and password are required"
+            return False
+
+        resp = self._request("GET", "/hubs")
+        if resp is None:
+            return False
+
+        data = self._json(resp)
+        if data is None:
+            self.last_error = (
+                f"Non-JSON response from {self._api_url('/hubs')} — is this an "
+                f"AirDC++ Web Client?"
+            )
+            return False
+        if not isinstance(data, list):
+            self.last_error = f"Unexpected response from {self._api_url('/hubs')}"
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(self, pattern: str, hub_urls: Optional[list] = None) -> Tuple[Optional[str], list]:
+        """Run a hub search and return ``(instance_id, results)``.
+
+        ``instance_id`` is needed to queue any of the returned results, so the
+        caller must keep it for as long as the results are actionable. Returns
+        ``(None, [])`` on failure with ``last_error`` set.
+        """
+        self.last_error = None
+
+        created = self._json(self._request("POST", "/search"))
+        if not isinstance(created, dict) or created.get("id") in (None, ""):
+            self.last_error = self.last_error or "AirDC++ did not return a search instance"
+            return None, []
+        instance_id = str(created["id"])
+
+        query = {
+            "pattern": pattern,
+            "extensions": _COMIC_EXTENSIONS,
+            "file_type": "file",
+        }
+        body = {"query": query}
+        hubs = hub_urls if hub_urls is not None else self._configured_hub_urls()
+        if hubs:
+            body["hub_urls"] = hubs
+
+        if self._request("POST", f"/search/{instance_id}/hub_search", json=body) is None:
+            return instance_id, []
+
+        return instance_id, self._collect_results(instance_id)
+
+    def _configured_hub_urls(self) -> list:
+        """Parse the optional comma-separated hub filter from config."""
+        cfg = self.config
+        raw = (cfg.hub_urls if cfg else None) or ""
+        return [h.strip() for h in str(raw).split(",") if h.strip()]
+
+    def _collect_results(self, instance_id: str) -> list:
+        """Poll the instance until the result count stops growing."""
+        deadline = time.monotonic() + _SEARCH_WAIT_TOTAL
+        results: list = []
+        while True:
+            time.sleep(_SEARCH_POLL_INTERVAL)
+            found = self._json(
+                self._request("GET", f"/search/{instance_id}/results/0/{_PAGE_SIZE}")
+            )
+            if isinstance(found, list):
+                # Hubs answer at different speeds; keep the largest set seen.
+                if len(found) > len(results):
+                    results = found
+                elif results:
+                    break  # stopped growing — the hubs are done answering
+            if time.monotonic() >= deadline:
+                break
+        return [self._parse_result(r) for r in results if isinstance(r, dict)]
+
+    @staticmethod
+    def _parse_result(raw: dict) -> dict:
+        """Normalize one AirDC++ search result into a plain dict."""
+        return {
+            "result_id": str(raw.get("id") or ""),
+            "name": raw.get("name") or "",
+            "size": _to_int(raw.get("size")),
+            "tth": raw.get("tth"),
+            "type": _result_type(raw.get("type")),
+            "users": _user_count(raw.get("users")),
+            "relevance": raw.get("relevance"),
+            "path": raw.get("path"),
+        }
+
+    def download_result(
+        self,
+        instance_id: str,
+        result_id: str,
+        target_directory: Optional[str] = None,
+        priority: Optional[str] = None,
+    ) -> NZBSubmitResult:
+        """Queue a search result for download; returns the bundle id.
+
+        Reuses ``NZBSubmitResult`` — it is protocol-neutral despite the name,
+        carrying only ``client_id`` / ``success`` / ``error``.
+        """
+        self.last_error = None
+        target = target_directory or (self.config.target_directory if self.config else None)
+
+        body = {}
+        if target:
+            body["target_directory"] = target
+        if priority:
+            body["priority"] = priority
+
+        resp = self._request(
+            "POST", f"/search/{instance_id}/results/{result_id}/download", json=body
+        )
+        if resp is None:
+            return NZBSubmitResult(success=False, error=self.last_error)
+
+        data = self._json(resp)
+        if not isinstance(data, dict):
+            # A 2xx with an unparseable body means it was queued but we cannot
+            # track it; report failure rather than inventing a bundle id.
+            self.last_error = "AirDC++ accepted the download but returned no bundle id"
+            return NZBSubmitResult(success=False, error=self.last_error)
+
+        bundle_id = data.get("id") or data.get("bundle_id")
+        if bundle_id in (None, ""):
+            self.last_error = "AirDC++ accepted the download but returned no bundle id"
+            return NZBSubmitResult(success=False, error=self.last_error)
+        return NZBSubmitResult(client_id=str(bundle_id), success=True)
+
+    # ------------------------------------------------------------------
+    # Queue / progress
+    # ------------------------------------------------------------------
+
+    def _bundles(self) -> list:
+        """Return the raw bundle list from the queue, or []."""
+        data = self._json(self._request("GET", f"/queue/bundles/0/{_PAGE_SIZE}"))
+        return data if isinstance(data, list) else []
+
+    @staticmethod
+    def _bundle_to_status(b: dict) -> DownloadStatus:
+        """Map one AirDC++ bundle to a unified DownloadStatus."""
+        status = b.get("status") or {}
+        total = _to_int(b.get("size"))
+        # downloaded_bytes lives at the top level; older builds nest it under
+        # status.downloaded.
+        downloaded = _to_int(b.get("downloaded_bytes"))
+        if downloaded is None:
+            downloaded = _to_int(status.get("downloaded"))
+
+        return DownloadStatus(
+            client_id=str(b.get("id") or ""),
+            name=b.get("name"),
+            status=_normalize_airdcpp_status(status),
+            percent=_percent(downloaded, total),
+            storage_path=b.get("target") or None,
+            stage=status.get("str") or None,
+            bytes_total=total,
+            bytes_downloaded=downloaded,
+        )
+
+    def get_queue(self) -> List[DownloadStatus]:
+        """Return bundles still in progress, with live percent/stage/bytes."""
+        try:
+            return [
+                self._bundle_to_status(b)
+                for b in self._bundles()
+                if isinstance(b, dict)
+                and _normalize_airdcpp_status(b.get("status") or {}) == "downloading"
+            ]
+        except Exception as e:
+            app_logger.error(f"AirDC++ get_queue failed: {e}")
+            return []
+
+    def get_history(self) -> List[DownloadStatus]:
+        """Return finished (completed or failed) bundles.
+
+        AirDC++ keeps finished bundles in the same queue listing until they are
+        removed, so both views come from one call, split on the status flags.
+        """
+        try:
+            return [
+                self._bundle_to_status(b)
+                for b in self._bundles()
+                if isinstance(b, dict)
+                and _normalize_airdcpp_status(b.get("status") or {}) != "downloading"
+            ]
+        except Exception as e:
+            app_logger.error(f"AirDC++ get_history failed: {e}")
+            return []
+
+    def get_status(self, client_id: str) -> Optional[DownloadStatus]:
+        """Return the status of a single bundle by id."""
+        try:
+            for b in self._bundles():
+                if isinstance(b, dict) and str(b.get("id") or "") == str(client_id):
+                    return self._bundle_to_status(b)
+        except Exception as e:
+            app_logger.error(f"AirDC++ get_status failed: {e}")
+        return None

--- a/models/download_clients/airdcpp_client.py
+++ b/models/download_clients/airdcpp_client.py
@@ -35,14 +35,26 @@ from . import register_download_client
 # Short timeout so a wrong host/port fails fast instead of hanging the UI.
 _TIMEOUT = 10
 
-# Hubs answer a search asynchronously. Poll the result list until it stops
-# growing (or the budget runs out) rather than sleeping a flat interval, so a
-# fast hub returns quickly and a slow one still gets a chance.
-_SEARCH_WAIT_TOTAL = 8.0
-_SEARCH_POLL_INTERVAL = 1.0
+# A hub search is slow in a way a Newznab query is not. AirDC++ *queues*
+# searches and paces them out to each hub to respect hub flood limits, then
+# results trickle back over several more seconds. Measured against a live
+# instance on a 2-hub setup: queue_time ~17s before the search was even sent,
+# first results at ~t+20s, settling at ~t+30s.
+#
+# So the wait is driven by the instance's own metadata (queued_count reaching
+# zero, then result_count going quiet) rather than a flat sleep, with a hard
+# cap. An 8s budget — the previous value — routinely expired before the hub
+# had been sent the query at all, and returned nothing.
+_SEARCH_WAIT_TOTAL = 45.0
+_SEARCH_POLL_INTERVAL = 2.0
+# Consecutive unchanged polls (after dispatch) that mean the hubs are done.
+_SEARCH_SETTLE_ROUNDS = 3
 
-# How many results/bundles to pull per listing call.
+# How many bundles to pull per queue listing call.
 _PAGE_SIZE = 100
+# Results are cheap to page and a broad series search returns a lot of them
+# (192 for a two-hub "Strange Tales"), so pull well past the queue page size.
+_RESULT_PAGE_SIZE = 250
 
 # Restrict hub searches to comic files. DC++ shares hold these directly, and
 # without the filter a bare series name returns mostly unrelated media. This
@@ -264,23 +276,46 @@ class AirDCPPClient(BaseDownloadClient):
         return [h.strip() for h in str(raw).split(",") if h.strip()]
 
     def _collect_results(self, instance_id: str) -> list:
-        """Poll the instance until the result count stops growing."""
+        """Wait for the hubs to answer, then fetch the results.
+
+        Polls the search instance rather than the result list: ``queued_count``
+        tells us whether the search has even been dispatched to every hub yet
+        (AirDC++ paces them), and ``result_count`` tells us when answers have
+        stopped arriving. Only then is the result page worth fetching.
+        """
         deadline = time.monotonic() + _SEARCH_WAIT_TOTAL
-        results: list = []
-        while True:
+        last_count = -1
+        stable = 0
+
+        while time.monotonic() < deadline:
             time.sleep(_SEARCH_POLL_INTERVAL)
-            found = self._json(
-                self._request("GET", f"/search/{instance_id}/results/0/{_PAGE_SIZE}")
+            meta = self._json(self._request("GET", f"/search/{instance_id}"))
+            if not isinstance(meta, dict):
+                break  # can't read progress; fetch whatever is there
+
+            count = _to_int(meta.get("result_count")) or 0
+            queued = _to_int(meta.get("queued_count")) or 0
+
+            if queued > 0 or count != last_count:
+                # Still being dispatched, or answers are still arriving.
+                stable = 0
+            else:
+                stable += 1
+                if stable >= _SEARCH_SETTLE_ROUNDS:
+                    break
+            last_count = count
+
+        found = self._json(
+            self._request("GET", f"/search/{instance_id}/results/0/{_RESULT_PAGE_SIZE}")
+        )
+        if not isinstance(found, list):
+            return []
+        if len(found) >= _RESULT_PAGE_SIZE:
+            app_logger.info(
+                f"AirDC++ search returned at least {_RESULT_PAGE_SIZE} results; "
+                f"the list may be truncated"
             )
-            if isinstance(found, list):
-                # Hubs answer at different speeds; keep the largest set seen.
-                if len(found) > len(results):
-                    results = found
-                elif results:
-                    break  # stopped growing — the hubs are done answering
-            if time.monotonic() >= deadline:
-                break
-        return [self._parse_result(r) for r in results if isinstance(r, dict)]
+        return [self._parse_result(r) for r in found if isinstance(r, dict)]
 
     @staticmethod
     def _parse_result(raw: dict) -> dict:
@@ -330,7 +365,13 @@ class AirDCPPClient(BaseDownloadClient):
             self.last_error = "AirDC++ accepted the download but returned no bundle id"
             return NZBSubmitResult(success=False, error=self.last_error)
 
-        bundle_id = data.get("id") or data.get("bundle_id")
+        # The real response nests the id: {"bundle_info": {"id": N, "merged": false}}.
+        # Reading a top-level "id" made every successful grab look like a
+        # failure, while the download actually started at the client.
+        info = data.get("bundle_info")
+        if not isinstance(info, dict):
+            info = data
+        bundle_id = info.get("id") or info.get("bundle_id")
         if bundle_id in (None, ""):
             self.last_error = "AirDC++ accepted the download but returned no bundle id"
             return NZBSubmitResult(success=False, error=self.last_error)

--- a/models/download_clients/base.py
+++ b/models/download_clients/base.py
@@ -19,11 +19,18 @@ class ClientType(Enum):
     """Enumeration of supported download clients."""
     SABNZBD = "sabnzbd"
     NZBGET = "nzbget"
+    AIRDCPP = "airdcpp"
 
 
 @dataclass
 class DownloadClientConfig:
-    """Connection/config for a Usenet download client."""
+    """Connection/config for a download client.
+
+    ``target_directory`` and ``hub_urls`` are DC++ (AirDC++) specific:
+    where the client should land finished files, and an optional
+    comma-separated subset of hubs to search. Both are optional and dropped
+    from ``to_dict`` when unset, so Usenet configs are unaffected.
+    """
     host: Optional[str] = None
     port: Optional[int] = None
     api_key: Optional[str] = None
@@ -33,6 +40,8 @@ class DownloadClientConfig:
     priority: Optional[int] = None
     use_ssl: bool = False
     url_base: Optional[str] = None
+    target_directory: Optional[str] = None
+    hub_urls: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary, excluding None values."""
@@ -46,6 +55,8 @@ class DownloadClientConfig:
             "priority": self.priority,
             "use_ssl": self.use_ssl,
             "url_base": self.url_base,
+            "target_directory": self.target_directory,
+            "hub_urls": self.hub_urls,
         }.items() if v is not None}
 
     @classmethod
@@ -61,6 +72,8 @@ class DownloadClientConfig:
             priority=data.get("priority"),
             use_ssl=bool(data.get("use_ssl", False)),
             url_base=data.get("url_base"),
+            target_directory=data.get("target_directory"),
+            hub_urls=data.get("hub_urls"),
         )
 
 
@@ -127,6 +140,10 @@ class BaseDownloadClient(ABC):
     display_name: str
     config_fields: List[str] = []
     requires_auth: bool = True
+    # Which download source this client serves. Clients compete for the single
+    # active slot only within their own group, so an active AirDC++ (dcpp) and
+    # an active SABnzbd (usenet) can coexist.
+    client_group: str = "usenet"
 
     def __init__(self, config: Optional[DownloadClientConfig] = None):
         """Initialize the client with optional connection config."""
@@ -201,4 +218,5 @@ class BaseDownloadClient(ABC):
             "name": self.display_name,
             "config_fields": self.config_fields,
             "requires_auth": self.requires_auth,
+            "client_group": self.client_group,
         }

--- a/models/download_sources.py
+++ b/models/download_sources.py
@@ -65,6 +65,27 @@ def ordered_sources(names=None) -> list:
     return sorted((n for n in candidates if n in order), key=order.index)
 
 
+def ordered_for_search(names=None) -> list:
+    """Return every known source ranked for the manual search modal.
+
+    Unlike :func:`ordered_sources`, nothing is dropped: a source the user has
+    not ranked is appended rather than excluded. The manual modal queries
+    every source the user has actually *configured* and lets each one stay
+    quiet if it has nothing set up — Source Priority decides the order the
+    sections appear in, not whether a search happens at all. (Auto-download
+    is the opposite, and uses :func:`ordered_sources`.)
+    """
+    candidates = list(names) if names is not None else list(KNOWN_SOURCES)
+    # Rank by priority, then by KNOWN_SOURCES position so unlisted sources
+    # keep a stable, predictable order behind the ranked ones.
+    def key(name):
+        fallback = (KNOWN_SOURCES.index(name)
+                    if name in KNOWN_SOURCES else len(KNOWN_SOURCES))
+        return (source_rank(name), fallback)
+
+    return sorted(candidates, key=key)
+
+
 def get_external_sources() -> list:
     """Return the enabled, configured non-GetComics sources in priority order.
 

--- a/models/download_sources.py
+++ b/models/download_sources.py
@@ -1,0 +1,137 @@
+"""
+Download source priority and shared search helpers.
+
+CLU can acquire an issue from three sources — GetComics (CLU downloads over
+HTTP itself), Usenet (submit an NZB to SABnzbd/NZBGet) and DC++ (queue a hub
+result in AirDC++). The user orders them on the Download Clients settings tab;
+that order is stored as a JSON list under the ``download_source_priority``
+preference and decides which source the scheduled auto-download tries first
+and how the manual search modal stacks its result sections.
+
+This module owns the ordering so nothing has to reason about it pairwise.
+``models/usenet.py`` re-exports :func:`get_source_priority` for backwards
+compatibility with its existing callers.
+"""
+
+# Every source CLU knows about, in the order used when the user has no saved
+# preference. GetComics first preserves the pre-Usenet/pre-DC++ behaviour.
+KNOWN_SOURCES = ("getcomics", "usenet", "dcpp")
+
+_DEFAULT_PRIORITY = ["getcomics"]
+
+
+def get_source_priority() -> list:
+    """Return the ordered download-source list (default GetComics only).
+
+    Stored as a JSON list under the ``download_source_priority`` preference.
+    An unset or unparseable preference falls back to GetComics alone, which
+    keeps a fresh install behaving as it always has.
+    """
+    import json
+
+    try:
+        from core.database import get_user_preference
+
+        raw = get_user_preference("download_source_priority", default=None)
+        if not raw:
+            return list(_DEFAULT_PRIORITY)
+        value = json.loads(raw) if isinstance(raw, str) else raw
+        if isinstance(value, list) and value:
+            return [str(s) for s in value]
+    except Exception:
+        pass
+    return list(_DEFAULT_PRIORITY)
+
+
+def source_rank(name: str) -> int:
+    """Return the priority index of a source; unlisted sources sort last."""
+    order = get_source_priority()
+    return order.index(name) if name in order else 999
+
+
+def source_enabled(name: str) -> bool:
+    """True if the user has this source in their priority list."""
+    return name in get_source_priority()
+
+
+def ordered_sources(names=None) -> list:
+    """Return ``names`` (default: all known sources) in priority order.
+
+    Sources the user has not enabled are dropped. Ties — which only happen
+    among unlisted sources — keep :data:`KNOWN_SOURCES` order for stability.
+    """
+    candidates = list(names) if names is not None else list(KNOWN_SOURCES)
+    order = get_source_priority()
+    return sorted((n for n in candidates if n in order), key=order.index)
+
+
+def get_external_sources() -> list:
+    """Return the enabled, configured non-GetComics sources in priority order.
+
+    Each entry is ``(name, label, try_download_for_issue)``. Every function
+    shares the signature and return contract of
+    ``models.usenet.try_download_for_issue``, so the auto-download loop can
+    call them interchangeably.
+
+    GetComics is excluded because it is not a pluggable client — it lives
+    inline in the download loop — so it is handled by
+    :func:`split_around_getcomics` instead.
+    """
+    from models.dcpp import dcpp_enabled_and_configured
+    from models.dcpp import try_download_for_issue as dcpp_try
+    from models.usenet import try_download_for_issue as usenet_try
+    from models.usenet import usenet_enabled_and_configured
+
+    candidates = {
+        "usenet": ("Usenet", usenet_enabled_and_configured, usenet_try),
+        "dcpp": ("DC++", dcpp_enabled_and_configured, dcpp_try),
+    }
+
+    out = []
+    for name in ordered_sources(candidates.keys()):
+        label, is_on, try_fn = candidates[name]
+        try:
+            if is_on():
+                out.append((name, label, try_fn))
+        except Exception:
+            continue  # a misconfigured source must not break the whole run
+    return out
+
+
+def split_around_getcomics(sources=None):
+    """Split external sources into those tried before vs after GetComics.
+
+    Sources the user ranked above GetComics are attempted first and skip
+    GetComics on a hit; the rest only run when GetComics queued nothing.
+    """
+    sources = get_external_sources() if sources is None else sources
+    gc_rank = source_rank("getcomics")
+    # Sort here rather than trusting the caller: each half must be attempted in
+    # priority order, and an explicitly-passed list may be in any order.
+    ranked = sorted(sources, key=lambda s: source_rank(s[0]))
+    pre = [s for s in ranked if source_rank(s[0]) < gc_rank]
+    post = [s for s in ranked if source_rank(s[0]) > gc_rank]
+    return pre, post
+
+
+def build_queries(series_name, issue_num) -> list:
+    """Build search query variants for a series/issue.
+
+    Releases commonly zero-pad the issue number (e.g. "004", "#4"), so we try
+    the raw number plus 2- and 3-digit padded forms. Shared by the Usenet and
+    DC++ searches; order matters only for logging, since callers de-duplicate.
+    """
+    s = str(issue_num or "").strip()
+    variants = []
+    if s:
+        variants.append(s)
+        if s.isdigit():
+            n = int(s)
+            for width in (2, 3):
+                p = str(n).zfill(width)
+                if p not in variants:
+                    variants.append(p)
+    else:
+        variants.append("")
+    base = series_name.strip()
+    return [f"{base} {v}".strip() for v in variants]

--- a/models/usenet.py
+++ b/models/usenet.py
@@ -12,7 +12,6 @@ This module never touches ``api.py``. It reads the WATCH path via
 ``core.config`` (the same source ``api.py`` uses) and lands files there;
 the folder monitor handles convert/rename/import from that point on.
 """
-import json
 import os
 import shutil
 import threading
@@ -47,20 +46,13 @@ _poller_lock = threading.Lock()
 def get_source_priority() -> list:
     """Return the ordered download-source list (default GetComics only).
 
-    Stored as a JSON list under the ``download_source_priority`` preference.
+    Thin wrapper over :func:`models.download_sources.get_source_priority`,
+    kept here so existing callers and tests importing it from this module
+    keep working.
     """
-    try:
-        from core.database import get_user_preference
+    from models.download_sources import get_source_priority as _get
 
-        raw = get_user_preference("download_source_priority", default=None)
-        if not raw:
-            return ["getcomics"]
-        value = json.loads(raw) if isinstance(raw, str) else raw
-        if isinstance(value, list) and value:
-            return [str(s) for s in value]
-    except Exception:
-        pass
-    return ["getcomics"]
+    return _get()
 
 
 def usenet_enabled_and_configured() -> bool:
@@ -77,10 +69,9 @@ def usenet_enabled_and_configured() -> bool:
 
 def usenet_precedes_getcomics() -> bool:
     """True if 'usenet' ranks before 'getcomics' in the source priority."""
-    order = get_source_priority()
-    un = order.index("usenet") if "usenet" in order else 999
-    gc = order.index("getcomics") if "getcomics" in order else 999
-    return un < gc
+    from models.download_sources import source_rank
+
+    return source_rank("usenet") < source_rank("getcomics")
 
 
 def _watch_dir() -> str:
@@ -220,24 +211,12 @@ def search_usenet_for_issue(
 def _build_queries(series_name, issue_num) -> list:
     """Build indexer query variants for a series/issue.
 
-    Releases commonly zero-pad the issue number (e.g. "004", "#4"), so we try
-    the raw number plus 2- and 3-digit padded forms. Order matters only for
-    logging; results are de-duplicated by NZB URL.
+    Shared with the DC++ search — see
+    :func:`models.download_sources.build_queries`.
     """
-    s = str(issue_num or "").strip()
-    variants = []
-    if s:
-        variants.append(s)
-        if s.isdigit():
-            n = int(s)
-            for width in (2, 3):
-                p = str(n).zfill(width)
-                if p not in variants:
-                    variants.append(p)
-    else:
-        variants.append("")
-    base = series_name.strip()
-    return [f"{base} {v}".strip() for v in variants]
+    from models.download_sources import build_queries
+
+    return build_queries(series_name, issue_num)
 
 
 # ---------------------------------------------------------------------------
@@ -502,20 +481,23 @@ def _set_status(download_id, status, error=None, percent=None):
                 job["percent"] = percent
 
 
-def _import_completed(storage_path, filename) -> bool:
+def _import_completed(storage_path, filename, source="Usenet") -> bool:
     """Move completed comic file(s) from the client's storage into WATCH.
 
     Returns True if the file(s) are (or already are) in the pipeline. Returns
     False when the completed path is not accessible to CLU — in that case the
     client must be configured to complete directly into a monitored folder.
+
+    Shared with the DC++ poller (``models/dcpp.py``); ``source`` only labels
+    the log lines, since landing a finished file is protocol-agnostic.
     """
     watch = _watch_dir()
     if not watch or not os.path.isdir(watch):
-        app_logger.error("Usenet import: WATCH folder is not configured/accessible")
+        app_logger.error(f"{source} import: WATCH folder is not configured/accessible")
         return False
     if not storage_path:
         app_logger.warning(
-            f"Usenet import: no storage path for {filename}; relying on the client's "
+            f"{source} import: no storage path for {filename}; relying on the client's "
             f"completed folder being a monitored path"
         )
         return False
@@ -525,7 +507,7 @@ def _import_completed(storage_path, filename) -> bool:
 
     if not os.path.exists(src_abs):
         app_logger.warning(
-            f"Usenet import: completed path {storage_path} is not accessible from CLU "
+            f"{source} import: completed path {storage_path} is not accessible from CLU "
             f"(is it on a shared volume?) — relying on the monitored folder"
         )
         return False
@@ -545,9 +527,9 @@ def _import_completed(storage_path, filename) -> bool:
                     moved += _move_into_watch(os.path.join(root, f), watch)
 
     if moved:
-        app_logger.info(f"Usenet import: moved {moved} file(s) into WATCH for {filename}")
+        app_logger.info(f"{source} import: moved {moved} file(s) into WATCH for {filename}")
         return True
-    app_logger.warning(f"Usenet import: no comic files found under {storage_path}")
+    app_logger.warning(f"{source} import: no comic files found under {storage_path}")
     return False
 
 

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -102,7 +102,11 @@ def save_download_client_config_route(client_type):
         existing = get_download_client_config(client_type) or {}
         merged = {**existing, **data}
 
-        success = save_download_client_config(client_type, merged)
+        from models.download_clients import get_client_group
+
+        success = save_download_client_config(
+            client_type, merged, client_group=get_client_group(client_type)
+        )
         if success:
             return jsonify({"success": True, "message": f"Config saved for {client_type}"})
         return jsonify({"error": "Failed to save config"}), 500
@@ -444,6 +448,130 @@ def usenet_search():
         })
     except Exception as e:
         app_logger.error(f"Error searching usenet: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+# =============================================================================
+# Download sources (ordering shared by the search UI)
+# =============================================================================
+
+@download_clients_bp.route('/api/download-clients/sources', methods=['GET'])
+def list_download_sources():
+    """Return the user's source priority and which sources are usable.
+
+    The manual search modal fans out to every available source and stacks the
+    sections in this order, so it needs one place to ask rather than inferring
+    order from pairwise flags on each search response.
+    """
+    try:
+        from models.dcpp import dcpp_enabled_and_configured
+        from models.download_sources import KNOWN_SOURCES, get_source_priority
+        from models.usenet import usenet_enabled_and_configured
+
+        order = get_source_priority()
+        available = {
+            # GetComics needs no configuration — it is usable whenever the user
+            # has it in their priority list.
+            "getcomics": "getcomics" in order,
+            "usenet": usenet_enabled_and_configured(),
+            "dcpp": dcpp_enabled_and_configured(),
+        }
+        return jsonify({
+            "success": True,
+            "order": order,
+            "known": list(KNOWN_SOURCES),
+            "available": available,
+        })
+    except Exception as e:
+        app_logger.error(f"Error listing download sources: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+# =============================================================================
+# DC++ (AirDC++)
+# =============================================================================
+
+@download_clients_bp.route('/api/dcpp/downloads', methods=['GET'])
+def list_dcpp_downloads():
+    """List in-memory DC++ downloads and their current status."""
+    try:
+        from models.dcpp import get_dcpp_downloads
+
+        return jsonify({"success": True, "downloads": get_dcpp_downloads()})
+    except Exception as e:
+        app_logger.error(f"Error listing dcpp downloads: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/dcpp/search', methods=['POST'])
+def dcpp_search():
+    """Manual DC++ search for a series/issue across the client's hubs.
+
+    Returns every scored result (not just accepted ones) so the user can pick,
+    sorted best-first. Each result carries a ``result_token`` — DC++ hits are
+    only addressable via their live search instance, so the token is what
+    ``/api/dcpp/grab`` takes instead of a URL.
+    """
+    try:
+        from models.dcpp import dcpp_enabled_and_configured, search_dcpp_for_issue
+
+        data = request.get_json() or {}
+        series = (data.get('series') or '').strip()
+        issue = str(data.get('issue') or '').strip()
+        if not series:
+            return jsonify({"error": "series is required"}), 400
+
+        # Unlike Usenet, searching and grabbing need the same thing: an active
+        # client. Without one there is nothing to search.
+        has_client = dcpp_enabled_and_configured()
+
+        results = []
+        errors = []
+        if has_client:
+            res = search_dcpp_for_issue(
+                series, issue,
+                issue_year=_as_year(data.get('issue_year')),
+                series_volume=data.get('series_volume'),
+            )
+            results = sorted(res.get("all_results", []),
+                             key=lambda r: r.get("score", 0), reverse=True)
+            errors = res.get("errors", [])
+        return jsonify({
+            "success": True,
+            "results": results,
+            "errors": errors,
+            "has_client": has_client,
+        })
+    except Exception as e:
+        app_logger.error(f"Error searching dcpp: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route('/api/dcpp/grab', methods=['POST'])
+def dcpp_grab():
+    """Queue a chosen DC++ search result in the active client."""
+    try:
+        from models.dcpp import grab_dcpp
+
+        data = request.get_json() or {}
+        result_token = data.get('result_token')
+        filename = data.get('filename')
+        if not result_token or not filename:
+            return jsonify({"error": "result_token and filename are required"}), 400
+
+        download_id = grab_dcpp(
+            result_token, filename,
+            series=data.get('series'), issue=data.get('issue'),
+        )
+        if download_id:
+            return jsonify({"success": True, "download_id": download_id})
+        return jsonify({
+            "success": False,
+            "error": "No active DC++ client, the result expired, or the client "
+                     "rejected the download",
+        }), 502
+    except Exception as e:
+        app_logger.error(f"Error grabbing DC++ result: {e}")
         return jsonify({"error": str(e)}), 500
 
 

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -465,7 +465,11 @@ def list_download_sources():
     """
     try:
         from models.dcpp import dcpp_enabled_and_configured
-        from models.download_sources import KNOWN_SOURCES, get_source_priority
+        from models.download_sources import (
+            KNOWN_SOURCES,
+            get_source_priority,
+            ordered_for_search,
+        )
         from models.usenet import usenet_enabled_and_configured
 
         order = get_source_priority()
@@ -478,7 +482,14 @@ def list_download_sources():
         }
         return jsonify({
             "success": True,
+            # The user's ranking, used by auto-download: a source absent here
+            # is never tried automatically.
             "order": order,
+            # What the manual search modal fans out to: every known source,
+            # ranked, with unranked ones appended. Each source suppresses its
+            # own section when it isn't configured, so an unranked-but-set-up
+            # source is still searchable by hand.
+            "search_order": ordered_for_search(),
             "known": list(KNOWN_SOURCES),
             "available": available,
         })
@@ -513,7 +524,8 @@ def dcpp_search():
     ``/api/dcpp/grab`` takes instead of a URL.
     """
     try:
-        from models.dcpp import dcpp_enabled_and_configured, search_dcpp_for_issue
+        from core.database import get_active_download_client
+        from models.dcpp import search_dcpp_for_issue
 
         data = request.get_json() or {}
         series = (data.get('series') or '').strip()
@@ -521,9 +533,12 @@ def dcpp_search():
         if not series:
             return jsonify({"error": "series is required"}), 400
 
-        # Unlike Usenet, searching and grabbing need the same thing: an active
-        # client. Without one there is nothing to search.
-        has_client = dcpp_enabled_and_configured()
+        # An active DC++ client is all a manual search needs — the hubs live
+        # inside AirDC++. Deliberately not gated on the Source Priority list
+        # (mirroring /api/usenet/search): that list governs auto-download, and
+        # a user who has set up DC++ should be able to search it by hand
+        # whether or not they have ranked it.
+        has_client = bool(get_active_download_client(client_group="dcpp"))
 
         results = []
         errors = []

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -195,10 +195,11 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
 
     mapped_series = get_all_mapped_series()
 
-    # Usenet source wiring (mirrors scheduled_getcomics_download).
-    from models import usenet as usenet_mod
-    _usenet_on = usenet_mod.usenet_enabled_and_configured()
-    _usenet_first = _usenet_on and usenet_mod.usenet_precedes_getcomics()
+    # External source wiring (mirrors scheduled_getcomics_download). Only the
+    # pre-GetComics sources matter here: the simulation never submits, so the
+    # fallback sources have nothing to show.
+    from models.download_sources import split_around_getcomics
+    _pre_sources, _ = split_around_getcomics()
 
     # If target_series_id is set, filter to just that series
     if target_series_id:
@@ -282,11 +283,13 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
                 ctx_parts.append(str(issue_year))
             search_context = "[" + ", ".join(ctx_parts) + "]"
 
-            # Usenet first (simulation): mirror the auto-download preference —
-            # if Usenet precedes GetComics and finds a match, show it and skip
-            # the GetComics search for this issue.
-            if _usenet_on and _usenet_first:
-                u = usenet_mod.try_download_for_issue(
+            # Higher-priority sources first (simulation): mirror the
+            # auto-download preference — if a source ranked above GetComics
+            # finds a match, show it and skip the GetComics search for this
+            # issue.
+            handled_by_pre_source = False
+            for src_name, _src_label, src_try in _pre_sources:
+                u = src_try(
                     series_name, issue_num,
                     issue_year=issue_year, series_volume=series_volume,
                     series_year=series_year, publisher_name=publisher_name,
@@ -297,11 +300,14 @@ def _run_wanted_simulation(limit, target_series_id, target_series_name):
                     simulation_results.append({
                         "series": series_name, "issue": issue_num, "issue_year": issue_year,
                         "series_volume": series_volume, "search_context": search_context,
-                        "source": "usenet",
+                        "source": src_name,
                         "best_accept": u.get("chosen"), "best_fallback": None,
                         "all_results": u.get("all_results", []), "status": "match_found",
                     })
-                    continue
+                    handled_by_pre_source = True
+                    break
+            if handled_by_pre_source:
+                continue
 
             results = search_getcomics_for_issue(
                 series_name=series_name,

--- a/static/js/clu-source-search.js
+++ b/static/js/clu-source-search.js
@@ -330,20 +330,33 @@
     };
 
     /**
-     * Fetch the user's source priority.
+     * Fetch the order to stack result sections in.
      *
-     * Falls back to GetComics alone if the endpoint is unreachable, matching
-     * the server-side default, so the modal still works.
+     * Uses `search_order`, not `order`: the modal queries every source the
+     * user has configured and lets each one stay quiet when it isn't set up.
+     * Source Priority decides the order sections appear in, not whether a
+     * source is searched — gating on it would silently stop searching Usenet
+     * and DC++ for anyone who never reordered the list.
+     *
+     * Falls back to every known source if the endpoint is unreachable, so a
+     * failed lookup degrades to "unordered" rather than "GetComics only".
      */
     async function fetchSourceOrder() {
+        const all = Object.keys(SOURCES);
         try {
             const resp = await fetch('/api/download-clients/sources');
             const data = await resp.json();
-            if (data && data.success && Array.isArray(data.order) && data.order.length) {
-                return data.order.filter(s => SOURCES[s]);
+            const order = data && data.success && data.search_order;
+            if (Array.isArray(order) && order.length) {
+                const known = order.filter(s => SOURCES[s]);
+                // Defend against a source the server doesn't know about yet.
+                for (const s of all) {
+                    if (!known.includes(s)) known.push(s);
+                }
+                return known;
             }
         } catch (e) { /* fall through */ }
-        return ['getcomics'];
+        return all;
     }
 
     CLU.createSourceSearch = function createSourceSearch(options) {

--- a/static/js/clu-source-search.js
+++ b/static/js/clu-source-search.js
@@ -1,0 +1,444 @@
+/**
+ * Multi-source issue search for the Wanted and Series pages.
+ *
+ * CLU can acquire an issue from GetComics, Usenet (indexers -> SABnzbd/NZBGet)
+ * or DC++ (AirDC++ hubs). The search modal queries every configured source at
+ * once and stacks the result sections in the user's Source Priority order.
+ *
+ * This module exists because that fan-out used to be copy-pasted into both
+ * wanted.html and series.html with a hardcoded two-source Promise.all and a
+ * pairwise "usenet first?" ternary, which does not extend to a third source.
+ * Pages now supply only their own context and callbacks.
+ *
+ * Result cards use event delegation rather than inline onclick handlers, so
+ * the module does not depend on page-level global function names (the two
+ * pages historically used different ones: showToast vs showToastGC).
+ *
+ * Usage:
+ *     const search = CLU.createSourceSearch({
+ *         resultsEl: document.getElementById('getcomicsResults'),
+ *         getContext: () => ({ series, issue, year }),
+ *         toast: (message, type) => showToast(message, type),
+ *         onQueued: ({ source, downloadId, issue }) => { ... },
+ *     });
+ *     search.run(queryString);
+ */
+(function (window, document) {
+    'use strict';
+
+    const CLU = window.CLU = window.CLU || {};
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = (text === null || text === undefined) ? '' : text;
+        return div.innerHTML;
+    }
+
+    function fmtSize(bytes) {
+        return bytes ? (bytes / (1024 * 1024)).toFixed(0) + ' MB' : '';
+    }
+
+    function sectionHeader(label, icon) {
+        return `<div class="text-muted small fw-bold text-uppercase mb-2 mt-1">
+                    <i class="bi bi-${icon} me-1"></i>${escapeHtml(label)}</div>`;
+    }
+
+    function alertBox(cssClass, icon, message) {
+        return `<div class="alert ${cssClass} py-2 small mb-2">
+                    <i class="bi bi-${icon} me-1"></i>${message}</div>`;
+    }
+
+    // Turn a wanted-issue filename into something the wanted-matcher will pick
+    // up: "<series> <issue>.cbz", stripped of characters that break filesystems.
+    function targetFilename(ctx) {
+        const base = `${ctx.series || ''} ${ctx.issue || ''}`.trim();
+        return base.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
+    }
+
+    /**
+     * Sort GetComics results by how well the title matches the wanted issue.
+     * GetComics returns raw page hits with no server-side scoring, unlike the
+     * Usenet and DC++ endpoints which score before responding.
+     */
+    function scoreGetComicsResults(results, ctx) {
+        return results.map(r => {
+            let score = 0;
+            const title = String(r.title || '').toLowerCase();
+            const series = String(ctx.series || '').toLowerCase();
+            const issue = ctx.issue;
+
+            if (series && title.includes(series)) score += 10;
+            if (title.includes(`#${issue}`) || title.includes(` ${issue} `) ||
+                title.endsWith(` ${issue}`)) score += 5;
+            // A matching year separates this volume's issue from every reprint
+            // and reboot that shares the number.
+            if (ctx.year && title.includes(String(ctx.year))) score += 8;
+
+            return Object.assign({}, r, { score: score });
+        }).sort((a, b) => b.score - a.score);
+    }
+
+    /**
+     * Render a scored result list with the low-scoring tail behind a toggle.
+     *
+     * Indexers and hubs can return 50+ hits for one issue; an unfiltered list
+     * pushes the other sources off the screen. The collapse element is keyed
+     * by source so two sections on the same page cannot collide.
+     */
+    function scoredResultList(sourceKey, results, cardFor) {
+        const isMatch = r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK';
+        const matched = results.filter(isMatch);
+        const others = results.filter(r => !isMatch(r));
+        const othersId = `cluSourceOthers-${sourceKey}`;
+
+        let html = matched.length
+            ? matched.map(cardFor).join('')
+            : '<div class="text-muted small mb-2">No confident match.</div>';
+
+        if (others.length) {
+            html += `
+            <div class="text-center my-2">
+                <button class="btn btn-sm btn-outline-secondary clu-src-toggle" type="button"
+                    data-target="${othersId}">
+                    <i class="bi bi-chevron-down me-1"></i>${othersLabel(others.length, false, matched.length > 0)}
+                </button>
+            </div>
+            <div id="${othersId}" class="d-none" data-count="${others.length}"
+                data-has-match="${matched.length > 0 ? '1' : ''}">
+                ${others.map(cardFor).join('')}
+            </div>`;
+        }
+        return html;
+    }
+
+    function othersLabel(count, expanded, hasMatch) {
+        const noun = count === 1 ? 'result' : 'results';
+        // "lower-scoring" only reads right when something better is shown above.
+        const qualifier = hasMatch ? 'lower-scoring ' : '';
+        return `${expanded ? 'Hide' : 'Show'} ${count} ${qualifier}${noun}`;
+    }
+
+    function decisionBadge(decision) {
+        if (decision === 'ACCEPT') return '<span class="badge bg-success ms-1">Match</span>';
+        if (decision === 'FALLBACK') return '<span class="badge bg-warning text-dark ms-1">Pack</span>';
+        return '';
+    }
+
+    /**
+     * A card for a scored (Usenet/DC++) result. `action` carries the data-*
+     * attributes the click delegate needs to queue it.
+     */
+    function scoredCard(r, subtitle, action, enabled) {
+        return `
+        <div class="card mb-2">
+            <div class="card-body d-flex align-items-center gap-3 py-2">
+                <div class="flex-grow-1 overflow-hidden">
+                    <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}${decisionBadge(r.decision)}</div>
+                    <small class="text-muted text-truncate d-block">${subtitle}</small>
+                </div>
+                <button class="btn btn-sm btn-primary flex-shrink-0 clu-src-grab" ${action}
+                    title="Send to download client" ${enabled ? '' : 'disabled'}>
+                    <i class="bi bi-cloud-download"></i>
+                </button>
+            </div>
+        </div>`;
+    }
+
+    // -----------------------------------------------------------------------
+    // Source definitions
+    //
+    // Each source builds its own section HTML and knows how to queue one of
+    // its results. `build` returns '' to stay silent when the source is not
+    // configured, so an unused source never adds noise to the modal.
+    // -----------------------------------------------------------------------
+
+    const SOURCES = {
+        getcomics: {
+            label: 'GetComics',
+            icon: 'globe',
+            async build(ctx) {
+                const resp = await fetch(`/api/getcomics/search?q=${encodeURIComponent(ctx.query)}`);
+                const data = await resp.json();
+                if (!data.success) {
+                    return alertBox('alert-danger', 'exclamation-octagon', escapeHtml(data.error));
+                }
+                if (!data.results || !data.results.length) return '';
+
+                const cards = scoreGetComicsResults(data.results, ctx).map((r, idx) => `
+                <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
+                    <div class="card-body d-flex align-items-center gap-3 py-2">
+                        ${r.image ? `<img src="${escapeHtml(r.image)}" style="width:50px;height:75px;object-fit:cover;" class="rounded" onerror="this.style.display='none'">` : '<div style="width:50px"></div>'}
+                        <div class="flex-grow-1 overflow-hidden">
+                            <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}</div>
+                            <small class="text-muted text-truncate d-block">${escapeHtml(r.link)}</small>
+                        </div>
+                        <button class="btn btn-sm btn-primary flex-shrink-0 clu-src-grab"
+                            data-source="getcomics" data-link="${escapeHtml(r.link)}"
+                            data-title="${escapeHtml(r.title)}" title="Download">
+                            <i class="bi bi-download"></i>
+                        </button>
+                    </div>
+                </div>`).join('');
+                return sectionHeader('GetComics', 'globe') + cards;
+            },
+            idleIcon: 'bi-download',
+            async queue(btn, ctx) {
+                // GetComics names the file after the post title, not the wanted
+                // issue — the post is the authority on what is inside it.
+                const title = btn.dataset.title || '';
+                const filename = title.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
+                const resp = await fetch('/api/getcomics/download', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ url: btn.dataset.link, filename: filename }),
+                });
+                const data = await resp.json();
+                return {
+                    ok: !!data.success,
+                    error: data.error,
+                    downloadId: data.download_id,
+                    message: 'Download queued successfully!',
+                };
+            },
+        },
+
+        usenet: {
+            label: 'Usenet (Indexers)',
+            icon: 'hdd-network',
+            async build(ctx) {
+                const resp = await fetch('/api/usenet/search', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        series: ctx.series,
+                        issue: ctx.issue,
+                        // Without a year every volume's #8 scores the same; with
+                        // it, wrong-year releases fall below the accept line.
+                        issue_year: ctx.year ? Number(ctx.year) : null,
+                    }),
+                });
+                const data = await resp.json();
+
+                // No indexers configured -> Usenet isn't set up; stay quiet.
+                if (!data.success || !data.has_indexers) return '';
+
+                const header = sectionHeader('Usenet (Indexers)', 'hdd-network');
+                const clientNote = data.has_client ? '' : alertBox(
+                    'alert-warning', 'exclamation-triangle',
+                    'No active download client — set one active on the Download Clients tab to send NZBs.'
+                );
+                const errNote = (data.errors && data.errors.length)
+                    ? alertBox('alert-danger', 'exclamation-octagon',
+                        data.errors.map(escapeHtml).join('<br>')) : '';
+
+                if (!data.results || !data.results.length) {
+                    return header + clientNote + errNote +
+                        '<div class="text-muted small mb-2">No Usenet results found.</div>';
+                }
+
+                const card = (r) => scoredCard(
+                    r,
+                    `${escapeHtml(r.indexer_name || '')} ${fmtSize(r.size)} · score ${r.score}`,
+                    `data-source="usenet" data-nzb-url="${escapeHtml(r.nzb_url)}"`,
+                    data.has_client
+                );
+                return header + clientNote + errNote +
+                    scoredResultList('usenet', data.results, card);
+            },
+            idleIcon: 'bi-cloud-download',
+            async queue(btn, ctx) {
+                const resp = await fetch('/api/usenet/grab', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        nzb_url: btn.dataset.nzbUrl,
+                        filename: targetFilename(ctx),
+                        series: ctx.series,
+                        issue: ctx.issue,
+                    }),
+                });
+                const data = await resp.json();
+                return {
+                    ok: !!data.success,
+                    error: data.error || 'grab failed',
+                    downloadId: data.download_id,
+                    message: 'Sent to download client!',
+                };
+            },
+        },
+
+        dcpp: {
+            label: 'DC++ (Hubs)',
+            icon: 'diagram-3',
+            async build(ctx) {
+                const resp = await fetch('/api/dcpp/search', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        series: ctx.series,
+                        issue: ctx.issue,
+                        issue_year: ctx.year ? Number(ctx.year) : null,
+                    }),
+                });
+                const data = await resp.json();
+
+                // No active DC++ client -> DC++ isn't set up; stay quiet.
+                if (!data.success || !data.has_client) return '';
+
+                const header = sectionHeader('DC++ (Hubs)', 'diagram-3');
+                const errNote = (data.errors && data.errors.length)
+                    ? alertBox('alert-danger', 'exclamation-octagon',
+                        data.errors.map(escapeHtml).join('<br>')) : '';
+
+                if (!data.results || !data.results.length) {
+                    return header + errNote +
+                        '<div class="text-muted small mb-2">No DC++ results found.</div>';
+                }
+
+                const card = (r) => {
+                    const users = r.users ? `${r.users} user${r.users === 1 ? '' : 's'} · ` : '';
+                    return scoredCard(
+                        r,
+                        `${users}${fmtSize(r.size)} · score ${r.score}`,
+                        `data-source="dcpp" data-token="${escapeHtml(r.result_token)}"`,
+                        true
+                    );
+                };
+                return header + errNote + scoredResultList('dcpp', data.results, card);
+            },
+            idleIcon: 'bi-cloud-download',
+            async queue(btn, ctx) {
+                const resp = await fetch('/api/dcpp/grab', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        result_token: btn.dataset.token,
+                        filename: targetFilename(ctx),
+                        series: ctx.series,
+                        issue: ctx.issue,
+                    }),
+                });
+                const data = await resp.json();
+                return {
+                    ok: !!data.success,
+                    error: data.error || 'grab failed',
+                    downloadId: data.download_id,
+                    message: 'Queued in AirDC++!',
+                };
+            },
+        },
+    };
+
+    /**
+     * Fetch the user's source priority.
+     *
+     * Falls back to GetComics alone if the endpoint is unreachable, matching
+     * the server-side default, so the modal still works.
+     */
+    async function fetchSourceOrder() {
+        try {
+            const resp = await fetch('/api/download-clients/sources');
+            const data = await resp.json();
+            if (data && data.success && Array.isArray(data.order) && data.order.length) {
+                return data.order.filter(s => SOURCES[s]);
+            }
+        } catch (e) { /* fall through */ }
+        return ['getcomics'];
+    }
+
+    CLU.createSourceSearch = function createSourceSearch(options) {
+        const resultsEl = options.resultsEl;
+        const getContext = options.getContext;
+        const toast = options.toast || function () {};
+        const onQueued = options.onQueued || function () {};
+
+        // One delegated listener for the whole results area, installed once —
+        // re-rendering the HTML cannot detach it.
+        resultsEl.addEventListener('click', function (event) {
+            const toggle = event.target.closest('.clu-src-toggle');
+            if (toggle) {
+                handleToggle(toggle);
+                return;
+            }
+            const grab = event.target.closest('.clu-src-grab');
+            if (grab) {
+                handleGrab(grab);
+            }
+        });
+
+        function handleToggle(btn) {
+            const el = document.getElementById(btn.dataset.target);
+            if (!el) return;
+            const hidden = el.classList.toggle('d-none');
+            const count = Number(el.dataset.count) || 0;
+            btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
+                othersLabel(count, !hidden, !!el.dataset.hasMatch);
+        }
+
+        async function handleGrab(btn) {
+            const source = SOURCES[btn.dataset.source];
+            if (!source || btn.disabled) return;
+
+            const ctx = getContext();
+            const idle = `<i class="bi ${source.idleIcon}"></i>`;
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+            try {
+                const outcome = await source.queue(btn, ctx);
+                if (outcome.ok) {
+                    btn.innerHTML = '<i class="bi bi-check"></i>';
+                    btn.classList.remove('btn-primary');
+                    btn.classList.add('btn-success');
+                    toast(outcome.message, 'success');
+                    onQueued({
+                        source: btn.dataset.source,
+                        downloadId: outcome.downloadId,
+                        issue: ctx.issue,
+                    });
+                } else {
+                    btn.disabled = false;
+                    btn.innerHTML = idle;
+                    toast('Error: ' + outcome.error, 'danger');
+                }
+            } catch (e) {
+                btn.disabled = false;
+                btn.innerHTML = idle;
+                toast('Error: ' + e.message, 'danger');
+            }
+        }
+
+        /** Query every configured source and render the sections in priority order. */
+        async function run(query) {
+            if (!query) return;
+
+            resultsEl.innerHTML = `
+            <div class="text-center py-4">
+                <div class="spinner-border text-primary"></div>
+                <p class="mt-2">Searching...</p>
+            </div>`;
+
+            const order = await fetchSourceOrder();
+            const ctx = Object.assign({ query: query }, getContext());
+
+            // All sources run concurrently; the priority order decides only how
+            // the finished sections are stacked.
+            const sections = await Promise.all(order.map(async (key) => {
+                try {
+                    return await SOURCES[key].build(ctx);
+                } catch (e) {
+                    return alertBox('alert-danger', 'exclamation-octagon',
+                        `${escapeHtml(SOURCES[key].label)} error: ${escapeHtml(e.message)}`);
+                }
+            }));
+
+            const combined = sections.join('');
+            resultsEl.innerHTML = combined.trim() ? combined : `
+            <div class="text-center text-muted py-4">
+                <i class="bi bi-emoji-frown display-4 opacity-25"></i>
+                <p class="mt-2">No results found</p>
+            </div>`;
+        }
+
+        return { run: run };
+    };
+})(window, document);

--- a/templates/config.html
+++ b/templates/config.html
@@ -3581,15 +3581,33 @@
     }
 
     // =====================================================================
-    // Download Clients (Usenet) — registry-driven, mirrors the provider tab
+    // Download Clients (Usenet + DC++) — registry-driven, mirrors the
+    // provider tab. Clients are grouped by client_group; "Set Active" is
+    // scoped to a group, so a Usenet client and a DC++ client can both be
+    // active at once.
     // =====================================================================
+
+    // Labels/help that read better than the auto-derived title-cased field name.
+    const CLIENT_FIELD_LABELS = { hub_urls: 'Hub URLs', url_base: 'URL Base', api_key: 'API Key' };
+    const CLIENT_FIELD_HELP = {
+        target_directory: 'Where AirDC++ should save finished downloads. Must be a path CLU can also read, so it can move comics into your WATCH folder.',
+        hub_urls: 'Optional. Comma-separated hub addresses to search. Leave blank to search every connected hub.',
+    };
+
+    const CLIENT_GROUP_LABELS = { usenet: 'Usenet', dcpp: 'DC++' };
+    const CLIENT_GROUP_NOTES = {
+        dcpp: 'Hubs are configured inside AirDC++ itself, not in CLU\'s Indexers list below.',
+    };
 
     function generateClientFields(client) {
         const cfg = client.config || {};
         let html = '';
         for (const field of client.config_fields) {
             const fieldId = `client-${client.type}-${field}`;
-            const fieldLabel = field.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            const fieldLabel = CLIENT_FIELD_LABELS[field]
+                || field.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            const fieldHelp = CLIENT_FIELD_HELP[field]
+                ? `<div class="form-text small">${escapeHtml(CLIENT_FIELD_HELP[field])}</div>` : '';
 
             if (field === 'use_ssl') {
                 const checked = cfg.use_ssl ? 'checked' : '';
@@ -3619,6 +3637,7 @@
                             <i class="bi bi-eye"></i>
                         </button>` : ''}
                     </div>
+                    ${fieldHelp}
                 </div>`;
         }
         return html;
@@ -3639,8 +3658,27 @@
                 return;
             }
 
-            let html = '<div class="row">';
+            // Group the cards so it's clear that "Set Active" picks one client
+            // per group, not one client overall.
+            const groups = [];
             for (const client of data.clients) {
+                const g = client.client_group || 'usenet';
+                let bucket = groups.find(b => b.key === g);
+                if (!bucket) {
+                    bucket = { key: g, clients: [] };
+                    groups.push(bucket);
+                }
+                bucket.clients.push(client);
+            }
+
+            let html = '';
+            for (const group of groups) {
+                const note = CLIENT_GROUP_NOTES[group.key]
+                    ? `<div class="text-muted small mb-2">${escapeHtml(CLIENT_GROUP_NOTES[group.key])}</div>` : '';
+                html += `<h6 class="text-uppercase text-muted small fw-bold mt-2 mb-2">
+                    ${escapeHtml(CLIENT_GROUP_LABELS[group.key] || group.key)}</h6>${note}
+                    <div class="row">`;
+            for (const client of group.clients) {
                 let statusBadge;
                 if (client.is_active) {
                     statusBadge = '<span class="badge bg-success"><i class="bi bi-broadcast me-1"></i>Active</span>';
@@ -3686,7 +3724,8 @@
                     </div>
                 </div>`;
             }
-            html += '</div>';
+                html += '</div>';
+            }
             container.innerHTML = html;
             initPasswordToggles(container);
         } catch (e) {
@@ -3974,12 +4013,16 @@
     // Source Priority (user preference: download_source_priority)
     // =====================================================================
 
-    const SOURCE_LABELS = { usenet: 'Usenet (Indexers)', getcomics: 'GetComics' };
+    const SOURCE_LABELS = {
+        usenet: 'Usenet (Indexers)',
+        getcomics: 'GetComics',
+        dcpp: 'DC++ (Hubs)',
+    };
 
     async function loadSourcePriority() {
         const container = document.getElementById('sourcePriorityList');
         if (!container) return;
-        let order = ['getcomics', 'usenet'];
+        let order = ['getcomics', 'usenet', 'dcpp'];
         try {
             const resp = await fetch('/api/preferences/download_source_priority');
             const data = await resp.json();

--- a/templates/series.html
+++ b/templates/series.html
@@ -1111,278 +1111,44 @@
         return list.length ? list[0] : '';
     }
 
+    let sourceSearch = null;
+
+    // The fan-out to GetComics/Usenet/DC++ lives in clu-source-search.js so
+    // this page and wanted.html share one implementation.
+    function ensureSourceSearch() {
+        if (!sourceSearch) {
+            sourceSearch = CLU.createSourceSearch({
+                resultsEl: document.getElementById('getcomicsResults'),
+                getContext: () => ({
+                    series: currentSearchSeries,
+                    issue: currentSearchIssue,
+                    year: currentSearchYear,
+                }),
+                toast: showToastGC,
+                onQueued: ({ source, downloadId, issue }) => {
+                    // Reflect the queued download on the issue row:
+                    // a wanted/not-found issue (table-danger) becomes table-warning.
+                    markIssueRowDownloading(issue);
+                    // Only GetComics downloads run inside CLU and can fail in a
+                    // way we can surface here (e.g. a Cloudflare-protected
+                    // mirror); Usenet and DC++ are tracked on the Status page.
+                    if (source === 'getcomics' && downloadId) {
+                        pollGetComicsDownload(downloadId, issue);
+                    }
+                    setTimeout(() => getcomicsModal.hide(), 500);
+                },
+            });
+        }
+        return sourceSearch;
+    }
+
     async function doGetComicsSearch() {
         const query = document.getElementById('getcomicsQuery').value.trim();
         if (!query) return;
 
-        // Keep the Usenet year filter in step with what's in the box.
+        // Keep the per-source year filter in step with what's in the box.
         currentSearchYear = extractQueryYear(query);
-
-        const resultsDiv = document.getElementById('getcomicsResults');
-        resultsDiv.innerHTML = `
-        <div class="text-center py-4">
-            <div class="spinner-border text-primary"></div>
-            <p class="mt-2">Searching...</p>
-        </div>`;
-
-        // Query both sources; render them in Source Priority order.
-        const [gc, un] = await Promise.all([
-            buildGetComicsSection(query),
-            buildUsenetSection(),
-        ]);
-
-        let combined = un.usenetFirst ? (un.html + gc.html) : (gc.html + un.html);
-        if (!combined.trim()) {
-            combined = `
-            <div class="text-center text-muted py-4">
-                <i class="bi bi-emoji-frown display-4 opacity-25"></i>
-                <p class="mt-2">No results found</p>
-            </div>`;
-        }
-        resultsDiv.innerHTML = combined;
-    }
-
-    function sectionHeader(label, icon) {
-        return `<div class="text-muted small fw-bold text-uppercase mb-2 mt-1">
-                    <i class="bi bi-${icon} me-1"></i>${label}</div>`;
-    }
-
-    async function buildGetComicsSection(query) {
-        try {
-            const resp = await fetch(`/api/getcomics/search?q=${encodeURIComponent(query)}`);
-            const data = await resp.json();
-            if (!data.success) {
-                return { html: `<div class="alert alert-danger">${escapeHtmlGC(data.error)}</div>` };
-            }
-            if (!data.results.length) return { html: '' };
-
-            const sorted = sortResultsGC(data.results, currentSearchSeries, currentSearchIssue,
-                currentSearchYear);
-            const cards = sorted.map((r, idx) => `
-            <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
-                <div class="card-body d-flex align-items-center gap-3 py-2">
-                    ${r.image ? `<img src="${escapeHtmlGC(r.image)}" style="width:50px;height:75px;object-fit:cover;" class="rounded" onerror="this.style.display='none'">` : '<div style="width:50px"></div>'}
-                    <div class="flex-grow-1 overflow-hidden">
-                        <div class="fw-bold text-truncate" title="${escapeHtmlGC(r.title)}">${escapeHtmlGC(r.title)}</div>
-                        <small class="text-muted text-truncate d-block">${escapeHtmlGC(r.link)}</small>
-                    </div>
-                    <button class="btn btn-sm btn-primary flex-shrink-0" onclick="downloadFromGetComics(this, '${escapeHtmlGC(r.link)}', '${escapeJsGC(r.title)}')" title="Download">
-                        <i class="bi bi-download"></i>
-                    </button>
-                </div>
-            </div>`).join('');
-            return { html: sectionHeader('GetComics', 'globe') + cards };
-        } catch (e) {
-            return { html: `<div class="alert alert-danger">GetComics error: ${escapeHtmlGC(e.message)}</div>` };
-        }
-    }
-
-    async function buildUsenetSection() {
-        try {
-            const resp = await fetch('/api/usenet/search', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    series: currentSearchSeries,
-                    issue: currentSearchIssue,
-                    // Without a year every volume's #8 scores the same; with it,
-                    // wrong-year releases are penalized below the accept line.
-                    issue_year: currentSearchYear ? Number(currentSearchYear) : null,
-                }),
-            });
-            const data = await resp.json();
-            const usenetFirst = !!data.usenet_first;
-
-            // No indexers configured -> Usenet isn't set up; stay quiet.
-            if (!data.success || !data.has_indexers) {
-                return { html: '', usenetFirst };
-            }
-
-            const header = sectionHeader('Usenet (Indexers)', 'hdd-network');
-            const clientNote = data.has_client ? '' :
-                `<div class="alert alert-warning py-2 small mb-2">
-                    <i class="bi bi-exclamation-triangle me-1"></i>No active download client — set one active
-                    on the Download Clients tab to send NZBs.</div>`;
-            const errNote = (data.errors && data.errors.length)
-                ? `<div class="alert alert-danger py-2 small mb-2">
-                    <i class="bi bi-exclamation-octagon me-1"></i>${data.errors.map(escapeHtmlGC).join('<br>')}</div>`
-                : '';
-
-            if (!data.results || !data.results.length) {
-                return {
-                    html: header + clientNote + errNote +
-                        `<div class="text-muted small mb-2">No Usenet results found.</div>`,
-                    usenetFirst,
-                };
-            }
-
-            const fmtSize = (b) => b ? (b / (1024 * 1024)).toFixed(0) + ' MB' : '';
-            const usenetCard = (r) => {
-                const badge = r.decision === 'ACCEPT'
-                    ? '<span class="badge bg-success ms-1">Match</span>'
-                    : (r.decision === 'FALLBACK'
-                        ? '<span class="badge bg-warning text-dark ms-1">Pack</span>' : '');
-                return `
-            <div class="card mb-2">
-                <div class="card-body d-flex align-items-center gap-3 py-2">
-                    <div class="flex-grow-1 overflow-hidden">
-                        <div class="fw-bold text-truncate" title="${escapeHtmlGC(r.title)}">${escapeHtmlGC(r.title)}${badge}</div>
-                        <small class="text-muted text-truncate d-block">${escapeHtmlGC(r.indexer_name || '')} ${fmtSize(r.size)} · score ${r.score}</small>
-                    </div>
-                    <button class="btn btn-sm btn-primary flex-shrink-0" onclick="grabUsenet(this, '${escapeJsGC(r.nzb_url)}')" title="Send to download client" ${data.has_client ? '' : 'disabled'}>
-                        <i class="bi bi-cloud-download"></i>
-                    </button>
-                </div>
-            </div>`;
-            };
-            return {
-                html: header + clientNote + errNote + usenetResultList(data.results, usenetCard),
-                usenetFirst,
-            };
-        } catch (e) {
-            return { html: `<div class="alert alert-danger">Usenet error: ${escapeHtmlGC(e.message)}</div>`, usenetFirst: false };
-        }
-    }
-
-    // Only badged results (Match/Pack) are shown up front; everything else —
-    // chiefly wrong-year releases of the same issue number — is hidden behind
-    // a toggle. Indexers can return 50+ hits for one issue, and an unfiltered
-    // list pushes the GetComics section off the screen, so the collapse
-    // applies even when nothing scored well enough to badge.
-    function usenetResultList(results, cardFor) {
-        const isMatch = r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK';
-        const matched = results.filter(isMatch);
-        const others = results.filter(r => !isMatch(r));
-
-        let html = matched.length
-            ? matched.map(cardFor).join('')
-            : '<div class="text-muted small mb-2">No confident match.</div>';
-
-        if (others.length) {
-            html += `
-            <div class="text-center my-2">
-                <button class="btn btn-sm btn-outline-secondary" type="button"
-                    onclick="toggleUsenetOthers(this)">
-                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false, matched.length > 0)}
-                </button>
-            </div>
-            <div id="usenetOtherResults" class="d-none" data-count="${others.length}"
-                data-has-match="${matched.length > 0 ? '1' : ''}">
-                ${others.map(cardFor).join('')}
-            </div>`;
-        }
-        return html;
-    }
-
-    function usenetOthersLabel(count, expanded, hasMatch) {
-        const noun = count === 1 ? 'result' : 'results';
-        // "lower-scoring" only reads right when something better is shown above.
-        const qualifier = hasMatch ? 'lower-scoring ' : '';
-        return `${expanded ? 'Hide' : 'Show'} ${count} ${qualifier}${noun}`;
-    }
-
-    function toggleUsenetOthers(btn) {
-        const el = document.getElementById('usenetOtherResults');
-        if (!el) return;
-        const hidden = el.classList.toggle('d-none');
-        const count = Number(el.dataset.count) || 0;
-        btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
-            usenetOthersLabel(count, !hidden, !!el.dataset.hasMatch);
-    }
-
-    async function grabUsenet(btn, nzbUrl) {
-        // File under the series/issue so wanted-matching picks it up.
-        const base = `${currentSearchSeries} ${currentSearchIssue}`.trim();
-        const filename = base.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
-
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-        try {
-            const resp = await fetch('/api/usenet/grab', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    nzb_url: nzbUrl, filename: filename,
-                    series: currentSearchSeries, issue: currentSearchIssue,
-                }),
-            });
-            const data = await resp.json();
-            if (data.success) {
-                btn.innerHTML = '<i class="bi bi-check"></i>';
-                btn.classList.remove('btn-primary');
-                btn.classList.add('btn-success');
-                showToastGC('Sent to download client!', 'success');
-                markIssueRowDownloading(currentSearchIssue);
-                setTimeout(() => getcomicsModal.hide(), 500);
-            } else {
-                btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-cloud-download"></i>';
-                showToastGC('Error: ' + (data.error || 'grab failed'), 'danger');
-            }
-        } catch (e) {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-cloud-download"></i>';
-            showToastGC('Error: ' + e.message, 'danger');
-        }
-    }
-
-    function sortResultsGC(results, seriesName, issueNumber, issueYear) {
-        return results.map(r => {
-            let score = 0;
-            const title = r.title.toLowerCase();
-            const series = seriesName.toLowerCase();
-
-            if (title.includes(series)) score += 10;
-            if (title.includes(`#${issueNumber}`) || title.includes(` ${issueNumber} `) || title.endsWith(` ${issueNumber}`)) score += 5;
-            // A matching year separates this volume's issue from every reprint
-            // and reboot that shares the number.
-            if (issueYear && title.includes(String(issueYear))) score += 8;
-
-            return { ...r, score };
-        }).sort((a, b) => b.score - a.score);
-    }
-
-    async function downloadFromGetComics(btn, pageUrl, title) {
-        const filename = title.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
-
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-
-        try {
-            const resp = await fetch('/api/getcomics/download', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ url: pageUrl, filename: filename })
-            });
-            const data = await resp.json();
-
-            if (data.success) {
-                btn.innerHTML = '<i class="bi bi-check"></i>';
-                btn.classList.remove('btn-primary');
-                btn.classList.add('btn-success');
-                showToastGC('Download queued successfully!', 'success');
-
-                // Reflect the queued download on the issue row:
-                // a wanted/not-found issue (table-danger) becomes table-warning
-                markIssueRowDownloading(currentSearchIssue);
-
-                // Poll the background download so we can surface a failure
-                // (e.g. a Cloudflare-protected mirror) with a manual link.
-                pollGetComicsDownload(data.download_id, currentSearchIssue);
-
-                setTimeout(() => {
-                    getcomicsModal.hide();
-                }, 500);
-            } else {
-                btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-download"></i>';
-                showToastGC('Error: ' + data.error, 'danger');
-            }
-        } catch (e) {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-download"></i>';
-            showToastGC('Error: ' + e.message, 'danger');
-        }
+        await ensureSourceSearch().run(query);
     }
 
     // When a download is queued for an issue, downgrade its row from
@@ -1503,10 +1269,6 @@
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
-    }
-
-    function escapeJsGC(str) {
-        return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
     }
 
     function showToastGC(message, type) {
@@ -1638,6 +1400,7 @@
     document.addEventListener('DOMContentLoaded', loadAliases);
 </script>
 <script src="{{ url_for('static', filename='js/clu-utils.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/clu-source-search.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-streaming.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-crop.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-cbz-edit.js') }}?v={{ range(1000, 9999) | random }}"></script>

--- a/templates/status.html
+++ b/templates/status.html
@@ -60,6 +60,7 @@
       comicbookplus:{ icon: 'bi-book',             color: 'text-info',     label: 'CBP' },
       sabnzbd:      { icon: 'bi-hdd-network',      color: 'text-warning',  label: 'SABnzbd' },
       nzbget:       { icon: 'bi-cloud-download',   color: 'text-info',     label: 'NZBGet' },
+      airdcpp:      { icon: 'bi-diagram-3',        color: 'text-primary',  label: 'AirDC++' },
     };
 
     const mb = bytes => (bytes / (1024 * 1024)).toFixed(2);
@@ -119,8 +120,10 @@
       return td;
     }
 
-    // Map a Usenet job's status/stage to a display label + styling.
-    function usenetStatusDisplay(job) {
+    // Map a managed-client job's status/stage to a display label + styling.
+    // Shared by Usenet (SABnzbd/NZBGet) and DC++ (AirDC++), which report the
+    // same status vocabulary.
+    function clientStatusDisplay(job) {
       switch (job.status) {
         case 'complete':
           return { text: 'Complete', cssClass: 'text-success' };
@@ -234,8 +237,10 @@
       }
     }
 
-    // Render Usenet (SABnzbd/NZBGet) download rows — view-only, no actions.
-    function renderUsenetRows(tbody, downloads) {
+    // Render externally-managed client rows (Usenet SABnzbd/NZBGet, DC++
+    // AirDC++) — view-only, no actions: the download lives in the user's own
+    // client, so cancel/retry belong there, not here.
+    function renderClientRows(tbody, downloads) {
       for (const job of downloads) {
         const tr = document.createElement('tr');
         tr.appendChild(filenameCell(job.filename));
@@ -243,28 +248,35 @@
         const isDone = job.status === 'complete' || job.status === 'complete_no_move';
         tr.appendChild(progressCell(isDone ? 100 : job.percent));
         tr.appendChild(bytesCell(job.bytes_downloaded, job.bytes_total));
-        const disp = usenetStatusDisplay(job);
+        const disp = clientStatusDisplay(job);
         tr.appendChild(statusCell(disp.text, disp.cssClass, disp.title));
         tr.appendChild(document.createElement('td')); // no actions
         tbody.appendChild(tr);
       }
     }
 
-    // Fetch both direct (api.py) and Usenet download statuses and rebuild the table.
+    // A managed-client endpoint may 404/500 when that source is unconfigured —
+    // never let it break the poll.
+    function fetchClientDownloads(url, signal) {
+      return fetch(url, { signal })
+        .then(r => r.ok ? r.json() : { success: false })
+        .then(d => (d && d.success && Array.isArray(d.downloads)) ? d.downloads : [])
+        .catch(() => []);
+    }
+
+    // Fetch direct (api.py), Usenet and DC++ download statuses and rebuild the table.
     function fetchStatus(signal) {
       const direct = fetch('/download_status_all', { signal })
         .then(r => r.json())
         .catch(() => ({}));
-      // Usenet endpoint may 404/500 when unconfigured — never let it break the poll.
-      const usenet = fetch('/api/usenet/downloads', { signal })
-        .then(r => r.ok ? r.json() : { success: false })
-        .then(d => (d && d.success && Array.isArray(d.downloads)) ? d.downloads : [])
-        .catch(() => []);
-      return Promise.all([direct, usenet]).then(([data, usenetDownloads]) => {
+      const usenet = fetchClientDownloads('/api/usenet/downloads', signal);
+      const dcpp = fetchClientDownloads('/api/dcpp/downloads', signal);
+      return Promise.all([direct, usenet, dcpp]).then(([data, usenetDownloads, dcppDownloads]) => {
         const tbody = document.querySelector('#downloads-table tbody');
         tbody.innerHTML = ''; // Clear previous rows.
         renderDirectRows(tbody, data || {});
-        renderUsenetRows(tbody, usenetDownloads);
+        renderClientRows(tbody, usenetDownloads);
+        renderClientRows(tbody, dcppDownloads);
       });
     }
 

--- a/templates/wanted.html
+++ b/templates/wanted.html
@@ -300,282 +300,39 @@
         return m ? m[1] : '';
     }
 
+    let sourceSearch = null;
+
+    // The fan-out to GetComics/Usenet/DC++ lives in clu-source-search.js so
+    // this page and series.html share one implementation.
+    function ensureSourceSearch() {
+        if (!sourceSearch) {
+            sourceSearch = CLU.createSourceSearch({
+                resultsEl: document.getElementById('getcomicsResults'),
+                getContext: () => ({
+                    series: currentSearchSeries,
+                    issue: currentSearchIssue,
+                    year: currentSearchYear,
+                }),
+                toast: showToast,
+                onQueued: () => setTimeout(() => getcomicsModal.hide(), 500),
+            });
+        }
+        return sourceSearch;
+    }
+
     async function doGetComicsSearch() {
         const query = document.getElementById('getcomicsQuery').value.trim();
         if (!query) return;
 
-        // Keep the Usenet year filter in step with what's in the box.
+        // Keep the per-source year filter in step with what's in the box.
         currentSearchYear = extractQueryYear(query);
-
-        const resultsDiv = document.getElementById('getcomicsResults');
-        resultsDiv.innerHTML = `
-        <div class="text-center py-4">
-            <div class="spinner-border text-primary"></div>
-            <p class="mt-2">Searching...</p>
-        </div>`;
-
-        // Query both sources; render them in Source Priority order.
-        const [gc, un] = await Promise.all([
-            buildGetComicsSection(query),
-            buildUsenetSection(),
-        ]);
-
-        let combined = un.usenetFirst ? (un.html + gc.html) : (gc.html + un.html);
-        if (!combined.trim()) {
-            combined = `
-            <div class="text-center text-muted py-4">
-                <i class="bi bi-emoji-frown display-4 opacity-25"></i>
-                <p class="mt-2">No results found</p>
-            </div>`;
-        }
-        resultsDiv.innerHTML = combined;
-    }
-
-    function sectionHeader(label, icon) {
-        return `<div class="text-muted small fw-bold text-uppercase mb-2 mt-1">
-                    <i class="bi bi-${icon} me-1"></i>${label}</div>`;
-    }
-
-    async function buildGetComicsSection(query) {
-        try {
-            const resp = await fetch(`/api/getcomics/search?q=${encodeURIComponent(query)}`);
-            const data = await resp.json();
-            if (!data.success) {
-                return { html: `<div class="alert alert-danger">${escapeHtml(data.error)}</div>` };
-            }
-            if (!data.results.length) return { html: '' };
-
-            const sorted = sortResults(data.results, currentSearchSeries, currentSearchIssue,
-                currentSearchYear);
-            const cards = sorted.map((r, idx) => `
-            <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
-                <div class="card-body d-flex align-items-center gap-3 py-2">
-                    ${r.image ? `<img src="${escapeHtml(r.image)}" style="width:50px;height:75px;object-fit:cover;" class="rounded" onerror="this.style.display='none'">` : '<div style="width:50px"></div>'}
-                    <div class="flex-grow-1 overflow-hidden">
-                        <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}</div>
-                        <small class="text-muted text-truncate d-block">${escapeHtml(r.link)}</small>
-                    </div>
-                    <button class="btn btn-sm btn-primary flex-shrink-0" onclick="downloadFromGetComics(this, '${escapeHtml(r.link)}', '${escapeJs(r.title)}')" title="Download">
-                        <i class="bi bi-download"></i>
-                    </button>
-                </div>
-            </div>`).join('');
-            return { html: sectionHeader('GetComics', 'globe') + cards };
-        } catch (e) {
-            return { html: `<div class="alert alert-danger">GetComics error: ${escapeHtml(e.message)}</div>` };
-        }
-    }
-
-    async function buildUsenetSection() {
-        try {
-            const resp = await fetch('/api/usenet/search', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    series: currentSearchSeries,
-                    issue: currentSearchIssue,
-                    // Without a year every volume's #8 scores the same; with it,
-                    // wrong-year releases are penalized below the accept line.
-                    issue_year: currentSearchYear ? Number(currentSearchYear) : null,
-                }),
-            });
-            const data = await resp.json();
-            const usenetFirst = !!data.usenet_first;
-
-            // No indexers configured -> Usenet isn't set up; stay quiet.
-            if (!data.success || !data.has_indexers) {
-                return { html: '', usenetFirst };
-            }
-
-            const header = sectionHeader('Usenet (Indexers)', 'hdd-network');
-            const clientNote = data.has_client ? '' :
-                `<div class="alert alert-warning py-2 small mb-2">
-                    <i class="bi bi-exclamation-triangle me-1"></i>No active download client — set one active
-                    on the Download Clients tab to send NZBs.</div>`;
-            const errNote = (data.errors && data.errors.length)
-                ? `<div class="alert alert-danger py-2 small mb-2">
-                    <i class="bi bi-exclamation-octagon me-1"></i>${data.errors.map(escapeHtml).join('<br>')}</div>`
-                : '';
-
-            if (!data.results || !data.results.length) {
-                return {
-                    html: header + clientNote + errNote +
-                        `<div class="text-muted small mb-2">No Usenet results found.</div>`,
-                    usenetFirst,
-                };
-            }
-
-            const fmtSize = (b) => b ? (b / (1024 * 1024)).toFixed(0) + ' MB' : '';
-            const usenetCard = (r) => {
-                const badge = r.decision === 'ACCEPT'
-                    ? '<span class="badge bg-success ms-1">Match</span>'
-                    : (r.decision === 'FALLBACK'
-                        ? '<span class="badge bg-warning text-dark ms-1">Pack</span>' : '');
-                return `
-            <div class="card mb-2">
-                <div class="card-body d-flex align-items-center gap-3 py-2">
-                    <div class="flex-grow-1 overflow-hidden">
-                        <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}${badge}</div>
-                        <small class="text-muted text-truncate d-block">${escapeHtml(r.indexer_name || '')} ${fmtSize(r.size)} · score ${r.score}</small>
-                    </div>
-                    <button class="btn btn-sm btn-primary flex-shrink-0" onclick="grabUsenet(this, '${escapeJs(r.nzb_url)}')" title="Send to download client" ${data.has_client ? '' : 'disabled'}>
-                        <i class="bi bi-cloud-download"></i>
-                    </button>
-                </div>
-            </div>`;
-            };
-            return {
-                html: header + clientNote + errNote + usenetResultList(data.results, usenetCard),
-                usenetFirst,
-            };
-        } catch (e) {
-            return { html: `<div class="alert alert-danger">Usenet error: ${escapeHtml(e.message)}</div>`, usenetFirst: false };
-        }
-    }
-
-    // Only badged results (Match/Pack) are shown up front; everything else —
-    // chiefly wrong-year releases of the same issue number — is hidden behind
-    // a toggle. Indexers can return 50+ hits for one issue, and an unfiltered
-    // list pushes the GetComics section off the screen, so the collapse
-    // applies even when nothing scored well enough to badge.
-    function usenetResultList(results, cardFor) {
-        const isMatch = r => r.decision === 'ACCEPT' || r.decision === 'FALLBACK';
-        const matched = results.filter(isMatch);
-        const others = results.filter(r => !isMatch(r));
-
-        let html = matched.length
-            ? matched.map(cardFor).join('')
-            : '<div class="text-muted small mb-2">No confident match.</div>';
-
-        if (others.length) {
-            html += `
-            <div class="text-center my-2">
-                <button class="btn btn-sm btn-outline-secondary" type="button"
-                    onclick="toggleUsenetOthers(this)">
-                    <i class="bi bi-chevron-down me-1"></i>${usenetOthersLabel(others.length, false, matched.length > 0)}
-                </button>
-            </div>
-            <div id="usenetOtherResults" class="d-none" data-count="${others.length}"
-                data-has-match="${matched.length > 0 ? '1' : ''}">
-                ${others.map(cardFor).join('')}
-            </div>`;
-        }
-        return html;
-    }
-
-    function usenetOthersLabel(count, expanded, hasMatch) {
-        const noun = count === 1 ? 'result' : 'results';
-        // "lower-scoring" only reads right when something better is shown above.
-        const qualifier = hasMatch ? 'lower-scoring ' : '';
-        return `${expanded ? 'Hide' : 'Show'} ${count} ${qualifier}${noun}`;
-    }
-
-    function toggleUsenetOthers(btn) {
-        const el = document.getElementById('usenetOtherResults');
-        if (!el) return;
-        const hidden = el.classList.toggle('d-none');
-        const count = Number(el.dataset.count) || 0;
-        btn.innerHTML = `<i class="bi bi-chevron-${hidden ? 'down' : 'up'} me-1"></i>` +
-            usenetOthersLabel(count, !hidden, !!el.dataset.hasMatch);
-    }
-
-    async function grabUsenet(btn, nzbUrl) {
-        // File under the series/issue so wanted-matching picks it up.
-        const base = `${currentSearchSeries} ${currentSearchIssue}`.trim();
-        const filename = base.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
-
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-        try {
-            const resp = await fetch('/api/usenet/grab', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    nzb_url: nzbUrl, filename: filename,
-                    series: currentSearchSeries, issue: currentSearchIssue,
-                }),
-            });
-            const data = await resp.json();
-            if (data.success) {
-                btn.innerHTML = '<i class="bi bi-check"></i>';
-                btn.classList.remove('btn-primary');
-                btn.classList.add('btn-success');
-                showToast('Sent to download client!', 'success');
-                setTimeout(() => getcomicsModal.hide(), 500);
-            } else {
-                btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-cloud-download"></i>';
-                showToast('Error: ' + (data.error || 'grab failed'), 'danger');
-            }
-        } catch (e) {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-cloud-download"></i>';
-            showToast('Error: ' + e.message, 'danger');
-        }
-    }
-
-    function sortResults(results, seriesName, issueNumber, issueYear) {
-        // Score results based on match quality
-        return results.map(r => {
-            let score = 0;
-            const title = r.title.toLowerCase();
-            const series = seriesName.toLowerCase();
-
-            if (title.includes(series)) score += 10;
-            if (title.includes(`#${issueNumber}`) || title.includes(` ${issueNumber} `) || title.endsWith(` ${issueNumber}`)) score += 5;
-            // A matching year separates this volume's issue from every reprint
-            // and reboot that shares the number.
-            if (issueYear && title.includes(String(issueYear))) score += 8;
-
-            return { ...r, score };
-        }).sort((a, b) => b.score - a.score);
-    }
-
-    async function downloadFromGetComics(btn, pageUrl, title) {
-        const filename = title.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
-
-        // Show loading state on the button
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-
-        try {
-            const resp = await fetch('/api/getcomics/download', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ url: pageUrl, filename: filename })
-            });
-            const data = await resp.json();
-
-            if (data.success) {
-                btn.innerHTML = '<i class="bi bi-check"></i>';
-                btn.classList.remove('btn-primary');
-                btn.classList.add('btn-success');
-                showToast('Download queued successfully!', 'success');
-
-                // Close modal after short delay
-                setTimeout(() => {
-                    getcomicsModal.hide();
-                }, 500);
-            } else {
-                btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-download"></i>';
-                showToast('Error: ' + data.error, 'danger');
-            }
-        } catch (e) {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-download"></i>';
-            showToast('Error: ' + e.message, 'danger');
-        }
+        await ensureSourceSearch().run(query);
     }
 
     function escapeHtml(text) {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
-    }
-
-    function escapeJs(str) {
-        return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
     }
 
     function showToast(message, type) {
@@ -711,4 +468,5 @@
     });
     {% endif %}
 </script>
+<script src="{{ url_for('static', filename='js/clu-source-search.js') }}?v={{ range(1000, 9999) | random }}"></script>
 {% endblock %}

--- a/tests/integration/test_database_clients.py
+++ b/tests/integration/test_database_clients.py
@@ -85,6 +85,105 @@ class TestDownloadClientConfig:
         assert get_download_client_config("sabnzbd") is None
 
 
+class TestClientGroups:
+    """Single-active is scoped per group so DC++ and Usenet can coexist."""
+
+    @skip_no_crypto
+    def test_activating_dcpp_keeps_usenet_active(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            set_active_download_client,
+            get_active_download_client,
+            get_all_download_clients_status,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "k1"}, client_group="usenet")
+        save_download_client_config("airdcpp", {"username": "u", "password": "p"},
+                                    client_group="dcpp")
+
+        set_active_download_client("sabnzbd")
+        set_active_download_client("airdcpp")
+
+        # Both stay active — they are not competing for one slot.
+        assert sum(s["is_active"] for s in get_all_download_clients_status()) == 2
+        assert get_active_download_client("usenet")["client_type"] == "sabnzbd"
+        assert get_active_download_client("dcpp")["client_type"] == "airdcpp"
+
+    @skip_no_crypto
+    def test_activating_usenet_keeps_dcpp_active(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            set_active_download_client,
+            get_active_download_client,
+        )
+        save_download_client_config("airdcpp", {"username": "u"}, client_group="dcpp")
+        save_download_client_config("sabnzbd", {"api_key": "k"}, client_group="usenet")
+
+        set_active_download_client("airdcpp")
+        set_active_download_client("sabnzbd")
+
+        assert get_active_download_client("dcpp")["client_type"] == "airdcpp"
+        assert get_active_download_client("usenet")["client_type"] == "sabnzbd"
+
+    @skip_no_crypto
+    def test_within_a_group_still_single_active(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            set_active_download_client,
+            get_active_download_client,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "k"}, client_group="usenet")
+        save_download_client_config("nzbget", {"username": "u"}, client_group="usenet")
+
+        set_active_download_client("sabnzbd")
+        set_active_download_client("nzbget")
+
+        assert get_active_download_client("usenet")["client_type"] == "nzbget"
+
+    @skip_no_crypto
+    def test_default_group_is_usenet(self, db_connection):
+        # Existing callers that don't pass a group must keep working.
+        from core.database import (
+            save_download_client_config,
+            set_active_download_client,
+            get_active_download_client,
+            get_all_download_clients_status,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "k"})
+        set_active_download_client("sabnzbd")
+
+        assert get_active_download_client()["client_type"] == "sabnzbd"
+        status = next(s for s in get_all_download_clients_status()
+                      if s["client_type"] == "sabnzbd")
+        assert status["client_group"] == "usenet"
+
+    @skip_no_crypto
+    def test_no_active_client_in_group(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            set_active_download_client,
+            get_active_download_client,
+        )
+        save_download_client_config("sabnzbd", {"api_key": "k"}, client_group="usenet")
+        set_active_download_client("sabnzbd")
+        assert get_active_download_client("dcpp") is None
+
+    def test_activate_unconfigured_client_fails(self, db_connection):
+        from core.database import set_active_download_client
+        assert set_active_download_client("airdcpp") is False
+
+    @skip_no_crypto
+    def test_saving_again_preserves_group(self, db_connection):
+        from core.database import (
+            save_download_client_config,
+            get_all_download_clients_status,
+        )
+        save_download_client_config("airdcpp", {"username": "u"}, client_group="dcpp")
+        save_download_client_config("airdcpp", {"username": "u2"}, client_group="dcpp")
+        status = next(s for s in get_all_download_clients_status()
+                      if s["client_type"] == "airdcpp")
+        assert status["client_group"] == "dcpp"
+
+
 class TestIndexers:
 
     @skip_no_crypto

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -355,3 +355,45 @@ class TestCollectionStatusBoundaryPurge:
             init_db()
 
         assert self._counts(db_connection) == (1, 1)
+
+
+class TestDownloadClientGroupMigration:
+    """download_clients.client_group was added after the table shipped."""
+
+    def test_column_exists(self, db_connection):
+        cols = [r[1] for r in
+                db_connection.execute("PRAGMA table_info(download_clients)").fetchall()]
+        assert "client_group" in cols
+
+    def test_migration_backfills_existing_rows_as_usenet(self, db_connection):
+        from core.database import init_db
+
+        # Rebuild the table as it existed before DC++ support, with a row in it.
+        db_connection.execute("DROP TABLE download_clients")
+        db_connection.execute("""
+            CREATE TABLE download_clients (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                client_type TEXT NOT NULL UNIQUE,
+                config_encrypted BLOB NOT NULL,
+                config_nonce BLOB NOT NULL,
+                is_active INTEGER DEFAULT 0,
+                is_valid INTEGER DEFAULT 0,
+                last_tested TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        db_connection.execute(
+            "INSERT INTO download_clients (client_type, config_encrypted, config_nonce, is_active)"
+            " VALUES ('sabnzbd', X'00', X'00', 1)"
+        )
+        db_connection.commit()
+
+        init_db()
+
+        row = db_connection.execute(
+            "SELECT client_group, is_active FROM download_clients WHERE client_type='sabnzbd'"
+        ).fetchone()
+        # The pre-existing Usenet client keeps working and lands in the right group.
+        assert row["client_group"] == "usenet"
+        assert row["is_active"] == 1

--- a/tests/mocked/test_airdcpp_client.py
+++ b/tests/mocked/test_airdcpp_client.py
@@ -1,0 +1,324 @@
+"""Tests for models/download_clients/airdcpp_client.py -- mocked HTTP."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from models.download_clients import (
+    ClientType,
+    DownloadClientConfig,
+    get_download_client,
+)
+from models.download_clients import airdcpp_client
+from models.download_clients.airdcpp_client import (
+    _normalize_airdcpp_status,
+    _percent,
+    _result_type,
+    _user_count,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_search(monkeypatch):
+    """Collapse the hub-response wait window.
+
+    ``_collect_results`` deliberately keeps polling for the full budget when a
+    search returns nothing, since hubs answer at different speeds — that would
+    add 8 real seconds per empty-result test.
+    """
+    monkeypatch.setattr(airdcpp_client, "_SEARCH_WAIT_TOTAL", 0.0)
+    monkeypatch.setattr(airdcpp_client, "_SEARCH_POLL_INTERVAL", 0.0)
+
+
+def _client(**cfg):
+    defaults = {
+        "host": "localhost", "port": 5600,
+        "username": "admin", "password": "pw",
+        "target_directory": "/downloads/dcpp",
+    }
+    defaults.update(cfg)
+    return get_download_client(ClientType.AIRDCPP, DownloadClientConfig(**defaults))
+
+
+def _resp(status_code=200, payload=None, content=b"{}"):
+    """Build a fake requests.Response."""
+    resp = MagicMock(status_code=status_code, content=content)
+    if payload is None:
+        resp.json.side_effect = ValueError("no json")
+    else:
+        resp.json.return_value = payload
+    return resp
+
+
+class TestAirDCPPTestConnection:
+
+    @patch("requests.request")
+    def test_valid_hub_list(self, mock_req):
+        mock_req.return_value = _resp(payload=[{"id": 1, "hub_url": "adcs://hub"}])
+        assert _client().test_connection() is True
+
+    @patch("requests.request")
+    def test_empty_hub_list_is_still_valid(self, mock_req):
+        # A working client with no hubs connected yet must not read as broken.
+        mock_req.return_value = _resp(payload=[])
+        assert _client().test_connection() is True
+
+    @patch("requests.request")
+    def test_bad_credentials(self, mock_req):
+        mock_req.return_value = _resp(status_code=401)
+        c = _client()
+        assert c.test_connection() is False
+        assert "uthentication" in c.last_error
+
+    @patch("requests.request")
+    def test_non_json_response(self, mock_req):
+        mock_req.return_value = _resp(payload=None)
+        c = _client()
+        assert c.test_connection() is False
+        assert "Non-JSON" in c.last_error
+
+    @patch("requests.request")
+    def test_unexpected_shape(self, mock_req):
+        mock_req.return_value = _resp(payload={"not": "a list"})
+        assert _client().test_connection() is False
+
+    @patch("requests.request", side_effect=Exception("boom"))
+    def test_exception_swallowed(self, mock_req):
+        # A bad host returns False, not an exception.
+        assert _client().test_connection() is False
+
+    def test_missing_credentials(self):
+        assert _client(username=None).test_connection() is False
+        assert _client(password=None).test_connection() is False
+
+
+class TestAirDCPPMetadata:
+
+    def test_config_fields(self):
+        cls = get_download_client(ClientType.AIRDCPP).__class__
+        assert "target_directory" in cls.config_fields
+        assert "hub_urls" in cls.config_fields
+        # AirDC++ authenticates with a username/password, not an API key.
+        assert "api_key" not in cls.config_fields
+
+    def test_client_group_is_dcpp(self):
+        # The whole point of the group: DC++ must not fight SABnzbd/NZBGet for
+        # the single active slot.
+        assert get_download_client(ClientType.AIRDCPP).client_group == "dcpp"
+        assert get_download_client(ClientType.SABNZBD).client_group == "usenet"
+
+    def test_client_info_exposes_group(self):
+        info = get_download_client(ClientType.AIRDCPP).get_client_info()
+        assert info["client_group"] == "dcpp"
+        assert info["type"] == "airdcpp"
+
+    def test_base_url_includes_api_prefix(self):
+        assert _client()._api_url("/hubs") == "http://localhost:5600/api/v1/hubs"
+
+    def test_ssl_and_url_base(self):
+        c = _client(use_ssl=True, url_base="airdc")
+        assert c._api_url("/hubs") == "https://localhost:5600/airdc/api/v1/hubs"
+
+
+class TestAirDCPPSearch:
+
+    @patch("models.download_clients.airdcpp_client.time.sleep")
+    @patch("requests.request")
+    def test_search_flow(self, mock_req, _sleep):
+        results = [{
+            "id": 42, "name": "Batman 001 (2016).cbz", "size": 50_000_000,
+            "tth": "ABC", "type": "file", "users": 3, "relevance": 90,
+        }]
+
+        def route(method, url, **kwargs):
+            if method == "POST" and url.endswith("/search"):
+                return _resp(payload={"id": "inst-1"})
+            if method == "POST" and url.endswith("/hub_search"):
+                return _resp(payload={}, content=b"")
+            if method == "GET" and "/results/" in url:
+                return _resp(payload=results)
+            raise AssertionError(f"unexpected {method} {url}")
+
+        mock_req.side_effect = route
+        instance_id, found = _client().search("Batman 1")
+
+        assert instance_id == "inst-1"
+        assert len(found) == 1
+        assert found[0]["result_id"] == "42"
+        assert found[0]["name"] == "Batman 001 (2016).cbz"
+        assert found[0]["tth"] == "ABC"
+        assert found[0]["users"] == 3
+
+    @patch("models.download_clients.airdcpp_client.time.sleep")
+    @patch("requests.request")
+    def test_hub_urls_filter_sent(self, mock_req, _sleep):
+        sent = {}
+
+        def route(method, url, **kwargs):
+            if method == "POST" and url.endswith("/search"):
+                return _resp(payload={"id": "i"})
+            if method == "POST" and url.endswith("/hub_search"):
+                sent.update(kwargs.get("json") or {})
+                return _resp(payload={}, content=b"")
+            return _resp(payload=[])
+
+        mock_req.side_effect = route
+        _client(hub_urls="adcs://a:411, adcs://b:411").search("Batman 1")
+
+        assert sent["hub_urls"] == ["adcs://a:411", "adcs://b:411"]
+        # Comic extensions keep unrelated media out of the results.
+        assert "cbz" in sent["query"]["extensions"]
+
+    @patch("models.download_clients.airdcpp_client.time.sleep")
+    @patch("requests.request")
+    def test_no_hub_filter_when_unset(self, mock_req, _sleep):
+        sent = {}
+
+        def route(method, url, **kwargs):
+            if method == "POST" and url.endswith("/search"):
+                return _resp(payload={"id": "i"})
+            if method == "POST" and url.endswith("/hub_search"):
+                sent.update(kwargs.get("json") or {})
+                return _resp(payload={}, content=b"")
+            return _resp(payload=[])
+
+        mock_req.side_effect = route
+        _client().search("Batman 1")
+        assert "hub_urls" not in sent
+
+    @patch("requests.request")
+    def test_instance_creation_failure(self, mock_req):
+        mock_req.return_value = _resp(status_code=500)
+        instance_id, found = _client().search("Batman 1")
+        assert instance_id is None
+        assert found == []
+
+
+class TestAirDCPPDownloadResult:
+
+    @patch("requests.request")
+    def test_download_returns_bundle_id(self, mock_req):
+        mock_req.return_value = _resp(payload={"id": 777, "merged": False})
+        result = _client().download_result("inst-1", "42")
+        assert result.success is True
+        assert result.client_id == "777"
+
+    @patch("requests.request")
+    def test_target_directory_from_config(self, mock_req):
+        mock_req.return_value = _resp(payload={"id": 1})
+        _client().download_result("inst-1", "42")
+        assert mock_req.call_args.kwargs["json"]["target_directory"] == "/downloads/dcpp"
+
+    @patch("requests.request")
+    def test_missing_bundle_id_is_failure(self, mock_req):
+        # Accepted but untrackable is a failure -- never invent a bundle id.
+        mock_req.return_value = _resp(payload={})
+        result = _client().download_result("inst-1", "42")
+        assert result.success is False
+
+    @patch("requests.request")
+    def test_http_error(self, mock_req):
+        mock_req.return_value = _resp(status_code=404)
+        result = _client().download_result("inst-1", "42")
+        assert result.success is False
+        assert result.error
+
+
+BUNDLES = [
+    {
+        "id": 1, "name": "Batman 001", "target": "/downloads/dcpp/Batman 001.cbz",
+        "size": 1000, "downloaded_bytes": 250,
+        "status": {"id": "downloading", "str": "Downloading",
+                   "completed": False, "failed": False},
+    },
+    {
+        "id": 2, "name": "Batman 002", "target": "/downloads/dcpp/Batman 002.cbz",
+        "size": 1000, "downloaded_bytes": 1000,
+        "status": {"id": "completed", "str": "Finished",
+                   "completed": True, "failed": False},
+    },
+    {
+        "id": 3, "name": "Batman 003", "target": "/downloads/dcpp/Batman 003.cbz",
+        "size": 1000, "downloaded_bytes": 10,
+        "status": {"id": "download_failed", "str": "Failed",
+                   "completed": False, "failed": True},
+    },
+]
+
+
+class TestAirDCPPQueue:
+
+    @patch("requests.request")
+    def test_queue_only_active(self, mock_req):
+        mock_req.return_value = _resp(payload=BUNDLES)
+        queue = _client().get_queue()
+        assert [s.client_id for s in queue] == ["1"]
+        assert queue[0].percent == 25.0
+        assert queue[0].bytes_total == 1000
+        assert queue[0].bytes_downloaded == 250
+        assert queue[0].stage == "Downloading"
+        assert queue[0].storage_path == "/downloads/dcpp/Batman 001.cbz"
+
+    @patch("requests.request")
+    def test_history_only_finished(self, mock_req):
+        mock_req.return_value = _resp(payload=BUNDLES)
+        hist = {s.client_id: s for s in _client().get_history()}
+        assert set(hist) == {"2", "3"}
+        assert hist["2"].status == "complete"
+        assert hist["3"].status == "failed"
+
+    @patch("requests.request")
+    def test_get_status_by_id(self, mock_req):
+        mock_req.return_value = _resp(payload=BUNDLES)
+        assert _client().get_status("2").status == "complete"
+        assert _client().get_status("nope") is None
+
+    @patch("requests.request")
+    def test_nested_downloaded_bytes_fallback(self, mock_req):
+        # Older builds report progress as status.downloaded, not downloaded_bytes.
+        mock_req.return_value = _resp(payload=[{
+            "id": 9, "name": "x", "size": 200,
+            "status": {"id": "downloading", "str": "Downloading",
+                       "completed": False, "failed": False, "downloaded": 100},
+        }])
+        assert _client().get_queue()[0].percent == 50.0
+
+    @patch("requests.request", side_effect=Exception("boom"))
+    def test_queue_errors_return_empty(self, mock_req):
+        # The poller calls these on a timer; they must never raise.
+        assert _client().get_queue() == []
+        assert _client().get_history() == []
+        assert _client().get_status("1") is None
+
+
+class TestAirDCPPHelpers:
+
+    @pytest.mark.parametrize("status,expected", [
+        ({"completed": True, "failed": False}, "complete"),
+        ({"completed": False, "failed": True}, "failed"),
+        ({"completed": False, "failed": False}, "downloading"),
+        # Flags absent -> fall back to the id string.
+        ({"id": "shared"}, "complete"),
+        ({"id": "validation_error"}, "failed"),
+        ({"id": "queued"}, "downloading"),
+        ({}, "downloading"),
+        (None, "downloading"),
+    ])
+    def test_normalize_status(self, status, expected):
+        assert _normalize_airdcpp_status(status) == expected
+
+    def test_percent_guards(self):
+        assert _percent(50, 100) == 50.0
+        assert _percent(None, 100) is None
+        assert _percent(10, 0) is None
+        assert _percent(10, None) is None
+        # Never report more than complete.
+        assert _percent(200, 100) == 100.0
+
+    def test_result_type_accepts_object_or_string(self):
+        assert _result_type("file") == "file"
+        assert _result_type({"id": "directory"}) == "directory"
+        assert _result_type(None) == ""
+
+    def test_user_count_accepts_object_or_int(self):
+        assert _user_count(5) == 5
+        assert _user_count({"user": {}, "count": 3}) == 3
+        assert _user_count(None) is None

--- a/tests/mocked/test_airdcpp_client.py
+++ b/tests/mocked/test_airdcpp_client.py
@@ -267,25 +267,97 @@ class TestAirDCPPQueue:
 
     @patch("requests.request")
     def test_get_status_by_id(self, mock_req):
-        mock_req.return_value = _resp(payload=BUNDLES)
+        # get_status now fetches the single bundle rather than scanning a page.
+        mock_req.return_value = _resp(payload=BUNDLES[1])
         assert _client().get_status("2").status == "complete"
-        assert _client().get_status("nope") is None
 
     @patch("requests.request")
-    def test_nested_downloaded_bytes_fallback(self, mock_req):
-        # Older builds report progress as status.downloaded, not downloaded_bytes.
+    def test_status_downloaded_is_a_flag_not_a_byte_count(self, mock_req):
+        # Live AirDC++ sends status.downloaded as a boolean. Using it as a
+        # progress fallback would report "1 byte downloaded".
         mock_req.return_value = _resp(payload=[{
             "id": 9, "name": "x", "size": 200,
             "status": {"id": "downloading", "str": "Downloading",
-                       "completed": False, "failed": False, "downloaded": 100},
+                       "completed": False, "failed": False, "downloaded": True},
         }])
-        assert _client().get_queue()[0].percent == 50.0
+        q = _client().get_queue()[0]
+        assert q.bytes_downloaded is None
+        assert q.percent is None
+
+    @patch("requests.request")
+    def test_float_sizes_and_int_ids(self, mock_req):
+        # Live AirDC++ returns size/downloaded_bytes as floats and id as an int.
+        mock_req.return_value = _resp(payload=[{
+            "id": 3770756270, "name": "Hulk.cbz",
+            "size": 27964355.0, "downloaded_bytes": 13982177.5,
+            "target": "F:\\downloads\\airdcpp\\Hulk.cbz",
+            "status": {"id": "queued", "str": "Waiting (0.0%)",
+                       "completed": False, "failed": False, "downloaded": False},
+        }])
+        q = _client().get_queue()[0]
+        assert q.client_id == "3770756270"
+        assert q.bytes_total == 27964355
+        assert q.bytes_downloaded == 13982177
+        assert q.stage == "Waiting (0.0%)"
 
     @patch("requests.request", side_effect=Exception("boom"))
     def test_queue_errors_return_empty(self, mock_req):
         # The poller calls these on a timer; they must never raise.
         assert _client().get_queue() == []
         assert _client().get_history() == []
+        assert _client().get_status("1") is None
+
+
+class TestAirDCPPBundleState:
+    """Per-bundle polling — the path the DC++ poller actually uses."""
+
+    @patch("requests.request")
+    def test_found(self, mock_req):
+        mock_req.return_value = _resp(payload={
+            "id": 1, "name": "Batman 001", "size": 1000, "downloaded_bytes": 500,
+            "target": "/downloads/dcpp/Batman 001.cbz",
+            "status": {"id": "downloading", "str": "Downloading",
+                       "completed": False, "failed": False, "downloaded": False},
+        })
+        state, status = _client().get_bundle_state("1")
+        assert state == "found"
+        assert status.percent == 50.0
+        assert status.storage_path == "/downloads/dcpp/Batman 001.cbz"
+
+    @patch("requests.request")
+    def test_gone_on_404(self, mock_req):
+        # AirDC++ 404s a bundle it no longer holds; with "remove finished
+        # bundles" on, that is the only signal a download completed.
+        mock_req.return_value = _resp(
+            status_code=404, payload={"message": "Bundle 1 was not found"})
+        state, status = _client().get_bundle_state("1")
+        assert state == "gone"
+        assert status is None
+
+    @patch("requests.request")
+    def test_error_on_server_failure(self, mock_req):
+        # A 500 must not be mistaken for completion.
+        mock_req.return_value = _resp(status_code=500)
+        assert _client().get_bundle_state("1") == ("error", None)
+
+    @patch("requests.request", side_effect=Exception("boom"))
+    def test_error_on_unreachable(self, mock_req):
+        assert _client().get_bundle_state("1") == ("error", None)
+
+    @patch("requests.request")
+    def test_polls_by_id_not_by_listing(self, mock_req):
+        # Scanning a paged queue listing would lose a bundle past page 1.
+        mock_req.return_value = _resp(payload={
+            "id": 42, "name": "x", "size": 1, "downloaded_bytes": 0,
+            "status": {"id": "queued", "str": "Waiting",
+                       "completed": False, "failed": False, "downloaded": False},
+        })
+        _client().get_bundle_state("42")
+        assert mock_req.call_args[0][1].endswith("/queue/bundles/42")
+
+    @patch("requests.request")
+    def test_get_status_hides_gone(self, mock_req):
+        mock_req.return_value = _resp(status_code=404, payload={"message": "nope"})
         assert _client().get_status("1") is None
 
 

--- a/tests/mocked/test_airdcpp_client.py
+++ b/tests/mocked/test_airdcpp_client.py
@@ -192,10 +192,100 @@ class TestAirDCPPSearch:
         assert found == []
 
 
+class TestAirDCPPSearchWait:
+    """The wait is driven by the instance's own progress metadata.
+
+    AirDC++ queues searches and paces them to each hub; measured live, the
+    query was not even dispatched for ~17s. Waiting a flat 8s returned
+    nothing at all.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _real_budget(self, monkeypatch):
+        monkeypatch.setattr(airdcpp_client, "_SEARCH_WAIT_TOTAL", 30.0)
+        monkeypatch.setattr(airdcpp_client, "_SEARCH_POLL_INTERVAL", 0.0)
+        monkeypatch.setattr(airdcpp_client, "_SEARCH_SETTLE_ROUNDS", 2)
+
+    def _run(self, meta_sequence, results):
+        """Drive a search whose instance reports the given metadata over time."""
+        polls = {"n": 0}
+
+        def route(method, url, **kwargs):
+            if method == "POST" and url.endswith("/search"):
+                return _resp(payload={"id": "i1"})
+            if method == "POST" and url.endswith("/hub_search"):
+                return _resp(payload={}, content=b"")
+            if method == "GET" and "/results/" in url:
+                return _resp(payload=results)
+            if method == "GET" and url.endswith("/search/i1"):
+                i = min(polls["n"], len(meta_sequence) - 1)
+                polls["n"] += 1
+                return _resp(payload=meta_sequence[i])
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with patch("requests.request", side_effect=route):
+            _, found = _client().search("Strange Tales")
+        return found, polls["n"]
+
+    def test_waits_while_the_search_is_still_queued(self):
+        # queued_count > 0 means some hub has not been sent the query yet;
+        # an unchanged result_count then must not be read as "settled".
+        meta = [
+            {"queued_count": 2, "result_count": 0},
+            {"queued_count": 2, "result_count": 0},
+            {"queued_count": 1, "result_count": 2},
+            {"queued_count": 0, "result_count": 163},
+            {"queued_count": 0, "result_count": 192},
+            {"queued_count": 0, "result_count": 192},
+            {"queued_count": 0, "result_count": 192},
+        ]
+        found, polls = self._run(meta, [{"id": "a", "name": "x.cbz"}])
+        assert len(found) == 1
+        # Kept polling past the queued rounds and the growth rounds.
+        assert polls >= 6
+
+    def test_stops_once_results_settle(self):
+        meta = [{"queued_count": 0, "result_count": 5}] * 10
+        found, polls = self._run(meta, [{"id": "a", "name": "x.cbz"}])
+        assert len(found) == 1
+        assert polls <= 4  # settled after the configured stable rounds
+
+    def test_empty_search_still_terminates(self):
+        meta = [{"queued_count": 0, "result_count": 0}] * 10
+        found, polls = self._run(meta, [])
+        assert found == []
+        assert polls <= 4
+
+    def test_unreadable_metadata_falls_through_to_a_fetch(self):
+        def route(method, url, **kwargs):
+            if method == "POST" and url.endswith("/search"):
+                return _resp(payload={"id": "i1"})
+            if method == "POST" and url.endswith("/hub_search"):
+                return _resp(payload={}, content=b"")
+            if method == "GET" and "/results/" in url:
+                return _resp(payload=[{"id": "a", "name": "x.cbz"}])
+            return _resp(status_code=500)
+
+        with patch("requests.request", side_effect=route):
+            _, found = _client().search("Strange Tales")
+        assert len(found) == 1
+
+
 class TestAirDCPPDownloadResult:
 
     @patch("requests.request")
-    def test_download_returns_bundle_id(self, mock_req):
+    def test_download_returns_nested_bundle_id(self, mock_req):
+        # The live response nests it: {"bundle_info": {"id": N, "merged": false}}.
+        # Reading a top-level "id" made every successful grab report failure
+        # while the download had in fact started at the client.
+        mock_req.return_value = _resp(
+            payload={"bundle_info": {"id": 136140681, "merged": False}})
+        result = _client().download_result("inst-1", "42")
+        assert result.success is True
+        assert result.client_id == "136140681"
+
+    @patch("requests.request")
+    def test_download_accepts_flat_bundle_id(self, mock_req):
         mock_req.return_value = _resp(payload={"id": 777, "merged": False})
         result = _client().download_result("inst-1", "42")
         assert result.success is True

--- a/tests/mocked/test_dcpp.py
+++ b/tests/mocked/test_dcpp.py
@@ -152,12 +152,38 @@ class TestSearchAndScore:
         assert any("hub offline" in e for e in res["errors"])
 
     @patch("models.dcpp._active_client")
-    def test_tries_zero_padded_queries(self, mock_client):
+    def test_one_search_on_the_series_name(self, mock_client):
+        # A hub search costs tens of seconds and AirDC++ paces them, so DC++
+        # must not fan out over zero-padding variants the way Usenet does.
+        # Searching the series alone returns every padding in one go.
         client = _fake_client()
         mock_client.return_value = client
-        dc.search_dcpp_for_issue("Batman", "1")
-        queried = [c.args[0] for c in client.search.call_args_list]
-        assert queried == ["Batman 1", "Batman 01", "Batman 001"]
+        dc.search_dcpp_for_issue("Strange Tales", "83")
+        assert [c.args[0] for c in client.search.call_args_list] == ["Strange Tales"]
+
+    @patch("models.dcpp._active_client")
+    def test_narrows_only_when_results_are_truncated(self, mock_client):
+        # A full page means the hub had more to say and the wanted issue could
+        # be past the cut, so one narrower search earns its cost.
+        client = _fake_client([
+            _hit(f"Strange Tales v1 {i:03d}.cbz", result_id=str(i), tth=f"T{i}")
+            for i in range(dc._TRUNCATED_RESULT_COUNT)
+        ])
+        mock_client.return_value = client
+        dc.search_dcpp_for_issue("Strange Tales", "83")
+        assert [c.args[0] for c in client.search.call_args_list] == [
+            "Strange Tales", "Strange Tales 083",
+        ]
+
+    @patch("models.dcpp._active_client")
+    def test_no_refinement_for_non_numeric_issues(self, mock_client):
+        client = _fake_client([
+            _hit(f"Series {i}.cbz", result_id=str(i), tth=f"T{i}")
+            for i in range(dc._TRUNCATED_RESULT_COUNT)
+        ])
+        mock_client.return_value = client
+        dc.search_dcpp_for_issue("Series", "1.MU")
+        assert len(client.search.call_args_list) == 1
 
 
 class TestTryDownloadForIssue:

--- a/tests/mocked/test_dcpp.py
+++ b/tests/mocked/test_dcpp.py
@@ -1,0 +1,332 @@
+"""Tests for models/dcpp.py -- search/score, token cache, grab, poller, import."""
+import time
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import models.dcpp as dc
+from models.download_clients import ClientType, DownloadStatus, NZBSubmitResult
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """DC++ tracks jobs and result tokens in module dicts; isolate each test."""
+    dc.dcpp_downloads.clear()
+    dc._result_tokens.clear()
+    yield
+    dc.dcpp_downloads.clear()
+    dc._result_tokens.clear()
+
+
+def _fake_client(results=None, instance_id="inst-1", bundle_id="b1"):
+    """A stand-in AirDC++ client returning one search page and accepting grabs."""
+    client = MagicMock()
+    client.client_type = ClientType.AIRDCPP
+    client.last_error = None
+    client.search.return_value = (instance_id, results if results is not None else [])
+    client.download_result.return_value = NZBSubmitResult(
+        client_id=bundle_id, success=True)
+    return client
+
+
+def _hit(name, result_id="1", tth=None, size=50_000_000, users=2):
+    return {
+        "result_id": result_id, "name": name, "size": size,
+        "tth": tth if tth is not None else f"TTH{result_id}",
+        "type": "file", "users": users, "relevance": 90, "path": "/",
+    }
+
+
+class TestDcppConfigured:
+
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "airdcpp", "config": {}})
+    @patch("core.database.get_user_preference", return_value='["dcpp"]')
+    def test_enabled(self, mock_pref, mock_active):
+        assert dc.dcpp_enabled_and_configured() is True
+
+    @patch("core.database.get_active_download_client", return_value=None)
+    @patch("core.database.get_user_preference", return_value='["dcpp"]')
+    def test_no_active_client(self, mock_pref, mock_active):
+        assert dc.dcpp_enabled_and_configured() is False
+
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "airdcpp", "config": {}})
+    @patch("core.database.get_user_preference", return_value='["getcomics","usenet"]')
+    def test_not_in_source_priority(self, mock_pref, mock_active):
+        assert dc.dcpp_enabled_and_configured() is False
+
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "airdcpp", "config": {}})
+    @patch("core.database.get_user_preference", return_value='["dcpp"]')
+    def test_asks_for_the_dcpp_group(self, mock_pref, mock_active):
+        # Must not pick up an active SABnzbd -- the groups are independent.
+        dc.dcpp_enabled_and_configured()
+        assert mock_active.call_args.kwargs["client_group"] == "dcpp"
+
+    @patch("core.database.get_user_preference", return_value='["dcpp"]')
+    @patch("core.database.get_active_download_client", side_effect=Exception("db down"))
+    def test_errors_are_not_fatal(self, mock_active, mock_pref):
+        assert dc.dcpp_enabled_and_configured() is False
+
+
+class TestTokenCache:
+
+    def test_store_and_resolve(self):
+        token = dc._store_token("inst-9", _hit("Batman 001.cbz", result_id="7"))
+        entry = dc._resolve_token(token)
+        assert entry["instance_id"] == "inst-9"
+        assert entry["result_id"] == "7"
+
+    def test_unknown_token(self):
+        assert dc._resolve_token("nope") is None
+
+    def test_expired_token_is_dropped(self):
+        token = dc._store_token("inst-9", _hit("Batman 001.cbz"))
+        # Expire it by hand rather than sleeping out the real TTL.
+        dc._result_tokens[token]["expires"] = time.time() - 1
+        assert dc._resolve_token(token) is None
+        assert token not in dc._result_tokens
+
+    def test_prune_leaves_live_tokens(self):
+        stale = dc._store_token("i", _hit("a.cbz", result_id="1"))
+        live = dc._store_token("i", _hit("b.cbz", result_id="2"))
+        dc._result_tokens[stale]["expires"] = time.time() - 1
+        dc._prune_tokens()
+        assert stale not in dc._result_tokens
+        assert live in dc._result_tokens
+
+
+class TestSearchAndScore:
+
+    @patch("models.dcpp._active_client")
+    def test_scores_and_picks_direct_match(self, mock_client):
+        mock_client.return_value = _fake_client([
+            _hit("Batman 001 (2016).cbz", result_id="1"),
+            _hit("Superman 001 (2016).cbz", result_id="2"),
+        ])
+        res = dc.search_dcpp_for_issue("Batman", "1", issue_year=2016)
+
+        assert res["chosen"] is not None
+        assert res["tier"] == "direct match"
+        assert res["chosen"][0]["title"].startswith("Batman 001")
+        # Every result is returned so the UI can show the rejects too.
+        assert len(res["all_results"]) == 2
+        # Each carries a grabbable token.
+        assert all(r["result_token"] for r in res["all_results"])
+
+    @patch("models.dcpp._active_client")
+    def test_dedupes_on_tth(self, mock_client):
+        # The same file from two users, matched by several query variants.
+        mock_client.return_value = _fake_client([
+            _hit("Batman 001 (2016).cbz", result_id="1", tth="SAME"),
+            _hit("Batman 001 (2016).cbz", result_id="2", tth="SAME"),
+        ])
+        res = dc.search_dcpp_for_issue("Batman", "1", issue_year=2016)
+        assert len(res["all_results"]) == 1
+
+    @patch("models.dcpp._active_client")
+    def test_unconfirmed_issue_is_rejected(self, mock_client):
+        # DC++ filenames rarely carry a '#', so series+year alone must not be
+        # enough to auto-accept the wrong issue.
+        mock_client.return_value = _fake_client([
+            _hit("Batman 099 (2016).cbz", result_id="1"),
+        ])
+        res = dc.search_dcpp_for_issue("Batman", "1", issue_year=2016)
+        assert res["chosen"] is None
+        assert res["all_results"][0]["decision"] == "REJECT"
+
+    @patch("models.dcpp._active_client", return_value=None)
+    def test_no_client_returns_empty(self, mock_client):
+        res = dc.search_dcpp_for_issue("Batman", "1")
+        assert res["all_results"] == []
+        assert res["errors"]
+
+    @patch("models.dcpp._active_client")
+    def test_search_exception_is_collected(self, mock_client):
+        client = _fake_client()
+        client.search.side_effect = Exception("hub offline")
+        mock_client.return_value = client
+        res = dc.search_dcpp_for_issue("Batman", "1")
+        assert res["all_results"] == []
+        assert any("hub offline" in e for e in res["errors"])
+
+    @patch("models.dcpp._active_client")
+    def test_tries_zero_padded_queries(self, mock_client):
+        client = _fake_client()
+        mock_client.return_value = client
+        dc.search_dcpp_for_issue("Batman", "1")
+        queried = [c.args[0] for c in client.search.call_args_list]
+        assert queried == ["Batman 1", "Batman 01", "Batman 001"]
+
+
+class TestTryDownloadForIssue:
+
+    @patch("models.dcpp.grab_dcpp", return_value="dl-1")
+    @patch("models.dcpp._active_client")
+    def test_submits_on_match(self, mock_client, mock_grab):
+        mock_client.return_value = _fake_client([_hit("Batman 001 (2016).cbz")])
+        out = dc.try_download_for_issue("Batman", "1", issue_year=2016)
+        assert out["source"] == "dcpp"
+        assert out["status"] == "submitted"
+        assert out["submitted"] is True
+        assert out["download_id"] == "dl-1"
+        assert out["chosen"]["filename"] == "Batman 1.cbz"
+
+    @patch("models.dcpp.grab_dcpp")
+    @patch("models.dcpp._active_client")
+    def test_dry_run_does_not_submit(self, mock_client, mock_grab):
+        mock_client.return_value = _fake_client([_hit("Batman 001 (2016).cbz")])
+        out = dc.try_download_for_issue("Batman", "1", issue_year=2016, dry_run=True)
+        assert out["status"] == "match_found"
+        assert out["submitted"] is False
+        mock_grab.assert_not_called()
+
+    @patch("models.dcpp._active_client")
+    def test_no_results(self, mock_client):
+        mock_client.return_value = _fake_client([])
+        out = dc.try_download_for_issue("Batman", "1")
+        assert out["status"] == "no_results"
+
+    @patch("models.dcpp._active_client")
+    def test_no_match(self, mock_client):
+        mock_client.return_value = _fake_client([_hit("Spider-Man 005.cbz")])
+        out = dc.try_download_for_issue("Batman", "1", issue_year=2016)
+        assert out["status"] == "no_match"
+
+    @patch("models.dcpp.grab_dcpp", return_value=None)
+    @patch("models.dcpp._active_client")
+    def test_submit_failure(self, mock_client, mock_grab):
+        mock_client.return_value = _fake_client([_hit("Batman 001 (2016).cbz")])
+        out = dc.try_download_for_issue("Batman", "1", issue_year=2016)
+        assert out["status"] == "submit_failed"
+        assert out["submitted"] is False
+
+    def test_signature_matches_usenet(self):
+        # The auto-download loop calls both interchangeably.
+        import inspect
+        import models.usenet as un
+        assert (inspect.signature(dc.try_download_for_issue)
+                == inspect.signature(un.try_download_for_issue))
+
+
+class TestGrabDcpp:
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("models.dcpp._active_client")
+    def test_tracks_the_bundle(self, mock_client, mock_poller):
+        client = _fake_client(bundle_id="bundle-7")
+        mock_client.return_value = client
+        token = dc._store_token("inst-1", _hit("Batman 001.cbz", result_id="5"))
+
+        download_id = dc.grab_dcpp(token, "Batman 1.cbz", series="Batman", issue="1")
+
+        assert download_id
+        job = dc.dcpp_downloads[download_id]
+        assert job["client_type"] == "airdcpp"
+        assert job["client_id"] == "bundle-7"
+        assert job["status"] == "downloading"
+        assert job["series"] == "Batman"
+        client.download_result.assert_called_once_with("inst-1", "5")
+        mock_poller.assert_called_once()
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("models.dcpp._active_client")
+    def test_expired_token_refuses(self, mock_client, mock_poller):
+        assert dc.grab_dcpp("stale-token", "Batman 1.cbz") is None
+        mock_client.assert_not_called()
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("models.dcpp._active_client", return_value=None)
+    def test_no_active_client(self, mock_client, mock_poller):
+        token = dc._store_token("inst-1", _hit("Batman 001.cbz"))
+        assert dc.grab_dcpp(token, "Batman 1.cbz") is None
+        assert dc.dcpp_downloads == {}
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("models.dcpp._active_client")
+    def test_client_rejects(self, mock_client, mock_poller):
+        client = _fake_client()
+        client.download_result.return_value = NZBSubmitResult(
+            success=False, error="no target")
+        mock_client.return_value = client
+        token = dc._store_token("inst-1", _hit("Batman 001.cbz"))
+        assert dc.grab_dcpp(token, "Batman 1.cbz") is None
+        assert dc.dcpp_downloads == {}
+
+
+class TestPollerProgress:
+
+    def test_update_progress_caches_live_fields(self):
+        dc.dcpp_downloads["d1"] = {
+            "client_type": "airdcpp", "client_id": "b1", "filename": "Batman 1.cbz",
+            "status": "downloading", "error": None, "series": "Batman", "issue": "1",
+            "percent": 0, "stage": "Queued", "bytes_total": None, "bytes_downloaded": None,
+        }
+        st = DownloadStatus(client_id="b1", status="downloading", percent=42.0,
+                            stage="Downloading", bytes_total=100, bytes_downloaded=42)
+        dc._update_progress("d1", st)
+
+        snap = {d["download_id"]: d for d in dc.get_dcpp_downloads()}
+        assert snap["d1"]["percent"] == 42.0
+        assert snap["d1"]["stage"] == "Downloading"
+        assert snap["d1"]["bytes_downloaded"] == 42
+
+    def test_set_status_terminal(self):
+        dc.dcpp_downloads["d1"] = {"status": "downloading", "error": None, "percent": 40}
+        dc._set_status("d1", "complete", percent=100)
+        assert dc.dcpp_downloads["d1"]["status"] == "complete"
+        assert dc.dcpp_downloads["d1"]["percent"] == 100
+        dc._set_status("d1", "failed", error="boom")
+        assert dc.dcpp_downloads["d1"]["error"] == "boom"
+
+    @patch("models.dcpp._active_client")
+    def test_statuses_merges_queue_and_history(self, mock_client):
+        client = MagicMock()
+        client.get_queue.return_value = [
+            DownloadStatus(client_id="active", status="downloading", percent=30),
+            DownloadStatus(client_id="both", status="downloading", percent=99),
+        ]
+        client.get_history.return_value = [
+            DownloadStatus(client_id="both", status="complete", storage_path="/done"),
+        ]
+        mock_client.return_value = client
+        merged = dc._statuses()
+        # Finished wins over a stale queue entry.
+        assert merged["both"].status == "complete"
+        assert merged["active"].status == "downloading"
+
+    @patch("models.dcpp._active_client", return_value=None)
+    def test_statuses_without_client(self, mock_client):
+        assert dc._statuses() == {}
+
+    @patch("models.dcpp._active_client", side_effect=Exception("boom"))
+    def test_statuses_error_is_not_fatal(self, mock_client):
+        assert dc._statuses() == {}
+
+
+class TestImportCompleted:
+
+    def test_moves_comic_into_watch(self, tmp_path, monkeypatch):
+        import models.usenet as un
+
+        watch = tmp_path / "watch"
+        watch.mkdir()
+        done = tmp_path / "done" / "Batman 1"
+        done.mkdir(parents=True)
+        (done / "Batman 1.cbz").write_bytes(b"x")
+        (done / "notes.txt").write_bytes(b"junk")
+        # DC++ shares the Usenet mover, so the WATCH lookup is patched there.
+        monkeypatch.setattr(un, "_watch_dir", lambda: str(watch))
+
+        assert dc._import_completed(str(done), "Batman 1.cbz") is True
+        assert (watch / "Batman 1.cbz").exists()
+        assert not (watch / "notes.txt").exists()
+
+    def test_inaccessible_path_returns_false(self, tmp_path, monkeypatch):
+        import models.usenet as un
+
+        watch = tmp_path / "watch"
+        watch.mkdir()
+        monkeypatch.setattr(un, "_watch_dir", lambda: str(watch))
+        assert dc._import_completed(str(tmp_path / "nope"), "x.cbz") is False

--- a/tests/mocked/test_dcpp.py
+++ b/tests/mocked/test_dcpp.py
@@ -186,6 +186,87 @@ class TestSearchAndScore:
         assert len(client.search.call_args_list) == 1
 
 
+class TestNormalizeHubTitle:
+    """Hub back-catalogues use a date prefix the shared scorer can't read."""
+
+    def test_yyyymm_prefix_and_volume_token(self):
+        title, vol = dc._normalize_hub_title(
+            "196103 Strange Tales v1 083.cbz", "Strange Tales")
+        assert title == "Strange Tales 083 (1961)"
+        assert vol == 1
+
+    def test_yyyy_prefix(self):
+        title, vol = dc._normalize_hub_title(
+            "1963 Strange Tales v1 114.cbr", "Strange Tales")
+        assert title == "Strange Tales 114 (1963)"
+
+    def test_short_sequence_prefix_yields_no_year(self):
+        title, _ = dc._normalize_hub_title(
+            "07 Strange Tales v1 120.cbr", "Strange Tales")
+        assert title == "Strange Tales 120"
+
+    def test_series_starting_with_digits_is_not_decapitated(self):
+        # The guard that matters: "100" here is the series, not a prefix.
+        title, _ = dc._normalize_hub_title("100 Bullets 001 (1999).cbz", "100 Bullets")
+        assert title == "100 Bullets 001 (1999)"
+
+    def test_leading_number_kept_when_series_does_not_follow(self):
+        title, _ = dc._normalize_hub_title("2011 Some Other Book 001.cbz", "Strange Tales")
+        assert title.startswith("2011 Some Other Book")
+
+    def test_modern_scene_name_is_left_alone_apart_from_the_extension(self):
+        title, vol = dc._normalize_hub_title(
+            "Strange Tales 004 (2026) (Digital) (Shan-Empire).cbz", "Strange Tales")
+        assert title == "Strange Tales 004 (2026) (Digital) (Shan-Empire)"
+        assert vol is None
+
+    def test_existing_year_is_not_duplicated(self):
+        title, _ = dc._normalize_hub_title(
+            "196103 Strange Tales v1 083 (1961).cbz", "Strange Tales")
+        assert title.count("(1961)") == 1
+
+    def test_handles_empty_input(self):
+        assert dc._normalize_hub_title("", "Strange Tales") == ("", None)
+        assert dc._normalize_hub_title("x.cbz", "") == ("x.cbz", None)
+
+
+class TestHubNamingIsMatchable:
+    """End-to-end scoring of real filenames seen on a live comic hub."""
+
+    @patch("models.dcpp._active_client")
+    def test_date_prefixed_back_catalogue_matches(self, mock_client):
+        mock_client.return_value = _fake_client([
+            _hit("196103 Strange Tales v1 083.cbz", result_id="1"),
+            _hit("196104 Strange Tales v1 084.cbz", result_id="2"),
+        ])
+        res = dc.search_dcpp_for_issue("Strange Tales", "83", issue_year=1961)
+        assert res["chosen"] is not None
+        assert res["chosen"][0]["decision"] == "ACCEPT"
+        # The user still sees the real filename, not the normalized form.
+        assert res["chosen"][0]["title"] == "196103 Strange Tales v1 083.cbz"
+
+    @patch("models.dcpp._active_client")
+    def test_wrong_volume_is_rejected(self, mock_client):
+        # Normalizing strips the vN token, so the volume check has to happen
+        # here or a v1 file would satisfy a request for v2.
+        mock_client.return_value = _fake_client([
+            _hit("196103 Strange Tales v1 083.cbz", result_id="1"),
+        ])
+        res = dc.search_dcpp_for_issue(
+            "Strange Tales", "83", issue_year=1961, series_volume=2)
+        assert res["chosen"] is None
+        assert res["all_results"][0]["decision"] == "REJECT"
+
+    @patch("models.dcpp._active_client")
+    def test_matching_volume_still_accepted(self, mock_client):
+        mock_client.return_value = _fake_client([
+            _hit("196103 Strange Tales v1 083.cbz", result_id="1"),
+        ])
+        res = dc.search_dcpp_for_issue(
+            "Strange Tales", "83", issue_year=1961, series_volume=1)
+        assert res["chosen"] is not None
+
+
 class TestTryDownloadForIssue:
 
     @patch("models.dcpp.grab_dcpp", return_value="dl-1")

--- a/tests/mocked/test_dcpp.py
+++ b/tests/mocked/test_dcpp.py
@@ -280,29 +280,92 @@ class TestPollerProgress:
         dc._set_status("d1", "failed", error="boom")
         assert dc.dcpp_downloads["d1"]["error"] == "boom"
 
-    @patch("models.dcpp._active_client")
-    def test_statuses_merges_queue_and_history(self, mock_client):
+    def test_update_progress_caches_target(self):
+        # Once AirDC++ drops a finished bundle there is nothing left to ask
+        # where the file landed, so the target must be captured while running.
+        dc.dcpp_downloads["d1"] = {"percent": 0, "stage": None, "bytes_total": None,
+                                   "bytes_downloaded": None, "target": None}
+        dc._update_progress("d1", DownloadStatus(
+            client_id="b1", status="downloading", percent=10,
+            storage_path="/downloads/dcpp/Batman 1.cbz"))
+        assert dc.dcpp_downloads["d1"]["target"] == "/downloads/dcpp/Batman 1.cbz"
+
+
+class TestPollOne:
+    """One poll of a tracked bundle, incl. the 404 completion path."""
+
+    def _job(self, **over):
+        job = {
+            "client_type": "airdcpp", "client_id": "b1", "filename": "Batman 1.cbz",
+            "status": "downloading", "error": None, "series": "Batman", "issue": "1",
+            "percent": 0, "stage": "Queued", "bytes_total": None,
+            "bytes_downloaded": None, "target": None,
+        }
+        job.update(over)
+        dc.dcpp_downloads["d1"] = job
+        return job
+
+    def _client(self, state, status=None):
         client = MagicMock()
-        client.get_queue.return_value = [
-            DownloadStatus(client_id="active", status="downloading", percent=30),
-            DownloadStatus(client_id="both", status="downloading", percent=99),
-        ]
-        client.get_history.return_value = [
-            DownloadStatus(client_id="both", status="complete", storage_path="/done"),
-        ]
-        mock_client.return_value = client
-        merged = dc._statuses()
-        # Finished wins over a stale queue entry.
-        assert merged["both"].status == "complete"
-        assert merged["active"].status == "downloading"
+        client.get_bundle_state.return_value = (state, status)
+        return client
 
-    @patch("models.dcpp._active_client", return_value=None)
-    def test_statuses_without_client(self, mock_client):
-        assert dc._statuses() == {}
+    @patch("models.dcpp._import_completed", return_value=True)
+    def test_gone_imports_from_cached_target(self, mock_import):
+        job = self._job(target="/downloads/dcpp/Batman 1.cbz")
+        dc._poll_one(self._client("gone"), "d1", job)
+        mock_import.assert_called_once_with("/downloads/dcpp/Batman 1.cbz", "Batman 1.cbz")
+        assert dc.dcpp_downloads["d1"]["status"] == "complete"
+        assert dc.dcpp_downloads["d1"]["percent"] == 100
 
-    @patch("models.dcpp._active_client", side_effect=Exception("boom"))
-    def test_statuses_error_is_not_fatal(self, mock_client):
-        assert dc._statuses() == {}
+    @patch("models.dcpp._import_completed", return_value=False)
+    def test_gone_without_importable_file(self, mock_import):
+        # A hand-cancelled bundle looks the same as a removed finished one;
+        # it just has nothing to import.
+        job = self._job()
+        dc._poll_one(self._client("gone"), "d1", job)
+        assert dc.dcpp_downloads["d1"]["status"] == "complete_no_move"
+
+    @patch("models.dcpp._import_completed")
+    def test_error_leaves_job_untouched(self, mock_import):
+        # A 500 or an unreachable client must never read as completion.
+        job = self._job()
+        dc._poll_one(self._client("error"), "d1", job)
+        mock_import.assert_not_called()
+        assert dc.dcpp_downloads["d1"]["status"] == "downloading"
+
+    @patch("models.dcpp._import_completed", return_value=True)
+    def test_completed_flag_imports_from_live_target(self, mock_import):
+        job = self._job()
+        status = DownloadStatus(client_id="b1", status="complete",
+                                storage_path="/downloads/dcpp/Batman 1.cbz")
+        dc._poll_one(self._client("found", status), "d1", job)
+        mock_import.assert_called_once_with("/downloads/dcpp/Batman 1.cbz", "Batman 1.cbz")
+        assert dc.dcpp_downloads["d1"]["status"] == "complete"
+
+    def test_failed(self):
+        job = self._job()
+        dc._poll_one(self._client(
+            "found", DownloadStatus(client_id="b1", status="failed")), "d1", job)
+        assert dc.dcpp_downloads["d1"]["status"] == "failed"
+
+    def test_active_updates_progress(self):
+        job = self._job()
+        dc._poll_one(self._client("found", DownloadStatus(
+            client_id="b1", status="downloading", percent=60, stage="Downloading",
+            storage_path="/downloads/dcpp/Batman 1.cbz")), "d1", job)
+        assert dc.dcpp_downloads["d1"]["status"] == "downloading"
+        assert dc.dcpp_downloads["d1"]["percent"] == 60
+        assert dc.dcpp_downloads["d1"]["target"] == "/downloads/dcpp/Batman 1.cbz"
+
+    @patch("models.dcpp._import_completed")
+    def test_client_exception_is_not_fatal(self, mock_import):
+        client = MagicMock()
+        client.get_bundle_state.side_effect = Exception("boom")
+        job = self._job()
+        dc._poll_one(client, "d1", job)
+        mock_import.assert_not_called()
+        assert dc.dcpp_downloads["d1"]["status"] == "downloading"
 
 
 class TestImportCompleted:

--- a/tests/mocked/test_download_sources.py
+++ b/tests/mocked/test_download_sources.py
@@ -63,6 +63,37 @@ class TestRankingAndOrdering:
         assert ds.ordered_sources() == ["getcomics", "usenet"]
 
 
+class TestOrderedForSearch:
+    """The manual search modal ranks sources but never drops them."""
+
+    @patch("core.database.get_user_preference", return_value=None)
+    def test_unset_preference_still_searches_everything(self, mock_pref):
+        # Regression: gating the modal on the priority list meant a default
+        # install (preference unset -> ["getcomics"]) silently stopped
+        # searching Usenet and never searched DC++.
+        assert set(ds.ordered_for_search()) == set(ds.KNOWN_SOURCES)
+        assert ds.ordered_for_search()[0] == "getcomics"
+
+    @patch("core.database.get_user_preference", return_value='["dcpp","usenet","getcomics"]')
+    def test_follows_priority(self, mock_pref):
+        assert ds.ordered_for_search() == ["dcpp", "usenet", "getcomics"]
+
+    @patch("core.database.get_user_preference", return_value='["dcpp"]')
+    def test_unranked_sources_are_appended_not_dropped(self, mock_pref):
+        order = ds.ordered_for_search()
+        assert order[0] == "dcpp"
+        assert set(order) == set(ds.KNOWN_SOURCES)
+        # Unranked ones keep KNOWN_SOURCES order behind the ranked one.
+        assert order[1:] == ["getcomics", "usenet"]
+
+    @patch("core.database.get_user_preference", return_value='["usenet","getcomics"]')
+    def test_differs_from_auto_download_ordering(self, mock_pref):
+        # ordered_sources drops DC++ (auto-download must not use it);
+        # ordered_for_search keeps it (the user can still search by hand).
+        assert "dcpp" not in ds.ordered_sources()
+        assert "dcpp" in ds.ordered_for_search()
+
+
 class TestSplitAroundGetComics:
 
     def _split(self, order, sources):

--- a/tests/mocked/test_download_sources.py
+++ b/tests/mocked/test_download_sources.py
@@ -1,0 +1,146 @@
+"""Tests for models/download_sources.py -- ordering shared by all sources."""
+import pytest
+from unittest.mock import patch
+
+import models.download_sources as ds
+
+
+class TestGetSourcePriority:
+
+    @patch("core.database.get_user_preference", return_value=None)
+    def test_default_is_getcomics_only(self, mock_pref):
+        # A fresh install must behave exactly as it did before Usenet/DC++.
+        assert ds.get_source_priority() == ["getcomics"]
+
+    @patch("core.database.get_user_preference", return_value='["dcpp","usenet","getcomics"]')
+    def test_json_string(self, mock_pref):
+        assert ds.get_source_priority() == ["dcpp", "usenet", "getcomics"]
+
+    @patch("core.database.get_user_preference", return_value=["usenet", "getcomics"])
+    def test_list_value(self, mock_pref):
+        assert ds.get_source_priority() == ["usenet", "getcomics"]
+
+    @patch("core.database.get_user_preference", return_value="not json")
+    def test_unparseable_falls_back(self, mock_pref):
+        assert ds.get_source_priority() == ["getcomics"]
+
+    @patch("core.database.get_user_preference", side_effect=Exception("db down"))
+    def test_error_falls_back(self, mock_pref):
+        assert ds.get_source_priority() == ["getcomics"]
+
+    @patch("core.database.get_user_preference", return_value='["getcomics"]')
+    def test_default_list_is_not_shared(self, mock_pref):
+        # Callers must not be able to mutate the module's default.
+        first = ds.get_source_priority()
+        first.append("dcpp")
+        assert ds.get_source_priority() == ["getcomics"]
+
+
+class TestRankingAndOrdering:
+
+    @patch("core.database.get_user_preference", return_value='["dcpp","getcomics","usenet"]')
+    def test_source_rank(self, mock_pref):
+        assert ds.source_rank("dcpp") == 0
+        assert ds.source_rank("getcomics") == 1
+        assert ds.source_rank("usenet") == 2
+
+    @patch("core.database.get_user_preference", return_value='["getcomics"]')
+    def test_unlisted_source_sorts_last(self, mock_pref):
+        assert ds.source_rank("dcpp") == 999
+
+    @patch("core.database.get_user_preference", return_value='["dcpp","getcomics"]')
+    def test_source_enabled(self, mock_pref):
+        assert ds.source_enabled("dcpp") is True
+        assert ds.source_enabled("usenet") is False
+
+    @patch("core.database.get_user_preference", return_value='["dcpp","usenet","getcomics"]')
+    def test_ordered_sources(self, mock_pref):
+        assert ds.ordered_sources() == ["dcpp", "usenet", "getcomics"]
+        assert ds.ordered_sources(["getcomics", "dcpp"]) == ["dcpp", "getcomics"]
+
+    @patch("core.database.get_user_preference", return_value='["getcomics","usenet"]')
+    def test_ordered_sources_drops_disabled(self, mock_pref):
+        assert ds.ordered_sources() == ["getcomics", "usenet"]
+
+
+class TestSplitAroundGetComics:
+
+    def _split(self, order, sources):
+        with patch("core.database.get_user_preference", return_value=order):
+            return ds.split_around_getcomics(sources)
+
+    def test_dcpp_first_usenet_fallback(self):
+        sources = [("dcpp", "DC++", None), ("usenet", "Usenet", None)]
+        pre, post = self._split('["dcpp","getcomics","usenet"]', sources)
+        assert [s[0] for s in pre] == ["dcpp"]
+        assert [s[0] for s in post] == ["usenet"]
+
+    def test_both_before_getcomics_keeps_priority_order(self):
+        sources = [("usenet", "Usenet", None), ("dcpp", "DC++", None)]
+        pre, post = self._split('["dcpp","usenet","getcomics"]', sources)
+        assert [s[0] for s in pre] == ["dcpp", "usenet"]
+        assert post == []
+
+    def test_both_after_getcomics(self):
+        sources = [("usenet", "Usenet", None), ("dcpp", "DC++", None)]
+        pre, post = self._split('["getcomics","usenet","dcpp"]', sources)
+        assert pre == []
+        assert [s[0] for s in post] == ["usenet", "dcpp"]
+
+    def test_getcomics_absent_means_everything_runs_first(self):
+        # With GetComics unlisted its rank is 999, so every external source
+        # outranks it and is tried up front.
+        sources = [("usenet", "Usenet", None), ("dcpp", "DC++", None)]
+        pre, post = self._split('["dcpp","usenet"]', sources)
+        assert [s[0] for s in pre] == ["dcpp", "usenet"]
+        assert post == []
+
+
+class TestGetExternalSources:
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=True)
+    @patch("core.database.get_user_preference", return_value='["dcpp","getcomics","usenet"]')
+    def test_returns_callables_in_priority_order(self, mock_pref, mock_un, mock_dc):
+        import models.dcpp
+        import models.usenet
+
+        sources = ds.get_external_sources()
+        assert [s[0] for s in sources] == ["dcpp", "usenet"]
+        assert [s[1] for s in sources] == ["DC++", "Usenet"]
+        assert sources[0][2] is models.dcpp.try_download_for_issue
+        assert sources[1][2] is models.usenet.try_download_for_issue
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=True)
+    @patch("core.database.get_user_preference", return_value='["dcpp","usenet","getcomics"]')
+    def test_unconfigured_source_is_skipped(self, mock_pref, mock_un, mock_dc):
+        assert [s[0] for s in ds.get_external_sources()] == ["usenet"]
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", side_effect=Exception("boom"))
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=True)
+    @patch("core.database.get_user_preference", return_value='["dcpp","usenet","getcomics"]')
+    def test_broken_source_does_not_break_the_run(self, mock_pref, mock_un, mock_dc):
+        assert [s[0] for s in ds.get_external_sources()] == ["usenet"]
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=True)
+    @patch("core.database.get_user_preference", return_value='["getcomics"]')
+    def test_sources_not_in_priority_are_excluded(self, mock_pref, mock_un, mock_dc):
+        assert ds.get_external_sources() == []
+
+
+class TestBuildQueries:
+
+    def test_zero_pads_numeric_issues(self):
+        assert ds.build_queries("Batman", "1") == ["Batman 1", "Batman 01", "Batman 001"]
+
+    def test_non_numeric_issue(self):
+        assert ds.build_queries("Batman", "1.MU") == ["Batman 1.MU"]
+
+    def test_no_issue(self):
+        assert ds.build_queries("Batman", None) == ["Batman"]
+
+    def test_shared_with_usenet(self):
+        import models.usenet as un
+        assert un._build_queries("Batman", "5") == ds.build_queries("Batman", "5")

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -357,6 +357,24 @@ class TestDownloadSources:
         assert data["order"] == ["getcomics"]
         assert data["available"]["getcomics"] is True
 
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=False)
+    @patch("core.database.get_user_preference", return_value=None)
+    def test_search_order_covers_every_source(self, mock_pref, mock_un, mock_dc, client):
+        # order gates auto-download; search_order drives the manual modal and
+        # must never drop a source, or a default install stops searching
+        # Usenet and DC++ entirely.
+        data = client.get("/api/download-clients/sources").get_json()
+        assert data["order"] == ["getcomics"]
+        assert set(data["search_order"]) == {"getcomics", "usenet", "dcpp"}
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=True)
+    @patch("core.database.get_user_preference", return_value='["dcpp","usenet","getcomics"]')
+    def test_search_order_follows_priority(self, mock_pref, mock_un, mock_dc, client):
+        data = client.get("/api/download-clients/sources").get_json()
+        assert data["search_order"] == ["dcpp", "usenet", "getcomics"]
+
 
 class TestDcppDownloads:
 
@@ -385,7 +403,8 @@ class TestDcppDownloads:
 
 class TestDcppSearch:
 
-    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "airdcpp", "config": {}})
     @patch("models.dcpp.search_dcpp_for_issue", return_value={
         "all_results": [
             {"title": "Batman 002", "result_token": "t2", "score": 10, "decision": "REJECT"},
@@ -393,7 +412,7 @@ class TestDcppSearch:
         ],
         "errors": [],
     })
-    def test_search(self, mock_search, mock_on, client):
+    def test_search(self, mock_search, mock_active, client):
         resp = client.post("/api/dcpp/search", json={"series": "Batman", "issue": "1"})
         assert resp.status_code == 200
         data = resp.get_json()
@@ -401,21 +420,36 @@ class TestDcppSearch:
         assert data["has_client"] is True
         # sorted best-first
         assert data["results"][0]["result_token"] == "t1"
+        # Scoped to the DC++ group so an active SABnzbd can't satisfy it.
+        assert mock_active.call_args.kwargs["client_group"] == "dcpp"
 
-    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
-    def test_search_no_client(self, mock_on, client):
+    @patch("core.database.get_active_download_client", return_value=None)
+    def test_search_no_client(self, mock_active, client):
         resp = client.post("/api/dcpp/search", json={"series": "Batman", "issue": "1"})
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["has_client"] is False
         assert data["results"] == []
 
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "airdcpp", "config": {}})
+    @patch("models.dcpp.search_dcpp_for_issue", return_value={"all_results": [], "errors": []})
+    @patch("core.database.get_user_preference", return_value='["getcomics"]')
+    def test_search_ignores_source_priority(self, mock_pref, mock_search, mock_active, client):
+        # A configured DC++ client must stay searchable by hand even when the
+        # user has not ranked DC++ — that list governs auto-download only.
+        data = client.post("/api/dcpp/search",
+                           json={"series": "Batman", "issue": "1"}).get_json()
+        assert data["has_client"] is True
+        mock_search.assert_called_once()
+
     def test_search_missing_series(self, client):
         assert client.post("/api/dcpp/search", json={"issue": "1"}).status_code == 400
 
-    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("core.database.get_active_download_client",
+           return_value={"client_type": "airdcpp", "config": {}})
     @patch("models.dcpp.search_dcpp_for_issue", return_value={"all_results": [], "errors": []})
-    def test_search_year_coercion(self, mock_search, mock_on, client):
+    def test_search_year_coercion(self, mock_search, mock_active, client):
         # Scoring compares the year numerically, so it must arrive as an int.
         for sent, expected in [
             (2026, 2026),

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -331,3 +331,124 @@ class TestUsenetDownloads:
         resp = client.post("/api/usenet/grab",
                            json={"nzb_url": "u1", "filename": "x.cbz"})
         assert resp.status_code == 502
+
+
+class TestDownloadSources:
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=False)
+    @patch("core.database.get_user_preference", return_value='["dcpp","getcomics","usenet"]')
+    def test_lists_order_and_availability(self, mock_pref, mock_un, mock_dc, client):
+        resp = client.get("/api/download-clients/sources")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["order"] == ["dcpp", "getcomics", "usenet"]
+        assert data["available"] == {
+            "getcomics": True, "usenet": False, "dcpp": True,
+        }
+        assert "dcpp" in data["known"]
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
+    @patch("models.usenet.usenet_enabled_and_configured", return_value=False)
+    @patch("core.database.get_user_preference", return_value=None)
+    def test_default_is_getcomics_only(self, mock_pref, mock_un, mock_dc, client):
+        data = client.get("/api/download-clients/sources").get_json()
+        assert data["order"] == ["getcomics"]
+        assert data["available"]["getcomics"] is True
+
+
+class TestDcppDownloads:
+
+    @patch("models.dcpp.get_dcpp_downloads", return_value=[
+        {"download_id": "x", "filename": "Batman 1.cbz", "status": "downloading",
+         "client_type": "airdcpp", "percent": 25, "stage": "Downloading",
+         "bytes_total": 104857600, "bytes_downloaded": 26214400},
+    ])
+    def test_list(self, mock_dl, client):
+        resp = client.get("/api/dcpp/downloads")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        dl = data["downloads"][0]
+        # Same item shape as /api/usenet/downloads, so the status page renders
+        # both with one code path.
+        assert dl["client_type"] == "airdcpp"
+        assert dl["percent"] == 25
+        assert dl["stage"] == "Downloading"
+        assert dl["bytes_downloaded"] == 26214400
+
+    @patch("models.dcpp.get_dcpp_downloads", side_effect=Exception("boom"))
+    def test_list_error(self, mock_dl, client):
+        assert client.get("/api/dcpp/downloads").status_code == 500
+
+
+class TestDcppSearch:
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.dcpp.search_dcpp_for_issue", return_value={
+        "all_results": [
+            {"title": "Batman 002", "result_token": "t2", "score": 10, "decision": "REJECT"},
+            {"title": "Batman 001", "result_token": "t1", "score": 90, "decision": "ACCEPT"},
+        ],
+        "errors": [],
+    })
+    def test_search(self, mock_search, mock_on, client):
+        resp = client.post("/api/dcpp/search", json={"series": "Batman", "issue": "1"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["has_client"] is True
+        # sorted best-first
+        assert data["results"][0]["result_token"] == "t1"
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
+    def test_search_no_client(self, mock_on, client):
+        resp = client.post("/api/dcpp/search", json={"series": "Batman", "issue": "1"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_client"] is False
+        assert data["results"] == []
+
+    def test_search_missing_series(self, client):
+        assert client.post("/api/dcpp/search", json={"issue": "1"}).status_code == 400
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.dcpp.search_dcpp_for_issue", return_value={"all_results": [], "errors": []})
+    def test_search_year_coercion(self, mock_search, mock_on, client):
+        # Scoring compares the year numerically, so it must arrive as an int.
+        for sent, expected in [
+            (2026, 2026),
+            ("2026-01-14", 2026),   # a store date, not just a year
+            ("", None),
+            (None, None),
+            ("not-a-year", None),
+            (1492, None),           # outside the plausible range
+        ]:
+            client.post("/api/dcpp/search",
+                        json={"series": "Iron Man", "issue": "8", "issue_year": sent})
+            assert mock_search.call_args.kwargs["issue_year"] == expected, sent
+
+
+class TestDcppGrab:
+
+    @patch("models.dcpp.grab_dcpp", return_value="dl-456")
+    def test_grab(self, mock_grab, client):
+        resp = client.post("/api/dcpp/grab",
+                           json={"result_token": "t1", "filename": "Batman 1.cbz",
+                                 "series": "Batman", "issue": "1"})
+        assert resp.status_code == 200
+        assert resp.get_json()["download_id"] == "dl-456"
+        assert mock_grab.call_args[0][0] == "t1"
+
+    def test_grab_missing_fields(self, client):
+        assert client.post("/api/dcpp/grab", json={"result_token": "t1"}).status_code == 400
+        assert client.post("/api/dcpp/grab", json={"filename": "x.cbz"}).status_code == 400
+
+    @patch("models.dcpp.grab_dcpp", return_value=None)
+    def test_grab_rejected(self, mock_grab, client):
+        # No active client, an expired result token, or a client-side refusal.
+        resp = client.post("/api/dcpp/grab",
+                           json={"result_token": "stale", "filename": "x.cbz"})
+        assert resp.status_code == 502
+        assert resp.get_json()["success"] is False

--- a/tests/routes/test_downloads_simulation.py
+++ b/tests/routes/test_downloads_simulation.py
@@ -68,3 +68,73 @@ def test_simulation_skips_issues_covered_by_range():
     # Issue 1 resolves to a range pack (#1-3); issues 2 and 3 are covered by it
     # and must not be searched again.
     assert searched == ["1"]
+
+
+def _sim_patches(order):
+    """Common patches for a simulation run with a given source priority."""
+    return [
+        patch("routes.downloads.get_issues_for_series",
+              return_value=[{"number": "1", "store_date": "2000-01-01"}]),
+        patch("routes.downloads.get_manual_status_for_series", return_value={}),
+        patch("routes.downloads.get_series_alias_list", return_value=[]),
+        patch("routes.downloads.match_issues_to_collection", return_value={}),
+        patch("core.database.get_user_preference", return_value=order),
+    ]
+
+
+def test_simulation_tries_dcpp_before_getcomics():
+    """A source ranked above GetComics is searched first and short-circuits it."""
+    import contextlib
+    import routes.downloads as dl
+
+    getcomics_searched = []
+    dcpp_match = {
+        "source": "dcpp", "status": "match_found",
+        "chosen": {"title": "S1 001", "result_token": "t1", "filename": "S1 1.cbz"},
+        "all_results": [{"title": "S1 001", "score": 90, "decision": "ACCEPT"}],
+    }
+
+    with contextlib.ExitStack() as stack:
+        for p in _sim_patches('["dcpp","getcomics","usenet"]'):
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("routes.downloads.get_all_mapped_series", return_value=[_series(1)]))
+        stack.enter_context(
+            patch("routes.downloads.search_getcomics_for_issue",
+                  side_effect=lambda **kw: getcomics_searched.append(kw) or []))
+        stack.enter_context(
+            patch("models.dcpp.dcpp_enabled_and_configured", return_value=True))
+        stack.enter_context(
+            patch("models.usenet.usenet_enabled_and_configured", return_value=False))
+        stack.enter_context(
+            patch("models.dcpp.try_download_for_issue", return_value=dcpp_match))
+
+        results = dl._run_wanted_simulation(limit=10, target_series_id=None,
+                                            target_series_name=None)
+
+    assert getcomics_searched == [], "GetComics ran despite a DC++ match"
+    assert any(r["source"] == "dcpp" and r["status"] == "match_found" for r in results)
+
+
+def test_simulation_skips_dcpp_ranked_below_getcomics():
+    """Fallback sources never run in the simulation — it does not submit."""
+    import contextlib
+    import routes.downloads as dl
+
+    with contextlib.ExitStack() as stack:
+        for p in _sim_patches('["getcomics","dcpp"]'):
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("routes.downloads.get_all_mapped_series", return_value=[_series(1)]))
+        stack.enter_context(
+            patch("routes.downloads.search_getcomics_for_issue", return_value=[]))
+        stack.enter_context(
+            patch("models.dcpp.dcpp_enabled_and_configured", return_value=True))
+        stack.enter_context(
+            patch("models.usenet.usenet_enabled_and_configured", return_value=False))
+        dcpp_try = stack.enter_context(patch("models.dcpp.try_download_for_issue"))
+
+        dl._run_wanted_simulation(limit=10, target_series_id=None,
+                                  target_series_name=None)
+
+    dcpp_try.assert_not_called()


### PR DESCRIPTION
Adds **DC++** alongside GetComics and Usenet: CLU connects to the user's own
**AirDC++ Web Client** over its `/api/v1` REST API, the same way it connects to
SABnzbd/NZBGet, with progress on the Download Status page.

DC++ itself has no remote API, so AirDC++ Web Client (the standard headless
client) is the target. Everything here was **verified against a live instance**,
which corrected several assumptions the published API docs left wrong or silent.

## What's included

- Config → Download Clients gains an AirDC++ card with Test Connection
- Manual search & grab from the Wanted/Series search modal
- Live progress on `/status`
- Participation in the scheduled wanted-issue auto-download, ordered by Source Priority

`api.py` is untouched. Completed DC++ bundles land in WATCH through the existing
Usenet mover, so there is one implementation of how files enter the pipeline.

## Structural changes it required

**`client_group` on `download_clients`.** `set_active_download_client` cleared
`is_active` on every row — correct for SABnzbd vs NZBGet, wrong for DC++.
Single-active is now scoped per group, so an active AirDC++ and an active
SABnzbd coexist. Existing rows backfill to `usenet` via the codebase's usual
`PRAGMA table_info` + `ALTER TABLE` idiom.

**Generalized source priority.** `usenet_precedes_getcomics()` was a two-source
boolean. `models/download_sources.py` replaces it with a rank and hands both
auto-download loops — the real one in `app.py` and its deliberate copy in
`routes/downloads.py` — an ordered source list split around GetComics.

**Extracted the search fan-out.** `static/js/clu-source-search.js` replaces the
block that was copy-pasted into `wanted.html` and `series.html` with a hardcoded
two-source `Promise.all`. This also fixed a latent bug: the collapse toggle used
one hardcoded element id that two sections would have collided on.

## Corrections made against the live instance

- The download POST returns `{"bundle_info": {"id": N}}`, not a top-level `id`.
  Reading the wrong key made **every successful grab report failure** while the
  download had in fact started at the client.
- `status.downloaded` is a **boolean**, not a byte count — using it as a progress
  fallback would have reported "1 byte downloaded".
- Finished bundles are not observable via the queue listing (AirDC++ can drop
  them). Completion is tracked per bundle via `GET /queue/bundles/{id}`, which
  404s once gone; the poller caches each bundle's target so it can still import.
  Polling by id also fixes losing sight of a bundle past the first page of a
  real queue.
- Hub searches are slow in a way Newznab queries are not: AirDC++ queues and
  paces them (measured `queue_time` ~17s before dispatch, results settling at
  ~t+30s). The original flat 8s wait routinely expired before the query was
  sent. The wait now follows the instance's own `queued_count`/`result_count`.
- Because searches are that expensive, DC++ runs **one** search on the series
  name rather than fanning out over zero-padding variants, narrowing only when
  a full result page shows truncation.
- Hub back-catalogues are named `196103 Strange Tales v1 083.cbz`, which the
  shared scorer rejects outright. `_normalize_hub_title()` reshapes that into
  `Strange Tales 083 (1961)` **inside `models/dcpp.py`** — the shared scorer is
  untouched, so GetComics and Usenet matching is unaffected. It is series-aware
  (`100 Bullets 001` keeps its `100`) and compares the declared volume, since
  stripping `vN` removes the scorer's own chance to catch a mismatch.

## Testing

`pytest` — **3276 passed, 6 skipped** (the standard POSIX-permission skips).

New: `tests/mocked/test_airdcpp_client.py`, `tests/mocked/test_dcpp.py`,
`tests/mocked/test_download_sources.py`, plus route, DB-integration and schema
coverage. `tests/integration/test_database_clients.py` pins the cross-group
activation guard; `tests/integration/test_database_schema.py` pins the migration.

Beyond the suite, the adapter was driven end to end against a live AirDC++:
connect, queue parse, `found`/`gone` bundle states, a 100-result hub search, and
a real grab (the test bundle was removed afterwards).

## Known gaps

- The shared scorer mishandles comma-grouped numbers: `Batman 1,000,000` is
  accepted for issue #1 and rejected for #1,000,000. Pre-existing, affects all
  three sources, deliberately left alone here.
- Hub result sets vary between identical searches (98–192 results for the same
  series) because different peers answer each time. Inherent to DC++; a wanted
  issue may be missed on one pass and found on the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)