### PR TITLE
Stop Usenet jobs from creating ".cbz" folders

### DIFF
--- a/models/usenet.py
+++ b/models/usenet.py
@@ -253,6 +253,21 @@ def _make_filename(series_name, issue_num, chosen_result, tier) -> str:
     return raw.replace("/", "-").replace("\\", "-").replace("#", "").strip() + ".cbz"
 
 
+def _job_name(filename) -> str:
+    """Strip the comic extension off a filename before handing it to the client.
+
+    NZB clients name the job — and therefore the completed *folder* — after the
+    name we submit. Submitting "Heavy Metal 5.cbz" makes the client create a
+    directory called ``Heavy Metal 5.cbz`` holding the real comic, which the
+    WATCH pipeline then treats as a comic file (wrong series folder in TARGET,
+    a ".cbz" directory in the library). The job name must stay extension-free.
+    """
+    base, ext = os.path.splitext(filename or "")
+    if base and ext.lower() in _COMIC_EXTS | {".nzb"}:
+        return base
+    return filename or ""
+
+
 def try_download_for_issue(
     series_name,
     issue_num,
@@ -336,7 +351,7 @@ def grab_nzb(nzb_url, filename, series=None, issue=None):
     # to the URL if the fetch doesn't yield an NZB.
     payload = _fetch_nzb(nzb_url) or nzb_url
 
-    result = client.add_nzb(payload, filename)
+    result = client.add_nzb(payload, _job_name(filename))
     if not result.success:
         app_logger.error(f"Usenet grab failed ({client_type}): {result.error}")
         return None

--- a/monitor.py
+++ b/monitor.py
@@ -12,7 +12,9 @@ from cbz_ops.rename import rename_file, clean_directory_name
 from cbz_ops.single_file import convert_to_cbz
 from core.config import config, load_config, get_watch_dir, get_target_dir
 from helpers import is_hidden
-from helpers.unwrap import classify_release_folder, unwrap_release, MULTIPART_ARCHIVE
+from helpers.unwrap import (
+    classify_release_folder, unwrap_release, MULTIPART_ARCHIVE, COMIC_EXTS,
+)
 from core.app_logging import MONITOR_LOG
 from core.database import init_db
 
@@ -60,6 +62,20 @@ monitor_logger.info(f"8. Auto Unpack Enabled: {auto_unpack}")
 monitor_logger.info(f"9. Auto Cleanup Orphan Files: {auto_cleanup}")
 monitor_logger.info(f"10. Cleanup Interval: {cleanup_interval_hours} hour(s)")
 monitor_logger.info(f"11. Reconciliation Sweep Interval: {reconcile_interval_minutes} minute(s)")
+
+def strip_comic_extension(name):
+    """Drop a trailing comic extension from a *directory* name.
+
+    Download clients name a job folder after the release/file they were asked
+    for, so a completed download can arrive as a directory called
+    "Heavy Metal 5.cbz". Left alone that extension leaks into TARGET as a
+    ".cbz" folder and blocks the trailing-issue-number strip below.
+    """
+    stem, ext = os.path.splitext(name or "")
+    if stem and ext.lower() in COMIC_EXTS:
+        return stem
+    return name
+
 
 class DownloadCompleteHandler(FileSystemEventHandler):
     def __init__(self, directory, target_directory, ignored_extensions):
@@ -275,7 +291,8 @@ class DownloadCompleteHandler(FileSystemEventHandler):
                 # Stage every emerged comic into the release folder under the
                 # cleaned release name, then process each. Staging all first keeps
                 # the folder non-empty until the last hand-off prunes it.
-                base = clean_directory_name(os.path.basename(folder_abs)) or os.path.basename(folder_abs)
+                folder_name = strip_comic_extension(os.path.basename(folder_abs))
+                base = clean_directory_name(folder_name) or folder_name
                 staged = []
                 for idx, comic in enumerate(result.comics):
                     c_ext = os.path.splitext(comic)[1]
@@ -642,7 +659,7 @@ class DownloadCompleteHandler(FileSystemEventHandler):
 
                 if original_count == 1:
                     # Derive series name from directory name
-                    dir_name = os.path.basename(abs_source_dir)
+                    dir_name = strip_comic_extension(os.path.basename(abs_source_dir))
                     series_name = re.sub(r'\s*\([^)]*\)', '', dir_name)  # Strip parenthetical groups
                     series_name = re.sub(r'\s+\d+\s*$', '', series_name)  # Strip trailing issue number
                     series_name = series_name.strip()
@@ -669,6 +686,13 @@ class DownloadCompleteHandler(FileSystemEventHandler):
         # This cleans the folder names (as per our directory cleaning rules)
         target_dir = os.path.dirname(target_path)
         cleaned_target_dir = clean_directory_name(target_dir)
+        # Never let a sub-folder of TARGET keep a comic extension (a download
+        # client's job folder named after the requested file).
+        if os.path.abspath(cleaned_target_dir) != os.path.abspath(self.target_directory):
+            parent, leaf = os.path.split(cleaned_target_dir)
+            stripped = strip_comic_extension(leaf)
+            if stripped != leaf:
+                cleaned_target_dir = os.path.join(parent, stripped)
         target_path = os.path.join(cleaned_target_dir, os.path.basename(target_path))
 
         try:

--- a/tests/mocked/test_usenet.py
+++ b/tests/mocked/test_usenet.py
@@ -245,6 +245,12 @@ class TestGrabNzb:
         assert un.usenet_downloads[did]["client_id"] == "nzo_1"
         # Real NZB bytes were submitted, not the URL.
         assert client.add_nzb.call_args[0][0] == b"<nzb/>"
+        # The job name must NOT carry a comic extension: the client names the
+        # completed folder after it, and a "Batman 1.cbz" directory then gets
+        # imported as if it were a comic file.
+        assert client.add_nzb.call_args[0][1] == "Batman 1"
+        # The tracked/display filename still keeps the extension.
+        assert un.usenet_downloads[did]["filename"] == "Batman 1.cbz"
         mock_poller.assert_called_once()
 
     @patch("models.usenet._fetch_nzb", return_value=None)
@@ -264,6 +270,18 @@ class TestGrabNzb:
     @patch("core.database.get_active_download_client", return_value=None)
     def test_grab_no_active_client(self, mock_active):
         assert un.grab_nzb("https://x/a.nzb", "x.cbz") is None
+
+    @pytest.mark.parametrize("filename,expected", [
+        ("Heavy Metal 5.cbz", "Heavy Metal 5"),
+        ("Batman 001.cbr", "Batman 001"),
+        ("Some Pack.nzb", "Some Pack"),
+        ("Batman v2 001", "Batman v2 001"),       # already extension-free
+        ("Saga Vol. 1", "Saga Vol. 1"),           # a dotted stem is not an extension
+        ("", ""),
+        (None, ""),
+    ])
+    def test_job_name_strips_comic_extensions(self, filename, expected):
+        assert un._job_name(filename) == expected
 
     @patch("models.usenet._fetch_nzb", return_value=b"<nzb/>")
     @patch("models.usenet._ensure_poller")

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -296,6 +296,51 @@ def test_process_file_normal_zip_still_unzips(handler, monkeypatch):
     assert calls == [zpath], "normal single zip must still unzip, not route to unwrap"
 
 
+def test_strip_comic_extension():
+    """Only real comic extensions come off; ordinary folder names are untouched."""
+    import monitor
+    assert monitor.strip_comic_extension("Heavy Metal 5.cbz") == "Heavy Metal 5"
+    assert monitor.strip_comic_extension("Batman 001.CBR") == "Batman 001"
+    assert monitor.strip_comic_extension("Batman (2024)") == "Batman (2024)"
+    assert monitor.strip_comic_extension("Saga Vol. 1") == "Saga Vol. 1"
+    assert monitor.strip_comic_extension("") == ""
+
+
+def test_consolidate_strips_comic_extension_from_job_folder(handler):
+    """A download client's job folder named after the requested comic file
+    ("Heavy Metal 5.cbz") must not become a ".cbz" series folder in TARGET —
+    and the trailing issue number must still be stripped."""
+    h, watch, target = handler
+    h.consolidate_directories = True
+    job_dir = os.path.join(watch, "Heavy Metal 5.cbz")
+    os.makedirs(job_dir)
+    name = "Heavy Metal 005.cbz"
+    _write(os.path.join(job_dir, name))
+
+    h._move_file(os.path.join(job_dir, name))
+
+    assert os.path.exists(_moved_path(os.path.join(target, "Heavy Metal"), name)), \
+        "should land in a 'Heavy Metal' series folder"
+    assert not os.path.exists(os.path.join(target, "Heavy Metal 5.cbz")), \
+        "TARGET must not gain a directory with a comic extension"
+
+
+def test_move_directories_strips_comic_extension_from_job_folder(handler):
+    """The same job folder under move_directories keeps its structure but loses
+    the bogus comic extension."""
+    h, watch, target = handler
+    h.move_directories = True
+    job_dir = os.path.join(watch, "Heavy Metal 5.cbz")
+    os.makedirs(job_dir)
+    name = "Heavy Metal 005.cbz"
+    _write(os.path.join(job_dir, name))
+
+    h._move_file(os.path.join(job_dir, name))
+
+    assert os.path.exists(_moved_path(os.path.join(target, "Heavy Metal 5"), name))
+    assert not os.path.exists(os.path.join(target, "Heavy Metal 5.cbz"))
+
+
 def test_file_under_in_flight_dir_is_skipped(handler, monkeypatch):
     """A file inside a release folder being unwrapped is not processed by the
     per-file loop (regression guard for 'parts moved individually')."""


### PR DESCRIPTION
## Problem

Usenet downloads completed at the client but nothing landed in TARGET, and the CLU log showed the CBZ being treated as a directory:

```
Processing file: /downloads/temp/Heavy Metal 5.cbz/Heavy Metal 005.cbr
Consolidating: 'Heavy Metal 5.cbz' -> series folder 'Heavy Metal 5.cbz'
Moved file to: /downloads/processed/Heavy Metal 5.cbz/Heavy Metal 005.cbr
Converted to: /downloads/processed/Heavy Metal 5.cbz/Heavy Metal 005.cbz
```

## Root cause

`_make_filename()` builds a destination filename with a `.cbz` extension, and `grab_nzb()` passed it straight to the download client as the **NZB job name**. SABnzbd (`nzbname`) and NZBGet (`NZBFilename`) name the completed *folder* after that name, so the client created a directory `/downloads/temp/Heavy Metal 5.cbz/` holding the real `Heavy Metal 005.cbr`.

Everything downstream then read that directory name as a comic file. `monitor.py`'s consolidation derives a series name by stripping a trailing issue number (`\s+\d+\s*$`), which can't match through `.cbz` — so the comic landed in a TARGET series folder literally named `Heavy Metal 5.cbz` rather than `Heavy Metal`. A directory masquerading as a comic, and nothing at the TARGET level.

## Changes

**`models/usenet.py`** — new `_job_name()` strips a comic/`.nzb` extension before submission; `grab_nzb()` now submits `_job_name(filename)`. The tracked/display `filename` keeps its `.cbz` for the status page. DC++ passes its `filename` for display only and never sends it to the client, so it is unchanged.

**`monitor.py`** — new `strip_comic_extension()` helper (reusing `helpers.unwrap.COMIC_EXTS`), applied in three places so folders already queued at the client — or created by any other download client — still land correctly:

- when deriving the consolidated series name → `Heavy Metal`
- to any TARGET sub-folder after `clean_directory_name()`, covering the `MOVE_DIRECTORY` path
- to the unwrap staging base, which previously produced `Heavy Metal 5.cbz.cbz`

## Tests

- `tests/mocked/test_usenet.py`: asserts the submitted job name is `Batman 1` while the tracked filename stays `Batman 1.cbz`, plus parametrized `_job_name` cases (including `Saga Vol. 1`, which must not be treated as an extension).
- `tests/unit/test_monitor.py`: `strip_comic_extension` unit cases and two `_move_file` regressions (consolidate and `move_directories`) asserting the file lands in `Heavy Metal` / `Heavy Metal 5` and that TARGET never gains a `.cbz` directory.

Full suite: **3286 passed, 6 skipped** (the usual POSIX-permission skips on Windows).

## Note

This prevents new occurrences but doesn't retro-clean. Any comic already sitting in a `*.cbz` folder under TARGET needs to be moved out and the folder deleted manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
