### PR TITLE
Let the search modal queue more than one download

### DIFF
--- a/static/js/clu-source-search.js
+++ b/static/js/clu-source-search.js
@@ -14,12 +14,18 @@
  * the module does not depend on page-level global function names (the two
  * pages historically used different ones: showToast vs showToastGC).
  *
+ * Each result offers two buttons: queue it, or queue it and keep the modal
+ * open. Which one was used arrives as `keepOpen` on the onQueued payload —
+ * closing the modal is the page's decision, not this module's.
+ *
  * Usage:
  *     const search = CLU.createSourceSearch({
  *         resultsEl: document.getElementById('getcomicsResults'),
  *         getContext: () => ({ series, issue, year }),
  *         toast: (message, type) => showToast(message, type),
- *         onQueued: ({ source, downloadId, issue }) => { ... },
+ *         onQueued: ({ source, downloadId, issue, keepOpen }) => {
+ *             if (!keepOpen) modal.hide();
+ *         },
  *     });
  *     search.run(queryString);
  */
@@ -125,10 +131,41 @@
     }
 
     /**
-     * A card for a scored (Usenet/DC++) result. `action` carries the data-*
-     * attributes the click delegate needs to queue it.
+     * The two ways to take a result: queue it and close the modal, or queue it
+     * and keep browsing. Queuing is not a terminal action — a user scanning a
+     * result list often wants two or three files out of one search — so the
+     * second button exists to keep the list in front of them.
+     *
+     * `attrs` carries the data-* attributes that source's queue() reads.
+     * `key` identifies the release itself (page link / NZB url / DC++ token).
+     * Both buttons in a row share it, so queuing through either one marks both,
+     * and a re-render can restore the marks (see queuedKeys).
      */
-    function scoredCard(r, subtitle, action, enabled) {
+    function grabButtons(sourceKey, idleIcon, attrs, key, enabled) {
+        // data-idle is per button, not per source: the two carry different
+        // icons, so restoring a failed grab has to know which one it is.
+        const common = `data-source="${sourceKey}" data-key="${escapeHtml(key)}" ` +
+            `${attrs} ${enabled ? '' : 'disabled'}`;
+        return `
+        <div class="btn-group btn-group-sm flex-shrink-0" role="group">
+            <button class="btn btn-primary clu-src-grab" ${common}
+                data-idle="${idleIcon}" title="Download" aria-label="Download">
+                <i class="bi ${idleIcon}"></i>
+            </button>
+            <button class="btn btn-outline-primary clu-src-grab" ${common}
+                data-idle="bi-plus-lg" data-keep="1"
+                title="Download and keep searching"
+                aria-label="Download and keep searching">
+                <i class="bi bi-plus-lg"></i>
+            </button>
+        </div>`;
+    }
+
+    /**
+     * A card for a scored (Usenet/DC++) result. `buttons` is the pre-built
+     * grabButtons() pair for it.
+     */
+    function scoredCard(r, subtitle, buttons) {
         return `
         <div class="card mb-2">
             <div class="card-body d-flex align-items-center gap-3 py-2">
@@ -136,10 +173,7 @@
                     <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}${decisionBadge(r.decision)}</div>
                     <small class="text-muted text-truncate d-block">${subtitle}</small>
                 </div>
-                <button class="btn btn-sm btn-primary flex-shrink-0 clu-src-grab" ${action}
-                    title="Send to download client" ${enabled ? '' : 'disabled'}>
-                    <i class="bi bi-cloud-download"></i>
-                </button>
+                ${buttons}
             </div>
         </div>`;
     }
@@ -172,16 +206,13 @@
                             <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}</div>
                             <small class="text-muted text-truncate d-block">${escapeHtml(r.link)}</small>
                         </div>
-                        <button class="btn btn-sm btn-primary flex-shrink-0 clu-src-grab"
-                            data-source="getcomics" data-link="${escapeHtml(r.link)}"
-                            data-title="${escapeHtml(r.title)}" title="Download">
-                            <i class="bi bi-download"></i>
-                        </button>
+                        ${grabButtons('getcomics', 'bi-download',
+                    `data-link="${escapeHtml(r.link)}" data-title="${escapeHtml(r.title)}"`,
+                    r.link, true)}
                     </div>
                 </div>`).join('');
                 return sectionHeader('GetComics', 'globe') + cards;
             },
-            idleIcon: 'bi-download',
             async queue(btn, ctx) {
                 // GetComics names the file after the post title, not the wanted
                 // issue — the post is the authority on what is inside it.
@@ -239,13 +270,13 @@
                 const card = (r) => scoredCard(
                     r,
                     `${escapeHtml(r.indexer_name || '')} ${fmtSize(r.size)} · score ${r.score}`,
-                    `data-source="usenet" data-nzb-url="${escapeHtml(r.nzb_url)}"`,
-                    data.has_client
+                    grabButtons('usenet', 'bi-cloud-download',
+                        `data-nzb-url="${escapeHtml(r.nzb_url)}"`,
+                        r.nzb_url, data.has_client)
                 );
                 return header + clientNote + errNote +
                     scoredResultList('usenet', data.results, card);
             },
-            idleIcon: 'bi-cloud-download',
             async queue(btn, ctx) {
                 const resp = await fetch('/api/usenet/grab', {
                     method: 'POST',
@@ -300,13 +331,13 @@
                     return scoredCard(
                         r,
                         `${users}${fmtSize(r.size)} · score ${r.score}`,
-                        `data-source="dcpp" data-token="${escapeHtml(r.result_token)}"`,
-                        true
+                        grabButtons('dcpp', 'bi-cloud-download',
+                            `data-token="${escapeHtml(r.result_token)}"`,
+                            r.result_token, true)
                     );
                 };
                 return header + errNote + scoredResultList('dcpp', data.results, card);
             },
-            idleIcon: 'bi-cloud-download',
             async queue(btn, ctx) {
                 const resp = await fetch('/api/dcpp/grab', {
                     method: 'POST',
@@ -365,6 +396,14 @@
         const toast = options.toast || function () {};
         const onQueued = options.onQueued || function () {};
 
+        // Releases already sent this visit, keyed by grabButtons()'s `key`.
+        // None of the three grab endpoints are idempotent — a second POST
+        // queues a second download — so a re-search must not re-arm a row the
+        // user already took. Caveat: a DC++ result_token belongs to one live
+        // search instance and is re-minted every time, so DC++ rows can't be
+        // recognised across searches. GetComics links and NZB urls are stable.
+        const queuedKeys = new Set();
+
         // One delegated listener for the whole results area, installed once —
         // re-rendering the HTML cannot detach it.
         resultsEl.addEventListener('click', function (event) {
@@ -388,34 +427,61 @@
                 othersLabel(count, !hidden, !!el.dataset.hasMatch);
         }
 
+        // Both buttons in a row point at the same release, so they move as a
+        // unit: locked together while a grab is in flight, and left as a check
+        // once it lands. Handling only the clicked button would leave its
+        // sibling live and let one release be queued twice.
+        function rowButtons(key) {
+            return resultsEl.querySelectorAll(`.clu-src-grab[data-key="${CSS.escape(key)}"]`);
+        }
+
+        function markQueued(key) {
+            rowButtons(key).forEach(el => {
+                el.disabled = true;
+                el.innerHTML = '<i class="bi bi-check"></i>';
+                el.classList.remove('btn-primary', 'btn-outline-primary');
+                el.classList.add('btn-success');
+            });
+        }
+
+        // Each button restores its own icon — the keep-open one differs from
+        // its source's.
+        function releaseRow(key) {
+            rowButtons(key).forEach(el => {
+                el.disabled = false;
+                el.innerHTML = `<i class="bi ${el.dataset.idle}"></i>`;
+            });
+        }
+
         async function handleGrab(btn) {
             const source = SOURCES[btn.dataset.source];
+            // A disabled button also covers the source having no download
+            // client, so a failed grab never re-enables a row that was never
+            // usable — we only get here from an enabled one.
             if (!source || btn.disabled) return;
 
+            const key = btn.dataset.key;
             const ctx = getContext();
-            const idle = `<i class="bi ${source.idleIcon}"></i>`;
-            btn.disabled = true;
+            rowButtons(key).forEach(el => { el.disabled = true; });
             btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
             try {
                 const outcome = await source.queue(btn, ctx);
                 if (outcome.ok) {
-                    btn.innerHTML = '<i class="bi bi-check"></i>';
-                    btn.classList.remove('btn-primary');
-                    btn.classList.add('btn-success');
+                    queuedKeys.add(key);
+                    markQueued(key);
                     toast(outcome.message, 'success');
                     onQueued({
                         source: btn.dataset.source,
                         downloadId: outcome.downloadId,
                         issue: ctx.issue,
+                        keepOpen: !!btn.dataset.keep,
                     });
                 } else {
-                    btn.disabled = false;
-                    btn.innerHTML = idle;
+                    releaseRow(key);
                     toast('Error: ' + outcome.error, 'danger');
                 }
             } catch (e) {
-                btn.disabled = false;
-                btn.innerHTML = idle;
+                releaseRow(key);
                 toast('Error: ' + e.message, 'danger');
             }
         }
@@ -450,6 +516,11 @@
                 <i class="bi bi-emoji-frown display-4 opacity-25"></i>
                 <p class="mt-2">No results found</p>
             </div>`;
+
+            // A fresh render arms every button again, including ones already
+            // sent — narrowing a query and re-running it must not invite a
+            // duplicate download.
+            queuedKeys.forEach(markQueued);
         }
 
         return { run: run };

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -3138,134 +3138,90 @@ function syncReadingList(listId) {
 }
 
 // ==========================================
-// GetComics Search
+// Source Search (GetComics / Usenet / DC++)
 // ==========================================
+//
+// The fan-out to all three sources lives in clu-source-search.js, shared with
+// the Series and Wanted pages. This page used to carry its own GetComics-only
+// copy of the modal.
 
-function openGetComicsSearch(series, issueNumber) {
-    const query = series + (issueNumber ? ' #' + issueNumber : '');
-    const input = document.getElementById('getcomicsQuery');
-    input.value = query;
+let currentSearchSeries = '';
+let currentSearchIssue = '';
+let currentSearchYear = '';
+let getcomicsModal = null;
+let sourceSearch = null;
 
-    const modal = new bootstrap.Modal(document.getElementById('getcomicsModal'));
+// The modal only exists for users who can manage the list, so nothing here may
+// be built on page load — CLU.createSourceSearch binds a listener to the
+// results element as soon as it is created.
+function ensureGetComicsModal() {
+    if (!getcomicsModal) {
+        const el = document.getElementById('getcomicsModal');
+        if (!el) return null;
+        getcomicsModal = new bootstrap.Modal(el);
+    }
+    return getcomicsModal;
+}
+
+function ensureSourceSearch() {
+    if (!sourceSearch) {
+        const resultsEl = document.getElementById('getcomicsResults');
+        if (!resultsEl) return null;
+        sourceSearch = CLU.createSourceSearch({
+            resultsEl: resultsEl,
+            getContext: () => ({
+                series: currentSearchSeries,
+                issue: currentSearchIssue,
+                year: currentSearchYear,
+            }),
+            // The shared module speaks Bootstrap severities; showToast() here
+            // only knows 'success'/'error' and renders anything else blue.
+            toast: (message, type) => showToast(message, type === 'danger' ? 'error' : type),
+            // The keep-open button leaves the results up so the user can grab
+            // more than one file from a single search.
+            onQueued: ({ keepOpen }) => {
+                if (!keepOpen) setTimeout(() => getcomicsModal.hide(), 500);
+            },
+        });
+    }
+    return sourceSearch;
+}
+
+function openGetComicsSearch(series, issueNumber, issueYear) {
+    const modal = ensureGetComicsModal();
+    if (!modal) return;
+
+    currentSearchSeries = series;
+    currentSearchIssue = issueNumber || '';
+    currentSearchYear = issueYear || '';
+
+    // The issue's year narrows every source — "Iron Man 8" matches every volume
+    // that ever had an #8, "Iron Man 8 2026" matches this one.
+    document.getElementById('getcomicsQuery').value =
+        [series, currentSearchIssue, currentSearchYear]
+            .filter(part => part !== '' && part !== null && part !== undefined)
+            .join(' ');
+
     modal.show();
+    doGetComicsSearch();
+}
 
-    // Auto-search after modal is shown
-    document.getElementById('getcomicsModal').addEventListener('shown.bs.modal', function handler() {
-        doGetComicsSearch();
-        document.getElementById('getcomicsModal').removeEventListener('shown.bs.modal', handler);
-    });
+// The query box is the source of truth for the year: seeded by
+// openGetComicsSearch(), but a user who edits or clears it widens/narrows
+// every source together.
+function extractQueryYear(query) {
+    const m = String(query).trim().match(/(?:^|\s)((?:19|20)\d{2})$/);
+    return m ? m[1] : '';
 }
 
 async function doGetComicsSearch() {
     const query = document.getElementById('getcomicsQuery').value.trim();
     if (!query) return;
 
-    const resultsDiv = document.getElementById('getcomicsResults');
-    resultsDiv.innerHTML = `
-    <div class="text-center py-4">
-        <div class="spinner-border text-primary"></div>
-        <p class="mt-2">Searching GetComics...</p>
-    </div>`;
+    const search = ensureSourceSearch();
+    if (!search) return;
 
-    try {
-        const resp = await fetch(`/api/getcomics/search?q=${encodeURIComponent(query)}`);
-        const data = await resp.json();
-
-        if (!data.success) {
-            resultsDiv.innerHTML = `<div class="alert alert-danger">${escapeHtmlGC(data.error)}</div>`;
-            return;
-        }
-
-        if (data.results.length === 0) {
-            resultsDiv.innerHTML = `
-            <div class="text-center text-muted py-4">
-                <i class="bi bi-emoji-frown display-4 opacity-25"></i>
-                <p class="mt-2">No results found</p>
-            </div>`;
-            return;
-        }
-
-        // Extract series/issue from query for sorting
-        const match = query.match(/^(.+?)(?:\s+#(\d+))?$/);
-        const seriesName = match ? match[1].trim() : query;
-        const issueNum = match ? (match[2] || '') : '';
-        const sorted = sortResultsGC(data.results, seriesName, issueNum);
-
-        resultsDiv.innerHTML = sorted.map((r, idx) => `
-        <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
-            <div class="card-body d-flex align-items-center gap-3 py-2">
-                ${r.image ? `<img src="${escapeHtmlGC(r.image)}" style="width:50px;height:75px;object-fit:cover;" class="rounded" onerror="this.style.display='none'">` : '<div style="width:50px"></div>'}
-                <div class="flex-grow-1 overflow-hidden">
-                    <div class="fw-bold text-truncate" title="${escapeHtmlGC(r.title)}">${escapeHtmlGC(r.title)}</div>
-                    <small class="text-muted text-truncate d-block">${escapeHtmlGC(r.link)}</small>
-                </div>
-                <button class="btn btn-sm btn-primary flex-shrink-0" onclick="downloadFromGetComics(this, '${escapeHtmlGC(r.link)}', '${escapeJsGC(r.title)}')" title="Download">
-                    <i class="bi bi-download"></i>
-                </button>
-            </div>
-        </div>
-    `).join('');
-
-    } catch (e) {
-        resultsDiv.innerHTML = `<div class="alert alert-danger">Error: ${escapeHtmlGC(e.message)}</div>`;
-    }
-}
-
-async function downloadFromGetComics(btn, pageUrl, title) {
-    const filename = title.replace(/[^a-zA-Z0-9\s\-#]/g, '').trim() + '.cbz';
-
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-
-    try {
-        const resp = await fetch('/api/getcomics/download', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url: pageUrl, filename: filename })
-        });
-        const data = await resp.json();
-
-        if (data.success) {
-            btn.innerHTML = '<i class="bi bi-check"></i>';
-            btn.classList.remove('btn-primary');
-            btn.classList.add('btn-success');
-            showToast('Download queued successfully!', 'success');
-
-            setTimeout(() => {
-                const modal = bootstrap.Modal.getInstance(document.getElementById('getcomicsModal'));
-                if (modal) modal.hide();
-            }, 500);
-        } else {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-download"></i>';
-            showToast('Error: ' + data.error, 'error');
-        }
-    } catch (e) {
-        btn.disabled = false;
-        btn.innerHTML = '<i class="bi bi-download"></i>';
-        showToast('Error: ' + e.message, 'error');
-    }
-}
-
-function sortResultsGC(results, seriesName, issueNumber) {
-    return results.map(r => {
-        let score = 0;
-        const title = r.title.toLowerCase();
-        const series = seriesName.toLowerCase();
-
-        if (series && title.includes(series)) score += 10;
-        if (issueNumber && (title.includes(`#${issueNumber}`) || title.includes(` ${issueNumber} `) || title.endsWith(` ${issueNumber}`))) score += 5;
-
-        return { ...r, score };
-    }).sort((a, b) => b.score - a.score);
-}
-
-function escapeHtmlGC(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-}
-
-function escapeJsGC(str) {
-    return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
+    // Keep the per-source year filter in step with what's in the box.
+    currentSearchYear = extractQueryYear(query);
+    await search.run(query);
 }

--- a/templates/reading_list_view.html
+++ b/templates/reading_list_view.html
@@ -262,9 +262,11 @@
                                 <i class="bi bi-crop me-2"></i>Crop Cover
                             </a></li>
                         {% endif %}
+                        {# The issue's year narrows every source — passing it stops
+                           "#8" matching every volume that ever had one. #}
                         <li><a class="dropdown-item" href="#"
-                                onclick="openGetComicsSearch('{{ entry.series|replace("'", "\\'") }}', '{{ entry.issue_number }}'); return false;">
-                                <i class="bi bi-search me-2"></i>Search GetComics
+                                onclick="openGetComicsSearch('{{ entry.series|replace("'", "\\'") }}', '{{ entry.issue_number }}', '{{ entry.year or '' }}'); return false;">
+                                <i class="bi bi-search me-2"></i>Search Sources
                             </a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item text-danger" href="#"
@@ -382,13 +384,13 @@
 </div>
 
 {% if _can_manage %}
-<!-- GetComics Search Modal -->
+<!-- Source Search Modal (GetComics / Usenet / DC++, driven by clu-source-search.js) -->
 <div class="modal fade" id="getcomicsModal" tabindex="-1">
     <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title fw-bold">
-                    <i class="bi bi-search me-2"></i>Search GetComics
+                    <i class="bi bi-search me-2"></i>Search Sources
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
@@ -450,5 +452,6 @@
 {{ super() }}
 <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+<script src="{{ url_for('static', filename='js/clu-source-search.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/reading_list.js') }}?v={{ range(1, 10000) | random }}"></script>
 {% endblock %}

--- a/templates/series.html
+++ b/templates/series.html
@@ -1125,9 +1125,11 @@
                     year: currentSearchYear,
                 }),
                 toast: showToastGC,
-                onQueued: ({ source, downloadId, issue }) => {
+                onQueued: ({ source, downloadId, issue, keepOpen }) => {
                     // Reflect the queued download on the issue row:
                     // a wanted/not-found issue (table-danger) becomes table-warning.
+                    // Still worth doing with the modal open — the row updates
+                    // behind it.
                     markIssueRowDownloading(issue);
                     // Only GetComics downloads run inside CLU and can fail in a
                     // way we can surface here (e.g. a Cloudflare-protected
@@ -1135,7 +1137,9 @@
                     if (source === 'getcomics' && downloadId) {
                         pollGetComicsDownload(downloadId, issue);
                     }
-                    setTimeout(() => getcomicsModal.hide(), 500);
+                    // The keep-open button leaves the results up so the user can
+                    // grab more than one file from a single search.
+                    if (!keepOpen) setTimeout(() => getcomicsModal.hide(), 500);
                 },
             });
         }

--- a/templates/wanted.html
+++ b/templates/wanted.html
@@ -314,7 +314,11 @@
                     year: currentSearchYear,
                 }),
                 toast: showToast,
-                onQueued: () => setTimeout(() => getcomicsModal.hide(), 500),
+                // The keep-open button leaves the results up so the user can
+                // grab more than one file from a single search.
+                onQueued: ({ keepOpen }) => {
+                    if (!keepOpen) setTimeout(() => getcomicsModal.hide(), 500);
+                },
             });
         }
         return sourceSearch;

--- a/tests/unit/test_source_search_ui.py
+++ b/tests/unit/test_source_search_ui.py
@@ -1,0 +1,124 @@
+"""The keep-open contract of the shared source-search modal.
+
+Each result in the modal offers two buttons: queue it, or queue it and keep the
+results up so the user can grab more than one file from a single search. Which
+one was pressed reaches the page as `keepOpen` on the onQueued payload, and
+closing the modal is the page's decision — so the module and all three of its
+callers have to stay in lockstep.
+
+There is no JS test runner in this repo, so these assert on the assets as text,
+following the precedent in test_themes.py. They are a wiring guard, not a
+behaviour test: they catch a caller that goes back to closing unconditionally,
+or a card renderer that loses one of the two buttons.
+"""
+import os
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+STATIC_JS = os.path.join(REPO_ROOT, "static", "js")
+TEMPLATE_DIR = os.path.join(REPO_ROOT, "templates")
+
+# Every surface that hosts the shared modal. A new page using
+# CLU.createSourceSearch belongs here too.
+CALLERS = [
+    os.path.join(TEMPLATE_DIR, "series.html"),
+    os.path.join(TEMPLATE_DIR, "wanted.html"),
+    os.path.join(STATIC_JS, "reading_list.js"),
+]
+
+
+def read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture(scope="module")
+def module_js():
+    return read(os.path.join(STATIC_JS, "clu-source-search.js"))
+
+
+class TestGrabButtons:
+
+    def test_renders_both_a_close_and_a_keep_open_button(self, module_js):
+        assert "function grabButtons(" in module_js
+        # Two grab buttons per result, exactly one of them marked keep-open.
+        assert module_js.count("clu-src-grab") >= 2
+        assert 'data-keep="1"' in module_js
+
+    def test_every_card_renderer_uses_the_shared_pair(self, module_js):
+        # Each source must go through grabButtons() — a hand-rolled single
+        # button would silently drop the keep-open option for that source.
+        for source in ("getcomics", "usenet", "dcpp"):
+            assert "grabButtons('%s'" % source in module_js
+
+    def test_buttons_carry_an_identity_key(self, module_js):
+        # markQueued() and the dedupe set both key off data-key.
+        assert "data-key=" in module_js
+        assert "function markQueued(" in module_js
+
+    def test_error_restore_reads_the_per_button_icon(self, module_js):
+        # The keep-open button's idle icon differs from its source's, so a
+        # failed grab must restore from the button, not from a per-source icon.
+        assert "dataset.idle" in module_js
+        assert "idleIcon:" not in module_js
+
+    def test_a_row_moves_as_a_unit(self, module_js):
+        # Otherwise a grab in flight on one button leaves its sibling live and
+        # the same release can be queued twice.
+        assert "function rowButtons(" in module_js
+        assert "function releaseRow(" in module_js
+
+
+class TestKeepOpenContract:
+
+    def test_module_reports_which_button_was_used(self, module_js):
+        assert "keepOpen: !!btn.dataset.keep" in module_js
+
+    def test_queued_releases_survive_a_re_render(self, module_js):
+        # None of the grab endpoints are idempotent, so re-searching must not
+        # re-arm a row the user already took.
+        assert "queuedKeys" in module_js
+        assert "queuedKeys.forEach(markQueued)" in module_js
+
+    @pytest.mark.parametrize("path", CALLERS, ids=lambda p: os.path.basename(p))
+    def test_caller_guards_the_hide_on_keep_open(self, path):
+        source = read(path)
+        assert "createSourceSearch" in source, "caller no longer uses the shared module"
+        assert "keepOpen" in source
+        # No caller may hide the modal unconditionally from onQueued.
+        for line in source.splitlines():
+            if "getcomicsModal.hide()" in line and "keepOpen" not in line:
+                pytest.fail("unguarded modal hide in %s: %s" % (os.path.basename(path), line.strip()))
+
+
+class TestReadingListMigration:
+
+    def test_legacy_getcomics_modal_is_gone(self):
+        source = read(os.path.join(STATIC_JS, "reading_list.js"))
+        # The page-local copy of the modal predated clu-source-search.js and
+        # only ever searched GetComics.
+        for dead in ("downloadFromGetComics", "sortResultsGC", "escapeJsGC"):
+            assert dead not in source, "%s should have been removed" % dead
+
+    def test_page_loads_the_shared_module(self):
+        template = read(os.path.join(TEMPLATE_DIR, "reading_list_view.html"))
+        assert "js/clu-source-search.js" in template
+
+    def test_search_is_seeded_with_the_issue_year(self):
+        template = read(os.path.join(TEMPLATE_DIR, "reading_list_view.html"))
+        # Without a year, "#8" matches every volume that ever had one.
+        assert "entry.year or ''" in template
+
+    def test_toast_severity_is_adapted(self):
+        source = read(os.path.join(STATIC_JS, "reading_list.js"))
+        # showToast() here only knows 'success'/'error'; the shared module
+        # emits Bootstrap's 'danger', which would render blue.
+        assert "'danger' ? 'error'" in source
+
+    def test_modal_is_built_lazily(self):
+        source = read(os.path.join(STATIC_JS, "reading_list.js"))
+        # The modal is inside {% if _can_manage %}, so a viewer without manage
+        # rights has no #getcomicsResults to bind to.
+        assert "function ensureSourceSearch(" in source
+        assert "function ensureGetComicsModal(" in source


### PR DESCRIPTION
## Why

Clicking a result in the source-search modal (Series, Wanted) queued it **and closed the modal**, which made queuing a terminal action. Browsing is the real task — a user scanning results often spots a second or third file they want, and the only way to get them was to reopen the modal and re-run the whole search per file.

## What changed

Each result row now offers two buttons:

| Button | Behaviour |
|---|---|
| **⤓ / ☁⤓** (solid) | Download and close — unchanged from today |
| **＋** (outline) | Download and keep browsing |

Which one was pressed reaches the page as `keepOpen` on the `onQueued` payload. Closing the modal stays the page's decision, not the module's.

### Duplicate protection

None of `/api/getcomics/download`, `/api/usenet/grab` or `/api/dcpp/grab` are idempotent — each POST mints a fresh `download_id` and queues another job — so keeping the modal open needed this to go with it:

- **Both buttons in a row move as a unit.** They lock together while a grab is in flight (otherwise you could click ⤓ then ＋ and send the same release twice) and both settle to a green check.
- **Queued releases are remembered for the visit.** Narrowing a query and re-searching brings already-taken rows back locked instead of arming them again. DC++ is the exception, and inherently so: a `result_token` belongs to one live search instance and is re-minted on every search. GetComics links and NZB URLs are stable and do carry over. The caveat is commented at the declaration.

### Reading-list page migrated

`static/js/reading_list.js` carried a third, un-migrated copy of this modal — GetComics only, inline `onclick` handlers, its own auto-close. It now uses `CLU.createSourceSearch`, so that page gains Usenet and DC++ sections, result scoring and the keep-open behaviour, and loses ~130 lines of duplicated code.

Three things that page needed specially:

- The modal sits inside `{% if _can_manage %}`, so the search object is built lazily — constructing it eagerly would throw on a null `resultsEl` for a read-only viewer.
- Its `showToast` only understands `success`/`error`; the module emits Bootstrap's `danger`, which would otherwise render blue. Adapted at the callback.
- The query now carries the issue year, which the entry already had (`reading_list_entries.year`) but never passed. Without it, `#8` matches every volume that ever had one.

## Testing

Full suite clean: **3346 passed, 6 skipped** (the known POSIX-only skips).

`tests/unit/test_source_search_ui.py` is new — a wiring guard in the style of `test_themes.py`, asserting on the assets as text since there's no JS runner in this repo. It catches a caller that goes back to closing unconditionally, or a card renderer that loses one of the two buttons.

Beyond that I drove the module against a stub DOM and `fetch` to check real behaviour: 8 buttons for 4 results, `keepOpen` true/false on the right button, both siblings locking and checking together, a re-search leaving GetComics/Usenet rows locked while an untouched row stays armed, and exactly 2 grabs sent across two searches.

That probe caught a bug worth flagging: I'd initially put one shared `data-idle` on both buttons, so a *failed* grab restored the ＋ button to the download icon, leaving two identical-looking buttons. Each button now carries its own idle icon.

## Not yet done

The app itself has not been run. Worth a manual pass before merge — particularly confirming a non-manager viewing a shared reading list gets no console error (the lazy-construction case above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
