### PR TITLE
Actually stop GetComics and Pixeldrain downloads when cancelled

### DIFF
--- a/api.py
+++ b/api.py
@@ -50,6 +50,31 @@ if not monitor_logger.handlers:
 # Global download progress dictionary
 download_progress = {}
 
+
+# Cooperative-cancellation helpers, bound to the progress dict above. The logic
+# lives in core/download_utils.py so it stays testable without importing api.py
+# (worker threads, cloudscraper, download dirs). See that module for the why.
+from core.download_utils import (
+    is_cancel_requested as _is_cancel_requested,
+    mark_cancelled as _mark_cancelled,
+    set_error_status as _set_error_status,
+)
+
+
+def is_cancel_requested(download_id):
+    """True when /cancel_download has flagged this download."""
+    return _is_cancel_requested(download_progress, download_id)
+
+
+def mark_cancelled(download_id, temp_paths=()):
+    """Record the cancelled status and delete any half-written temp files."""
+    _mark_cancelled(download_progress, download_id, temp_paths, monitor_logger)
+
+
+def set_error_status(download_id, error=None):
+    """Set the error status unless the user already cancelled this download."""
+    _set_error_status(download_progress, download_id, error)
+
 # Setup the download directory from config.
 watch = config.get("SETTINGS", "WATCH", fallback="watch")
 from core.database import get_user_preference
@@ -224,8 +249,8 @@ def process_download(task):
     use_headers = basic_headers if internal else headers
 
     # If cancelled while queued, don't start at all
-    if download_progress.get(download_id, {}).get('cancelled'):
-        download_progress[download_id]['status'] = 'cancelled'
+    if is_cancel_requested(download_id):
+        mark_cancelled(download_id)
         return
 
     download_progress[download_id]['status'] = 'in_progress'
@@ -254,6 +279,11 @@ def process_download(task):
 
     for attempt_idx, (provider_name, try_url) in enumerate(urls_to_try):
         try:
+            # A cancel that landed during the previous attempt (or while it was
+            # backing off) must not be answered by starting the next mirror.
+            if is_cancel_requested(download_id):
+                mark_cancelled(download_id)
+                return
             if attempt_idx > 0:
                 monitor_logger.info(f"Failover attempt {attempt_idx}: trying {provider_name} ({try_url})")
                 download_progress[download_id]['status'] = 'in_progress'
@@ -353,8 +383,8 @@ def process_download(task):
                         monitor_logger.error(f"Post-download rename failed for {file_path}: {e}")
 
             # Success – but honour a cancellation that arrived while downloading
-            if download_progress.get(download_id, {}).get('cancelled'):
-                download_progress[download_id]['status'] = 'cancelled'
+            if is_cancel_requested(download_id):
+                mark_cancelled(download_id)
                 return
             download_progress[download_id]['filename'] = file_path
             download_progress[download_id]['status']   = 'complete'
@@ -407,6 +437,12 @@ def process_download(task):
 
         except Exception as e:
             last_error = e
+            # Aborting the transfer is how a cancel surfaces from some
+            # providers — don't fail over to the next mirror because of it.
+            if is_cancel_requested(download_id):
+                monitor_logger.info(f"Download {download_id} cancelled: {e}")
+                mark_cancelled(download_id)
+                return
             remaining = len(urls_to_try) - attempt_idx - 1
             if remaining > 0:
                 monitor_logger.warning(f"Download failed for {provider_name} ({try_url}): {e} — {remaining} fallback(s) remaining")
@@ -415,8 +451,9 @@ def process_download(task):
             monitor_logger.error(f"All download attempts failed for {download_id}: {e}")
 
     # All URLs failed
-    download_progress[download_id]['status'] = 'error'
-    download_progress[download_id]['error'] = str(last_error)
+    set_error_status(download_id, last_error)
+    if is_cancel_requested(download_id):
+        return
 
     # Update weekly pack status to 'failed' if applicable
     if weekly_pack_info:
@@ -525,6 +562,14 @@ def download_getcomics(url, download_id, hdrs=None, source_url=None):
 
     for attempt in range(retries):
         try:
+            # A stalled read can sit on the socket for the full 300s timeout, so
+            # a cancel often only becomes actionable once the attempt unwinds.
+            # Check here so the retry doesn't restart a cancelled download.
+            if is_cancel_requested(download_id):
+                monitor_logger.info(f"Download {download_id} cancelled before attempt {attempt + 1}")
+                session.close()
+                mark_cancelled(download_id)
+                return None
             monitor_logger.info(f"Attempt {attempt + 1} to download {url}")
             # Increase timeout for large files: 60s connection, 300s read (5 minutes)
             response = session.get(url, stream=True, timeout=(60, 300))
@@ -620,12 +665,14 @@ def download_getcomics(url, download_id, hdrs=None, source_url=None):
                 last_downloaded = 0
 
                 for chunk in response.iter_content(chunk_size=chunk_size):
-                    if download_progress.get(download_id, {}).get('cancelled'):
+                    if is_cancel_requested(download_id):
                         monitor_logger.info(f"Download {download_id} cancelled; deleting temp file.")
                         f.close()
-                        if os.path.exists(temp_file_path):
-                            os.remove(temp_file_path)
-                        download_progress[download_id]['status'] = 'cancelled'
+                        # Drop the connection so the mirror stops streaming
+                        # instead of filling the socket buffer behind us.
+                        response.close()
+                        session.close()
+                        mark_cancelled(download_id, (temp_file_path,))
                         return None
                     if chunk:
                         f.write(chunk)
@@ -696,16 +743,28 @@ def download_getcomics(url, download_id, hdrs=None, source_url=None):
             else:
                 monitor_logger.debug("No temp file to clean up between retries")
 
-            # Wait before next retry (exponential backoff)
+            # Wait before next retry (exponential backoff), in short slices so a
+            # cancel isn't ignored for the whole backoff window.
             if attempt < retries - 1:  # Don't sleep after the last attempt
-                time.sleep(delay * (2 ** attempt))
+                remaining_sleep = delay * (2 ** attempt)
+                while remaining_sleep > 0 and not is_cancel_requested(download_id):
+                    time.sleep(min(1, remaining_sleep))
+                    remaining_sleep -= 1
 
     # All retries failed - cleanup
     session.close()
 
+    if is_cancel_requested(download_id):
+        monitor_logger.info(f"Download {download_id} cancelled; abandoning {url}")
+        mark_cancelled(download_id, [
+            f"{file_path}.{i}.crdownload" for i in range(retries)
+        ] if 'file_path' in locals() else ())
+        return None
+
     monitor_logger.error(f"Download failed for {url}: {last_exception}")
-    download_progress[download_id]['status'] = 'error'
-    download_progress[download_id]['progress'] = -1
+    set_error_status(download_id)
+    if download_id in download_progress:
+        download_progress[download_id]['progress'] = -1
 
     # Remove leftover crdownload files from all attempts
     if 'file_path' in locals():
@@ -864,6 +923,12 @@ def download_pixeldrain(url: str, download_id: str, dest_name: Optional[str] = N
     chunk = 8 * 1024 * 1024  # 8 MiB
 
     try:
+        # Cancelled between queueing and the metadata round-trips above.
+        if is_cancel_requested(download_id):
+            monitor_logger.info(f"PixelDrain download {download_id} cancelled before start")
+            mark_cancelled(download_id, (tmp_path,))
+            return None
+
         with session.get(dl_url, stream=True, headers=req_headers, auth=auth,
                          allow_redirects=True, timeout=(10, 180)) as r, open(tmp_path, mode) as f:
 
@@ -901,6 +966,12 @@ def download_pixeldrain(url: str, download_id: str, dest_name: Optional[str] = N
                         download_progress[download_id]["bytes_total"] = total
                     done = 0
                     for chunk_bytes in r2.iter_content(chunk_size=chunk):
+                        if is_cancel_requested(download_id):
+                            monitor_logger.info(f"PixelDrain download {download_id} cancelled; discarding partial file")
+                            f2.close()
+                            r2.close()
+                            mark_cancelled(download_id, (tmp_path,))
+                            return None
                         if chunk_bytes:
                             f2.write(chunk_bytes)
                             done += len(chunk_bytes)
@@ -918,6 +989,12 @@ def download_pixeldrain(url: str, download_id: str, dest_name: Optional[str] = N
                     download_progress[download_id]["progress"] = int(existing / total * 100)
 
                 for chunk_bytes in r.iter_content(chunk_size=chunk):
+                    if is_cancel_requested(download_id):
+                        monitor_logger.info(f"PixelDrain download {download_id} cancelled; discarding partial file")
+                        f.close()
+                        r.close()
+                        mark_cancelled(download_id, (tmp_path,))
+                        return None
                     if not chunk_bytes:
                         continue
                     f.write(chunk_bytes)
@@ -1033,12 +1110,11 @@ def download_comicbookplus(url: str, download_id: str, dest_name: Optional[str] 
             done = 0
             with open(tmp_path, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=chunk_size):
-                    if download_progress.get(download_id, {}).get('cancelled'):
+                    if is_cancel_requested(download_id):
                         monitor_logger.info(f"Download {download_id} cancelled")
                         f.close()
-                        if os.path.exists(tmp_path):
-                            os.remove(tmp_path)
-                        download_progress[download_id]['status'] = 'cancelled'
+                        r.close()
+                        mark_cancelled(download_id, (tmp_path,))
                         return None
                     if chunk:
                         f.write(chunk)
@@ -1054,15 +1130,15 @@ def download_comicbookplus(url: str, download_id: str, dest_name: Optional[str] 
 
     except requests.Timeout as e:
         monitor_logger.error(f"Timeout during ComicBookPlus download: {e}")
-        download_progress[download_id]['status'] = 'error'
+        set_error_status(download_id)
         raise Exception(f"Timeout during download: {e}")
     except requests.RequestException as e:
         monitor_logger.error(f"Request error during ComicBookPlus download: {e}")
-        download_progress[download_id]['status'] = 'error'
+        set_error_status(download_id)
         raise Exception(f"Request error during download: {e}")
     except Exception as e:
         monitor_logger.error(f"Unexpected error during ComicBookPlus download: {e}")
-        download_progress[download_id]['status'] = 'error'
+        set_error_status(download_id)
         raise
     finally:
         session.close()
@@ -1129,7 +1205,7 @@ def download_mega(url: str, download_id: str, dest_name: Optional[str] = None, h
         # Progress callback that updates download_progress and checks cancellation
         def progress_callback(downloaded_bytes, total_bytes, percent):
             # Check for cancellation
-            if download_progress.get(download_id, {}).get('cancelled'):
+            if is_cancel_requested(download_id):
                 monitor_logger.info(f"Cancellation requested for {download_id}")
                 return False  # Signal cancellation
 
@@ -1161,10 +1237,9 @@ def download_mega(url: str, download_id: str, dest_name: Optional[str] = None, h
         monitor_logger.error(f"Traceback: {traceback.format_exc()}")
 
         if "cancelled" in error_msg.lower():
-            download_progress[download_id]['status'] = 'cancelled'
+            mark_cancelled(download_id)
         else:
-            download_progress[download_id]['status'] = 'error'
-            download_progress[download_id]['error'] = error_msg
+            set_error_status(download_id, error_msg)
         raise
 
 # -------------------------------
@@ -1220,12 +1295,19 @@ def download_status(download_id):
 
 @app.route('/cancel_download/<download_id>', methods=['POST'])
 def cancel_download(download_id):
-    if download_id in download_progress:
-        download_progress[download_id]['cancelled'] = True
-        download_progress[download_id]['status'] = 'cancelled'
-        return jsonify({'message': 'Download cancelled'}), 200
-    else:
+    details = download_progress.get(download_id)
+    if details is None:
         return jsonify({'error': 'Download not found'}), 404
+
+    # Cancellation is cooperative: setting the flag is all this endpoint does.
+    # The worker notices it between chunks/retries/failover attempts, drops the
+    # connection and deletes the partial file. Setting it before touching
+    # 'status' matters — the worker keys off the flag, not the label.
+    details['cancelled'] = True
+    if details.get('status') in ('queued', 'in_progress'):
+        details['status'] = 'cancelled'
+        monitor_logger.info(f"Cancel requested for download {download_id}")
+    return jsonify({'message': 'Download cancelled', 'status': details.get('status')}), 200
 
 @app.route('/download_status_all', methods=['GET'])
 def download_status_all():

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -6,6 +6,7 @@ connection, cloudscraper). Nothing here imports ``api`` or ``core.database`` at
 module scope; the weekly-pack reconciler reaches for both lazily.
 """
 
+import os
 import sys
 
 # Live api.download_progress status -> weekly_packs_history status. 'queued'
@@ -69,6 +70,75 @@ def is_cloudflare_challenge(response) -> bool:
                 or b'challenge-platform' in snippet)
     except Exception:
         return False
+
+
+# ---------------------------------------------------------------------------
+# Cooperative cancellation
+#
+# /cancel_download only sets a flag on the download's progress entry; nothing
+# can interrupt a worker thread mid-transfer. Every download loop therefore has
+# to poll for that flag and stop itself — between chunks, between retries and
+# between failover mirrors — otherwise "Cancelled" is only a label and the file
+# keeps downloading into WATCH, where the monitor happily imports it.
+# ---------------------------------------------------------------------------
+
+def is_cancel_requested(progress, download_id) -> bool:
+    """True when the download has been flagged for cancellation.
+
+    Tolerates a missing/cleared entry (a dismissed download must read as "not
+    cancelled" rather than raise inside a tight chunk loop).
+    """
+    if not isinstance(progress, dict):
+        return False
+    entry = progress.get(download_id)
+    return bool(isinstance(entry, dict) and entry.get('cancelled'))
+
+
+def cleanup_partial_files(paths, logger=None) -> list:
+    """Delete half-written temp files, returning the ones actually removed.
+
+    A cancelled download must leave nothing behind: ``.part`` files are resume
+    state for the next attempt, and a ``.crdownload`` left in WATCH is picked up
+    once its extension stops being ignored.
+    """
+    removed = []
+    for path in paths or ():
+        if not path or not os.path.exists(path):
+            continue
+        try:
+            os.remove(path)
+            removed.append(path)
+        except Exception as e:
+            if logger:
+                logger.warning(f"Failed to remove temp file on cancel: {path} — {e}")
+    return removed
+
+
+def mark_cancelled(progress, download_id, temp_paths=(), logger=None) -> None:
+    """Settle a download as cancelled and discard its partial output."""
+    cleanup_partial_files(temp_paths, logger)
+    entry = progress.get(download_id) if isinstance(progress, dict) else None
+    if isinstance(entry, dict):
+        entry['status'] = 'cancelled'
+
+
+def set_error_status(progress, download_id, error=None) -> None:
+    """Record a failure, unless the user already cancelled this download.
+
+    Aborting a transfer is how a cancel usually surfaces — as a read error,
+    exhausted retries, or a truncated body. Without this guard that self-
+    inflicted failure overwrites 'cancelled', and the download the user just
+    stopped comes back as 'Failed' with a Retry button.
+    """
+    entry = progress.get(download_id) if isinstance(progress, dict) else None
+    if not isinstance(entry, dict):
+        return
+    if entry.get('cancelled'):
+        entry['status'] = 'cancelled'
+        return
+    entry['status'] = 'error'
+    if error is not None:
+        entry['error'] = str(error)
 
 
 def _live_download_progress():

--- a/templates/status.html
+++ b/templates/status.html
@@ -169,15 +169,19 @@
               cancelIcon.title = "Cancel download";
               cancelIcon.addEventListener('click', () => {
                 showConfirmToast('Are you sure you want to cancel this download?', () => {
+                  // The worker stops cooperatively — it may take a chunk or a
+                  // stalled read to notice — so refresh rather than assume.
                   fetch(`/cancel_download/${downloadId}`, { method: 'POST' })
-                    .then(response => response.json())
+                    .then(response => response.json().then(data => {
+                      if (!response.ok) throw new Error(data.error || 'Cancel failed');
+                      return data;
+                    }))
                     .then(data => {
-                      console.log(data.message);
                       showToast('Download cancelled', 'success');
-                      // Optionally, update the UI immediately.
+                      fetchStatus();
                     })
                     .catch(error => {
-                      showToast('Error cancelling download', 'error');
+                      showToast(error.message || 'Error cancelling download', 'error');
                     });
                 });
               });

--- a/tests/unit/test_download_cancel.py
+++ b/tests/unit/test_download_cancel.py
@@ -1,0 +1,207 @@
+"""Cooperative-cancellation helpers used by every api.py download loop.
+
+Regression context: clicking Cancel on the Status page only ever set a flag on
+``api.download_progress``. GetComics honoured it between chunks but let the
+failure it caused overwrite 'cancelled' with 'error'; PixelDrain never looked at
+it at all, so a cancelled download ran to completion, landed in WATCH and got
+imported anyway.
+
+api.py itself is not importable here (worker threads, cloudscraper, download
+dirs — see tests/routes/conftest.py), which is exactly why this logic lives in
+core/download_utils.py.
+"""
+import os
+
+import pytest
+
+from core.download_utils import (
+    cleanup_partial_files,
+    is_cancel_requested,
+    mark_cancelled,
+    set_error_status,
+)
+
+
+@pytest.fixture
+def progress():
+    """A minimal stand-in for api.download_progress with one live download."""
+    return {"dl-1": {"status": "in_progress", "progress": 42}}
+
+
+class TestIsCancelRequested:
+
+    def test_false_while_running(self, progress):
+        assert is_cancel_requested(progress, "dl-1") is False
+
+    def test_true_once_flagged(self, progress):
+        progress["dl-1"]["cancelled"] = True
+        assert is_cancel_requested(progress, "dl-1") is True
+
+    def test_status_label_alone_does_not_count(self, progress):
+        # The worker keys off the flag, not the label: a row shown as
+        # 'cancelled' without the flag must not abort a running transfer.
+        progress["dl-1"]["status"] = "cancelled"
+        assert is_cancel_requested(progress, "dl-1") is False
+
+    def test_missing_entry_reads_as_not_cancelled(self, progress):
+        # Cleared/dismissed mid-download — must not raise inside a chunk loop.
+        assert is_cancel_requested(progress, "gone") is False
+        assert is_cancel_requested({}, "dl-1") is False
+
+    def test_non_dict_progress_is_safe(self):
+        assert is_cancel_requested(None, "dl-1") is False
+
+    def test_non_dict_entry_is_safe(self):
+        assert is_cancel_requested({"dl-1": 0}, "dl-1") is False
+
+
+class TestCleanupPartialFiles:
+
+    def test_removes_existing_partials(self, tmp_path):
+        part = tmp_path / "Batman 001.cbz.part"
+        part.write_bytes(b"half a comic")
+
+        removed = cleanup_partial_files([str(part)])
+
+        assert removed == [str(part)]
+        assert not part.exists()
+
+    def test_skips_missing_and_empty_paths(self, tmp_path):
+        assert cleanup_partial_files([str(tmp_path / "nope.part"), None, ""]) == []
+
+    def test_none_is_accepted(self):
+        assert cleanup_partial_files(None) == []
+
+    def test_undeletable_file_is_logged_not_raised(self, tmp_path, monkeypatch):
+        part = tmp_path / "locked.crdownload"
+        part.write_bytes(b"x")
+
+        def boom(_path):
+            raise PermissionError("file is open")
+
+        monkeypatch.setattr(os, "remove", boom)
+
+        class _Log:
+            def __init__(self):
+                self.warnings = []
+
+            def warning(self, msg):
+                self.warnings.append(msg)
+
+        log = _Log()
+        # A failed cleanup must never take down the worker thread.
+        assert cleanup_partial_files([str(part)], log) == []
+        assert len(log.warnings) == 1
+
+
+class TestMarkCancelled:
+
+    def test_sets_status_and_deletes_partial(self, progress, tmp_path):
+        part = tmp_path / "Batman 001.cbz.part"
+        part.write_bytes(b"partial")
+        progress["dl-1"]["cancelled"] = True
+
+        mark_cancelled(progress, "dl-1", (str(part),))
+
+        assert progress["dl-1"]["status"] == "cancelled"
+        assert not part.exists()
+
+    def test_cleans_every_retry_temp_file(self, progress, tmp_path):
+        # download_getcomics names its temp file per attempt.
+        parts = []
+        for i in range(3):
+            p = tmp_path / f"Batman 001.cbz.{i}.crdownload"
+            p.write_bytes(b"x")
+            parts.append(str(p))
+
+        mark_cancelled(progress, "dl-1", parts)
+
+        assert not any(os.path.exists(p) for p in parts)
+
+    def test_cleared_entry_does_not_resurrect_the_row(self, tmp_path):
+        part = tmp_path / "x.part"
+        part.write_bytes(b"x")
+        progress = {}
+
+        mark_cancelled(progress, "dl-1", (str(part),))
+
+        assert progress == {}
+        assert not part.exists()
+
+
+class TestSetErrorStatus:
+
+    def test_records_a_genuine_failure(self, progress):
+        set_error_status(progress, "dl-1", "HTTP 500")
+
+        assert progress["dl-1"]["status"] == "error"
+        assert progress["dl-1"]["error"] == "HTTP 500"
+
+    def test_cancel_is_not_overwritten_by_the_failure_it_caused(self, progress):
+        # The regression: aborting the transfer raises, retries run out, and the
+        # download the user just cancelled reappears as Failed with a Retry.
+        progress["dl-1"]["cancelled"] = True
+
+        set_error_status(progress, "dl-1", "Connection aborted")
+
+        assert progress["dl-1"]["status"] == "cancelled"
+        assert "error" not in progress["dl-1"]
+
+    def test_error_is_optional(self, progress):
+        set_error_status(progress, "dl-1")
+
+        assert progress["dl-1"]["status"] == "error"
+        assert "error" not in progress["dl-1"]
+
+    def test_exception_object_is_stringified(self, progress):
+        set_error_status(progress, "dl-1", RuntimeError("boom"))
+
+        assert progress["dl-1"]["error"] == "boom"
+
+    def test_missing_entry_is_a_no_op(self, progress):
+        set_error_status(progress, "gone", "boom")
+
+        assert "gone" not in progress
+
+
+class TestChunkLoopContract:
+    """The shape every streaming download in api.py now follows."""
+
+    def _stream(self, progress, download_id, chunks, tmp_path):
+        """Mimic download_pixeldrain/download_getcomics' write loop."""
+        part = tmp_path / "out.cbz.part"
+        written = 0
+        with open(part, "wb") as f:
+            for chunk in chunks:
+                if is_cancel_requested(progress, download_id):
+                    f.close()
+                    mark_cancelled(progress, download_id, (str(part),))
+                    return None, written
+                f.write(chunk)
+                written += len(chunk)
+                progress[download_id]["bytes_downloaded"] = written
+        return str(part), written
+
+    def test_cancel_mid_stream_stops_and_leaves_nothing_behind(self, progress, tmp_path):
+        def chunks():
+            yield b"a" * 10
+            # Cancel arrives from the request thread between chunks.
+            progress["dl-1"]["cancelled"] = True
+            yield b"b" * 10
+            yield b"c" * 10
+
+        result, written = self._stream(progress, "dl-1", chunks(), tmp_path)
+
+        assert result is None
+        assert written == 10, "must stop at the next chunk boundary, not finish"
+        assert progress["dl-1"]["status"] == "cancelled"
+        assert not (tmp_path / "out.cbz.part").exists()
+
+    def test_uncancelled_stream_completes(self, progress, tmp_path):
+        result, written = self._stream(
+            progress, "dl-1", [b"a" * 10, b"b" * 10], tmp_path
+        )
+
+        assert result is not None
+        assert written == 20
+        assert progress["dl-1"]["status"] == "in_progress"


### PR DESCRIPTION
Clicking **Cancel** on the Status page relabelled the row but did not reliably stop the transfer.

Cancellation is cooperative: `/cancel_download` only sets `download_progress[id]['cancelled'] = True`. The worker has to notice it. Two things stopped that from happening.

## What was broken

**Pixeldrain never looked at the flag.** `download_pixeldrain` had no cancel check in either of its `iter_content` loops. The row flipped to "cancelled" in the UI while the transfer ran to completion, `os.replace`'d the file into WATCH, and the monitor imported it. Cancel was purely cosmetic there.

**GetComics honoured it, then undid it:**
- a cancel arriving during a stalled read waited out the full 300s timeout, after which the retry loop started attempts 2 and 3 anyway — no check between attempts, and the exponential backoff slept through it
- `download_getcomics` and `process_download` both set `status = 'error'` on the way out, overwriting `'cancelled'` with the failure the cancel itself caused, so the download came back as **Failed** with a Retry button
- `process_download`'s failover loop moved on to the next mirror after a cancelled attempt

## Changes

**`core/download_utils.py`** — new `is_cancel_requested()`, `cleanup_partial_files()`, `mark_cancelled()`, `set_error_status()`. Put here rather than in api.py because api.py isn't importable under test (worker threads, cloudscraper, download dirs); this module already exists for exactly that reason.

**`api.py`** — thin bindings over those, applied at every point a cancel can land:
- Pixeldrain: checks before the transfer starts and in both chunk loops; closes the response and deletes the `.part` (which is resume state — it must not survive a cancel)
- GetComics: checks before each retry attempt and in 1-second slices through the backoff; closes the response/session so the mirror stops streaming
- `process_download`: checks at the top of each failover attempt, and treats an exception raised while cancelled as a cancel rather than a reason to try the next mirror
- error paths route through `set_error_status()`, which refuses to overwrite a cancelled download; same guard applied to ComicBookPlus and MEGA for consistency
- `/cancel_download` no longer mislabels an already-completed download as cancelled, and returns the resulting status

**`templates/status.html`** — the cancel handler checks `response.ok` (a 404 previously still showed a green "Download cancelled") and refreshes the table immediately.

## Tests

`tests/unit/test_download_cancel.py` — 20 new tests covering flag detection, partial-file cleanup, the cancelled-vs-error precedence regression, and the chunk-loop stop-at-next-boundary contract.

Full suite: **3426 passed, 6 skipped** (the known POSIX-only skips).

## Note

Cancel granularity is still bounded by chunk size — 8 MiB on Pixeldrain, up to 4 MiB on large GetComics files — so on a slow link there are a few seconds between the click and the stop. Transfer tuning left alone, since shrinking chunks trades throughput for responsiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)