### PR TITLE
Fix AirDC++ downloads landing as one mangled filename

### DIFF
--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -414,31 +414,39 @@ def try_download_for_issue(
     return out
 
 
-def grab_dcpp(result_token, filename, series=None, issue=None):
+def grab_dcpp(result_token, filename, series=None, issue=None, errors=None):
     """Queue a previously-searched DC++ result and start tracking it.
 
     Returns the tracking ``download_id`` on success, or None on failure.
+
+    ``errors`` is an optional list the reason for a failure is appended to.
+    Some failures are user-fixable configuration (a Target Directory the
+    AirDC++ host can't parse) and reading "something went wrong" in a toast
+    while the real explanation sits in the log helps nobody.
     """
+    def _fail(reason, level="error"):
+        getattr(app_logger, level)(f"DC++ grab failed: {reason}")
+        if errors is not None:
+            errors.append(reason)
+        return None
+
     entry = _resolve_token(result_token)
     if not entry:
-        app_logger.warning(
-            "DC++ grab: search result expired — re-run the search and try again"
+        return _fail(
+            "This search result has expired — re-run the search and try again",
+            level="warning",
         )
-        return None
 
     try:
         client = _active_client()
     except Exception as e:
-        app_logger.error(f"DC++ grab: could not build client: {e}")
-        return None
+        return _fail(f"Could not build the DC++ client: {e}")
     if client is None:
-        app_logger.warning("DC++ grab requested but no active DC++ client")
-        return None
+        return _fail("No active DC++ client is configured", level="warning")
 
     result = client.download_result(entry["instance_id"], entry["result_id"])
     if not result.success:
-        app_logger.error(f"DC++ grab failed: {result.error}")
-        return None
+        return _fail(result.error or "The DC++ client rejected the download")
 
     download_id = str(uuid.uuid4())
     with _jobs_lock:
@@ -535,13 +543,17 @@ def _poll_one(client, download_id, job):
         # as done and import from the target we cached while it was running.
         # A user who cancelled by hand lands here too; the import simply finds
         # nothing and the job records complete_no_move.
-        imported = _import_completed(job.get("target"), job["filename"])
+        imported = _import_completed(
+            _to_local_path(client, job.get("target")), job["filename"]
+        )
         _set_status(download_id, "complete" if imported else "complete_no_move",
                     percent=100)
         return
 
     if status.status == "complete":
-        imported = _import_completed(status.storage_path, job["filename"])
+        imported = _import_completed(
+            _to_local_path(client, status.storage_path), job["filename"]
+        )
         _set_status(download_id, "complete" if imported else "complete_no_move",
                     percent=100)
     elif status.status == "failed":
@@ -577,6 +589,61 @@ def _set_status(download_id, status, error=None, percent=None):
             job["error"] = error
             if percent is not None:
                 job["percent"] = percent
+
+
+def translate_remote_path(path, remote_root, local_root):
+    """Rewrite a path AirDC++ reported into CLU's own view of it.
+
+    AirDC++ is usually not in CLU's filesystem namespace, and in more than one
+    way:
+
+    * a native Windows install reports ``F:\\downloads\\temp\\x.cbz`` — not a
+      path a Linux container can open, and not even the same separator;
+    * an AirDC++ *container* reports its own mount point (``/downloads/x.cbz``)
+      which CLU may mount elsewhere (``/data/downloads/x.cbz``).
+
+    Both are the same problem: a shared folder with two names. When the client
+    config records both views (``target_directory`` and
+    ``local_target_directory``), swap the prefix and convert separators.
+    Anything that doesn't sit under the remote root — or a client with no
+    local path configured, which is the correct setup when both sides agree —
+    is returned untouched, leaving the existing monitored-folder fallback in
+    ``_import_completed`` to handle it.
+    """
+    if not path or not remote_root or not local_root:
+        return path
+
+    remote_sep = "\\" if "\\" in remote_root else "/"
+    local_sep = "\\" if "\\" in local_root else "/"
+
+    r_root = str(remote_root).rstrip("/\\")
+    if not r_root:
+        return path
+
+    # Windows paths compare case-insensitively; POSIX ones must not.
+    if remote_sep == "\\":
+        matched = path.lower().startswith(r_root.lower())
+    else:
+        matched = path.startswith(r_root)
+    if not matched:
+        return path
+
+    remainder = path[len(r_root):].lstrip("/\\")
+    l_root = str(local_root).rstrip("/\\")
+    if not remainder:
+        return l_root or local_sep
+    remainder = remainder.replace(remote_sep, local_sep)
+    return (l_root + local_sep + remainder) if l_root else (local_sep + remainder)
+
+
+def _to_local_path(client, path):
+    """Apply :func:`translate_remote_path` using the active client's config."""
+    cfg = getattr(client, "config", None)
+    return translate_remote_path(
+        path,
+        getattr(cfg, "target_directory", None),
+        getattr(cfg, "local_target_directory", None),
+    )
 
 
 def _import_completed(storage_path, filename) -> bool:

--- a/models/download_clients/airdcpp_client.py
+++ b/models/download_clients/airdcpp_client.py
@@ -25,6 +25,7 @@ Field names below follow the published API docs. Every read is defensive
 (``.get`` with fallbacks) so an AirDC++ version that renames or drops a
 field degrades to "no progress shown" rather than raising inside the poller.
 """
+import os
 import time
 from typing import List, Optional, Tuple
 
@@ -61,6 +62,9 @@ _RESULT_PAGE_SIZE = 250
 # also means directory (whole-run) hits are not returned — CLU wants single
 # issues, and a directory download on DC++ is rarely what the user intended.
 _COMIC_EXTENSIONS = ["cbz", "cbr", "cbt", "pdf"]
+
+# "not asked yet", distinct from "asked, and this version doesn't say" (None).
+_UNPROBED = object()
 
 
 def _normalize_airdcpp_status(status: dict) -> str:
@@ -106,6 +110,64 @@ def _result_type(raw) -> str:
     return str(raw or "")
 
 
+def _normalize_target_directory(path: Optional[str], sep: Optional[str] = None) -> Optional[str]:
+    """Ensure a target directory ends with a path separator.
+
+    AirDC++ concatenates ``target_directory`` with the result's filename
+    rather than joining them, so "/downloads/temp" plus a result named
+    "Marvel Classics Comics 017.cbz" becomes the single path
+    "/downloads/tempMarvel Classics Comics 017.cbz". Directory paths in the
+    AirDC++ API always carry a trailing separator, so add one when the
+    configured value omits it.
+
+    ``sep`` is the AirDC++ host's own separator when known (see
+    :meth:`AirDCPPClient.path_separator`); otherwise it is inferred from the
+    path, so a Windows-style target ("C:\\downloads\\temp") keeps its
+    backslash.
+    """
+    target = (path or "").strip()
+    if not target:
+        return None
+    if target.endswith(("/", "\\")):
+        return target
+    if sep not in ("/", "\\"):
+        sep = "\\" if ("\\" in target and "/" not in target) else "/"
+    return target + sep
+
+
+def _wrong_separator(target: Optional[str], sep: Optional[str]) -> bool:
+    """True when ``target`` is not a valid path shape for the AirDC++ host.
+
+    AirDC++ does not reject a target directory it cannot parse. On a Windows
+    host, ``/`` is a forbidden filename character rather than a separator, so
+    the whole POSIX path is swallowed into the bundle *name* and sanitized:
+    "/downloads/temp/Farmhouse 007.cbr" is queued as the single file
+    "_downloads_temp_Farmhouse 007.cbr" in AirDC++'s default download
+    directory. The reverse (a Windows path on a Linux host) fails the same
+    way. Neither is recoverable by CLU — the configured path has to be one
+    the AirDC++ host itself understands — so this is only used to refuse the
+    download with an explanation.
+    """
+    if not target or sep not in ("/", "\\"):
+        return False
+    return "/" in target if sep == "\\" else "\\" in target
+
+
+def _separator_error(target: str, sep: str) -> str:
+    """Actionable message for a target directory the AirDC++ host can't use."""
+    style = "Windows" if sep == "\\" else "Unix"
+    example = "C:\\Downloads\\comics\\" if sep == "\\" else "/downloads/comics/"
+    return (
+        f"Target Directory '{target}' is not a valid path on the AirDC++ host, "
+        f"which reports {style}-style paths separated by '{sep}'. Set it to a "
+        f"path as AirDC++ itself sees it (e.g. {example}), and make sure CLU can "
+        f"read that same folder — either map the AirDC++ download folder into "
+        f"CLU's docker-compose, or use the same path as CLU's WATCH folder. "
+        f"Left as-is, AirDC++ folds the whole path into the filename and "
+        f"downloads it to its own default directory."
+    )
+
+
 def _user_count(raw) -> Optional[int]:
     """Extract the number of users sharing a result.
 
@@ -133,8 +195,12 @@ class AirDCPPClient(BaseDownloadClient):
         "use_ssl",
         "url_base",
         "target_directory",
+        "local_target_directory",
         "hub_urls",
     ]
+
+    # Per-instance cache of the host's path separator (see path_separator).
+    _path_sep = _UNPROBED
 
     # ------------------------------------------------------------------
     # Request plumbing
@@ -232,7 +298,64 @@ class AirDCPPClient(BaseDownloadClient):
         if not isinstance(data, list):
             self.last_error = f"Unexpected response from {self._api_url('/hubs')}"
             return False
+
+        # The connection works; the target directory is the other thing that
+        # has to be right, and it fails silently at download time rather than
+        # here, so check it while the user is looking at the result.
+        target = (cfg.target_directory or "").strip()
+        sep = self.path_separator()
+        if _wrong_separator(target, sep):
+            self.last_error = _separator_error(target, sep)
+            return False
+
+        # The local view is CLU's own namespace, so it can simply be checked.
+        # Getting it wrong otherwise surfaces only much later, as a finished
+        # download that never reaches the library.
+        local = (cfg.local_target_directory or "").strip()
+        if local and not os.path.isdir(local):
+            self.last_error = (
+                f"CLU cannot see '{local}'. This is the Target Directory as CLU "
+                f"sees it, so it has to be a path inside CLU's own container — "
+                f"check the volume mapping in CLU's docker-compose covers the "
+                f"folder AirDC++ downloads into."
+            )
+            return False
         return True
+
+    def get_system_info(self) -> Optional[dict]:
+        """Return AirDC++'s ``/system/system_info``, or None when unreadable.
+
+        Note the ``system`` module prefix: the API answers a request to a bare
+        ``/system_info`` with ``{"message": "Section not found"}``.
+        """
+        data = self._json(self._request("GET", "/system/system_info"))
+        return data if isinstance(data, dict) else None
+
+    def path_separator(self) -> Optional[str]:
+        """The AirDC++ host's own path separator ('/' or '\\'), cached.
+
+        None when the endpoint is unreachable or the running AirDC++ version
+        doesn't report one — callers then skip the separator check rather than
+        guess at the host's platform.
+        """
+        if self._path_sep is _UNPROBED:
+            # Probing must not clobber a caller's in-flight error state.
+            prior_error = self.last_error
+            info = self.get_system_info() or {}
+            probe_error = self.last_error
+            self.last_error = prior_error
+            sep = info.get("path_separator")
+            self._path_sep = sep if sep in ("/", "\\") else None
+            if self._path_sep is None:
+                # Say so out loud: an unreadable separator silently disables
+                # the Target Directory check, which is how a bad path reaches
+                # AirDC++ and comes back as a mangled filename.
+                app_logger.warning(
+                    f"AirDC++ did not report a path separator"
+                    f"{f' ({probe_error})' if probe_error else ''} — the Target "
+                    f"Directory check is disabled for this client"
+                )
+        return self._path_sep
 
     # ------------------------------------------------------------------
     # Search
@@ -344,7 +467,17 @@ class AirDCPPClient(BaseDownloadClient):
         carrying only ``client_id`` / ``success`` / ``error``.
         """
         self.last_error = None
-        target = target_directory or (self.config.target_directory if self.config else None)
+        sep = self.path_separator()
+        target = _normalize_target_directory(
+            target_directory or (self.config.target_directory if self.config else None),
+            sep,
+        )
+        if _wrong_separator(target, sep):
+            # Queueing anyway produces a bundle named after the mangled path,
+            # landed somewhere CLU can't import from. Refuse and say why.
+            self.last_error = _separator_error(target, sep)
+            app_logger.error(f"AirDC++ download refused: {self.last_error}")
+            return NZBSubmitResult(success=False, error=self.last_error)
 
         body = {}
         if target:

--- a/models/download_clients/base.py
+++ b/models/download_clients/base.py
@@ -26,10 +26,17 @@ class ClientType(Enum):
 class DownloadClientConfig:
     """Connection/config for a download client.
 
-    ``target_directory`` and ``hub_urls`` are DC++ (AirDC++) specific:
-    where the client should land finished files, and an optional
-    comma-separated subset of hubs to search. Both are optional and dropped
+    ``target_directory``, ``local_target_directory`` and ``hub_urls`` are
+    DC++ (AirDC++) specific: where the client should land finished files, how
+    CLU sees that same folder when the two disagree, and an optional
+    comma-separated subset of hubs to search. All are optional and dropped
     from ``to_dict`` when unset, so Usenet configs are unaffected.
+
+    ``local_target_directory`` exists because AirDC++ is frequently not in
+    CLU's filesystem namespace — a native Windows install reports
+    ``F:\\downloads\\temp\\``, and an AirDC++ container reports its own mount
+    point, neither of which CLU can open. Leave it blank when both see the
+    same path.
     """
     host: Optional[str] = None
     port: Optional[int] = None
@@ -41,6 +48,7 @@ class DownloadClientConfig:
     use_ssl: bool = False
     url_base: Optional[str] = None
     target_directory: Optional[str] = None
+    local_target_directory: Optional[str] = None
     hub_urls: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
@@ -56,6 +64,7 @@ class DownloadClientConfig:
             "use_ssl": self.use_ssl,
             "url_base": self.url_base,
             "target_directory": self.target_directory,
+            "local_target_directory": self.local_target_directory,
             "hub_urls": self.hub_urls,
         }.items() if v is not None}
 
@@ -73,6 +82,7 @@ class DownloadClientConfig:
             use_ssl=bool(data.get("use_ssl", False)),
             url_base=data.get("url_base"),
             target_directory=data.get("target_directory"),
+            local_target_directory=data.get("local_target_directory"),
             hub_urls=data.get("hub_urls"),
         )
 

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -135,7 +135,14 @@ def delete_download_client_config_route(client_type):
 
 @download_clients_bp.route('/api/download-clients/<client_type>/test', methods=['POST'])
 def test_download_client(client_type):
-    """Test connection to a download client using saved config."""
+    """Test connection to a download client.
+
+    Tests the saved config, unless the request carries config fields — the
+    settings form sends what is currently on screen, so Test reports on the
+    value the user is looking at rather than on the last saved one. (Testing
+    an unsaved edit against the stored config makes a corrected setting look
+    like it changed nothing.) Partial input is merged over the stored config.
+    """
     try:
         from core.database import (
             get_download_client_config,
@@ -149,7 +156,10 @@ def test_download_client(client_type):
         if not _validate_client_type(client_type):
             return jsonify({"error": f"Unknown client type: {client_type}"}), 400
 
-        config_dict = get_download_client_config(client_type)
+        config_dict = get_download_client_config(client_type) or {}
+        overrides = request.get_json(silent=True) or {}
+        if isinstance(overrides, dict) and overrides:
+            config_dict = {**config_dict, **overrides}
         if not config_dict:
             return jsonify({"success": False, "error": "No config configured"}), 400
 
@@ -574,15 +584,20 @@ def dcpp_grab():
         if not result_token or not filename:
             return jsonify({"error": "result_token and filename are required"}), 400
 
+        errors = []
         download_id = grab_dcpp(
             result_token, filename,
             series=data.get('series'), issue=data.get('issue'),
+            errors=errors,
         )
         if download_id:
             return jsonify({"success": True, "download_id": download_id})
         return jsonify({
             "success": False,
-            "error": "No active DC++ client, the result expired, or the client "
+            # Prefer the real reason (e.g. a Target Directory the AirDC++ host
+            # can't parse) over the catch-all.
+            "error": errors[0] if errors else
+                     "No active DC++ client, the result expired, or the client "
                      "rejected the download",
         }), 502
     except Exception as e:

--- a/templates/config.html
+++ b/templates/config.html
@@ -3588,9 +3588,13 @@
     // =====================================================================
 
     // Labels/help that read better than the auto-derived title-cased field name.
-    const CLIENT_FIELD_LABELS = { hub_urls: 'Hub URLs', url_base: 'URL Base', api_key: 'API Key' };
+    const CLIENT_FIELD_LABELS = {
+        hub_urls: 'Hub URLs', url_base: 'URL Base', api_key: 'API Key',
+        local_target_directory: 'Target Directory (as CLU sees it)',
+    };
     const CLIENT_FIELD_HELP = {
-        target_directory: 'Where AirDC++ should save finished downloads. Must be a path CLU can also read, so it can move comics into your WATCH folder.',
+        target_directory: 'Where AirDC++ saves finished downloads, written exactly as AirDC++ itself sees the path (a trailing slash is added for you). CLU has to read that same folder to move comics into WATCH, so either map the AirDC++ download folder into CLU\'s docker-compose so both containers see it, or point AirDC++ at the same path you use for CLU\'s WATCH folder.',
+        local_target_directory: 'Optional. The same folder as above, but as CLU sees it — needed whenever AirDC++ and CLU disagree on the path. AirDC++ on Windows might write to F:\\downloads\\temp\\ while CLU sees /downloads/temp; AirDC++ in its own container might call it /downloads while CLU mounts it at /data/downloads. Leave blank if both use the identical path.',
         hub_urls: 'Optional. Comma-separated hub addresses to search. Leave blank to search every connected hub.',
     };
 
@@ -3733,15 +3737,14 @@
         }
     }
 
-    async function saveDownloadClientConfig(clientType, event) {
-        if (event) { event.preventDefault(); event.stopPropagation(); }
-        const form = document.getElementById(`client-form-${clientType}`);
-        const submitBtn = form.querySelector('button[type="submit"]');
-        const originalBtnHtml = submitBtn.innerHTML;
-        submitBtn.disabled = true;
-        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
-
+    // Read the values currently in a client's form. Shared by Save and Test so
+    // that testing an edited-but-unsaved field checks what the user is looking
+    // at — testing the stored config instead reports on the old value and reads
+    // as the edit having no effect.
+    function collectClientConfig(clientType) {
         const config = {};
+        const form = document.getElementById(`client-form-${clientType}`);
+        if (!form) return config;
         form.querySelectorAll('input').forEach(input => {
             if (input.type === 'checkbox') {
                 config[input.name] = input.checked;
@@ -3750,6 +3753,18 @@
                 config[input.name] = (input.type === 'number') ? Number(v) : v;
             }
         });
+        return config;
+    }
+
+    async function saveDownloadClientConfig(clientType, event) {
+        if (event) { event.preventDefault(); event.stopPropagation(); }
+        const form = document.getElementById(`client-form-${clientType}`);
+        const submitBtn = form.querySelector('button[type="submit"]');
+        const originalBtnHtml = submitBtn.innerHTML;
+        submitBtn.disabled = true;
+        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
+
+        const config = collectClientConfig(clientType);
 
         try {
             const response = await fetch(`/api/download-clients/${clientType}/config`, {
@@ -3779,7 +3794,11 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Testing...';
         try {
-            const response = await fetch(`/api/download-clients/${clientType}/test`, { method: 'POST' });
+            const response = await fetch(`/api/download-clients/${clientType}/test`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(collectClientConfig(clientType)),
+            });
             const data = await readJsonResponse(response);
             if (data.success && data.valid) {
                 showToast(`Connection to ${clientType} successful!`, 'success');

--- a/tests/mocked/test_airdcpp_client.py
+++ b/tests/mocked/test_airdcpp_client.py
@@ -295,7 +295,171 @@ class TestAirDCPPDownloadResult:
     def test_target_directory_from_config(self, mock_req):
         mock_req.return_value = _resp(payload={"id": 1})
         _client().download_result("inst-1", "42")
-        assert mock_req.call_args.kwargs["json"]["target_directory"] == "/downloads/dcpp"
+        # Trailing separator added: AirDC++ concatenates rather than joins, so
+        # "/downloads/dcpp" would land the file as "/downloads/dcppName.cbz".
+        assert mock_req.call_args.kwargs["json"]["target_directory"] == "/downloads/dcpp/"
+
+    @patch("requests.request")
+    def test_target_directory_keeps_existing_separator(self, mock_req):
+        mock_req.return_value = _resp(payload={"id": 1})
+        _client().download_result("inst-1", "42", target_directory="/downloads/temp/")
+        assert mock_req.call_args.kwargs["json"]["target_directory"] == "/downloads/temp/"
+
+    @patch("requests.request")
+    def test_windows_target_directory_keeps_backslashes(self, mock_req):
+        mock_req.return_value = _resp(payload={"id": 1})
+        _client().download_result("inst-1", "42", target_directory="C:\\downloads\\temp")
+        assert mock_req.call_args.kwargs["json"]["target_directory"] == "C:\\downloads\\temp\\"
+
+    @patch("requests.request")
+    def test_blank_target_directory_is_omitted(self, mock_req):
+        mock_req.return_value = _resp(payload={"id": 1})
+        _client().download_result("inst-1", "42", target_directory="   ")
+        assert "target_directory" not in mock_req.call_args.kwargs["json"]
+
+
+def _route_with_separator(sep, download_payload=None):
+    """Route system_info to a host reporting `sep`, everything else to a download."""
+    def route(method, url, **kwargs):
+        if url.endswith("/system/system_info"):
+            return _resp(payload={"path_separator": sep, "platform": "test"})
+        if url.endswith("/hubs"):
+            return _resp(payload=[])
+        return _resp(payload=download_payload if download_payload is not None else {"id": 1})
+    return route
+
+
+class TestAirDCPPTargetSeparator:
+    """A POSIX target on a Windows AirDC++ is swallowed into the filename.
+
+    AirDC++ doesn't reject it: '/' is a forbidden *filename* char on Windows,
+    so "/downloads/temp/Farmhouse 007.cbr" is queued as the single file
+    "_downloads_temp_Farmhouse 007.cbr" in AirDC++'s default directory. CLU
+    can't fix the path for the user, so it refuses and explains.
+    """
+
+    @patch("requests.request")
+    def test_posix_target_on_windows_host_is_refused(self, mock_req):
+        mock_req.side_effect = _route_with_separator("\\")
+        result = _client(target_directory="/downloads/temp/").download_result("i1", "42")
+        assert result.success is False
+        assert "not a valid path on the AirDC++ host" in result.error
+        # Nothing was queued.
+        assert not any(
+            "/download" in c.args[1] for c in mock_req.call_args_list
+        )
+
+    @patch("requests.request")
+    def test_windows_target_on_posix_host_is_refused(self, mock_req):
+        mock_req.side_effect = _route_with_separator("/")
+        result = _client(target_directory="C:\\downloads\\temp\\").download_result("i1", "42")
+        assert result.success is False
+        assert "not a valid path on the AirDC++ host" in result.error
+
+    @patch("requests.request")
+    def test_matching_separator_downloads_normally(self, mock_req):
+        mock_req.side_effect = _route_with_separator("/")
+        result = _client(target_directory="/downloads/temp").download_result("i1", "42")
+        assert result.success is True
+        assert mock_req.call_args.kwargs["json"]["target_directory"] == "/downloads/temp/"
+
+    @patch("requests.request")
+    def test_windows_host_gets_a_backslash_appended(self, mock_req):
+        mock_req.side_effect = _route_with_separator("\\")
+        result = _client(target_directory="C:\\downloads\\temp").download_result("i1", "42")
+        assert result.success is True
+        assert mock_req.call_args.kwargs["json"]["target_directory"] == "C:\\downloads\\temp\\"
+
+    @patch("requests.request")
+    def test_unreported_separator_skips_the_check(self, mock_req):
+        # Older AirDC++ versions have no /system_info: proceed rather than guess.
+        mock_req.return_value = _resp(payload={"id": 1})
+        result = _client(target_directory="/downloads/temp/").download_result("i1", "42")
+        assert result.success is True
+
+    @patch("requests.request")
+    def test_separator_is_probed_once_per_client(self, mock_req):
+        mock_req.side_effect = _route_with_separator("/")
+        client = _client()
+        client.download_result("i1", "42")
+        client.download_result("i1", "43")
+        info_calls = [c for c in mock_req.call_args_list if c.args[1].endswith("/system_info")]
+        assert len(info_calls) == 1
+
+    @patch("requests.request")
+    def test_probe_failure_does_not_leak_into_the_result_error(self, mock_req):
+        def route(method, url, **kwargs):
+            if url.endswith("/system/system_info"):
+                return _resp(status_code=500)
+            return _resp(payload={"id": 1})
+
+        mock_req.side_effect = route
+        result = _client().download_result("i1", "42")
+        assert result.success is True
+        assert result.error is None
+
+    @patch("requests.request")
+    def test_system_info_uses_the_system_module_path(self, mock_req):
+        # The endpoint lives under the "system" module; a bare "/system_info"
+        # returns {"message": "Section not found"}, which silently disabled the
+        # target-directory check and let mangled paths through to AirDC++.
+        mock_req.side_effect = _route_with_separator("/")
+        _client().path_separator()
+        urls = [c.args[1] for c in mock_req.call_args_list]
+        assert urls == ["http://localhost:5600/api/v1/system/system_info"]
+
+    @patch("requests.request")
+    def test_section_not_found_disables_the_check_without_failing(self, mock_req):
+        # What an unknown/older endpoint actually returns: HTTP 404 + a message
+        # body. Downloads must still work, just without the path validation.
+        def route(method, url, **kwargs):
+            if "system" in url:
+                return _resp(status_code=404, payload={"message": "Section not found"})
+            return _resp(payload={"id": 1})
+
+        mock_req.side_effect = route
+        client = _client(target_directory="/downloads/temp/")
+        assert client.path_separator() is None
+        assert client.download_result("i1", "42").success is True
+
+    @patch("requests.request")
+    def test_test_connection_flags_a_bad_target_directory(self, mock_req):
+        mock_req.side_effect = _route_with_separator("\\")
+        client = _client(target_directory="/downloads/temp/")
+        assert client.test_connection() is False
+        assert "not a valid path on the AirDC++ host" in client.last_error
+
+    @patch("requests.request")
+    def test_test_connection_passes_with_a_matching_target(self, mock_req):
+        mock_req.side_effect = _route_with_separator("/")
+        assert _client(target_directory="/downloads/temp/").test_connection() is True
+
+
+class TestAirDCPPLocalTargetDirectory:
+    """The local view is CLU's own namespace, so CLU can verify it directly."""
+
+    @patch("requests.request")
+    def test_unreachable_local_path_fails_the_test(self, mock_req, tmp_path):
+        # Built from tmp_path: a literal "/downloads/temp" resolves against the
+        # current drive on Windows and may genuinely exist there.
+        mock_req.side_effect = _route_with_separator("\\")
+        client = _client(target_directory="F:\\downloads\\temp\\",
+                         local_target_directory=str(tmp_path / "not-mounted"))
+        assert client.test_connection() is False
+        assert "CLU cannot see" in client.last_error
+
+    @patch("requests.request")
+    def test_reachable_local_path_passes(self, mock_req, tmp_path):
+        mock_req.side_effect = _route_with_separator("\\")
+        client = _client(target_directory="F:\\downloads\\temp\\",
+                         local_target_directory=str(tmp_path))
+        assert client.test_connection() is True
+
+    @patch("requests.request")
+    def test_blank_local_path_is_not_checked(self, mock_req):
+        # Both sides seeing the same path is a valid setup, not a missing one.
+        mock_req.side_effect = _route_with_separator("/")
+        assert _client(target_directory="/downloads/temp/").test_connection() is True
 
     @patch("requests.request")
     def test_missing_bundle_id_is_failure(self, mock_req):

--- a/tests/mocked/test_dcpp.py
+++ b/tests/mocked/test_dcpp.py
@@ -5,7 +5,12 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import models.dcpp as dc
-from models.download_clients import ClientType, DownloadStatus, NZBSubmitResult
+from models.download_clients import (
+    ClientType,
+    DownloadClientConfig,
+    DownloadStatus,
+    NZBSubmitResult,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -16,6 +21,58 @@ def _clean_state():
     yield
     dc.dcpp_downloads.clear()
     dc._result_tokens.clear()
+
+
+class TestTranslateRemotePath:
+    """AirDC++ and CLU frequently see the same folder under different names."""
+
+    @pytest.mark.parametrize("path,remote,local,expected", [
+        # Native Windows AirDC++ -> CLU in Docker.
+        ("F:\\downloads\\temp\\x.cbz", "F:\\downloads\\temp\\", "/downloads/temp",
+         "/downloads/temp/x.cbz"),
+        # Trailing separators on either side are irrelevant.
+        ("F:\\downloads\\temp\\x.cbz", "F:\\downloads\\temp", "/downloads/temp/",
+         "/downloads/temp/x.cbz"),
+        # Nested subfolders keep their shape, with separators converted.
+        ("F:\\dl\\temp\\Batman\\x.cbz", "F:\\dl", "/downloads",
+         "/downloads/temp/Batman/x.cbz"),
+        # AirDC++ in its own container -> different mount point in CLU's.
+        ("/downloads/temp/x.cbz", "/downloads", "/data/downloads",
+         "/data/downloads/temp/x.cbz"),
+        # CLU mounted at the filesystem root.
+        ("/downloads/x.cbz", "/downloads", "/", "/x.cbz"),
+        # Windows drive letters compare case-insensitively.
+        ("f:\\downloads\\temp\\x.cbz", "F:\\Downloads\\Temp", "/downloads/temp",
+         "/downloads/temp/x.cbz"),
+        # CLU on Windows too: separators stay native.
+        ("/downloads/x.cbz", "/downloads", "D:\\comics", "D:\\comics\\x.cbz"),
+    ])
+    def test_translates(self, path, remote, local, expected):
+        assert dc.translate_remote_path(path, remote, local) == expected
+
+    @pytest.mark.parametrize("path,remote,local", [
+        # No local view configured — the correct setup when both agree.
+        ("/downloads/temp/x.cbz", "/downloads/temp", None),
+        ("/downloads/temp/x.cbz", "/downloads/temp", ""),
+        # Path isn't under the configured root; don't invent a mapping.
+        ("/elsewhere/x.cbz", "/downloads", "/data/downloads"),
+        # POSIX paths are case-sensitive, unlike the Windows case above.
+        ("/Downloads/x.cbz", "/downloads", "/data/downloads"),
+        # Nothing to translate.
+        (None, "/downloads", "/data"),
+        ("", "/downloads", "/data"),
+    ])
+    def test_returns_path_untouched(self, path, remote, local):
+        assert dc.translate_remote_path(path, remote, local) == path
+
+    def test_root_itself_maps_to_the_local_root(self):
+        assert dc.translate_remote_path(
+            "F:\\downloads\\temp", "F:\\downloads\\temp\\", "/downloads/temp"
+        ) == "/downloads/temp"
+
+    def test_no_config_leaves_the_path_alone(self):
+        # A client built without config must not blow up mid-poll.
+        assert dc._to_local_path(MagicMock(config=None), "/x.cbz") == "/x.cbz"
 
 
 def _fake_client(results=None, instance_id="inst-1", bundle_id="b1"):
@@ -416,6 +473,50 @@ class TestPollOne:
         client = MagicMock()
         client.get_bundle_state.return_value = (state, status)
         return client
+
+    def _client_with_paths(self, state, status, remote, local):
+        client = self._client(state, status)
+        client.config = DownloadClientConfig(
+            target_directory=remote, local_target_directory=local)
+        return client
+
+    @patch("models.dcpp._import_completed", return_value=True)
+    def test_windows_host_path_is_translated_for_import(self, mock_import):
+        # AirDC++ running natively on Windows reports a path no Linux
+        # container can open.
+        job = self._job()
+        status = DownloadStatus(
+            client_id="b1", status="complete",
+            storage_path="F:\\downloads\\temp\\Batman 1.cbz")
+        dc._poll_one(
+            self._client_with_paths("found", status,
+                                    "F:\\downloads\\temp\\", "/downloads/temp"),
+            "d1", job)
+        mock_import.assert_called_once_with("/downloads/temp/Batman 1.cbz", "Batman 1.cbz")
+        assert dc.dcpp_downloads["d1"]["status"] == "complete"
+
+    @patch("models.dcpp._import_completed", return_value=True)
+    def test_containerized_airdcpp_path_is_translated(self, mock_import):
+        # Both sides Linux, but AirDC++'s container mounts the share somewhere
+        # else than CLU's does.
+        job = self._job()
+        status = DownloadStatus(client_id="b1", status="complete",
+                                storage_path="/downloads/temp/Batman 1.cbz")
+        dc._poll_one(
+            self._client_with_paths("found", status, "/downloads", "/data/downloads"),
+            "d1", job)
+        mock_import.assert_called_once_with(
+            "/data/downloads/temp/Batman 1.cbz", "Batman 1.cbz")
+
+    @patch("models.dcpp._import_completed", return_value=True)
+    def test_gone_path_is_translated_too(self, mock_import):
+        # The cached target takes the same route when AirDC++ drops the bundle.
+        job = self._job(target="F:\\downloads\\temp\\Batman 1.cbz")
+        dc._poll_one(
+            self._client_with_paths("gone", None,
+                                    "F:\\downloads\\temp", "/downloads/temp"),
+            "d1", job)
+        mock_import.assert_called_once_with("/downloads/temp/Batman 1.cbz", "Batman 1.cbz")
 
     @patch("models.dcpp._import_completed", return_value=True)
     def test_gone_imports_from_cached_target(self, mock_import):

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -129,6 +129,41 @@ class TestDownloadClientTest:
         resp = client.post("/api/download-clients/sabnzbd/test")
         assert resp.status_code == 400
 
+    @patch("core.database.update_download_client_validity")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_download_client_config",
+           return_value={"host": "h", "target_directory": "/downloads/temp/"})
+    def test_form_values_override_saved_config(self, mock_cfg, mock_get, mock_validity, client):
+        # Test must report on what the user is looking at. Testing the stored
+        # value instead re-reports the old path and the fix looks ineffective.
+        mock_get.return_value = MagicMock(test_connection=MagicMock(return_value=True))
+        client.post("/api/download-clients/airdcpp/test",
+                    json={"target_directory": "F:\\downloads\\temp\\"})
+        cfg = mock_get.call_args[0][1]
+        assert cfg.target_directory == "F:\\downloads\\temp\\"
+        assert cfg.host == "h"  # untouched fields survive the merge
+
+    @patch("core.database.update_download_client_validity")
+    @patch("models.download_clients.get_download_client_by_name")
+    @patch("core.database.get_download_client_config",
+           return_value={"host": "h", "api_key": "k"})
+    def test_bodyless_post_still_tests_saved_config(self, mock_cfg, mock_get, mock_validity, client):
+        mock_get.return_value = MagicMock(test_connection=MagicMock(return_value=True))
+        resp = client.post("/api/download-clients/sabnzbd/test")
+        assert resp.get_json()["valid"] is True
+        assert mock_get.call_args[0][1].host == "h"
+
+    @patch("core.database.get_download_client_config", return_value=None)
+    def test_form_values_alone_are_enough_to_test(self, mock_cfg, client):
+        # Nothing saved yet: a first-time config should still be testable.
+        with patch("models.download_clients.get_download_client_by_name") as mock_get, \
+                patch("core.database.update_download_client_validity"):
+            mock_get.return_value = MagicMock(test_connection=MagicMock(return_value=True))
+            resp = client.post("/api/download-clients/sabnzbd/test",
+                               json={"host": "newhost", "api_key": "k"})
+        assert resp.status_code == 200
+        assert mock_get.call_args[0][1].host == "newhost"
+
 
 class TestDownloadClientActivate:
 
@@ -486,3 +521,16 @@ class TestDcppGrab:
                            json={"result_token": "stale", "filename": "x.cbz"})
         assert resp.status_code == 502
         assert resp.get_json()["success"] is False
+
+    def test_grab_surfaces_the_real_reason(self, client):
+        # A user-fixable failure (a Target Directory the AirDC++ host can't
+        # parse) has to reach the toast, not just the log.
+        def _refuse(*args, errors=None, **kwargs):
+            errors.append("Target Directory '/downloads/temp/' is not a valid path")
+            return None
+
+        with patch("models.dcpp.grab_dcpp", side_effect=_refuse):
+            resp = client.post("/api/dcpp/grab",
+                               json={"result_token": "t1", "filename": "x.cbz"})
+        assert resp.status_code == 502
+        assert "not a valid path" in resp.get_json()["error"]


### PR DESCRIPTION
## Problem

Downloading a wanted issue via DC++ (from **Wanted** or a **Series** page) queued it in AirDC++ as a single file named after the entire target path:

```
_downloads_temp_Farmhouse 007 (2013) (Digital) (K6-Empire).cbr
```

AirDC++ concatenates `target_directory` with the result name rather than joining them, and it does not reject a target directory it cannot parse. On a **Windows** host `/` is a forbidden *filename* character rather than a path separator, so the whole POSIX path is folded into the bundle name, sanitized (`/` → `_`), and the file lands in AirDC++'s own default download directory — never in the folder CLU watches.

## Changes

**Target directory is sent in a form AirDC++ can actually use**
- Append the trailing separator AirDC++ expects on a directory path — without it, `/downloads/temp` + `Name.cbz` becomes `/downloads/tempName.cbz`.
- Read the host's own separator from `GET /system/system_info` and refuse a target directory it cannot parse, with a message naming the fix. Note the `system` module prefix: a bare `/system_info` answers `{"message": "Section not found"}`, which silently disabled the check on the first attempt at this.
- An unreadable separator (older AirDC++, unreachable endpoint) logs a warning and skips validation rather than guessing at the platform.

**AirDC++ is usually outside CLU's filesystem namespace**

New optional client field `local_target_directory` — "Target Directory (as CLU sees it)". Completed paths reported by AirDC++ are translated through it before import, covering both topologies:

| Topology | Target Directory | As CLU sees it |
|---|---|---|
| AirDC++ native on Windows, CLU in Docker | `F:\downloads\temp\` | `/downloads/temp` |
| AirDC++ in its own container, different mount | `/downloads` | `/data/downloads` |
| Both sides see the same path | `/downloads/temp/` | *(blank)* |

Translation swaps the prefix and converts separators, matching case-insensitively for Windows roots and case-sensitively for POSIX ones. A path outside the configured root — or no local path configured — passes through untouched, so the existing monitored-folder fallback still applies. `test_connection` also verifies CLU can open the local path, since that one *is* CLU's own namespace; a typo'd volume mapping now fails at Test rather than silently becoming `complete_no_move` later.

**Two things that made this hard to diagnose, fixed**
- `grab_dcpp` now reports the actual reason for a failure instead of a catch-all, so a user-fixable misconfiguration reaches the toast rather than only the log.
- **Test Connection tested the last *saved* config, not the form.** Correcting the path and clicking Test re-reported the old value, making the fix look ineffective. It now tests what is on screen, merged over stored config (a never-saved client is testable too; bodyless POSTs behave as before).

## Testing

`pytest`: **3331 passed, 6 skipped** (the usual POSIX-only permission skips on Windows).

21 new tests:
- `tests/mocked/test_airdcpp_client.py` — both separator mismatches, matching case, trailing-separator normalization, unreported separator, `Section not found`, single probe per client, probe failure not leaking into the result error, local-path validation. One test pins the exact `/api/v1/system/system_info` URL, since a wrong path fails silently — that is the bug it guards.
- `tests/mocked/test_dcpp.py` — parametrised path translation (both topologies, trailing separators, nested folders, root mount, drive-letter case-insensitivity, POSIX case-sensitivity, no-op cases) and both poller completion routes.
- `tests/routes/test_download_clients_routes.py` — form values overriding stored config on test, bodyless POST unchanged, first-time config testable, grab surfacing the real reason.

Verified against a live AirDC++ instance: `/system/system_info` reports `path_separator: "\"`, confirming the Windows diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
