### PR TITLE
Add "Want to Read" and "Add to Pull List" folder actions

### DIFF
--- a/models/library_automap.py
+++ b/models/library_automap.py
@@ -847,6 +847,143 @@ def apply_and_sync(items, api=None):
     return result
 
 
+# Outcomes of add_folder_to_pull_list, in the order they are checked:
+#   already_mapped -- this folder is already on the Pull List (no-op)
+#   needs_match    -- no usable sidecar; the caller should let the user pick
+#                     the series by hand and call back with ``series_id``
+#   conflict       -- the resolved series is mapped to a *different* folder
+#   applied        -- mapped; issues sync and file matching run in background
+#   failed         -- bad input, or the mapping could not be saved
+
+
+def add_folder_to_pull_list(
+    folder, series_id=None, fallback=None, api=None, cv_available=None
+):
+    """Add a single folder to the Pull List -- Scan Library for one folder.
+
+    Same resolution cascade and same apply path as the library-wide scan, so a
+    folder added here is indistinguishable from one the scan picked up: sidecars
+    are backfilled, issues sync, and owned/missing is rebuilt in the background.
+
+    Args:
+        folder: Absolute path to the series folder. Must sit inside a library.
+        series_id: Series the user picked by hand. When given, the sidecar
+            cascade is skipped entirely -- this is the escape hatch for a folder
+            with no ``series.json``/``cvinfo``.
+        fallback: Optional dict of ``series_name``/``publisher_name``/``year``/
+            ``cv_id`` from the user's pick, used only if the provider fetch
+            fails (mirrors the sidecar fallback the scan supplies).
+        api: Optional Metron API client (fetched if None).
+        cv_available: Whether ComicVine can be read (detected if None).
+
+    Returns:
+        dict with a ``status`` key -- see the outcomes listed above. Never
+        raises for an unreadable sidecar: that comes back as ``needs_match`` so
+        the user can still map the folder by hand.
+    """
+    from core.database import get_all_mapped_series
+
+    folder = (folder or "").strip()
+    if not folder:
+        return {"status": "failed", "message": "No folder given"}
+    if not os.path.isdir(folder):
+        return {"status": "failed", "message": "Folder no longer exists"}
+
+    # Only library folders belong on the Pull List -- keeps /downloads (and
+    # anything else the caller could name) out of it.
+    nfolder = _norm(folder)
+    roots = [_norm(root) for root in get_library_roots() if root]
+    if not any(nfolder == root or nfolder.startswith(root + "/") for root in roots):
+        return {
+            "status": "failed",
+            "message": "Folder is not inside a configured library",
+        }
+
+    mapped_by_path = {}
+    mapped_by_id = {}
+    for row in get_all_mapped_series():
+        path = row.get("mapped_path")
+        if path:
+            mapped_by_path[_norm(path)] = row
+            mapped_by_id[row.get("id")] = _norm(path)
+
+    if nfolder in mapped_by_path:
+        row = mapped_by_path[nfolder]
+        return {
+            "status": "already_mapped",
+            "series_id": row.get("id"),
+            "series_name": row.get("name"),
+        }
+
+    if api is None:
+        api = metron.get_flask_api()
+    if cv_available is None:
+        cv_available = comicvine_source.is_available()
+
+    fallback = fallback or {}
+    chosen_id = _to_int(series_id)
+    if chosen_id:
+        item = {
+            "folder": folder,
+            "metron_id": chosen_id,
+            "series_name": (
+                fallback.get("series_name") or _series_name_from_folder(folder)
+            ),
+            "publisher_name": fallback.get("publisher_name"),
+            "year": fallback.get("year"),
+            "status": fallback.get("status"),
+            "cv_id": _to_int(fallback.get("cv_id")),
+            "source": "manual",
+            "reason": None,
+            "conflict_with": None,
+        }
+    else:
+        try:
+            item = _resolve_identity(folder, api, cv_available=cv_available)
+        except Exception as e:
+            app_logger.warning(f"automap: could not resolve sidecar in {folder}: {e}")
+            item = None
+            reason = f"Sidecar present but could not be read: {e}"
+        else:
+            reason = "No series.json or cvinfo file in this folder"
+
+        if item is None:
+            return {
+                "status": "needs_match",
+                "suggested_name": _series_name_from_folder(folder),
+                "reason": reason,
+            }
+        if not item["metron_id"]:
+            return {
+                "status": "needs_match",
+                "suggested_name": item["series_name"],
+                "reason": item.get("reason"),
+            }
+
+    existing = mapped_by_id.get(item["metron_id"])
+    if existing and existing != nfolder:
+        return {
+            "status": "conflict",
+            "series_id": item["metron_id"],
+            "series_name": item["series_name"],
+            "mapped_to": existing,
+        }
+
+    result = apply_and_sync([item], api=api)
+    if result["applied"]:
+        return {
+            "status": "applied",
+            "series_id": item["metron_id"],
+            "series_name": item["series_name"],
+            "source": item.get("source"),
+        }
+
+    message = (
+        result["failed"][0]["error"] if result["failed"] else "Failed to map folder"
+    )
+    return {"status": "failed", "message": message}
+
+
 # ── Background scan jobs ───────────────────────────────────────────────────
 # A small self-contained job store so the Pull List can poll a long scan and
 # retrieve the review/skipped lists once it finishes. (app_state's operation

--- a/routes/series.py
+++ b/routes/series.py
@@ -490,6 +490,54 @@ def apply_library_automap():
     })
 
 
+@series_bp.route("/api/pull-list/add-folder", methods=["POST"])
+def add_folder_to_pull_list():
+    """Add one folder to the Pull List -- Scan Library for a single folder.
+
+    Called from the folder dropdowns in the File Manager and the collection
+    grid. Two shapes:
+
+      {"folder": "/data/DC/Batman"}
+          Resolve the folder's series.json / cvinfo sidecars. A folder with no
+          usable sidecar comes back as ``status: needs_match`` plus a
+          ``suggested_name``, so the caller can offer a series search.
+
+      {"folder": ..., "series_id": 123, "series_name": ..., ...}
+          The user picked the series by hand; map straight to it.
+
+    Always 200 for a well-formed request -- the ``status`` field carries the
+    outcome (applied / already_mapped / needs_match / conflict / failed).
+    """
+    from models import library_automap
+
+    data = request.get_json(silent=True) or {}
+    folder = data.get("folder")
+    if not folder:
+        return jsonify({"success": False, "error": "Missing folder"}), 400
+
+    try:
+        result = library_automap.add_folder_to_pull_list(
+            folder,
+            series_id=data.get("series_id"),
+            fallback={
+                "series_name": data.get("series_name"),
+                "publisher_name": data.get("publisher_name"),
+                "year": data.get("year"),
+                "status": data.get("status"),
+                "cv_id": data.get("cv_id"),
+            },
+        )
+    except Exception as e:
+        app_logger.error(f"Error adding {folder} to pull list: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+    payload = dict(result)
+    payload["success"] = result["status"] != "failed"
+    if result["status"] == "failed":
+        payload["error"] = result.get("message")
+    return jsonify(payload)
+
+
 @series_bp.route("/series-search")
 def series_search():
     """

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -1402,6 +1402,7 @@ function renderGrid(items) {
                         <li><a class="dropdown-item folder-action-fetch-metadata" href="#"><i class="bi bi-cloud-download"></i> Fetch All Metadata</a></li>
                         <li><a class="dropdown-item folder-action-missing" href="#"><i class="bi bi-file-earmark-text"></i> Missing File Check</a></li>
                         <li><a class="dropdown-item folder-action-update-xml" href="#"><i class="bi bi-filetype-xml"></i> Update XML</a></li>
+                        <li><a class="dropdown-item folder-action-pull-list" href="#"><i class="bi bi-list-check"></i> Add to Pull List</a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item folder-action-delete text-danger" href="#"><i class="bi bi-trash"></i> Delete</a></li>
                         `;
@@ -1433,6 +1434,16 @@ function renderGrid(items) {
                                 e.preventDefault();
                                 e.stopPropagation();
                                 CLU.openUpdateXmlModal(item.path, item.name);
+                            };
+                        }
+
+                        // Bind Add to Pull List action (folders only — a folder is a series)
+                        const pullListAction = dropdownMenu.querySelector('.folder-action-pull-list');
+                        if (pullListAction) {
+                            pullListAction.onclick = (e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                CLU.addFolderToPullList(item.path, item.name);
                             };
                         }
                     }

--- a/static/js/files.js
+++ b/static/js/files.js
@@ -56,6 +56,11 @@ let destLibraryProviders = [];
 // Global variable to store current file path for editing
 let currentEditFilePath = null;
 
+// Paths currently flagged "Want to Read" (feeds the collection dashboard swiper).
+// Refreshed on page load and before each directory render so the dropdown can
+// show Add vs Remove without a per-item /to-read/check round trip.
+let wantToReadPaths = new Set();
+
 // Format file size helper function
 function formatSize(bytes) {
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -324,6 +329,80 @@ function renameItem(oldPath, newName, panel) {
     });
 }
 
+
+// ==========================================
+// Want to Read
+// ==========================================
+
+// Refresh the cached set of "Want to Read" paths. Never rejects – a failed
+// lookup just leaves the dropdown offering "Add", which the server dedupes.
+function refreshWantToReadPaths() {
+  return fetch('/api/favorites/to-read')
+    .then(response => response.json())
+    .then(data => {
+      if (data.success && Array.isArray(data.items)) {
+        wantToReadPaths = new Set(data.items.map(item => item.path));
+      }
+    })
+    .catch(error => {
+      console.error("Error loading Want to Read list:", error);
+    });
+}
+
+// Build the dropdown entry that flags a file or folder for the "Want to Read"
+// swiper on the collection page. itemType is 'file' or 'folder'.
+function createWantToReadItem(fullPath, name, itemType) {
+  const item = document.createElement("li");
+  const link = document.createElement("a");
+  link.className = "dropdown-item";
+  link.href = "#";
+  applyWantToReadLabel(link, wantToReadPaths.has(fullPath));
+  link.onclick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleWantToRead(fullPath, name, itemType, link);
+  };
+  item.appendChild(link);
+  return item;
+}
+
+function applyWantToReadLabel(link, isMarked) {
+  link.innerHTML = isMarked
+    ? '<i class="bi bi-bookmark-dash me-2"></i>Remove from Want to Read'
+    : '<i class="bi bi-bookmark-plus me-2"></i>Add to Want to Read';
+}
+
+function toggleWantToRead(fullPath, name, itemType, link) {
+  const isMarked = wantToReadPaths.has(fullPath);
+  const method = isMarked ? 'DELETE' : 'POST';
+
+  fetch('/api/favorites/to-read', {
+    method: method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path: fullPath, type: itemType })
+  })
+    .then(response => response.json())
+    .then(data => {
+      if (data.success) {
+        if (isMarked) {
+          wantToReadPaths.delete(fullPath);
+          CLU.showSuccess(`${name} removed from Want to Read`);
+        } else {
+          wantToReadPaths.add(fullPath);
+          CLU.showSuccess(`${name} added to Want to Read`);
+        }
+        applyWantToReadLabel(link, !isMarked);
+      } else {
+        CLU.showError('Failed to update Want to Read: ' + (data.error || 'Unknown error'));
+      }
+    })
+    .catch(error => {
+      console.error("Error updating Want to Read:", error);
+      CLU.showError('Failed to update Want to Read');
+    });
+}
+
+document.addEventListener('DOMContentLoaded', refreshWantToReadPaths);
 
 // Function to create a list item with edit and delete functionality.
 function createListItem(itemName, fullPath, type, panel, isDraggable) {
@@ -709,6 +788,23 @@ function createListItem(itemName, fullPath, type, panel, isDraggable) {
       smartRenameItem.appendChild(smartRenameLink);
       dropdownMenu.appendChild(smartRenameItem);
 
+      // Add to Pull List option (folders only — a folder is a series)
+      const pullListItem = document.createElement("li");
+      const pullListLink = document.createElement("a");
+      pullListLink.className = "dropdown-item";
+      pullListLink.href = "#";
+      pullListLink.innerHTML = '<i class="bi bi-list-check me-2"></i>Add to Pull List';
+      pullListLink.onclick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        CLU.addFolderToPullList(fullPath, fileData.name);
+      };
+      pullListItem.appendChild(pullListLink);
+      dropdownMenu.appendChild(pullListItem);
+
+      // Want to Read option (flags the whole series/folder)
+      dropdownMenu.appendChild(createWantToReadItem(fullPath, fileData.name, 'folder'));
+
       // Remove All XML option
       const removeXmlItem = document.createElement("li");
       const removeXmlLink = document.createElement("a");
@@ -915,6 +1011,9 @@ function createListItem(itemName, fullPath, type, panel, isDraggable) {
       const dividerItem = document.createElement("li");
       dividerItem.innerHTML = '<hr class="dropdown-divider">';
       dropdownMenu.appendChild(dividerItem);
+
+      // Want to Read option
+      dropdownMenu.appendChild(createWantToReadItem(fullPath, fileData.name, 'file'));
 
       // Add to Reading List option
       const addToListItem = document.createElement("li");
@@ -1281,9 +1380,13 @@ function loadDirectories(path, panel) {
                                   Loading...
                                 </button>
                               </div>`;
-  fetch(`/list-directories?path=${encodeURIComponent(path)}`)
-    .then(response => response.json())
-    .then(data => {
+  // Refresh the Want to Read set alongside the listing so the dropdown entries
+  // are built with the correct Add/Remove label.
+  Promise.all([
+    fetch(`/list-directories?path=${encodeURIComponent(path)}`).then(response => response.json()),
+    refreshWantToReadPaths()
+  ])
+    .then(([data]) => {
       console.log("Received data for panel", panel, ":", data);
 
       // Check for server errors

--- a/static/js/pull_list_add.js
+++ b/static/js/pull_list_add.js
@@ -1,0 +1,236 @@
+/**
+ * Add to Pull List — shared "Scan Library for one folder" flow.
+ *
+ * Entry point: CLU.addFolderToPullList(folderPath, folderName)
+ *
+ * Posts the folder to /api/pull-list/add-folder, which resolves it from its
+ * series.json / cvinfo sidecars exactly like the Scan Library button on the
+ * Pull List page. A folder with no usable sidecar comes back as `needs_match`,
+ * and this opens the picker modal so the user can choose the series by hand.
+ *
+ * Requires: clu-utils.js (CLU.showToast) and, for the manual pick,
+ * partials/modal_add_to_pull_list.html included in the page.
+ */
+(function () {
+  var CLU = window.CLU = window.CLU || {};
+
+  var pickerModal = null;
+  var pendingFolder = null;
+  var pendingName = null;
+
+  function folderLabel(folderPath, folderName) {
+    if (folderName) return folderName;
+    var parts = String(folderPath || '').replace(/\/+$/, '').split('/');
+    return parts[parts.length - 1] || folderPath;
+  }
+
+  function esc(value) {
+    var d = document.createElement('div');
+    d.textContent = (value == null ? '' : String(value));
+    return d.innerHTML;
+  }
+
+  /**
+   * Flag a folder as a tracked series on the Pull List.
+   *
+   * @param {string} folderPath - Absolute path to the series folder.
+   * @param {string} [folderName] - Display name for toasts (defaults to the leaf).
+   */
+  CLU.addFolderToPullList = function (folderPath, folderName) {
+    if (!folderPath) return;
+    pendingFolder = folderPath;
+    pendingName = folderLabel(folderPath, folderName);
+    CLU.showToast('Pull List', 'Checking ' + pendingName + '…', 'info');
+    submit({ folder: folderPath });
+  };
+
+  function submit(body, onFailure) {
+    return fetch('/api/pull-list/add-folder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) { handleResult(data, onFailure); })
+      .catch(function (error) {
+        console.error('Error adding folder to Pull List:', error);
+        CLU.showError('Failed to add to Pull List');
+        if (onFailure) onFailure();
+      });
+  }
+
+  function handleResult(data, onFailure) {
+    var name = data.series_name || pendingName;
+
+    switch (data.status) {
+      case 'applied':
+        hidePicker();
+        CLU.showSuccess(name + ' added to your Pull List — syncing issues in the background');
+        break;
+
+      case 'already_mapped':
+        hidePicker();
+        CLU.showToast('Pull List', (name || pendingName) + ' is already tracked', 'info');
+        break;
+
+      case 'conflict':
+        CLU.showToast(
+          'Already mapped',
+          name + ' is already mapped to ' + data.mapped_to,
+          'warning'
+        );
+        if (onFailure) onFailure();
+        break;
+
+      case 'needs_match':
+        openPicker(data);
+        break;
+
+      default:
+        CLU.showError(data.error || 'Failed to add to Pull List');
+        if (onFailure) onFailure();
+    }
+  }
+
+  // ── Manual series picker ──────────────────────────────────────────────────
+
+  function openPicker(data) {
+    var modalEl = document.getElementById('addToPullListModal');
+    if (!modalEl) {
+      // Page didn't include the partial — report the reason rather than
+      // silently doing nothing.
+      CLU.showError(data.reason || 'No series.json or cvinfo in this folder');
+      return;
+    }
+
+    var input = document.getElementById('pullListSearchInput');
+    var reason = document.getElementById('pullListAddReason');
+
+    if (reason) {
+      reason.innerHTML = esc(pendingFolder) + ' — ' +
+        esc(data.reason || 'No series.json or cvinfo in this folder') +
+        '. Pick the series to track it.';
+    }
+    resetResults();
+    if (input) input.value = data.suggested_name || pendingName || '';
+
+    if (!pickerModal) {
+      pickerModal = new bootstrap.Modal(modalEl);
+      wirePicker();
+    }
+    pickerModal.show();
+    if (input) {
+      // Focus once the modal has finished animating in.
+      modalEl.addEventListener('shown.bs.modal', function once() {
+        modalEl.removeEventListener('shown.bs.modal', once);
+        input.focus();
+        input.select();
+      });
+    }
+  }
+
+  function hidePicker() {
+    if (pickerModal) pickerModal.hide();
+  }
+
+  function wirePicker() {
+    var btn = document.getElementById('pullListSearchBtn');
+    var input = document.getElementById('pullListSearchInput');
+    if (btn) btn.onclick = runSearch;
+    if (input) {
+      input.addEventListener('keypress', function (e) {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          runSearch();
+        }
+      });
+    }
+  }
+
+  function resetResults() {
+    var table = document.getElementById('pullListResultsTable');
+    var body = document.getElementById('pullListResultsBody');
+    var status = document.getElementById('pullListSearchStatus');
+    if (table) table.classList.add('d-none');
+    if (body) body.innerHTML = '';
+    if (status) status.textContent = '';
+  }
+
+  function runSearch() {
+    var input = document.getElementById('pullListSearchInput');
+    var status = document.getElementById('pullListSearchStatus');
+    var query = input ? input.value.trim() : '';
+    if (!query) return;
+
+    resetResults();
+    if (status) status.textContent = 'Searching…';
+
+    fetch('/api/series/search?q=' + encodeURIComponent(query))
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.success) {
+          if (status) status.textContent = data.error || 'Search failed';
+          return;
+        }
+        renderResults(data.series || []);
+      })
+      .catch(function (error) {
+        console.error('Pull List series search failed:', error);
+        if (status) status.textContent = 'Search failed';
+      });
+  }
+
+  function renderResults(series) {
+    var table = document.getElementById('pullListResultsTable');
+    var body = document.getElementById('pullListResultsBody');
+    var status = document.getElementById('pullListSearchStatus');
+    if (!body) return;
+
+    if (!series.length) {
+      if (status) status.textContent = 'No matches — try a different name.';
+      return;
+    }
+    if (status) status.textContent = '';
+
+    body.innerHTML = series.map(function (s, i) {
+      var volume = s.volume ? ' <span class="text-muted">Vol. ' + esc(s.volume) + '</span>' : '';
+      var tracked = s.subscribed
+        ? ' <span class="badge bg-secondary ms-1">Tracked</span>'
+        : '';
+      return '<tr>' +
+        '<td class="fw-bold">' + esc(s.name) + volume + tracked + '</td>' +
+        '<td>' + esc(s.publisher || '-') + '</td>' +
+        '<td>' + esc(s.year_began || '-') + '</td>' +
+        '<td class="text-center">' + esc(s.issue_count == null ? '-' : s.issue_count) + '</td>' +
+        '<td class="text-end">' +
+          '<button type="button" class="btn btn-sm btn-primary pull-list-pick" data-idx="' + i + '">' +
+            '<i class="bi bi-plus-lg me-1"></i>Add' +
+          '</button>' +
+        '</td>' +
+      '</tr>';
+    }).join('');
+
+    if (table) table.classList.remove('d-none');
+
+    body.querySelectorAll('.pull-list-pick').forEach(function (btn) {
+      btn.onclick = function () {
+        var chosen = series[parseInt(btn.dataset.idx, 10)];
+        if (!chosen || !pendingFolder) return;
+        var original = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+        submit({
+          folder: pendingFolder,
+          series_id: chosen.id,
+          series_name: chosen.name,
+          publisher_name: chosen.publisher,
+          year: chosen.year_began,
+          status: chosen.status
+        }, function () {
+          btn.disabled = false;
+          btn.innerHTML = original;
+        });
+      };
+    });
+  }
+})();

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -264,6 +264,7 @@
 {% include 'partials/modal_delete_confirm.html' %}
 {% include 'partials/modal_metadata_select.html' %}
 {% include 'partials/modal_add_to_reading_list.html' %}
+{% include 'partials/modal_add_to_pull_list.html' %}
 {% include 'partials/modal_bulk_metadata_review.html' %}
 <!-- Comic Reader Modal -->
 <div id="comicReaderModal" class="comic-reader-modal" style="display: none;">
@@ -567,6 +568,7 @@
 <script src="{{ url_for('static', filename='js/clu-delete.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script src="{{ url_for('static', filename='js/reader.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script src="{{ url_for('static', filename='js/reading_list_picker.js') }}?v={{ range(1, 10000) | random }}"></script>
+<script src="{{ url_for('static', filename='js/pull_list_add.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script src="{{ url_for('static', filename='js/collection.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script src="{{ url_for('static', filename='js/bulk-metadata-review.js') }}?v={{ range(1, 10000) | random }}"></script>
 <script>

--- a/templates/files.html
+++ b/templates/files.html
@@ -622,6 +622,7 @@
 
 {% include 'partials/modal_update_xml.html' %}
 {% include 'partials/modal_add_to_reading_list.html' %}
+{% include 'partials/modal_add_to_pull_list.html' %}
 {% include 'partials/modal_bulk_metadata_review.html' %}
 
 {% endblock %}
@@ -638,6 +639,7 @@
 <script src="{{ url_for('static', filename='js/clu-update-xml.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/clu-delete.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/reading_list_picker.js') }}?v={{ range(1000, 9999) | random }}"></script>
+<script src="{{ url_for('static', filename='js/pull_list_add.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script src="{{ url_for('static', filename='js/files.js') }}?v={{ range(1000, 9999) | random }}&t=202502"></script>
 <script src="{{ url_for('static', filename='js/bulk-metadata-review.js') }}?v={{ range(1000, 9999) | random }}"></script>
 <script

--- a/templates/partials/modal_add_to_pull_list.html
+++ b/templates/partials/modal_add_to_pull_list.html
@@ -1,0 +1,53 @@
+<!-- Add Folder to Pull List Modal -->
+<!-- Only shown when the folder has no usable series.json / cvinfo sidecar:
+     the user searches Metron and picks the series by hand. Driven by
+     static/js/pull_list_add.js (CLU.addFolderToPullList). -->
+<div class="modal fade" id="addToPullListModal" tabindex="-1" aria-labelledby="addToPullListModalLabel"
+    aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title fw-bold" id="addToPullListModalLabel">
+                    <i class="bi bi-list-check me-2"></i>Add to Pull List
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted small mb-3" id="pullListAddReason"></p>
+                <div class="mb-3">
+                    <label for="pullListSearchInput" class="form-label fw-bold">Search for the series</label>
+                    <div class="input-group">
+                        <span class="input-group-text bg-body"><i class="bi bi-search"></i></span>
+                        <!-- Enter searches; there is no confirm button to target. -->
+                        <input type="text" class="form-control" id="pullListSearchInput"
+                            placeholder="Series name..." autocomplete="off">
+                        <button class="btn btn-primary" type="button" id="pullListSearchBtn">Search</button>
+                    </div>
+                    <div class="form-text">
+                        Mapping writes <code>series.json</code> and <code>cvinfo</code> into the folder, so
+                        a later Scan Library picks it up on its own.
+                    </div>
+                </div>
+                <div id="pullListSearchStatus" class="text-muted small"></div>
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle mb-0 d-none" id="pullListResultsTable">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Series</th>
+                                <th scope="col">Publisher</th>
+                                <th scope="col">Year</th>
+                                <th scope="col" class="text-center">Issues</th>
+                                <th scope="col" class="text-end">&nbsp;</th>
+                            </tr>
+                        </thead>
+                        <tbody id="pullListResultsBody"></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- End of Add Folder to Pull List Modal -->

--- a/tests/mocked/test_library_automap.py
+++ b/tests/mocked/test_library_automap.py
@@ -262,6 +262,147 @@ class TestApply:
         assert result["applied"] == 0
         assert len(result["failed"]) == 1
 
+class TestAddFolderToPullList:
+    """Single-folder add — the File Manager / collection dropdown action."""
+
+    def _patch(self, roots, mapped_rows):
+        # api defaults to metron.get_flask_api() like the rest of the module, so
+        # stub it out — there is no Flask app context in these tests.
+        return (
+            patch.object(library_automap, "get_library_roots", return_value=roots),
+            patch("core.database.get_all_mapped_series", return_value=mapped_rows),
+            patch.object(library_automap.metron, "get_flask_api", return_value=None),
+        )
+
+    def test_sidecar_folder_is_applied(self, tmp_path):
+        folder = _make_folder(tmp_path, "Batman",
+                              series_json={"name": "Batman", "metron_id": 555})
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "apply_and_sync",
+                          return_value={"applied": 1, "failed": [],
+                                        "applied_ids": [555]}) as apply_mock:
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "applied"
+        assert result["series_id"] == 555
+        assert result["series_name"] == "Batman"
+        # Same apply path as the library-wide scan.
+        item = apply_mock.call_args[0][0][0]
+        assert item["folder"] == folder
+        assert item["metron_id"] == 555
+
+    def test_folder_already_mapped_is_a_no_op(self, tmp_path):
+        folder = _make_folder(tmp_path, "Batman",
+                              series_json={"name": "Batman", "metron_id": 555})
+        mapped = [{"id": 555, "name": "Batman",
+                   "mapped_path": library_automap._norm(folder)}]
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], mapped)
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "apply_and_sync") as apply_mock:
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "already_mapped"
+        assert result["series_id"] == 555
+        apply_mock.assert_not_called()
+
+    def test_series_mapped_elsewhere_is_a_conflict(self, tmp_path):
+        folder = _make_folder(tmp_path, "Batman",
+                              series_json={"name": "Batman", "metron_id": 555})
+        mapped = [{"id": 555, "name": "Batman", "mapped_path": "/data/OtherBatman"}]
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], mapped)
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "apply_and_sync") as apply_mock:
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "conflict"
+        assert result["mapped_to"] == "/data/OtherBatman"
+        apply_mock.assert_not_called()
+
+    def test_no_sidecar_needs_a_manual_match(self, tmp_path):
+        folder = _make_folder(tmp_path, "Some Series", comics=2)
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api:
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "needs_match"
+        assert result["suggested_name"] == "Some Series"
+
+    def test_idless_sidecar_needs_a_manual_match(self, tmp_path):
+        folder = _make_folder(tmp_path, "Mystery", series_json={"name": "Mystery"})
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api:
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "needs_match"
+        assert result["suggested_name"] == "Mystery"
+        assert "no Metron or ComicVine ID" in result["reason"]
+
+    def test_unreadable_sidecar_needs_a_manual_match(self, tmp_path):
+        # A corrupt sidecar must not 500 the dropdown — the user can still pick.
+        folder = _make_folder(tmp_path, "Broken", series_json={"name": "Broken"})
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "_resolve_identity",
+                          side_effect=ValueError("corrupt sidecar")):
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "needs_match"
+        assert "corrupt sidecar" in result["reason"]
+
+    def test_manual_series_id_skips_the_sidecar_cascade(self, tmp_path):
+        folder = _make_folder(tmp_path, "Some Series", comics=1)
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "_resolve_identity") as resolve, \
+             patch.object(library_automap, "apply_and_sync",
+                          return_value={"applied": 1, "failed": [],
+                                        "applied_ids": [42]}) as apply_mock:
+            result = library_automap.add_folder_to_pull_list(
+                folder, series_id=42, cv_available=False,
+                fallback={"series_name": "Chosen", "publisher_name": "DC",
+                          "year": 2011},
+            )
+        resolve.assert_not_called()
+        assert result["status"] == "applied"
+        assert result["series_name"] == "Chosen"
+        item = apply_mock.call_args[0][0][0]
+        assert item["metron_id"] == 42
+        assert item["publisher_name"] == "DC"
+        assert item["year"] == 2011
+        assert item["source"] == "manual"
+
+    def test_folder_outside_a_library_is_rejected(self, tmp_path):
+        library = tmp_path / "library"
+        library.mkdir()
+        outside = _make_folder(tmp_path, "downloads",
+                               series_json={"name": "X", "metron_id": 1})
+        p_roots, p_map, p_api = self._patch([str(library)], [])
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "apply_and_sync") as apply_mock:
+            result = library_automap.add_folder_to_pull_list(outside, cv_available=False)
+        assert result["status"] == "failed"
+        assert "not inside a configured library" in result["message"]
+        apply_mock.assert_not_called()
+
+    def test_missing_folder_is_rejected(self, tmp_path):
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api:
+            result = library_automap.add_folder_to_pull_list(
+                str(tmp_path / "gone"), cv_available=False
+            )
+        assert result["status"] == "failed"
+        assert "no longer exists" in result["message"]
+
+    def test_apply_failure_is_reported(self, tmp_path):
+        folder = _make_folder(tmp_path, "Batman",
+                              series_json={"name": "Batman", "metron_id": 555})
+        p_roots, p_map, p_api = self._patch([str(tmp_path)], [])
+        with p_roots, p_map, p_api, \
+             patch.object(library_automap, "apply_and_sync",
+                          return_value={"applied": 0,
+                                        "failed": [{"folder": folder,
+                                                    "error": "Failed to save mapping"}],
+                                        "applied_ids": []}):
+            result = library_automap.add_folder_to_pull_list(folder, cv_available=False)
+        assert result["status"] == "failed"
+        assert result["message"] == "Failed to save mapping"
+
+
 class TestComicVineResolution:
     def test_cv_only_resolves_when_comicvine_available(self, tmp_path):
         folder = _make_folder(

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -991,3 +991,78 @@ class TestSyncComicVineSeries:
 
         assert resp.status_code == 500
         assert "ComicVine not configured" in resp.get_json()["error"]
+
+
+class TestPullListAddFolder:
+    """POST /api/pull-list/add-folder -- Scan Library for a single folder,
+    driven by the folder dropdowns in the File Manager and collection grid."""
+
+    ENDPOINT = "/api/pull-list/add-folder"
+
+    def test_missing_folder_is_rejected(self, client):
+        resp = client.post(self.ENDPOINT, json={})
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    def test_applied_folder_reports_the_series(self, client):
+        with patch("models.library_automap.add_folder_to_pull_list",
+                   return_value={"status": "applied", "series_id": 555,
+                                 "series_name": "Batman",
+                                 "source": "series.json:metron_id"}) as add:
+            resp = client.post(self.ENDPOINT, json={"folder": "/data/DC/Batman"})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["status"] == "applied"
+        assert data["series_name"] == "Batman"
+        assert add.call_args[0][0] == "/data/DC/Batman"
+
+    def test_manual_pick_passes_series_id_and_fallback(self, client):
+        with patch("models.library_automap.add_folder_to_pull_list",
+                   return_value={"status": "applied", "series_id": 42,
+                                 "series_name": "Chosen"}) as add:
+            resp = client.post(self.ENDPOINT, json={
+                "folder": "/data/DC/Batman", "series_id": 42,
+                "series_name": "Chosen", "publisher_name": "DC", "year": 2011,
+            })
+
+        assert resp.status_code == 200
+        kwargs = add.call_args[1]
+        assert kwargs["series_id"] == 42
+        assert kwargs["fallback"]["series_name"] == "Chosen"
+        assert kwargs["fallback"]["publisher_name"] == "DC"
+        assert kwargs["fallback"]["year"] == 2011
+
+    def test_needs_match_is_not_an_error(self, client):
+        # A folder with no sidecar is a prompt to pick the series, not a failure.
+        with patch("models.library_automap.add_folder_to_pull_list",
+                   return_value={"status": "needs_match",
+                                 "suggested_name": "Some Series",
+                                 "reason": "No series.json or cvinfo file in this folder"}):
+            resp = client.post(self.ENDPOINT, json={"folder": "/data/DC/Some Series"})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["status"] == "needs_match"
+        assert data["suggested_name"] == "Some Series"
+
+    def test_failed_status_carries_an_error(self, client):
+        with patch("models.library_automap.add_folder_to_pull_list",
+                   return_value={"status": "failed",
+                                 "message": "Folder is not inside a configured library"}):
+            resp = client.post(self.ENDPOINT, json={"folder": "/downloads/Batman"})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "not inside a configured library" in data["error"]
+
+    def test_unexpected_error_is_a_500(self, client):
+        with patch("models.library_automap.add_folder_to_pull_list",
+                   side_effect=RuntimeError("boom")):
+            resp = client.post(self.ENDPOINT, json={"folder": "/data/DC/Batman"})
+
+        assert resp.status_code == 500
+        assert resp.get_json()["success"] is False


### PR DESCRIPTION
Adds two dropdown actions, both reachable from the File Manager and the collection grid.

## Want to Read (files and folders)

Flags an item for the **Want to Read** swiper on the collection page.

The backend already had everything needed — `POST`/`DELETE /api/favorites/to-read` takes `{path, type}`, and `/api/favorites` is already a reader-writable auth prefix — so this is UI only. The set of flagged paths is fetched once per directory load rather than per-item via `/to-read/check`, so the entry renders the correct Add/Remove label without an N+1.

Placed immediately before *Add to Reading List* on the file menu, and on the folder menu too so a whole series can be flagged — that's the case the swiper renders as a folder card.

## Add to Pull List (folders only)

`models.library_automap.add_folder_to_pull_list()` is Scan Library for a single folder: the same `_resolve_identity` sidecar cascade and the same `apply_and_sync` path, so a folder added here is indistinguishable from one the library scan picked up — sidecars backfilled, issues synced, owned/missing rebuilt in the background.

It returns a `status` the caller keys off:

| status | meaning |
|---|---|
| `already_mapped` | folder is already tracked — no-op |
| `needs_match` | no usable `series.json`/`cvinfo`; let the user pick |
| `conflict` | the series is mapped to a different folder |
| `applied` | mapped, syncing in the background |
| `failed` | bad input, outside a library, or the save failed |

Two guards worth calling out: a folder must sit inside a configured library root, which keeps `/downloads` off the Pull List; and an unreadable sidecar comes back as `needs_match` rather than raising, so the user can still map it by hand.

`POST /api/pull-list/add-folder` exposes it, under the existing `/api/pull-list` clerk-level auth prefix — no auth changes.

`CLU.addFolderToPullList()` in the new `static/js/pull_list_add.js` is the shared entry point: it posts the folder, toasts the outcome, and on `needs_match` opens a picker that searches Metron via the existing `/api/series/search`. Wired into the File Manager folder dropdown and the non-root folder menu in the collection grid — root-level folders are publishers, not series, so they're left out.

## Judgment call

A `conflict` reports where the series is already mapped rather than silently re-pointing the mapping, even for a hand-picked series. Moving an existing mapping stays a deliberate action on the series page. Easy to change if you'd rather a manual pick override it.

## Testing

16 new tests — `TestAddFolderToPullList` (10, covering every status plus library containment and the manual-pick path) and `TestPullListAddFolder` (6, route contract). Full suite: **3362 passed, 6 skipped** (the usual POSIX-only skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
