### PR TITLE
Fix Smart Rename dropping the issue number on bare-year filenames

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -1080,6 +1080,33 @@ def extract_comic_values(filename, width=3):
         values["issue_number"] = _pad_issue_number(issue_num.lstrip("_"), width)
         return values
 
+    # Handle "Series ### YYYY" with a bare (unparenthesized) year, e.g.
+    # "Star Wars - Poe Dameron 001 2016.cbz" or "... 007- 2016.cbz". Must run
+    # BEFORE the no-year fallback below, which otherwise reads the trailing year
+    # as the issue number and folds the real issue into the series name
+    # ("series=Star Wars - Poe Dameron 001, issue=2016"). Two numbers are
+    # required and the last must look like a year, so a lone trailing number
+    # ("Batman 2016.cbz") is still treated as an issue.
+    series_issue_bare_year_match = re.match(
+        r"^(?P<series>.+?)\s+#?(?P<issue>\d{1,4}(?:\.(?!cbz|cbr|zip|pdf|epub|rar)\w+)?)"
+        r"\s*[-–]?\s+(?P<year>(?:19|20)\d{2})(?P<ext>\.\w+)?$",
+        filename,
+        re.IGNORECASE,
+    )
+    if series_issue_bare_year_match:
+        series_name = series_issue_bare_year_match.group("series").replace("_", " ").strip()
+        series_name = re.sub(r"[#\-\s]+$", "", series_name).strip()
+        values["series_name"] = smart_title_case(series_name)
+        values["issue_number"] = _pad_issue_number(
+            series_issue_bare_year_match.group("issue"), width
+        )  # preserves ".1"/".MU"
+        values["year"] = series_issue_bare_year_match.group("year")
+        app_logger.info(
+            f"Matched series/issue/bare-year pattern: series={values['series_name']}, "
+            f"issue={values['issue_number']}, year={values['year']}"
+        )
+        return values
+
     # Handle already-clean "Series Issue.ext" names with no year, e.g.
     # "Civil War - Unmasked 002.cbz" (output of an earlier rename pass before
     # metadata is available). Keeps re-renames idempotent instead of failing

--- a/cbz_ops/smart_rename.py
+++ b/cbz_ops/smart_rename.py
@@ -366,6 +366,12 @@ def _plan_file(
     # {volume_year}; {issue_year} is the issue's own year from the XML.
     issue_meta = _read_issue_meta(file_path) if needs_issue_meta else {}
 
+    # When the file carries no ComicInfo Year, fall back to a year parsed out of
+    # the filename ("Series 008 2017" / "Series 008 (2017)"). That is still the
+    # issue's own year -- per file, not the series start year -- so the rule that
+    # {issue_year} never resolves to the series year holds.
+    issue_year = issue_meta.get("issue_year", "") or (extracted.get("year") or "").strip()
+
     values = {
         "series_name": _sanitize_series_name((metadata.get("name") or "").strip()),
         "volume_number": volume_number,
@@ -373,10 +379,10 @@ def _plan_file(
         "volume_year": _format_year(metadata.get("year")),
         # "year" is the {volume_year} fallback only; the issue's own year (from
         # ComicInfo) feeds {issue_year}, never the series start year.
-        "year": issue_meta.get("issue_year", ""),
+        "year": issue_year,
         "issue_number": issue,
         "issue_title": issue_meta.get("issue_title", ""),
-        "issue_year": issue_meta.get("issue_year", ""),
+        "issue_year": issue_year,
         "issue_month_M": issue_meta.get("issue_month_M", ""),
         "issue_month_m": issue_meta.get("issue_month_m", ""),
     }

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -682,6 +682,12 @@ class TestExtractComicValues:
         ("Avengers 001.1 (2017).cbz", "Avengers", "001.1", "2017"),
         # Already-clean name with alphanumeric suffix, no year
         ("Avengers - Standoff 700.BEY.cbz", "Avengers - Standoff", "700.BEY", ""),
+        # Bare (unparenthesized) trailing year must not be read as the issue
+        ("Star Wars - Poe Dameron 001 2016.cbz", "Star Wars - Poe Dameron", "001", "2016"),
+        ("Star Wars - Poe Dameron 007- 2016.cbz", "Star Wars - Poe Dameron", "007", "2016"),
+        ("Star Wars - Poe Dameron 008 2017", "Star Wars - Poe Dameron", "008", "2017"),
+        # ...but a lone trailing number is still the issue, not a year
+        ("Batman 2016.cbz", "Batman", "2016", ""),
     ])
     def test_value_extraction(self, filename, expected_series, expected_issue, expected_year):
         from cbz_ops.rename import extract_comic_values

--- a/tests/unit/test_smart_rename.py
+++ b/tests/unit/test_smart_rename.py
@@ -528,6 +528,53 @@ class TestSmartRenameIssueTokens:
         names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
         assert names == ["Sandman 005 - The Sound of Her Wings.cbz"]
 
+    def test_bare_year_filenames_keep_issue_and_year(self, tmp_path):
+        # "Series ### YYYY" (unparenthesized year, no ComicInfo). The trailing
+        # year used to be read as the issue number, so every file collapsed to
+        # "Series <year>.cbz" and collided into " (2)", " (3)" suffixes.
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Poe"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Star Wars - Poe Dameron", volume=1, year=2016)
+        for stem in (
+            "Star Wars - Poe Dameron 001 2016",
+            "Star Wars - Poe Dameron 006 2016",
+            "Star Wars - Poe Dameron 007- 2016",
+            "Star Wars - Poe Dameron 008 2017",
+        ):
+            (d / f"{stem}.cbz").write_bytes(b"x")
+
+        pattern = "{series_name} {issue_number} ({issue_year})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = sorted(
+            f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"
+        )
+        assert names == [
+            "Star Wars - Poe Dameron 001 (2016).cbz",
+            "Star Wars - Poe Dameron 006 (2016).cbz",
+            "Star Wars - Poe Dameron 007 (2016).cbz",
+            "Star Wars - Poe Dameron 008 (2017).cbz",
+        ]
+
+    def test_comicinfo_year_wins_over_filename_year(self, tmp_path):
+        # The filename year is only a fallback; ComicInfo stays authoritative.
+        from cbz_ops.smart_rename import plan_smart_rename
+        d = tmp_path / "Sandman"
+        d.mkdir()
+        _write_cvinfo(d)
+        _write_series_json(d, name="Sandman", volume=2, year=1989)
+        _write_cbz_with_comicinfo(d / "Sandman 5 2016.cbz", year=2026, month=3)
+
+        pattern = "{series_name} - {issue_number} ({issue_year})"
+        with _enable_custom_rename(pattern=pattern):
+            plan = plan_smart_rename(str(d), recursive=False)
+
+        names = [f["new_name"] for f in plan["directories"][0]["files"] if f["status"] == "ok"]
+        assert names == ["Sandman - 005 (2026).cbz"]
+
 
 class TestApplySmartRename:
 


### PR DESCRIPTION
## Problem

Smart Rename on a folder of `Series ### YYYY` files (unparenthesized year) produced:

| Old name | New name |
|---|---|
| Star Wars - Poe Dameron 001 2016.cbz | Star Wars - Poe Dameron 2016.cbz |
| Star Wars - Poe Dameron 006 2016.cbz | Star Wars - Poe Dameron 2016 (2).cbz |
| Star Wars - Poe Dameron 007- 2016.cbz | Star Wars - Poe Dameron 2016 (3).cbz |
| Star Wars - Poe Dameron 008 2017.cbz | Star Wars - Poe Dameron 2017.cbz |

The issue number was gone and the files collided into ` (2)` / ` (3)`.

## Cause

Two separate bugs in the extraction path Smart Rename feeds off:

1. **The trailing year was parsed as the issue number.** These names fall through to the already-clean/no-year pattern in `extract_comic_values` (`cbz_ops/rename.py`), which greedily reads the *last* number as the issue — `series="Star Wars - Poe Dameron 001", issue="2016"`. Smart Rename discards the parsed series (`series.json` is authoritative) and keeps only the issue, so every file collapsed to `Series <year>.cbz`. There was already a pattern for `Series ### <extra text> YYYY` (`Batman 046 52p ctc 04-05 1948`), but nothing for the no-extra-text form.

2. **`{issue_year}` had no fallback.** These files carry no ComicInfo `Year`, so the token resolved empty and the whole year group was stripped. Fixing (1) alone would have yielded `Star Wars - Poe Dameron 001.cbz` — still missing the year.

## Fix

- `cbz_ops/rename.py`: new `Series ### YYYY` pattern placed ahead of the no-year fallback. Requires two numbers with the last looking like a year (`19xx`/`20xx`) and tolerates a stray dash after the issue (`007- 2016`), so a lone trailing number (`Batman 2016.cbz`) is still treated as the issue.
- `cbz_ops/smart_rename.py`: `{issue_year}` falls back to the year parsed from the filename when ComicInfo has none. That is still the issue's own year — per file, not the series year — so the existing rule that `{issue_year}` never resolves to the series start year holds. ComicInfo stays authoritative when present.

Result with pattern `{series_name} {issue_number} ({issue_year})`:

```
Star Wars - Poe Dameron 001 (2016).cbz
Star Wars - Poe Dameron 006 (2016).cbz
Star Wars - Poe Dameron 007 (2016).cbz
Star Wars - Poe Dameron 008 (2017).cbz
```

## Tests

- `tests/unit/test_rename.py`: extraction cases for the bare-year forms, plus a guard that a lone trailing number stays an issue.
- `tests/unit/test_smart_rename.py`: the four-file scenario end to end, and one asserting ComicInfo year beats the filename year.

Full suite: 3291 passed, 6 POSIX skips, 1 failure — `test_restore_round_trip`, the known Windows file-lock flake; passes in isolation (24/24) and is unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)