### PR TITLE
Keep DC++ downloads across a CLU restart

### DIFF
--- a/app.py
+++ b/app.py
@@ -8536,6 +8536,18 @@ def start_background_services():
     except Exception as e:
         app_logger.error(f"Weekly pack reconciliation failed at startup: {e}")
 
+    # Re-adopt DC++ bundles left in flight by the previous process. AirDC++ is
+    # a separate process and keeps downloading across a CLU restart, so without
+    # this a bundle that finished while we were down is never imported. DB-only
+    # and non-blocking — the poller does the network reconcile on its first
+    # round, so a slow or unreachable AirDC++ cannot stall boot.
+    try:
+        from models.dcpp import recover_dcpp_jobs
+
+        recover_dcpp_jobs()
+    except Exception as e:
+        app_logger.error(f"DC++ job recovery failed at startup: {e}")
+
     # Configure Weekly Packs schedule from database
     configure_weekly_packs_schedule()
 

--- a/core/database.py
+++ b/core/database.py
@@ -1000,6 +1000,41 @@ def init_db():
                 "ADD COLUMN client_group TEXT NOT NULL DEFAULT 'usenet'"
             )
 
+        # Create dcpp_jobs table — a crash-recovery ledger for DC++ bundles.
+        #
+        # AirDC++ runs as its own process and keeps downloading across a CLU
+        # restart, but the bundle id and the last-known target path lived only
+        # in models.dcpp.dcpp_downloads, so a restart orphaned the job: CLU
+        # could neither re-attach to it nor work out where the file landed.
+        # `target` is the load-bearing column — with "remove finished bundles"
+        # enabled in AirDC++, the last target seen while the bundle was running
+        # is the ONLY remaining signal of where a completed file went.
+        #
+        # This is a ledger, not a history: rows are deleted once resolved.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS dcpp_jobs (
+                download_id TEXT PRIMARY KEY,
+                client_type TEXT NOT NULL,
+                client_id TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                series TEXT,
+                issue TEXT,
+                status TEXT NOT NULL DEFAULT 'downloading',
+                error TEXT,
+                percent INTEGER DEFAULT 0,
+                stage TEXT,
+                bytes_total INTEGER,
+                bytes_downloaded INTEGER,
+                target TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(client_type, client_id)
+            )
+        """)
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dcpp_jobs_status ON dcpp_jobs(status)"
+        )
+
         # Create indexers table (id-keyed, priority-ordered list of indexers).
         c.execute("""
             CREATE TABLE IF NOT EXISTS indexers (
@@ -11857,6 +11892,105 @@ def delete_download_client_config(client_type: str) -> bool:
         return True
     except Exception as e:
         app_logger.error(f"Failed to delete download client config for {client_type}: {e}")
+        return False
+
+
+# =============================================================================
+# DC++ Job Functions (crash-recovery ledger for in-flight AirDC++ bundles)
+# =============================================================================
+
+# The columns a caller may write. Anything else in a job dict (``download_id``
+# itself, the ``untracked`` display flag) is ignored rather than raising, so
+# models.dcpp can hand its in-memory job dict straight over.
+_DCPP_JOB_FIELDS = (
+    "client_type", "client_id", "filename", "series", "issue", "status",
+    "error", "percent", "stage", "bytes_total", "bytes_downloaded", "target",
+)
+
+
+def save_dcpp_job(download_id: str, job: dict) -> bool:
+    """Insert or replace the ledger row for a tracked DC++ bundle.
+
+    Upserts on ``download_id`` so a re-save during recovery is idempotent.
+    """
+    try:
+        values = [job.get(f) for f in _DCPP_JOB_FIELDS]
+        assignments = ", ".join(f"{f} = excluded.{f}" for f in _DCPP_JOB_FIELDS)
+        placeholders = ", ".join("?" for _ in _DCPP_JOB_FIELDS)
+        conn = get_db_connection()
+        conn.execute(
+            f"""
+            INSERT INTO dcpp_jobs (download_id, {', '.join(_DCPP_JOB_FIELDS)})
+            VALUES (?, {placeholders})
+            ON CONFLICT(download_id) DO UPDATE SET
+                {assignments},
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            [download_id] + values,
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to save DC++ job {download_id}: {e}")
+        return False
+
+
+def update_dcpp_job(download_id: str, **fields) -> bool:
+    """Update selected columns of one ledger row. Unknown fields are ignored."""
+    updates = {k: v for k, v in fields.items() if k in _DCPP_JOB_FIELDS}
+    if not updates:
+        return False
+    try:
+        assignments = ", ".join(f"{k} = ?" for k in updates)
+        conn = get_db_connection()
+        conn.execute(
+            f"UPDATE dcpp_jobs SET {assignments}, updated_at = CURRENT_TIMESTAMP "
+            "WHERE download_id = ?",
+            list(updates.values()) + [download_id],
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        app_logger.error(f"Failed to update DC++ job {download_id}: {e}")
+        return False
+
+
+def get_active_dcpp_jobs() -> list:
+    """Return every DC++ ledger row, oldest first.
+
+    No status filter: the table only ever holds unresolved work, because a
+    job that completes and imports cleanly deletes its own row.
+    """
+    try:
+        conn = get_db_connection()
+        # rowid breaks the tie: CURRENT_TIMESTAMP only has second granularity,
+        # so two jobs queued in the same second would otherwise come back in an
+        # arbitrary order.
+        rows = conn.execute(
+            "SELECT * FROM dcpp_jobs ORDER BY created_at ASC, rowid ASC"
+        ).fetchall()
+        conn.close()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        app_logger.error(f"Failed to load DC++ jobs: {e}")
+        return []
+
+
+def delete_dcpp_job(download_id: str) -> bool:
+    """Delete one ledger row. Returns True if a row was actually removed."""
+    try:
+        conn = get_db_connection()
+        cur = conn.execute(
+            "DELETE FROM dcpp_jobs WHERE download_id = ?", (download_id,)
+        )
+        conn.commit()
+        deleted = cur.rowcount > 0
+        conn.close()
+        return deleted
+    except Exception as e:
+        app_logger.error(f"Failed to delete DC++ job {download_id}: {e}")
         return False
 
 

--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -30,11 +30,13 @@ import uuid
 
 from core.app_logging import app_logger
 
-# How often the completion poller runs while idle (winding down before exit).
-_POLL_INTERVAL = 15
-# Faster cadence while jobs are active, so cached progress stays fresh without
+# Cadence while jobs are active, so cached progress stays fresh without
 # hammering AirDC++.
 _ACTIVE_POLL_INTERVAL = 5
+# Heartbeat cadence with no tracked jobs pending. The poller stays alive while
+# DC++ is configured so the status page can show AirDC++'s real queue — one
+# request every half minute is a fair price for that.
+_IDLE_POLL_INTERVAL = 30
 
 # How long a manual search result stays grabbable. AirDC++ reports
 # expires_in = 1800000ms (30 min) for a search instance, so this sits well
@@ -52,6 +54,11 @@ dcpp_downloads: dict = {}
 _jobs_lock = threading.Lock()
 _poller_thread = None
 _poller_lock = threading.Lock()
+
+# Last bundle listing seen by the poller, as {client_id: DownloadStatus}. Lets
+# get_dcpp_downloads() surface bundles queued directly in AirDC++ without
+# putting a 10s-timeout HTTP call behind a 1s status-page poll.
+_bundle_snapshot: dict = {}
 
 # token -> {instance_id, result_id, name, size, expires}
 _result_tokens: dict = {}
@@ -449,22 +456,30 @@ def grab_dcpp(result_token, filename, series=None, issue=None, errors=None):
         return _fail(result.error or "The DC++ client rejected the download")
 
     download_id = str(uuid.uuid4())
+    job = {
+        "client_type": client.client_type.value,
+        "client_id": result.client_id,
+        "filename": filename,
+        "status": "downloading",
+        "error": None,
+        "series": series,
+        "issue": issue,
+        "percent": 0,
+        "stage": "Queued",
+        "bytes_total": entry.get("size"),
+        "bytes_downloaded": None,
+        # Filled in by the poller from the bundle's target path.
+        "target": None,
+    }
     with _jobs_lock:
-        dcpp_downloads[download_id] = {
-            "client_type": client.client_type.value,
-            "client_id": result.client_id,
-            "filename": filename,
-            "status": "downloading",
-            "error": None,
-            "series": series,
-            "issue": issue,
-            "percent": 0,
-            "stage": "Queued",
-            "bytes_total": entry.get("size"),
-            "bytes_downloaded": None,
-            # Filled in by the poller from the bundle's target path.
-            "target": None,
-        }
+        dcpp_downloads[download_id] = job
+
+    # Persist before starting the poller, for the same reason the weekly-pack
+    # history row is written before the queue put: the bundle is already live
+    # inside AirDC++, and a crash between here and the first poll must not lose
+    # our only record of it.
+    _persist_new(download_id, job)
+
     app_logger.info(
         f"Queued DC++ download for {filename} (bundle={result.client_id})"
     )
@@ -473,9 +488,118 @@ def grab_dcpp(result_token, filename, series=None, issue=None, errors=None):
 
 
 def get_dcpp_downloads() -> list:
-    """Return a snapshot of tracked DC++ downloads (for status display)."""
+    """Return tracked DC++ downloads, plus AirDC++'s own untracked bundles.
+
+    Untracked entries are bundles queued directly in AirDC++ that CLU never
+    submitted. They are shown so the panel reflects the client's real queue,
+    and are flagged ``untracked`` so the UI can render them read-only: CLU has
+    no idea what series or issue they are, and they may have nothing to do with
+    comics, so it must never move their files.
+    """
     with _jobs_lock:
-        return [dict(download_id=k, **v) for k, v in dcpp_downloads.items()]
+        tracked = [
+            dict(download_id=k, untracked=False, **v)
+            for k, v in dcpp_downloads.items()
+        ]
+        known = {str(v.get("client_id")) for v in dcpp_downloads.values()}
+        untracked = [
+            dict(v) for cid, v in _bundle_snapshot.items() if cid not in known
+        ]
+    return tracked + untracked
+
+
+# ---------------------------------------------------------------------------
+# Persistence — the dcpp_jobs ledger
+# ---------------------------------------------------------------------------
+#
+# The ledger exists purely so a CLU restart is a non-event. AirDC++ is a
+# separate process and keeps downloading regardless, but the bundle id and the
+# last-known target path used to live only in ``dcpp_downloads`` — so a restart
+# orphaned the job and the finished file was never imported into WATCH.
+#
+# Every write is best-effort: losing a ledger row is bad, but failing a live
+# download because SQLite hiccuped would be worse.
+
+def _persist_new(download_id, job):
+    try:
+        from core.database import save_dcpp_job
+
+        save_dcpp_job(download_id, job)
+    except Exception as e:
+        app_logger.error(f"Could not persist DC++ job {download_id}: {e}")
+
+
+def _persist_update(download_id, **fields):
+    try:
+        from core.database import update_dcpp_job
+
+        update_dcpp_job(download_id, **fields)
+    except Exception as e:
+        app_logger.error(f"Could not update DC++ job {download_id}: {e}")
+
+
+def _persist_delete(download_id) -> bool:
+    """Delete a ledger row. Returns True if one was actually removed."""
+    try:
+        from core.database import delete_dcpp_job
+
+        return delete_dcpp_job(download_id)
+    except Exception as e:
+        app_logger.error(f"Could not delete DC++ job {download_id}: {e}")
+        return False
+
+
+def recover_dcpp_jobs() -> int:
+    """Re-adopt DC++ bundles left in flight by a previous CLU process.
+
+    Deliberately DB-only. This runs from ``start_background_services()``, which
+    executes at import time under Gunicorn, and a per-bundle HTTP call with a
+    10s timeout would stall boot.
+
+    The network reconcile happens on the poller's first round instead, where
+    :func:`_poll_one` already handles every case — including a bundle AirDC++
+    finished and dropped from its queue while CLU was down, which it sees as
+    "gone" and imports using the ``target`` path restored here. That path is the
+    whole reason it is persisted: once the bundle is gone there is nothing left
+    to ask where the file landed.
+
+    Returns the number of jobs re-adopted.
+    """
+    try:
+        from core.database import get_active_dcpp_jobs
+
+        rows = get_active_dcpp_jobs()
+    except Exception as e:
+        app_logger.error(f"DC++ recovery could not read the job ledger: {e}")
+        return 0
+
+    recovered = 0
+    with _jobs_lock:
+        for row in rows:
+            download_id = row.get("download_id")
+            if not download_id or download_id in dcpp_downloads:
+                continue
+            dcpp_downloads[download_id] = {
+                "client_type": row.get("client_type"),
+                "client_id": row.get("client_id"),
+                "filename": row.get("filename"),
+                "status": row.get("status") or "downloading",
+                "error": row.get("error"),
+                "series": row.get("series"),
+                "issue": row.get("issue"),
+                "percent": row.get("percent") or 0,
+                "stage": row.get("stage"),
+                "bytes_total": row.get("bytes_total"),
+                "bytes_downloaded": row.get("bytes_downloaded"),
+                "target": row.get("target"),
+            }
+            recovered += 1
+
+    if recovered:
+        app_logger.info(f"Recovered {recovered} DC++ download(s) from the ledger")
+    if recovered or dcpp_enabled_and_configured():
+        _ensure_poller()
+    return recovered
 
 
 # ---------------------------------------------------------------------------
@@ -501,29 +625,89 @@ def _pending_jobs():
 
 
 def _poll_loop():
-    """Poll AirDC++ until all tracked bundles reach a terminal state."""
-    idle_rounds = 0
+    """Poll AirDC++ for as long as DC++ is configured.
+
+    This used to exit after two idle rounds, which meant the poller existed
+    only between a grab and the last completion. It now runs continuously at a
+    slow heartbeat when nothing is pending, for two reasons: the idle rounds
+    refresh the bundle snapshot backing the status page's view of AirDC++'s own
+    queue, and a job recovered from the ledger no longer has to wait for a new
+    grab before anything looks at it.
+    """
     while True:
-        pending = _pending_jobs()
-        if not pending:
-            idle_rounds += 1
-            if idle_rounds >= 2:
-                return
-            time.sleep(_POLL_INTERVAL)
-            continue
-        idle_rounds = 0
-
+        pending = {}
+        client = None
         try:
-            client = _active_client()
+            pending = _pending_jobs()
+            try:
+                client = _active_client()
+            except Exception as e:
+                app_logger.error(f"DC++ poll: could not build client: {e}")
+                client = None
+
+            if client is None:
+                _set_bundle_snapshot({})
+                # Nothing to poll with. Exit only if DC++ is gone entirely —
+                # a client that merely failed to build is worth retrying, but
+                # a deconfigured one never resolves, and holding the thread on
+                # a pending job would keep it alive for the process's life.
+                # grab_dcpp() and recover_dcpp_jobs() both restart it.
+                if not dcpp_enabled_and_configured():
+                    return
+            else:
+                _refresh_bundle_snapshot(client)
+                for download_id, job in pending.items():
+                    _poll_one(client, download_id, job)
         except Exception as e:
-            app_logger.error(f"DC++ poll: could not build client: {e}")
-            client = None
+            # A bad round must never kill the thread: nothing restarts it, and
+            # every tracked bundle would silently stall for the process's life.
+            app_logger.error(f"DC++ poll round failed: {e}")
 
-        if client is not None:
-            for download_id, job in pending.items():
-                _poll_one(client, download_id, job)
+        # Only hurry when there is something to hurry for. With no client, a
+        # job stuck pending would otherwise spin two DB reads every 5s forever.
+        hurry = pending and client is not None
+        time.sleep(_ACTIVE_POLL_INTERVAL if hurry else _IDLE_POLL_INTERVAL)
 
-        time.sleep(_ACTIVE_POLL_INTERVAL)
+
+def _set_bundle_snapshot(snapshot: dict):
+    global _bundle_snapshot
+    with _jobs_lock:
+        _bundle_snapshot = snapshot
+
+
+def _refresh_bundle_snapshot(client):
+    """Cache AirDC++'s live queue as display-ready untracked-job dicts.
+
+    Built here, where the client type is known, so serving it costs
+    ``/api/dcpp/downloads`` nothing — the status page polls that endpoint every
+    second and cannot afford a 10s-timeout HTTP call per request.
+    """
+    try:
+        queue = client.get_queue()
+    except Exception as e:
+        app_logger.error(f"DC++ queue listing failed: {e}")
+        return
+
+    client_type = client.client_type.value
+    _set_bundle_snapshot({
+        str(s.client_id): {
+            "download_id": None,
+            "untracked": True,
+            "client_type": client_type,
+            "client_id": str(s.client_id),
+            "filename": s.name or str(s.client_id),
+            "status": "downloading",
+            "error": None,
+            "series": None,
+            "issue": None,
+            "percent": s.percent,
+            "stage": s.stage,
+            "bytes_total": s.bytes_total,
+            "bytes_downloaded": s.bytes_downloaded,
+            "target": None,
+        }
+        for s in queue if s.client_id
+    })
 
 
 def _poll_one(client, download_id, job):
@@ -573,22 +757,66 @@ def _update_progress(download_id, status):
         job = dcpp_downloads.get(download_id)
         if job is None:
             return
+        # Only write to the ledger when something a restart would need has
+        # actually moved. This runs every few seconds per bundle, and an
+        # unconditional write would be pure churn.
+        changed = (
+            int(status.percent or 0) != int(job.get("percent") or 0)
+            or status.stage != job.get("stage")
+            or (status.storage_path and status.storage_path != job.get("target"))
+        )
         job["percent"] = status.percent
         job["stage"] = status.stage
         job["bytes_total"] = status.bytes_total
         job["bytes_downloaded"] = status.bytes_downloaded
         if status.storage_path:
             job["target"] = status.storage_path
+        current = dict(job)
+
+    if changed:
+        _persist_update(
+            download_id,
+            percent=current.get("percent"),
+            stage=current.get("stage"),
+            bytes_total=current.get("bytes_total"),
+            bytes_downloaded=current.get("bytes_downloaded"),
+            target=current.get("target"),
+        )
 
 
 def _set_status(download_id, status, error=None, percent=None):
     with _jobs_lock:
         job = dcpp_downloads.get(download_id)
-        if job is not None:
-            job["status"] = status
-            job["error"] = error
-            if percent is not None:
-                job["percent"] = percent
+        if job is None:
+            return
+        job["status"] = status
+        job["error"] = error
+        if percent is not None:
+            job["percent"] = percent
+        current_percent = job["percent"]
+
+    # Retention: the ledger holds unresolved work only. A clean completion is
+    # resolved — the file is in WATCH and monitor.py owns it from here. A
+    # failure, or a completion whose file could not be found, still needs a
+    # human, so its row survives a restart until the user dismisses it.
+    if status == "complete":
+        _persist_delete(download_id)
+    else:
+        _persist_update(
+            download_id, status=status, error=error, percent=current_percent
+        )
+
+
+def dismiss_dcpp_job(download_id: str) -> bool:
+    """Drop a resolved-but-unimported DC++ job from the ledger and memory.
+
+    Returns False if the job isn't tracked, so the route can 404.
+    """
+    with _jobs_lock:
+        known = download_id in dcpp_downloads
+        dcpp_downloads.pop(download_id, None)
+    deleted = _persist_delete(download_id)
+    return known or deleted
 
 
 def translate_remote_path(path, remote_root, local_root):

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -514,13 +514,34 @@ def list_download_sources():
 
 @download_clients_bp.route('/api/dcpp/downloads', methods=['GET'])
 def list_dcpp_downloads():
-    """List in-memory DC++ downloads and their current status."""
+    """List tracked DC++ downloads, plus AirDC++'s own untracked bundles."""
     try:
         from models.dcpp import get_dcpp_downloads
 
         return jsonify({"success": True, "downloads": get_dcpp_downloads()})
     except Exception as e:
         app_logger.error(f"Error listing dcpp downloads: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@download_clients_bp.route(
+    '/api/dcpp/downloads/<download_id>/dismiss', methods=['POST']
+)
+def dismiss_dcpp_download(download_id):
+    """Drop a resolved-but-unimported DC++ job from the ledger and memory.
+
+    Only failed and complete_no_move jobs survive in the ledger — a clean
+    completion deletes its own row — so this is the user acknowledging one of
+    those. Mirrors the ``/dismiss_download/<id>`` contract in api.py.
+    """
+    try:
+        from models.dcpp import dismiss_dcpp_job
+
+        if not dismiss_dcpp_job(download_id):
+            return jsonify({"error": "Download not found"}), 404
+        return jsonify({"success": True})
+    except Exception as e:
+        app_logger.error(f"Error dismissing dcpp download {download_id}: {e}")
         return jsonify({"error": str(e)}), 500
 
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -238,19 +238,56 @@
     }
 
     // Render externally-managed client rows (Usenet SABnzbd/NZBGet, DC++
-    // AirDC++) — view-only, no actions: the download lives in the user's own
-    // client, so cancel/retry belong there, not here.
-    function renderClientRows(tbody, downloads) {
+    // AirDC++). Cancel/retry belong in the user's own client, not here, so the
+    // only action offered is dismissing a job CLU can no longer resolve.
+    function renderClientRows(tbody, downloads, dismissUrl) {
       for (const job of downloads) {
         const tr = document.createElement('tr');
+        if (job.untracked) tr.className = 'text-muted';
         tr.appendChild(filenameCell(job.filename));
         tr.appendChild(providerCell(job.client_type));
         const isDone = job.status === 'complete' || job.status === 'complete_no_move';
         tr.appendChild(progressCell(isDone ? 100 : job.percent));
         tr.appendChild(bytesCell(job.bytes_downloaded, job.bytes_total));
+
+        if (job.untracked) {
+          // Queued directly in the client, not by CLU. Shown so the panel
+          // matches the client's real queue, but CLU has no idea what series
+          // or issue it is and must never move its files.
+          tr.appendChild(statusCell('Not tracked by CLU', 'text-muted fst-italic',
+            'Queued directly in the client — CLU will not import this'));
+          tr.appendChild(document.createElement('td'));
+          tbody.appendChild(tr);
+          continue;
+        }
+
         const disp = clientStatusDisplay(job);
         tr.appendChild(statusCell(disp.text, disp.cssClass, disp.title));
-        tr.appendChild(document.createElement('td')); // no actions
+
+        // Only unresolved jobs are dismissable: a clean completion clears
+        // itself, while a failure or an unimported file is waiting on a human.
+        const tdActions = document.createElement('td');
+        const needsAck = job.status === 'failed' || job.status === 'complete_no_move';
+        if (dismissUrl && needsAck && job.download_id) {
+          const dismissIcon = document.createElement('i');
+          dismissIcon.className = "bi bi-trash text-muted action-icon";
+          dismissIcon.style.cursor = "pointer";
+          dismissIcon.style.fontSize = "1.2em";
+          dismissIcon.title = "Dismiss this download";
+          dismissIcon.addEventListener('click', () => {
+            showConfirmToast('Remove this download from the list?', () => {
+              fetch(dismissUrl(job.download_id), { method: 'POST' })
+                .then(response => response.json())
+                .then(() => {
+                  showToast('Download dismissed', 'success');
+                  fetchStatus();
+                })
+                .catch(() => showToast('Error dismissing download', 'error'));
+            });
+          });
+          tdActions.appendChild(dismissIcon);
+        }
+        tr.appendChild(tdActions);
         tbody.appendChild(tr);
       }
     }
@@ -276,7 +313,8 @@
         tbody.innerHTML = ''; // Clear previous rows.
         renderDirectRows(tbody, data || {});
         renderClientRows(tbody, usenetDownloads);
-        renderClientRows(tbody, dcppDownloads);
+        renderClientRows(tbody, dcppDownloads,
+          id => `/api/dcpp/downloads/${encodeURIComponent(id)}/dismiss`);
       });
     }
 

--- a/tests/integration/test_database_clients.py
+++ b/tests/integration/test_database_clients.py
@@ -246,3 +246,78 @@ class TestIndexers:
         assert get_indexer(iid)["is_valid"] is True
         delete_indexer(iid)
         assert get_indexer(iid) is None
+
+
+class TestDcppJobLedger:
+    """The dcpp_jobs crash-recovery ledger: no encryption, plain CRUD."""
+
+    JOB = {
+        "client_type": "airdcpp", "client_id": "b1", "filename": "Batman 1.cbz",
+        "series": "Batman", "issue": "1", "status": "downloading", "error": None,
+        "percent": 0, "stage": "Queued", "bytes_total": 100,
+        "bytes_downloaded": None, "target": None,
+    }
+
+    def test_save_and_read_back(self, db_connection):
+        from core.database import save_dcpp_job, get_active_dcpp_jobs
+
+        assert save_dcpp_job("d1", dict(self.JOB)) is True
+        rows = get_active_dcpp_jobs()
+        assert len(rows) == 1
+        assert rows[0]["download_id"] == "d1"
+        assert rows[0]["client_id"] == "b1"
+        assert rows[0]["series"] == "Batman"
+
+    def test_save_is_idempotent(self, db_connection):
+        # Recovery may re-save a row it just hydrated; that must not duplicate.
+        from core.database import save_dcpp_job, get_active_dcpp_jobs
+
+        save_dcpp_job("d1", dict(self.JOB))
+        save_dcpp_job("d1", dict(self.JOB, percent=50))
+        rows = get_active_dcpp_jobs()
+        assert len(rows) == 1
+        assert rows[0]["percent"] == 50
+
+    def test_extra_keys_are_ignored(self, db_connection):
+        # models.dcpp hands its in-memory job dict straight over, and that dict
+        # carries display-only fields the table has no column for.
+        from core.database import save_dcpp_job, get_active_dcpp_jobs
+
+        assert save_dcpp_job("d1", dict(self.JOB, untracked=False)) is True
+        assert get_active_dcpp_jobs()[0]["download_id"] == "d1"
+
+    def test_partial_update(self, db_connection):
+        from core.database import (
+            save_dcpp_job, update_dcpp_job, get_active_dcpp_jobs,
+        )
+        save_dcpp_job("d1", dict(self.JOB))
+        assert update_dcpp_job(
+            "d1", percent=75, target=r"F:\downloads\temp\Batman 1.cbz") is True
+
+        row = get_active_dcpp_jobs()[0]
+        assert row["percent"] == 75
+        assert row["target"] == r"F:\downloads\temp\Batman 1.cbz"
+        assert row["filename"] == "Batman 1.cbz"  # untouched
+
+    def test_update_with_no_known_fields_is_a_no_op(self, db_connection):
+        from core.database import save_dcpp_job, update_dcpp_job
+
+        save_dcpp_job("d1", dict(self.JOB))
+        assert update_dcpp_job("d1", nonsense="x") is False
+
+    def test_delete(self, db_connection):
+        from core.database import (
+            save_dcpp_job, delete_dcpp_job, get_active_dcpp_jobs,
+        )
+        save_dcpp_job("d1", dict(self.JOB))
+        assert delete_dcpp_job("d1") is True
+        assert get_active_dcpp_jobs() == []
+        # A second delete reports the miss so the route can 404.
+        assert delete_dcpp_job("d1") is False
+
+    def test_rows_come_back_oldest_first(self, db_connection):
+        from core.database import save_dcpp_job, get_active_dcpp_jobs
+
+        save_dcpp_job("d1", dict(self.JOB, client_id="b1"))
+        save_dcpp_job("d2", dict(self.JOB, client_id="b2"))
+        assert [r["download_id"] for r in get_active_dcpp_jobs()] == ["d1", "d2"]

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -65,6 +65,7 @@ class TestTablesExist:
         "schedules",
         "download_clients",
         "indexers",
+        "dcpp_jobs",
     ]
 
     @pytest.mark.parametrize("table_name", EXPECTED_TABLES)
@@ -134,6 +135,37 @@ class TestWeeklyPacksHistoryColumns:
         assert cols.count("download_id") == 1
 
 
+class TestDcppJobsColumns:
+    """The crash-recovery ledger for in-flight AirDC++ bundles.
+
+    ``target`` is the load-bearing column: with "remove finished bundles"
+    enabled, the last target seen while a bundle was running is the only
+    remaining signal of where a completed file went.
+    """
+
+    def test_core_columns(self, db_connection):
+        cur = db_connection.execute("PRAGMA table_info(dcpp_jobs)")
+        columns = {row[1] for row in cur.fetchall()}
+        expected = {
+            "download_id", "client_type", "client_id", "filename", "series",
+            "issue", "status", "error", "percent", "stage", "bytes_total",
+            "bytes_downloaded", "target", "created_at", "updated_at",
+        }
+        assert expected.issubset(columns)
+
+    def test_one_row_per_bundle(self, db_connection):
+        # Two tracking ids for the same AirDC++ bundle would double-import it.
+        db_connection.execute(
+            "INSERT INTO dcpp_jobs (download_id, client_type, client_id, filename) "
+            "VALUES ('d1', 'airdcpp', 'b1', 'Batman 1.cbz')"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            db_connection.execute(
+                "INSERT INTO dcpp_jobs (download_id, client_type, client_id, filename) "
+                "VALUES ('d2', 'airdcpp', 'b1', 'Batman 1.cbz')"
+            )
+
+
 class TestIndexesExist:
 
     EXPECTED_INDEXES = [
@@ -168,6 +200,7 @@ class TestIndexesExist:
         "idx_browse_cache_path",
         "idx_komga_sync_book",
         "idx_indexers_priority",
+        "idx_dcpp_jobs_status",
     ]
 
     @pytest.mark.parametrize("index_name", EXPECTED_INDEXES)

--- a/tests/mocked/test_dcpp.py
+++ b/tests/mocked/test_dcpp.py
@@ -14,13 +14,25 @@ from models.download_clients import (
 
 
 @pytest.fixture(autouse=True)
-def _clean_state():
-    """DC++ tracks jobs and result tokens in module dicts; isolate each test."""
+def _clean_state(monkeypatch):
+    """Isolate the module dicts, and keep the ledger writes off a real DB.
+
+    Job state lives in module-level dicts, and every state change now also
+    writes to the dcpp_jobs table. These are mocked tests, so the three
+    persistence wrappers are stubbed out; tests that care about *when* a write
+    happens assert on the stubs, and the real SQL round-trip is covered in
+    tests/integration.
+    """
     dc.dcpp_downloads.clear()
     dc._result_tokens.clear()
+    dc._bundle_snapshot.clear()
+    monkeypatch.setattr(dc, "_persist_new", MagicMock())
+    monkeypatch.setattr(dc, "_persist_update", MagicMock())
+    monkeypatch.setattr(dc, "_persist_delete", MagicMock(return_value=True))
     yield
     dc.dcpp_downloads.clear()
     dc._result_tokens.clear()
+    dc._bundle_snapshot.clear()
 
 
 class TestTranslateRemotePath:
@@ -601,3 +613,316 @@ class TestImportCompleted:
         watch.mkdir()
         monkeypatch.setattr(un, "_watch_dir", lambda: str(watch))
         assert dc._import_completed(str(tmp_path / "nope"), "x.cbz") is False
+
+
+class TestLedgerWrites:
+    """When a job state change reaches the dcpp_jobs table, and when it doesn't."""
+
+    def _job(self, **over):
+        job = {
+            "client_type": "airdcpp", "client_id": "b1", "filename": "Batman 1.cbz",
+            "status": "downloading", "error": None, "series": "Batman", "issue": "1",
+            "percent": 0, "stage": "Queued", "bytes_total": None,
+            "bytes_downloaded": None, "target": None,
+        }
+        job.update(over)
+        dc.dcpp_downloads["d1"] = job
+        return job
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("models.dcpp._active_client")
+    def test_grab_persists_before_starting_the_poller(self, mock_client, mock_poller):
+        # The bundle is already live in AirDC++ by this point, so a crash
+        # before the first poll must not lose our only record of it.
+        client = _fake_client(bundle_id="bundle-7")
+        mock_client.return_value = client
+        token = dc._store_token("inst-1", _hit("Batman 001.cbz", result_id="5"))
+
+        download_id = dc.grab_dcpp(token, "Batman 1.cbz", series="Batman", issue="1")
+
+        dc._persist_new.assert_called_once()
+        saved_id, saved_job = dc._persist_new.call_args[0]
+        assert saved_id == download_id
+        assert saved_job["client_id"] == "bundle-7"
+        assert saved_job["series"] == "Batman"
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("models.dcpp._active_client")
+    def test_a_failed_grab_writes_nothing(self, mock_client, mock_poller):
+        client = _fake_client()
+        client.download_result.return_value = NZBSubmitResult(
+            success=False, error="no target")
+        mock_client.return_value = client
+        token = dc._store_token("inst-1", _hit("Batman 001.cbz"))
+
+        assert dc.grab_dcpp(token, "Batman 1.cbz") is None
+        dc._persist_new.assert_not_called()
+
+    def test_progress_writes_only_when_something_moved(self):
+        self._job(percent=40, stage="Downloading", target="/dl/Batman 1.cbz")
+        unchanged = DownloadStatus(
+            client_id="b1", status="downloading", percent=40,
+            stage="Downloading", storage_path="/dl/Batman 1.cbz")
+
+        dc._update_progress("d1", unchanged)
+        dc._persist_update.assert_not_called()
+
+    @pytest.mark.parametrize("field,value", [
+        ("percent", 41),
+        ("stage", "Hashing"),
+        ("storage_path", "/dl/elsewhere/Batman 1.cbz"),
+    ])
+    def test_progress_writes_when_a_tracked_field_changes(self, field, value):
+        self._job(percent=40, stage="Downloading", target="/dl/Batman 1.cbz")
+        kwargs = {"percent": 40, "stage": "Downloading",
+                  "storage_path": "/dl/Batman 1.cbz"}
+        kwargs[field] = value
+
+        dc._update_progress("d1", DownloadStatus(
+            client_id="b1", status="downloading", **kwargs))
+        dc._persist_update.assert_called_once()
+
+    def test_target_is_always_persisted_with_progress(self):
+        # The cached target is the only thing that makes a completed-while-down
+        # bundle importable, so it must reach the ledger, not just memory.
+        self._job()
+        dc._update_progress("d1", DownloadStatus(
+            client_id="b1", status="downloading", percent=10,
+            storage_path="/dl/Batman 1.cbz"))
+        assert dc._persist_update.call_args.kwargs["target"] == "/dl/Batman 1.cbz"
+
+    def test_clean_completion_clears_the_row(self):
+        self._job()
+        dc._set_status("d1", "complete", percent=100)
+        dc._persist_delete.assert_called_once_with("d1")
+        dc._persist_update.assert_not_called()
+
+    @pytest.mark.parametrize("status", ["failed", "complete_no_move"])
+    def test_unresolved_terminals_keep_their_row(self, status):
+        # These are the jobs that still need a human; purging them would mean a
+        # restart silently swallows exactly the ones worth seeing.
+        self._job()
+        dc._set_status("d1", status, error="boom")
+        dc._persist_delete.assert_not_called()
+        assert dc._persist_update.call_args.kwargs["status"] == status
+
+    def test_status_change_on_an_unknown_job_writes_nothing(self):
+        dc._set_status("missing", "complete")
+        dc._persist_delete.assert_not_called()
+        dc._persist_update.assert_not_called()
+
+
+class TestRecoverDcppJobs:
+    """Re-adopting bundles left in flight by a previous CLU process."""
+
+    ROW = {
+        "download_id": "d1", "client_type": "airdcpp", "client_id": "b1",
+        "filename": "Batman 1.cbz", "series": "Batman", "issue": "1",
+        "status": "downloading", "error": None, "percent": 55,
+        "stage": "Downloading", "bytes_total": 100, "bytes_downloaded": 55,
+        "target": "F:\\downloads\\temp\\Batman 1.cbz",
+    }
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs")
+    def test_rehydrates_and_starts_the_poller(self, mock_rows, mock_poller):
+        mock_rows.return_value = [dict(self.ROW)]
+
+        assert dc.recover_dcpp_jobs() == 1
+
+        job = dc.dcpp_downloads["d1"]
+        assert job["client_id"] == "b1"
+        assert job["percent"] == 55
+        # The target is what makes a completed-while-down bundle importable.
+        assert job["target"] == "F:\\downloads\\temp\\Batman 1.cbz"
+        mock_poller.assert_called_once()
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs")
+    def test_makes_no_network_calls(self, mock_rows, mock_poller):
+        # Recovery runs at import time under Gunicorn; a 10s-timeout HTTP call
+        # per bundle would stall boot. The poller does the reconcile instead.
+        mock_rows.return_value = [dict(self.ROW)]
+        with patch("models.dcpp._active_client") as mock_client:
+            dc.recover_dcpp_jobs()
+        mock_client.assert_not_called()
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs")
+    def test_does_not_clobber_a_live_job(self, mock_rows, mock_poller):
+        dc.dcpp_downloads["d1"] = {"status": "downloading", "percent": 99}
+        mock_rows.return_value = [dict(self.ROW)]
+
+        assert dc.recover_dcpp_jobs() == 0
+        assert dc.dcpp_downloads["d1"]["percent"] == 99
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs", return_value=[])
+    def test_nothing_to_recover_and_dcpp_off(self, mock_rows, mock_poller, mock_cfg):
+        assert dc.recover_dcpp_jobs() == 0
+        mock_poller.assert_not_called()
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs", return_value=[])
+    def test_empty_ledger_still_polls_when_dcpp_is_on(self, mock_rows, mock_poller,
+                                                     mock_cfg):
+        # The snapshot backing the "untracked bundles" view needs the poller
+        # running even with nothing of our own in flight.
+        assert dc.recover_dcpp_jobs() == 0
+        mock_poller.assert_called_once()
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs", side_effect=Exception("db down"))
+    def test_unreadable_ledger_is_not_fatal(self, mock_rows, mock_poller):
+        assert dc.recover_dcpp_jobs() == 0
+
+    @patch("models.dcpp._ensure_poller")
+    @patch("core.database.get_active_dcpp_jobs")
+    def test_recovered_job_completes_on_the_first_poll(self, mock_rows, mock_poller):
+        # The whole point: AirDC++ finished and dropped the bundle while CLU
+        # was down, so the only signal is a 404 plus the persisted target.
+        mock_rows.return_value = [dict(self.ROW)]
+        dc.recover_dcpp_jobs()
+
+        client = MagicMock()
+        client.get_bundle_state.return_value = ("gone", None)
+        client.config = DownloadClientConfig(
+            target_directory="F:\\downloads\\temp",
+            local_target_directory="/downloads/temp")
+
+        with patch("models.dcpp._import_completed", return_value=True) as mock_import:
+            dc._poll_one(client, "d1", dc.dcpp_downloads["d1"])
+
+        mock_import.assert_called_once_with(
+            "/downloads/temp/Batman 1.cbz", "Batman 1.cbz")
+        assert dc.dcpp_downloads["d1"]["status"] == "complete"
+        dc._persist_delete.assert_called_once_with("d1")
+
+
+class TestUntrackedBundles:
+    """AirDC++'s own queue, surfaced read-only alongside CLU's jobs."""
+
+    def _status(self, client_id="b9", name="Some Other Thing.rar"):
+        return DownloadStatus(client_id=client_id, name=name, status="downloading",
+                              percent=12.0, stage="Downloading",
+                              bytes_total=200, bytes_downloaded=24)
+
+    def _client(self, queue):
+        client = MagicMock()
+        client.client_type = ClientType.AIRDCPP
+        client.get_queue.return_value = queue
+        return client
+
+    def test_snapshot_surfaces_bundles_clu_never_submitted(self):
+        dc._refresh_bundle_snapshot(self._client([self._status()]))
+
+        rows = dc.get_dcpp_downloads()
+        assert len(rows) == 1
+        assert rows[0]["untracked"] is True
+        assert rows[0]["download_id"] is None
+        assert rows[0]["filename"] == "Some Other Thing.rar"
+        assert rows[0]["client_type"] == "airdcpp"
+        assert rows[0]["percent"] == 12.0
+
+    def test_a_tracked_bundle_is_never_listed_twice(self):
+        dc.dcpp_downloads["d1"] = {
+            "client_type": "airdcpp", "client_id": "b9", "filename": "Batman 1.cbz",
+            "status": "downloading", "percent": 50,
+        }
+        dc._refresh_bundle_snapshot(self._client([self._status(client_id="b9")]))
+
+        rows = dc.get_dcpp_downloads()
+        assert len(rows) == 1
+        assert rows[0]["untracked"] is False
+        assert rows[0]["filename"] == "Batman 1.cbz"
+
+    def test_a_failed_listing_leaves_the_last_snapshot_alone(self):
+        dc._refresh_bundle_snapshot(self._client([self._status()]))
+        broken = MagicMock()
+        broken.client_type = ClientType.AIRDCPP
+        broken.get_queue.side_effect = Exception("unreachable")
+
+        dc._refresh_bundle_snapshot(broken)
+        assert len(dc.get_dcpp_downloads()) == 1
+
+    def test_bundles_without_an_id_are_skipped(self):
+        dc._refresh_bundle_snapshot(
+            self._client([DownloadStatus(client_id="", status="downloading")]))
+        assert dc.get_dcpp_downloads() == []
+
+
+class TestPollLoopLifecycle:
+    """The loop no longer exits the moment nothing is pending."""
+
+    @pytest.fixture(autouse=True)
+    def _no_sleeping(self, monkeypatch):
+        monkeypatch.setattr(dc.time, "sleep", MagicMock())
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=False)
+    @patch("models.dcpp._active_client", return_value=None)
+    def test_exits_when_dcpp_is_off_and_nothing_pending(self, mock_client, mock_cfg):
+        dc._poll_loop()  # returns rather than hanging
+        assert dc.get_dcpp_downloads() == []
+
+    @patch("models.dcpp.dcpp_enabled_and_configured", return_value=True)
+    @patch("models.dcpp._active_client")
+    def test_keeps_running_with_nothing_pending(self, mock_client, mock_cfg):
+        # The idle heartbeat is what keeps AirDC++'s own queue visible.
+        client = MagicMock()
+        client.client_type = ClientType.AIRDCPP
+        client.get_queue.return_value = [
+            DownloadStatus(client_id="b9", name="Other.rar", status="downloading")
+        ]
+        # Second round: DC++ has been switched off, so the loop may exit.
+        mock_client.side_effect = [client, None]
+        mock_cfg.side_effect = [False]
+
+        dc._poll_loop()
+
+        assert client.get_queue.called
+        assert dc.time.sleep.call_args_list[0][0][0] == dc._IDLE_POLL_INTERVAL
+
+    @patch("models.dcpp.dcpp_enabled_and_configured")
+    @patch("models.dcpp._pending_jobs")
+    @patch("models.dcpp._active_client", return_value=None)
+    def test_a_broken_round_does_not_kill_the_thread(self, mock_client, mock_pending,
+                                                     mock_cfg):
+        # If an exception escaped, nothing would ever restart the poller and
+        # every tracked bundle would stall for the life of the process.
+        mock_pending.side_effect = [Exception("boom"), {}]
+        mock_cfg.side_effect = [False]
+
+        dc._poll_loop()
+        assert mock_pending.call_count == 2
+
+    @patch("models.dcpp.dcpp_enabled_and_configured")
+    @patch("models.dcpp._active_client", return_value=None)
+    def test_backs_off_when_pending_but_clientless(self, mock_client, mock_cfg):
+        # Nothing can be polled, so don't spin the fast cadence; and once DC++
+        # is deconfigured the loop must exit even with a job still pending,
+        # rather than holding the thread open forever.
+        dc.dcpp_downloads["d1"] = {"status": "downloading"}
+        mock_cfg.side_effect = [True, False]
+
+        dc._poll_loop()
+        assert dc.time.sleep.call_args_list[0][0][0] == dc._IDLE_POLL_INTERVAL
+        assert mock_cfg.call_count == 2
+
+
+class TestDismissDcppJob:
+
+    def test_forgets_a_tracked_job(self):
+        dc.dcpp_downloads["d1"] = {"status": "failed"}
+        assert dc.dismiss_dcpp_job("d1") is True
+        assert "d1" not in dc.dcpp_downloads
+        dc._persist_delete.assert_called_once_with("d1")
+
+    def test_row_only_job_is_still_dismissable(self):
+        # A restart hydrates from the ledger, but a dismiss can race a restart.
+        assert dc.dismiss_dcpp_job("d-ghost") is True
+
+    def test_unknown_job_reports_miss(self):
+        dc._persist_delete.return_value = False
+        assert dc.dismiss_dcpp_job("nope") is False

--- a/tests/routes/test_download_clients_routes.py
+++ b/tests/routes/test_download_clients_routes.py
@@ -435,6 +435,35 @@ class TestDcppDownloads:
     def test_list_error(self, mock_dl, client):
         assert client.get("/api/dcpp/downloads").status_code == 500
 
+    @patch("models.dcpp.get_dcpp_downloads", return_value=[
+        {"download_id": None, "untracked": True, "filename": "Some Other Thing.rar",
+         "status": "downloading", "client_type": "airdcpp", "percent": 12},
+    ])
+    def test_list_includes_untracked_bundles(self, mock_dl, client):
+        # Bundles queued directly in AirDC++ are surfaced so the panel matches
+        # the client's real queue, flagged so the UI keeps them read-only.
+        dl = client.get("/api/dcpp/downloads").get_json()["downloads"][0]
+        assert dl["untracked"] is True
+        assert dl["download_id"] is None
+
+
+class TestDcppDismiss:
+
+    @patch("models.dcpp.dismiss_dcpp_job", return_value=True)
+    def test_dismiss(self, mock_dismiss, client):
+        resp = client.post("/api/dcpp/downloads/d1/dismiss")
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_dismiss.assert_called_once_with("d1")
+
+    @patch("models.dcpp.dismiss_dcpp_job", return_value=False)
+    def test_dismiss_unknown_job(self, mock_dismiss, client):
+        assert client.post("/api/dcpp/downloads/nope/dismiss").status_code == 404
+
+    @patch("models.dcpp.dismiss_dcpp_job", side_effect=Exception("boom"))
+    def test_dismiss_error(self, mock_dismiss, client):
+        assert client.post("/api/dcpp/downloads/d1/dismiss").status_code == 500
+
 
 class TestDcppSearch:
 


### PR DESCRIPTION
## The problem

DC++ downloads can sit in the AirDC++ queue for hours or days — sources go offline, slots are scarce, big bundles crawl. CLU tracked those jobs in a module-level dict (`models/dcpp.py`, `dcpp_downloads`) and wrote nothing to SQLite.

AirDC++ runs as its own process and keeps downloading through a CLU restart, so on restart:

1. `dcpp_downloads` reset to `{}` — the job vanished from the Status page and `/api/dcpp/downloads` returned `[]`.
2. The bundle id was gone, so CLU could never re-attach.
3. `_import_completed()` never ran — the finished file was **not moved into WATCH**.

Worst case: AirDC++ configured to drop finished bundles from its queue. The last `target` path it reported was cached in memory only, so after a restart there was nothing left to ask where the file had landed.

The only recovery was incidental — `monitor.py`'s reconcile sweep, and only if AirDC++'s target directory happened to sit inside WATCH.

## The fix

**`dcpp_jobs` table** (`core/database.py`) — a crash-recovery ledger, not a history. `target` is the load-bearing column: persisting it is what makes a completed-while-down bundle importable at all.

**Write-through in `models/dcpp.py`** — persisted at grab time *before* the poller starts (same ordering rule as the weekly-pack history row), throttled on progress so a 5s poll cadence doesn't churn the DB, applied on status change.

**`recover_dcpp_jobs()`** — called from `start_background_services()` next to the existing weekly-pack reconciler. Deliberately DB-only: that function runs at import time under Gunicorn, and a 10s-timeout HTTP call per bundle would stall boot. The network reconcile happens on the poller's first round, reusing `_poll_one()` unchanged — it already treats a 404 as completion and imports from the cached target, so **processing completions missed during downtime needed no new code**.

**Poller lifecycle** — now runs for as long as DC++ is configured instead of exiting after two idle rounds, and a bad round no longer kills the thread. Idle rounds refresh a cached snapshot of AirDC++'s queue.

**Status page** — bundles queued directly in AirDC++ show greyed and read-only (CLU has no idea what series they are and must never move their files), plus a dismiss action for jobs CLU couldn't resolve.

## Retention

A clean completion deletes its own row. `failed` and `complete_no_move` survive until dismissed — purging those would mean a restart silently swallows exactly the jobs that still need a human.

## Bugs found on the way

- `_update_progress` raised `KeyError` on a job dict missing a key.
- The poll loop could never exit when a job was pending but the client unavailable — spinning two DB reads every 5s for the life of the process.

Both fixed and covered by tests.

## Scope

Usenet (`models/usenet.py`) has the identical in-memory-only gap and is **untouched here** — the DB helpers are named and shaped so it can adopt the same pattern later. Search-result tokens (`_result_tokens`, 900s TTL) legitimately die with the process and are not persisted.

## Testing

`pytest`: **3406 passed, 6 skipped** (the 6 are the usual POSIX chmod/group skips on Windows).

New coverage:
- `tests/mocked/test_dcpp.py` — ledger write timing (persist-before-poller, progress throttling, delete-on-complete, retain-on-failure), `recover_dcpp_jobs()` incl. the no-network guarantee and the completed-while-down import path, untracked-bundle merging, poller lifecycle, dismiss.
- `tests/integration/` — `dcpp_jobs` schema/columns/index, the one-row-per-bundle constraint, and a full CRUD round-trip.
- `tests/routes/test_download_clients_routes.py` — the new dismiss route (success/404/500) and untracked rows in the listing.

**Not verified:** the manual end-to-end check needs a real restart of the CLU container mid-download against the AirDC++ host — restart with a bundle in flight, and separately let AirDC++ finish one while CLU is down (with "remove finished bundles" on) and confirm the file reaches WATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
