### PR TITLE
Let users pick the issue when only the issue number fails to match

### DIFF
--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -1300,7 +1300,12 @@ def batch_metadata():
                 'renamed': 0,
                 'skipped': 0,
                 'errors': 0,
-                'details': []
+                'details': [],
+                # Files whose series/volume we identified (usually from cvinfo)
+                # but whose issue number didn't resolve. The client walks these
+                # after the run and offers an issue picker for each, rather than
+                # us special-casing every odd numbering scheme ("003 [23]").
+                'unmatched': []
             }
 
             total_files = len(comic_files)
@@ -1385,6 +1390,18 @@ def batch_metadata():
                     # Try sources based on volume year
                     metadata = None
                     source = None
+                    # First provider that knew which series/volume this is but
+                    # couldn't find the issue — offered to the user afterwards.
+                    near_miss = None
+
+                    def note_near_miss(provider, series_display, selected_match):
+                        nonlocal near_miss
+                        if near_miss is None:
+                            near_miss = {
+                                'provider': provider,
+                                'series_name': series_display,
+                                'selected_match': selected_match,
+                            }
 
                     # Helper function for GCD lookup
                     def try_gcd():
@@ -1406,6 +1423,8 @@ def batch_metadata():
                                     source = 'GCD'
                                     app_logger.info(f"Found metadata from GCD for {filename}")
                                     return True
+                                note_near_miss('gcd', gcd_series.get('name') or gcd_series_name,
+                                               {'provider': 'gcd', 'series_id': gcd_series['id']})
                         except Exception as e:
                             app_logger.warning(f"GCD lookup failed for {filename}: {e}")
                         return False
@@ -1427,6 +1446,9 @@ def batch_metadata():
                                 source = 'ComicVine'
                                 app_logger.info(f"Found metadata from ComicVine for {filename}")
                                 return True
+                            note_near_miss('comicvine', os.path.basename(directory),
+                                           {'provider': 'comicvine', 'volume_id': cv_volume_id,
+                                            'publisher_name': cvinfo_publisher_name})
                         except Exception as e:
                             app_logger.warning(f"ComicVine lookup failed for {filename}: {e}")
                         return False
@@ -1446,6 +1468,9 @@ def batch_metadata():
                                 source = 'ComicVine (Local DB)'
                                 app_logger.info(f"Found metadata from ComicVine SQLite for {filename}")
                                 return True
+                            note_near_miss('comicvine_sqlite', os.path.basename(directory),
+                                           {'provider': 'comicvine_sqlite', 'volume_id': cv_volume_id,
+                                            'publisher_name': cvinfo_publisher_name})
                         except Exception as e:
                             app_logger.warning(f"ComicVine SQLite lookup failed for {filename}: {e}")
                         return False
@@ -1462,6 +1487,8 @@ def batch_metadata():
                                 source = 'Metron'
                                 app_logger.info(f"Found metadata from Metron for {filename}")
                                 return True
+                            note_near_miss('metron', os.path.basename(directory),
+                                           {'provider': 'metron', 'series_id': series_id})
                         except Exception as e:
                             app_logger.warning(f"Metron lookup failed for {filename}: {e}")
                         return False
@@ -1667,6 +1694,8 @@ def batch_metadata():
                                 source = 'GCD API'
                                 app_logger.info(f"Found metadata from GCD API for {filename}")
                                 return True
+                            note_near_miss('gcd_api', match.title,
+                                           {'provider': 'gcd_api', 'series_id': match.id})
                         except Exception as e:
                             app_logger.warning(f"GCD API lookup failed for {filename}: {e}")
                         return False
@@ -1745,8 +1774,26 @@ def batch_metadata():
                         app_logger.info(f"Added metadata to {filename} from {source}")
                     else:
                         result['errors'] += 1
-                        result['details'].append({'file': filename, 'status': 'error', 'reason': 'not found'})
-                        app_logger.warning(f"No metadata found for {filename}")
+                        detail = {'file': filename, 'status': 'error', 'reason': 'not found'}
+                        if near_miss:
+                            # We know the series — the issue number is what didn't
+                            # land. Hand it to the client so the user can pick the
+                            # right issue from the volume.
+                            detail['reason'] = 'issue not found'
+                            detail['can_select_issue'] = True
+                            result['unmatched'].append({
+                                'file': filename,
+                                'file_path': file_path,
+                                'issue_number': issue_number,
+                                **near_miss,
+                            })
+                            app_logger.info(
+                                f"No issue #{issue_number} in {near_miss['provider']} "
+                                f"series for {filename} — queued for issue selection"
+                            )
+                        else:
+                            app_logger.warning(f"No metadata found for {filename}")
+                        result['details'].append(detail)
 
                     # Rate limiting - Metron makes 2 API calls per file, needs longer delay
                     if source == 'Metron':
@@ -2986,7 +3033,108 @@ def search_gcd_metadata_with_selection():
 # Unified Metadata Search (Provider Priority Cascade)
 # =============================================================================
 
-def _try_metron_single(cvinfo_path, series_name, issue_number, year):
+def _issue_sort_key(issue):
+    """Sort issues numerically where possible ("2" before "10"), else by string."""
+    raw = str(issue.get('issue_number') or '')
+    match = re.match(r'\s*(\d+(?:\.\d+)?)', raw)
+    if match:
+        try:
+            return (0, float(match.group(1)), raw.lower())
+        except ValueError:
+            pass
+    return (1, 0.0, raw.lower())
+
+
+def _issue_options_for(provider, series_id):
+    """Every issue in a volume/series, normalized for the issue-picker modal.
+
+    Returns [{id, issue_number, title, cover_date, cover_url}, ...] sorted by
+    issue number, or [] when the provider can't supply a list. Never raises —
+    the picker is a fallback, so a provider outage must not turn a clean "not
+    found" into a 500.
+    """
+    if not provider or series_id in (None, ''):
+        return []
+
+    try:
+        options = []
+
+        if provider in ('comicvine', 'comicvine_sqlite'):
+            # comicvine_source paginates (comicvine.get_all_issues_for_volume)
+            # and prefers the local DB over the API, unlike
+            # ComicVineProvider.get_issues which caps at a single 100-issue page.
+            from models import comicvine_source
+            for issue in comicvine_source.get_all_issues_for_volume(int(series_id)) or []:
+                options.append({
+                    "id": issue.get('cv_id') or issue.get('id'),
+                    "issue_number": str(issue.get('number') or ''),
+                    "title": issue.get('name'),
+                    "cover_date": issue.get('cover_date') or issue.get('store_date'),
+                    "cover_url": issue.get('image'),
+                })
+        else:
+            from core.bulk_metadata import _instantiate_provider
+            prov = _instantiate_provider(provider)
+            if prov is None:
+                return []
+            for issue in prov.get_issues(str(series_id)) or []:
+                record = issue.to_dict()
+                options.append({
+                    "id": record.get('id'),
+                    "issue_number": str(record.get('issue_number') or ''),
+                    "title": record.get('title'),
+                    "cover_date": record.get('cover_date') or record.get('store_date'),
+                    "cover_url": record.get('cover_url'),
+                })
+
+        options = [o for o in options if o['issue_number']]
+        options.sort(key=_issue_sort_key)
+        app_logger.info(
+            f"[search-metadata] {provider} returned {len(options)} issues for series {series_id}"
+        )
+        return options
+    except Exception as e:
+        app_logger.warning(
+            f"[search-metadata] Could not list issues for {provider} series {series_id}: {e}"
+        )
+        return []
+
+
+def _issue_selection_response(provider, selected_match, issues, series_name,
+                              parsed_filename, provider_order=None):
+    """Payload asking the user to pick the right issue from a known volume."""
+    payload = {
+        "success": False,
+        "requires_issue_selection": True,
+        "provider": provider,
+        "selected_match": selected_match,
+        "series_name": series_name,
+        "possible_issues": issues,
+        "parsed_filename": parsed_filename,
+        "error": (
+            f"Issue #{parsed_filename.get('issue_number')} not found in the selected volume"
+        ),
+    }
+    if provider_order is not None:
+        payload["provider_order"] = provider_order
+    return payload
+
+
+def _record_near_miss(near_misses, provider, series_name, selected_match):
+    """Remember a volume we identified but couldn't find the issue in.
+
+    Used to offer the issue picker once the whole cascade comes up empty.
+    """
+    if near_misses is None:
+        return
+    near_misses.append({
+        "provider": provider,
+        "series_name": series_name,
+        "selected_match": selected_match,
+    })
+
+
+def _try_metron_single(cvinfo_path, series_name, issue_number, year, near_misses=None):
     """Try Metron provider for a single file.
     Returns (metadata_dict, image_url, None) on success,
     or (None, None, selection_data) when user selection is needed,
@@ -2998,6 +3146,7 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
             return None, None, None
 
         series_id = None
+        matched_name = series_name
 
         # Try cvinfo first for a direct series ID
         if cvinfo_path:
@@ -3018,6 +3167,7 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
             )
             if confident:
                 series_id = confident.get("id")
+                matched_name = confident.get("name") or series_name
             elif len(candidates) > 1:
                 return None, None, {
                     "requires_selection": True,
@@ -3026,12 +3176,17 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
                 }
             else:
                 series_id = candidates[0].get("id")
+                matched_name = candidates[0].get("name") or series_name
 
         if not series_id:
             return None, None, None
 
         issue_data = metron.get_issue_metadata(metron_api, series_id, issue_number)
         if not issue_data:
+            # Series is right, issue isn't there — remember it so the cascade
+            # can offer an issue picker if nothing else matches.
+            _record_near_miss(near_misses, 'metron', matched_name,
+                              {"provider": "metron", "series_id": series_id})
             return None, None, None
 
         metadata = metron.map_to_comicinfo(issue_data)
@@ -3049,7 +3204,7 @@ def _try_metron_single(cvinfo_path, series_name, issue_number, year):
         return None, None, None
 
 
-def _try_comicvine_single(cvinfo_path, series_name, issue_number, year):
+def _try_comicvine_single(cvinfo_path, series_name, issue_number, year, near_misses=None):
     """Try ComicVine provider for a single file, bounded by a wall-clock guard.
 
     Runs the actual lookup in a worker thread and gives up after
@@ -3065,9 +3220,16 @@ def _try_comicvine_single(cvinfo_path, series_name, issue_number, year):
     # (which has no request/app context of its own) can push one.
     app = current_app._get_current_object()
 
+    # The worker gets its own list: on timeout we abandon the thread, and a
+    # late append from it must not leak into the caller's near misses.
+    worker_near_misses = []
+
     def _run():
         with app.app_context():
-            return _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year)
+            return _try_comicvine_single_impl(
+                cvinfo_path, series_name, issue_number, year,
+                near_misses=worker_near_misses
+            )
 
     # Don't use ThreadPoolExecutor as a context manager: its __exit__ calls
     # shutdown(wait=True), which would block on a hung worker and defeat the
@@ -3076,7 +3238,10 @@ def _try_comicvine_single(cvinfo_path, series_name, issue_number, year):
     # (CV_REQUEST_TIMEOUT) fires.
     ex = ThreadPoolExecutor(max_workers=1)
     try:
-        return ex.submit(_run).result(timeout=CV_ATTEMPT_TIMEOUT)
+        result = ex.submit(_run).result(timeout=CV_ATTEMPT_TIMEOUT)
+        if near_misses is not None:
+            near_misses.extend(worker_near_misses)
+        return result
     except FutureTimeout:
         app_logger.warning(
             f"[search-metadata] ComicVine timed out after {CV_ATTEMPT_TIMEOUT}s "
@@ -3090,7 +3255,7 @@ def _try_comicvine_single(cvinfo_path, series_name, issue_number, year):
         ex.shutdown(wait=False)
 
 
-def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year):
+def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year, near_misses=None):
     """Try ComicVine provider for a single file.
     Returns (metadata_dict, image_url, volume_data, None) on success,
     or (None, None, None, selection_data) when user selection is needed,
@@ -3121,6 +3286,12 @@ def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year):
                     if img_url and not isinstance(img_url, str):
                         img_url = str(img_url)
                     return metadata, img_url, volume_data, None
+                # cvinfo pins the volume but the issue isn't in it: a strong
+                # near miss. The search-by-name fallback below still runs.
+                _record_near_miss(
+                    near_misses, 'comicvine', series_name,
+                    {"provider": "comicvine", "volume_id": cv_volume_id}
+                )
 
         # No cvinfo or no volume_id - search by series name
         if not series_name:
@@ -3159,6 +3330,11 @@ def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year):
         # Get the issue from selected volume
         issue_data = comicvine.get_issue_by_number(api_key, selected_volume['id'], issue_number, year)
         if not issue_data:
+            _record_near_miss(
+                near_misses, 'comicvine', selected_volume.get('name'),
+                {"provider": "comicvine", "volume_id": selected_volume['id'],
+                 "publisher_name": selected_volume.get('publisher_name')}
+            )
             return None, None, None, None
 
         metadata = comicvine.map_to_comicinfo(issue_data, selected_volume)
@@ -3172,7 +3348,7 @@ def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year):
         return None, None, None, None
 
 
-def _try_comicvine_sqlite_single(cvinfo_path, series_name, issue_number, year):
+def _try_comicvine_sqlite_single(cvinfo_path, series_name, issue_number, year, near_misses=None):
     """Try the local ComicVine SQLite provider for a single file.
     Returns (metadata_dict, image_url, volume_data, None) on success,
     or (None, None, None, selection_data) when user selection is needed,
@@ -3203,6 +3379,12 @@ def _try_comicvine_sqlite_single(cvinfo_path, series_name, issue_number, year):
                         issue_data, volume_data, start_year=start_year,
                         source_label=comicvine_sqlite.SOURCE_LABEL)
                     return metadata, issue_data.get('image_url'), volume_data, None
+                # Volume pinned by cvinfo, issue absent — remember it in case
+                # the whole cascade comes up empty.
+                _record_near_miss(
+                    near_misses, 'comicvine_sqlite', series_name,
+                    {"provider": "comicvine_sqlite", "volume_id": cv_volume_id}
+                )
 
         # No cvinfo or no volume_id - search by series name
         if not series_name:
@@ -3239,6 +3421,11 @@ def _try_comicvine_sqlite_single(cvinfo_path, series_name, issue_number, year):
 
         issue_data = comicvine_sqlite.get_issue_by_number(selected_volume['id'], issue_number, year)
         if not issue_data:
+            _record_near_miss(
+                near_misses, 'comicvine_sqlite', selected_volume.get('name'),
+                {"provider": "comicvine_sqlite", "volume_id": selected_volume['id'],
+                 "publisher_name": selected_volume.get('publisher_name')}
+            )
             return None, None, None, None
 
         metadata = comicvine.map_to_comicinfo(
@@ -3500,6 +3687,33 @@ def _rename_config_for(folder_path):
     }
 
 
+@metadata_bp.route('/api/provider-issues', methods=['POST'])
+def provider_issues():
+    """List every issue in a provider's series/volume.
+
+    Backs the issue picker for the folder batch, where the run already knows
+    which series each file belongs to (usually from cvinfo) and only the issue
+    number failed to resolve. Fetching the list once per volume beats making
+    each file rediscover it.
+
+    Input: {provider, series_id}
+    """
+    try:
+        data = request.get_json() or {}
+        provider = data.get('provider')
+        series_id = data.get('series_id')
+
+        if not provider or series_id in (None, ''):
+            return jsonify({"success": False, "error": "Missing provider or series_id"}), 400
+
+        issues = _issue_options_for(provider, series_id)
+        return jsonify({"success": True, "provider": provider,
+                        "series_id": series_id, "issues": issues})
+    except Exception as e:
+        app_logger.error(f"[provider-issues] Error: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 @metadata_bp.route('/api/search-metadata', methods=['POST'])
 def search_metadata():
     """
@@ -3595,6 +3809,17 @@ def search_metadata():
             provider = selected_match.get('provider')
             app_logger.info(f"[search-metadata] Selection follow-up for provider: {provider}")
 
+            # The user may have picked an exact issue from the issue-picker
+            # modal. That number came from the provider's own issue list, so it
+            # overrides whatever we parsed out of the filename. Clearing the
+            # year matters for the ComicVine API path, whose issue lookup drops
+            # results whose cover year doesn't match.
+            chosen_issue = selected_match.get('issue_number')
+            if chosen_issue not in (None, ''):
+                issue_number = str(chosen_issue)
+                year = None
+                app_logger.info(f"[search-metadata] Using user-selected issue #{issue_number}")
+
             metadata = None
             img_url = None
             volume_data = None
@@ -3663,9 +3888,13 @@ def search_metadata():
                 preferred_title = selected_match.get('preferred_title')
                 alternate_title = selected_match.get('alternate_title')
                 if series_id:
-                    # Use volume number if available
+                    # Use volume number if available — unless the user picked an
+                    # exact issue, which always wins over the filename.
                     vol_match = re.search(r'\bv(\d+)', file_name, re.IGNORECASE)
-                    manga_issue = vol_match.group(1).lstrip('0') or '1' if vol_match else issue_number
+                    if chosen_issue not in (None, '') or not vol_match:
+                        manga_issue = issue_number
+                    else:
+                        manga_issue = vol_match.group(1).lstrip('0') or '1'
 
                     if provider == 'anilist':
                         from models.providers.anilist_provider import AniListProvider
@@ -3681,6 +3910,23 @@ def search_metadata():
                         preferred_title=preferred_title, alternate_title=alternate_title)
 
             if not metadata:
+                # The volume is the one the user asked for, so the issue number
+                # parsed from the filename is what's wrong (odd numbering like
+                # "1.MU", "13A", a half-issue...). Offer that volume's issues
+                # instead of dead-ending on a toast. Guarded on chosen_issue so
+                # a picked issue that still misses can't loop the picker.
+                if chosen_issue in (None, ''):
+                    picker_series_id = (selected_match.get('series_id')
+                                        or selected_match.get('volume_id'))
+                    issue_options = _issue_options_for(provider, picker_series_id)
+                    if issue_options:
+                        return jsonify(_issue_selection_response(
+                            provider, selected_match, issue_options,
+                            selected_match.get('series_name'),
+                            {"series_name": series_name,
+                             "issue_number": issue_number,
+                             "year": year},
+                        ))
                 return jsonify({"success": False, "error": "No metadata found for selection"}), 404
 
             # Apply metadata
@@ -3749,6 +3995,11 @@ def search_metadata():
 
         app_logger.info(f"[search-metadata] Provider order: {provider_order}")
 
+        # Volumes a provider identified confidently but couldn't find the issue
+        # in. Collected in priority order and only used once every provider has
+        # failed, so a provider that can satisfy the issue still wins outright.
+        near_misses = []
+
         # Try each provider in priority order
         for provider_type in provider_order:
             app_logger.info(f"[search-metadata] Trying provider: {provider_type} for {file_name}")
@@ -3760,7 +4011,8 @@ def search_metadata():
 
             if provider_type == 'metron':
                 metadata, img_url, selection_data = _try_metron_single(
-                    cvinfo_path, series_name, issue_number, year
+                    cvinfo_path, series_name, issue_number, year,
+                    near_misses=near_misses
                 )
                 if selection_data:
                     selection_data["parsed_filename"] = {
@@ -3774,7 +4026,8 @@ def search_metadata():
 
             elif provider_type == 'comicvine_sqlite':
                 metadata, img_url, volume_data, selection_data = _try_comicvine_sqlite_single(
-                    cvinfo_path, series_name, issue_number, year
+                    cvinfo_path, series_name, issue_number, year,
+                    near_misses=near_misses
                 )
                 if selection_data:
                     # Pause cascade - need user selection
@@ -3789,7 +4042,8 @@ def search_metadata():
 
             elif provider_type == 'comicvine':
                 metadata, img_url, volume_data, selection_data = _try_comicvine_single(
-                    cvinfo_path, series_name, issue_number, year
+                    cvinfo_path, series_name, issue_number, year,
+                    near_misses=near_misses
                 )
                 if selection_data:
                     # Pause cascade - need user selection
@@ -3937,15 +4191,36 @@ def search_metadata():
             app_logger.info(f"[search-metadata] {provider_type} found no results, trying next provider")
 
         # All providers exhausted
+        parsed_filename = {
+            "series_name": series_name,
+            "issue_number": issue_number,
+            "year": year
+        }
+
+        # A provider matched the series confidently but not the issue, and
+        # nothing else could fill the gap — let the user pick the issue from
+        # that volume rather than falling through to the refine-search modal.
+        for near_miss in near_misses:
+            issue_options = _issue_options_for(
+                near_miss['provider'], near_miss['selected_match'].get('series_id')
+                or near_miss['selected_match'].get('volume_id')
+            )
+            if issue_options:
+                app_logger.info(
+                    f"[search-metadata] Offering issue selection from {near_miss['provider']} "
+                    f"series '{near_miss['series_name']}' for {file_name}"
+                )
+                return jsonify(_issue_selection_response(
+                    near_miss['provider'], near_miss['selected_match'], issue_options,
+                    near_miss['series_name'], parsed_filename,
+                    provider_order=provider_order,
+                ))
+
         app_logger.info(f"[search-metadata] No metadata found from any provider for {file_name}")
         return jsonify({
             "success": False,
             "error": "No metadata found from any provider",
-            "parsed_filename": {
-                "series_name": series_name,
-                "issue_number": issue_number,
-                "year": year
-            }
+            "parsed_filename": parsed_filename
         }), 404
 
     except Exception as e:

--- a/static/js/clu-metadata.js
+++ b/static/js/clu-metadata.js
@@ -214,6 +214,11 @@
   var _cvSortNameAsc = true;
   var _cvSortYearAsc = true;
   var _cvFilterFn = null;  // Override for custom filtering (e.g., GCD API language filter)
+  var _cvRenderFn = null;  // Override for custom rendering (e.g., the issue picker)
+
+  function _renderCVList(items) {
+    (_cvRenderFn || _renderCVVolumeList)(items);
+  }
 
   function _renderCVVolumeList(volumes) {
     var volumeList = document.getElementById('cvVolumeList');
@@ -300,7 +305,10 @@
     var yearBtn = document.getElementById('cvSortByYear');
     var filterInput = document.getElementById('cvFilterInput');
 
-    // Reset UI state
+    // Reset UI state. The sort buttons are shown by default and hidden again
+    // by the issue picker, which sorts by issue number server-side.
+    var sortGroup = document.getElementById('cvSortGroup');
+    if (sortGroup) sortGroup.style.display = '';
     if (filterInput) filterInput.value = '';
     if (nameBtn) {
       nameBtn.className = 'btn btn-outline-secondary btn-sm';
@@ -329,7 +337,7 @@
         otherBtn.className = 'btn btn-outline-secondary btn-sm';
         otherBtn.querySelector('i').className = 'bi bi-sort-numeric-down me-1';
         _cvSortYearAsc = true;
-        _renderCVVolumeList((_cvFilterFn || _getFilteredVolumes)());
+        _renderCVList((_cvFilterFn || _getFilteredVolumes)());
       });
     }
     if (yearBtn) {
@@ -347,14 +355,14 @@
         otherBtn.className = 'btn btn-outline-secondary btn-sm';
         otherBtn.querySelector('i').className = 'bi bi-sort-alpha-down me-1';
         _cvSortNameAsc = true;
-        _renderCVVolumeList((_cvFilterFn || _getFilteredVolumes)());
+        _renderCVList((_cvFilterFn || _getFilteredVolumes)());
       });
     }
     if (filterInput) {
       var newFilterInput = filterInput.cloneNode(true);
       filterInput.parentNode.replaceChild(newFilterInput, filterInput);
       newFilterInput.addEventListener('input', function () {
-        _renderCVVolumeList((_cvFilterFn || _getFilteredVolumes)());
+        _renderCVList((_cvFilterFn || _getFilteredVolumes)());
       });
     }
   }
@@ -364,7 +372,10 @@
   function _removeGCDApiLangFilter() {
     var el = document.getElementById('gcdApiLangFilter');
     if (el) el.parentNode.removeChild(el);
+    // Also drops the render/filter overrides a previous open may have left
+    // behind (GCD API language filter, issue picker).
     _cvFilterFn = null;
+    _cvRenderFn = null;
     _gcdApiLangFilter = '';
   }
 
@@ -471,6 +482,15 @@
     modal.show();
   }
 
+  /**
+   * Carried into the selection follow-up so that, if the issue lookup misses
+   * and we fall back to the issue picker, "Skip to next provider" still knows
+   * where it is in the cascade.
+   */
+  function _selectionContext(data, skipProviders) {
+    return { skipProviders: skipProviders || [], providerOrder: data.provider_order };
+  }
+
   function _showCVVolumeModal(data, filePath, fileName, skipProviders) {
     _showCVStyleModal(data, filePath, fileName, skipProviders, {
       provider: 'comicvine',
@@ -480,8 +500,9 @@
         CLU.searchMetadataWithSelection(filePath, fileName, {
           provider: 'comicvine',
           volume_id: volume.id,
-          publisher_name: volume.publisher_name
-        });
+          publisher_name: volume.publisher_name,
+          series_name: volume.name
+        }, _selectionContext(data, skipProviders));
       }
     });
   }
@@ -495,8 +516,9 @@
         CLU.searchMetadataWithSelection(filePath, fileName, {
           provider: 'comicvine_sqlite',
           volume_id: volume.id,
-          publisher_name: volume.publisher_name
-        });
+          publisher_name: volume.publisher_name,
+          series_name: volume.name
+        }, _selectionContext(data, skipProviders));
       }
     });
   }
@@ -509,10 +531,157 @@
       onSelect: function (volume) {
         CLU.searchMetadataWithSelection(filePath, fileName, {
           provider: 'metron',
-          series_id: volume.id
-        });
+          series_id: volume.id,
+          series_name: volume.name
+        }, _selectionContext(data, skipProviders));
       }
     });
+  }
+
+  // ── Issue picker (reuses the ComicVine volume modal UI) ───────────────
+
+  /**
+   * Render provider issues into #cvVolumeList. Same card shape as the volume
+   * list so the modal looks identical whichever list it is showing.
+   * Covers are lazy — a long-running volume can carry hundreds of issues.
+   */
+  function _renderCVIssueList(issues) {
+    var list = document.getElementById('cvVolumeList');
+    if (!list) return;
+    list.innerHTML = '';
+
+    issues.forEach(function (issue) {
+      var item = document.createElement('div');
+      item.className = 'list-group-item list-group-item-action d-flex align-items-start';
+      item.style.cursor = 'pointer';
+
+      var thumbnailHtml;
+      if (issue.cover_url) {
+        // src is assigned as a property below — CLU.escapeHtml leaves quotes
+        // intact, so a URL is not safe to interpolate into an attribute.
+        thumbnailHtml = '<img data-issue-cover loading="lazy" ' +
+          'class="img-thumbnail me-3" style="width: 60px; height: 90px; object-fit: cover;" ' +
+          'alt="Issue ' + CLU.escapeHtml(issue.issue_number) + ' cover">';
+      } else {
+        thumbnailHtml = '<div class="me-3 d-flex align-items-center justify-content-center bg-secondary text-white" ' +
+          'style="width: 60px; height: 90px; font-size: 10px;">No Cover</div>';
+      }
+
+      var titleHtml = issue.title ?
+        '<small class="text-muted d-block">' + CLU.escapeHtml(issue.title) + '</small>' : '';
+      var dateBadge = issue.cover_date ?
+        '<span class="badge bg-success rounded-pill">' + CLU.escapeHtml(issue.cover_date) + '</span>' : '';
+
+      item.innerHTML =
+        thumbnailHtml +
+        '<div class="flex-grow-1 d-flex justify-content-between align-items-start">' +
+          '<div class="me-2">' +
+            '<div class="fw-bold">Issue #' + CLU.escapeHtml(issue.issue_number) + '</div>' +
+            titleHtml +
+          '</div>' +
+          '<div class="text-end">' + dateBadge + '</div>' +
+        '</div>';
+
+      var cover = item.querySelector('[data-issue-cover]');
+      if (cover) cover.src = issue.cover_url;
+
+      item.addEventListener('click', function () {
+        _cvClickHandler(issue);
+      });
+
+      list.appendChild(item);
+    });
+  }
+
+  function _getFilteredIssues() {
+    var filterInput = document.getElementById('cvFilterInput');
+    var filterText = (filterInput && filterInput.value || '').toLowerCase();
+    if (!filterText) return _cvVolumes;
+    return _cvVolumes.filter(function (i) {
+      return String(i.issue_number || '').toLowerCase().indexOf(filterText) !== -1 ||
+        (i.title || '').toLowerCase().indexOf(filterText) !== -1;
+    });
+  }
+
+  /**
+   * The volume is right but the issue number parsed from the filename isn't in
+   * it (odd numbering like "1.MU" or "13A"). Re-open the same modal listing
+   * that volume's issues so the user can pick the correct match.
+   *
+   * context = { skipProviders, providerOrder } — carried from the volume modal
+   * so "Skip to next provider" still works from here.
+   */
+  function _showCVIssueModal(data, filePath, fileName, context) {
+    context = context || {};
+    var issues = data.possible_issues || [];
+    var picked = false;
+    var seriesName = data.series_name ||
+      (data.selected_match && data.selected_match.series_name) || '';
+    var parsedIssue = (data.parsed_filename && data.parsed_filename.issue_number) || '';
+
+    _removeGCDApiLangFilter();
+    // Refining the series name is meaningless once the volume is settled.
+    var refineRow = document.getElementById('cvRefineSearchRow');
+    if (refineRow) refineRow.style.display = 'none';
+
+    var modalTitle = document.getElementById('comicVineVolumeModalLabel');
+    if (modalTitle) {
+      modalTitle.textContent = 'Issue #' + parsedIssue + ' not found' +
+        (seriesName ? ' in ' + seriesName : '') +
+        ' — select the correct issue (' + issues.length + ')';
+    }
+
+    var cvSeries = document.getElementById('cvParsedSeries');
+    var cvIssue = document.getElementById('cvParsedIssue');
+    var cvYear = document.getElementById('cvParsedYear');
+    if (cvSeries && data.parsed_filename) cvSeries.textContent = data.parsed_filename.series_name || '';
+    if (cvIssue) cvIssue.textContent = parsedIssue;
+    if (cvYear && data.parsed_filename) cvYear.textContent = data.parsed_filename.year || 'Unknown';
+
+    _cvVolumes = issues.slice();
+    _cvClickHandler = function (issue) {
+      picked = true;
+      var modal = bootstrap.Modal.getInstance(document.getElementById('comicVineVolumeModal'));
+      if (modal) modal.hide();
+
+      // Re-send the volume the user already chose, plus the issue they just
+      // picked. issue_number is what the backend resolves on; issue_id rides
+      // along for parity with the bulk-review payload.
+      var followUp = Object.assign({}, data.selected_match || {}, {
+        issue_number: issue.issue_number,
+        issue_id: issue.id
+      });
+      CLU.searchMetadataWithSelection(filePath, fileName, followUp, context);
+    };
+
+    _wireCVSortAndFilter();
+    // Issues arrive sorted by number — the filter box covers the rest.
+    var sortGroup = document.getElementById('cvSortGroup');
+    if (sortGroup) sortGroup.style.display = 'none';
+
+    _cvRenderFn = _renderCVIssueList;
+    _cvFilterFn = _getFilteredIssues;
+    _renderCVList(_cvVolumes);
+
+    _wireSkipButton(
+      'cvSkipProviderBtn',
+      { provider: data.provider, provider_order: data.provider_order || context.providerOrder },
+      filePath, fileName, context.skipProviders || []
+    );
+
+    var modalEl = document.getElementById('comicVineVolumeModal');
+    // Dismissing without picking resolves the file as "left alone" — the batch
+    // queue needs to know so it can move on to the next unmatched file. When an
+    // issue IS picked the follow-up request owns the resolution instead.
+    modalEl.addEventListener('hidden.bs.modal', function handler() {
+      modalEl.removeEventListener('hidden.bs.modal', handler);
+      if (!picked && typeof context.onResolved === 'function') {
+        context.onResolved({ applied: false, cancelled: true });
+      }
+    });
+
+    var modal = new bootstrap.Modal(modalEl);
+    modal.show();
   }
 
   // ── GCD API series modal (reuses ComicVine volume modal UI) ───────────
@@ -523,6 +692,7 @@
   function _showGCDApiVolumeModal(data, filePath, fileName, skipProviders) {
     // The inline refine row lets the user fix a mis-parsed series name and
     // re-search GCD API (wired below).
+    _cvRenderFn = null;  // drop the issue-picker renderer if it was left set
     var refineRow = document.getElementById('cvRefineSearchRow');
     if (refineRow) refineRow.style.display = '';
 
@@ -549,8 +719,9 @@
 
       CLU.searchMetadataWithSelection(filePath, fileName, {
         provider: 'gcd_api',
-        series_id: volume.id
-      });
+        series_id: volume.id,
+        series_name: volume.name
+      }, _selectionContext(data, skipProviders));
     };
 
     // Set custom filter function for GCD API (includes language filtering)
@@ -873,6 +1044,17 @@
       return;
     }
 
+    // A provider matched the series but not the issue, and nothing else could
+    // fill the gap — let the user pick the issue instead of dropping them into
+    // the refine-search modal.
+    if (data.requires_issue_selection) {
+      _showCVIssueModal(data, filePath, fileName, {
+        skipProviders: skipProviders,
+        providerOrder: data.provider_order
+      });
+      return;
+    }
+
     if (data.success) {
       CLU.showToast('Metadata Found', 'Metadata found via ' + data.source, 'success');
       if (typeof contract.onMetadataFound === 'function') {
@@ -972,14 +1154,17 @@
   // ── Public API: Single-file with user selection ───────────────────────
 
   /**
-   * Follow-up search after user picks a volume/series.
+   * Follow-up search after user picks a volume/series (or an issue within one).
    * @param {string} filePath
    * @param {string} fileName
-   * @param {Object} selectedMatch  { provider, volume_id, publisher_name }
+   * @param {Object} selectedMatch  { provider, volume_id, publisher_name, issue_number? }
+   * @param {Object} [context]      { skipProviders, providerOrder } — kept so the
+   *                                issue-picker fallback can still skip providers
    */
-  CLU.searchMetadataWithSelection = function (filePath, fileName, selectedMatch) {
+  CLU.searchMetadataWithSelection = function (filePath, fileName, selectedMatch, context) {
     var libraryId = _getLibraryId();
     var contract = _getContract();
+    var onResolved = (context && context.onResolved) || null;
 
     CLU.showToast('Fetching Metadata', 'Fetching metadata from ' + selectedMatch.provider + '...', 'info');
 
@@ -1005,11 +1190,18 @@
           if (typeof contract.onMetadataFound === 'function') {
             contract.onMetadataFound(filePath, data);
           }
+          if (onResolved) onResolved({ applied: true });
+        } else if (data.requires_issue_selection) {
+          // Right volume, wrong issue number — let the user pick the issue
+          // rather than dead-ending on an error toast. The picker owns
+          // resolution from here (it carries the same context).
+          _showCVIssueModal(data, filePath, fileName, context);
         } else {
           CLU.showToast('Metadata Error', data.error || 'No metadata found for selection', 'error');
           if (typeof contract.onMetadataError === 'function') {
             contract.onMetadataError(filePath, data.error);
           }
+          if (onResolved) onResolved({ applied: false });
         }
       })
       .catch(function (error) {
@@ -1018,7 +1210,120 @@
         if (typeof contract.onMetadataError === 'function') {
           contract.onMetadataError(filePath, error.message);
         }
+        if (onResolved) onResolved({ applied: false });
       });
+  };
+
+  // ── Public API: Resolve a batch run's unmatched issues ────────────────
+  //
+  // The folder batch reports files whose series it identified but whose issue
+  // number never resolved (odd numbering like "003 [23]"). Rather than teaching
+  // the parser every scheme, we show the user that volume's issue list and let
+  // them pick — one file at a time, one issue-list fetch per volume.
+
+  /**
+   * Run `fn` once no Bootstrap modal is on screen, so pickers never stack (and
+   * never open mid-transition, which strands a backdrop). Polls rather than
+   * listening for `hidden.bs.modal`: Bootstrap drops `.modal.show` at the START
+   * of the hide animation while `body.modal-open` survives until it finishes,
+   * and a modal opened behind this one has no event we could have subscribed to.
+   */
+  function _whenModalsClosed(fn, attempts) {
+    attempts = attempts || 0;
+    var busy = document.querySelector('.modal.show') ||
+      document.body.classList.contains('modal-open');
+    // ~10s backstop — never strand the queue on a modal that won't close.
+    if (!busy || attempts > 100) {
+      fn();
+      return;
+    }
+    setTimeout(function () { _whenModalsClosed(fn, attempts + 1); }, 100);
+  }
+
+  function _fetchProviderIssues(provider, seriesId) {
+    return fetch('/api/provider-issues', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: provider, series_id: seriesId })
+    })
+      .then(function (response) { return response.json(); })
+      .then(function (data) { return (data && data.issues) || []; })
+      .catch(function (error) {
+        console.error('Provider issue list error:', error);
+        return [];
+      });
+  }
+
+  /**
+   * Walk a batch run's `unmatched` entries, offering an issue picker for each.
+   * @param {Array} entries  [{file, file_path, issue_number, provider, series_name, selected_match}]
+   */
+  CLU.resolveUnmatchedIssues = function (entries) {
+    entries = (entries || []).filter(function (e) {
+      return e && e.file_path && e.selected_match;
+    });
+    if (!entries.length) return;
+
+    var index = 0;
+    var applied = 0;
+    var issueCache = {};  // provider+series -> issue list, fetched once
+
+    CLU.showToast(
+      'Issue Not Matched',
+      entries.length + ' file(s) matched a series but not an issue — pick the right issue for each.',
+      'warning'
+    );
+
+    function finish() {
+      if (applied > 0) {
+        CLU.showToast('Metadata Applied', 'Applied metadata to ' + applied + ' file(s).', 'success');
+      }
+    }
+
+    function next() {
+      if (index >= entries.length) {
+        finish();
+        return;
+      }
+      var entry = entries[index++];
+      var seriesId = entry.selected_match.series_id || entry.selected_match.volume_id;
+      var cacheKey = entry.provider + ':' + seriesId;
+
+      var lookup = issueCache[cacheKey] ?
+        Promise.resolve(issueCache[cacheKey]) :
+        _fetchProviderIssues(entry.provider, seriesId).then(function (issues) {
+          issueCache[cacheKey] = issues;
+          return issues;
+        });
+
+      lookup.then(function (issues) {
+        if (!issues.length) {
+          // Nothing to choose from — skip this file rather than show an empty list.
+          next();
+          return;
+        }
+        _whenModalsClosed(function () {
+          _showCVIssueModal({
+            provider: entry.provider,
+            selected_match: entry.selected_match,
+            series_name: entry.series_name,
+            possible_issues: issues,
+            parsed_filename: {
+              series_name: entry.series_name,
+              issue_number: entry.issue_number,
+              year: null
+            }
+          }, entry.file_path, entry.file, {
+            onResolved: function (outcome) {
+              if (outcome && outcome.applied) applied++;
+              next();
+            }
+          });
+        });
+      });
+    }
+
+    next();
   };
 
   // ── Public API: Directory batch metadata ──────────────────────────────
@@ -1070,6 +1375,8 @@
           if (typeof contract.onBatchComplete === 'function') {
             contract.onBatchComplete(dirPath, result);
           }
+
+          CLU.resolveUnmatchedIssues(result.unmatched);
         });
       })
       .catch(function (error) {
@@ -1123,6 +1430,8 @@
           if (typeof contract.onBatchComplete === 'function') {
             contract.onBatchComplete(dirPath, result);
           }
+
+          CLU.resolveUnmatchedIssues(result.unmatched);
         });
       })
       .catch(function (error) {

--- a/templates/partials/modal_metadata_select.html
+++ b/templates/partials/modal_metadata_select.html
@@ -78,7 +78,7 @@
             <div class="d-flex align-items-center gap-2">
               <input type="text" class="form-control form-control-sm" id="cvFilterInput"
                 placeholder="Filter..." style="width: 150px;">
-              <div class="btn-group" role="group" aria-label="Sort options">
+              <div class="btn-group" role="group" aria-label="Sort options" id="cvSortGroup">
                 <button type="button" class="btn btn-outline-secondary btn-sm" id="cvSortByName">
                   <i class="bi bi-sort-alpha-down me-1"></i>Name
                 </button>

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1398,3 +1398,329 @@ class TestComicVineSqliteRoutes:
         assert data2['success'] is True
         assert data2['source'] == 'comicvine_sqlite'
         assert data2['metadata']['Writer'] == 'Bob Kane'
+
+
+class TestIssueSelectionFallback:
+    """The volume is right but the issue number isn't in it.
+
+    Rather than dead-ending on "No metadata found for selection", the route
+    hands back that volume's issue list so the user can pick the right match.
+    """
+
+    def _isolate_to_cv_sqlite(self, stack, client, db_path):
+        return TestComicVineSqliteRoutes()._isolate_to_cv_sqlite(stack, client, db_path)
+
+    def _cbz(self, tmp_path, name):
+        cbz = tmp_path / name
+        _make_cbz(str(cbz), with_comicinfo=False)
+        return str(cbz)
+
+    # Volume 4050 in the fixture holds exactly one issue, #1, so a file
+    # claiming #2 is the natural "odd issue number" case.
+    def test_volume_pick_offers_issue_list(self, client, tmp_path):
+        from contextlib import ExitStack
+        from tests.mocked.conftest import build_comicvine_sqlite
+        db = build_comicvine_sqlite(tmp_path / "cv.db")
+        cbz = self._cbz(tmp_path, "Batman 002.cbz")
+
+        with ExitStack() as stack:
+            self._isolate_to_cv_sqlite(stack, client, db)
+            resp = client.post('/api/search-metadata', json={
+                'file_path': cbz,
+                'file_name': 'Batman 002.cbz',
+                'selected_match': {
+                    'provider': 'comicvine_sqlite',
+                    'volume_id': 4050,
+                    'publisher_name': 'DC Comics',
+                    'series_name': 'Batman',
+                },
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is False
+        assert data['requires_issue_selection'] is True
+        assert data['provider'] == 'comicvine_sqlite'
+        assert data['series_name'] == 'Batman'
+        assert data['parsed_filename']['issue_number'] == '2'
+        # The chosen volume is echoed back so the client can re-send it verbatim.
+        assert data['selected_match']['volume_id'] == 4050
+        assert [i['issue_number'] for i in data['possible_issues']] == ['1']
+        issue = data['possible_issues'][0]
+        assert issue['title'] == 'The Beginning'
+        assert issue['cover_date'] == '2016-06-01'
+
+    def test_issue_pick_applies_metadata(self, client, tmp_path):
+        from contextlib import ExitStack
+        from tests.mocked.conftest import build_comicvine_sqlite
+        db = build_comicvine_sqlite(tmp_path / "cv.db")
+        cbz = self._cbz(tmp_path, "Batman 002.cbz")
+
+        with ExitStack() as stack:
+            self._isolate_to_cv_sqlite(stack, client, db)
+            resp = client.post('/api/search-metadata', json={
+                'file_path': cbz,
+                'file_name': 'Batman 002.cbz',
+                'selected_match': {
+                    'provider': 'comicvine_sqlite',
+                    'volume_id': 4050,
+                    'publisher_name': 'DC Comics',
+                    'issue_number': '1',
+                },
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is True
+        assert data['source'] == 'comicvine_sqlite'
+        # The user's issue choice wins over the "2" parsed from the filename.
+        assert data['metadata']['Number'] == '1'
+        assert data['metadata']['Writer'] == 'Bob Kane'
+
+    def test_explicit_issue_miss_does_not_loop(self, client, tmp_path):
+        """A picked issue that still misses must 404, not re-open the picker."""
+        from contextlib import ExitStack
+        from tests.mocked.conftest import build_comicvine_sqlite
+        db = build_comicvine_sqlite(tmp_path / "cv.db")
+        cbz = self._cbz(tmp_path, "Batman 002.cbz")
+
+        with ExitStack() as stack:
+            self._isolate_to_cv_sqlite(stack, client, db)
+            resp = client.post('/api/search-metadata', json={
+                'file_path': cbz,
+                'file_name': 'Batman 002.cbz',
+                'selected_match': {
+                    'provider': 'comicvine_sqlite',
+                    'volume_id': 4050,
+                    'issue_number': '999',
+                },
+            })
+
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert 'requires_issue_selection' not in data
+        assert data['error'] == 'No metadata found for selection'
+
+    def test_no_issue_list_keeps_original_404(self, client, tmp_path):
+        from contextlib import ExitStack
+        from tests.mocked.conftest import build_comicvine_sqlite
+        db = build_comicvine_sqlite(tmp_path / "cv.db")
+        cbz = self._cbz(tmp_path, "Batman 002.cbz")
+
+        with ExitStack() as stack:
+            self._isolate_to_cv_sqlite(stack, client, db)
+            stack.enter_context(patch("routes.metadata._issue_options_for", return_value=[]))
+            resp = client.post('/api/search-metadata', json={
+                'file_path': cbz,
+                'file_name': 'Batman 002.cbz',
+                'selected_match': {'provider': 'comicvine_sqlite', 'volume_id': 4050},
+            })
+
+        assert resp.status_code == 404
+        assert resp.get_json()['error'] == 'No metadata found for selection'
+
+    def test_cascade_near_miss_offers_issue_list(self, app, client):
+        """Series matched confidently, issue missing, no other provider helped."""
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            TestSearchMetadataMetronSelection()._metron_only(app, stack)
+            stack.enter_context(patch("models.metron.search_series_list", return_value=[
+                {"id": 5, "name": "Batman", "start_year": 2016},
+            ]))
+            stack.enter_context(patch("models.metron.get_issue_metadata", return_value=None))
+            stack.enter_context(patch("routes.metadata._issue_options_for", return_value=[
+                {"id": "77", "issue_number": "1.MU", "title": "Monsters Unleashed",
+                 "cover_date": "2017-03-01", "cover_url": None},
+            ]))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['requires_issue_selection'] is True
+        assert data['provider'] == 'metron'
+        assert data['series_name'] == 'Batman'
+        assert data['selected_match'] == {'provider': 'metron', 'series_id': 5}
+        assert data['provider_order'] == ['metron']
+        assert data['possible_issues'][0]['issue_number'] == '1.MU'
+
+    def test_cascade_without_near_miss_still_404s(self, app, client):
+        """No provider identified a series — the plain 404 path is unchanged."""
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            TestSearchMetadataMetronSelection()._metron_only(app, stack)
+            stack.enter_context(patch("models.metron.search_series_list", return_value=[]))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Batman 001 (2020).cbz',
+                'file_name': 'Batman 001 (2020).cbz',
+            })
+
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert 'requires_issue_selection' not in data
+        assert data['parsed_filename']['series_name'] == 'Batman'
+
+
+def _sse_complete_result(body):
+    """Pull the `complete` event's result payload out of an SSE response body."""
+    for line in body.splitlines():
+        if not line.startswith('data: '):
+            continue
+        event = json.loads(line[len('data: '):])
+        if event.get('type') == 'complete':
+            return event['result']
+    raise AssertionError('no complete event in SSE body')
+
+
+class TestBatchUnmatchedIssues:
+    """The folder batch knows the series from cvinfo; when the issue number
+    doesn't resolve ("003 [23]"), it queues the file for an issue picker rather
+    than reporting a bare 'not found'."""
+
+    def _batch_stack(self, app, stack, providers):
+        app.config["COMICVINE_API_KEY"] = "k"
+        stack.enter_context(patch("routes.metadata.is_valid_library_path", return_value=True))
+        stack.enter_context(patch("app.get_target_dir_live", return_value="/nonexistent_target"))
+        stack.enter_context(patch("core.database.get_library_providers", return_value=providers))
+        stack.enter_context(patch("models.metron.get_flask_api", return_value=None))
+        stack.enter_context(patch("models.metron.is_connection_error", return_value=False))
+        stack.enter_context(patch("models.comicvine.get_volume_details", return_value={}))
+        stack.enter_context(patch("models.comicvine.read_cvinfo_fields",
+                                  return_value={"start_year": 1951, "publisher_name": "Harvey"}))
+
+    def _folder(self, tmp_path, filename="Chamber of Chills 003 [23] (1951).cbz"):
+        folder = tmp_path / "Chamber of Chills (1951)"
+        folder.mkdir()
+        (folder / "cvinfo").write_text("https://comicvine.gamespot.com/volume/4050-1487/")
+        _make_cbz(str(folder / filename), with_comicinfo=False)
+        return folder
+
+    def test_unmatched_issue_is_queued_for_selection(self, app, client, tmp_path):
+        from contextlib import ExitStack
+        folder = self._folder(tmp_path)
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack, [{"provider_type": "comicvine", "enabled": True}])
+            stack.enter_context(patch("models.comicvine.get_metadata_by_volume_id",
+                                      return_value=None))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+            body = resp.get_data(as_text=True)
+
+        result = _sse_complete_result(body)
+        assert result['errors'] == 1
+        assert len(result['unmatched']) == 1
+        entry = result['unmatched'][0]
+        assert entry['provider'] == 'comicvine'
+        assert entry['issue_number'] == '3'
+        assert entry['file'] == 'Chamber of Chills 003 [23] (1951).cbz'
+        assert entry['file_path'].endswith('Chamber of Chills 003 [23] (1951).cbz')
+        assert entry['selected_match'] == {
+            'provider': 'comicvine', 'volume_id': 1487, 'publisher_name': 'Harvey',
+        }
+        assert result['details'][0]['can_select_issue'] is True
+        assert result['details'][0]['reason'] == 'issue not found'
+
+    def test_unknown_series_is_not_queued(self, app, client, tmp_path):
+        """No provider identified a volume — nothing to pick from, so no queue."""
+        from contextlib import ExitStack
+        folder = tmp_path / "Nowhere (1951)"
+        folder.mkdir()
+        _make_cbz(str(folder / "Nowhere 003 (1951).cbz"), with_comicinfo=False)
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack, [{"provider_type": "comicvine", "enabled": True}])
+            stack.enter_context(patch("models.comicvine.search_volumes", return_value=[]))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+            body = resp.get_data(as_text=True)
+
+        result = _sse_complete_result(body)
+        assert result['unmatched'] == []
+        assert 'can_select_issue' not in result['details'][0]
+
+    def test_successful_match_queues_nothing(self, app, client, tmp_path):
+        from contextlib import ExitStack
+        folder = self._folder(tmp_path, filename="Chamber of Chills 003 (1951).cbz")
+
+        with ExitStack() as stack:
+            self._batch_stack(app, stack, [{"provider_type": "comicvine", "enabled": True}])
+            stack.enter_context(patch("models.comicvine.get_metadata_by_volume_id",
+                                      return_value={"Series": "Chamber of Chills", "Number": "3"}))
+            stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+            stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+            resp = client.post('/api/batch-metadata', json={
+                'directory': str(folder), 'library_id': 1,
+            })
+            body = resp.get_data(as_text=True)
+
+        result = _sse_complete_result(body)
+        assert result['processed'] == 1
+        assert result['unmatched'] == []
+
+
+class TestProviderIssuesRoute:
+    """/api/provider-issues backs the batch issue picker."""
+
+    def test_requires_provider_and_series(self, client):
+        assert client.post('/api/provider-issues', json={}).status_code == 400
+        assert client.post('/api/provider-issues',
+                           json={'provider': 'metron'}).status_code == 400
+
+    def test_returns_issue_list(self, client):
+        issues = [{"id": "1", "issue_number": "23", "title": "The Thing",
+                   "cover_date": "1951-06-01", "cover_url": None}]
+        with patch("routes.metadata._issue_options_for", return_value=issues) as opts:
+            resp = client.post('/api/provider-issues',
+                               json={'provider': 'comicvine', 'series_id': 1487})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is True
+        assert data['issues'] == issues
+        opts.assert_called_once_with('comicvine', 1487)
+
+    def test_unavailable_provider_returns_empty_list(self, client):
+        """A provider that can't list issues is not an error — just no picker."""
+        with patch("routes.metadata._issue_options_for", return_value=[]):
+            resp = client.post('/api/provider-issues',
+                               json={'provider': 'gcd', 'series_id': 9})
+
+        assert resp.status_code == 200
+        assert resp.get_json()['issues'] == []
+
+
+class TestIssueOptionsFor:
+    """Unit coverage for the issue-list helper behind the picker."""
+
+    def test_unknown_provider_returns_empty(self):
+        from routes.metadata import _issue_options_for
+        assert _issue_options_for('nope', 1) == []
+        assert _issue_options_for('metron', None) == []
+
+    def test_provider_failure_returns_empty_not_raise(self):
+        from routes.metadata import _issue_options_for
+        with patch("models.comicvine_source.get_all_issues_for_volume",
+                   side_effect=RuntimeError("boom")):
+            assert _issue_options_for('comicvine', 4050) == []
+
+    def test_sorted_numerically_and_blank_numbers_dropped(self):
+        from routes.metadata import _issue_options_for
+        raw = [
+            {"cv_id": 3, "number": "10", "name": None},
+            {"cv_id": 1, "number": "2", "name": None},
+            {"cv_id": 4, "number": "", "name": None},
+            {"cv_id": 5, "number": "Annual 1", "name": None},
+            {"cv_id": 2, "number": "2.1", "name": None},
+        ]
+        with patch("models.comicvine_source.get_all_issues_for_volume", return_value=raw):
+            options = _issue_options_for('comicvine', 4050)
+
+        # Numeric issues sort ascending; non-numeric ones trail behind.
+        assert [o['issue_number'] for o in options] == ['2', '2.1', '10', 'Annual 1']


### PR DESCRIPTION
## Problem

Applying metadata resolves the issue by **exact number** against the chosen volume. Odd numbering means the volume is right but the issue is never found — and both flows dead-ended:

- **Single file**: after picking from "Please select the correct volume:", the modal closes and the user gets a red `No metadata found for selection` toast. Nothing to act on.
- **Folder batch**: a bare `not found`, even when cvinfo already pinned the series:

```
Processing Chamber of Chills 003 [23] (1951).cbz (issue/vol #3)
Metron API: searching issue #3 in series 6677
Issue 3 not found in Metron series 6677
Searching for issue #3 in volume 1487 (year: None)
No issues found for volume 1487, issue #3
GCD API: Issue #3 not found in series 885 (Chamber of Chills Magazine)
No metadata found for Chamber of Chills 003 [23] (1951).cbz
```

That file is issue #3 of the reprint numbering but #23 in the provider's. Others hit the same wall: `1.MU`, `13A`, half-issues, dumps that store `0.5` where the file says `000.5`.

Rather than teaching the parser every numbering scheme, **show the volume's issues and let the user pick**.

## What changed

### Backend — `routes/metadata.py`

- **`_issue_options_for(provider, series_id)`** lists a volume's issues as `{id, issue_number, title, cover_date, cover_url}`, sorted numerically. ComicVine goes through `models/comicvine_source.py`, which paginates and prefers the local dump; `ComicVineProvider.get_issues` makes one unpaginated call and silently caps at ~100 issues. Never raises — a provider outage just means no picker, not a 500.
- The selection follow-up honours **`selected_match.issue_number`** and clears `year`, which the ComicVine API path would otherwise use to filter out the very issue the user just picked. No new per-provider lookup code: the number comes from the provider's own list, so the existing by-number resolvers match exactly.
- The post-selection 404 becomes a **`requires_issue_selection`** payload when a list is available — guarded on `chosen_issue`, so a picked issue that still misses 404s instead of looping.
- **Near misses**: a provider that identified a concrete volume but no issue is recorded. Only consulted once every provider has failed, so a provider that *can* satisfy the issue still wins outright. The ComicVine worker thread keeps its own list so an abandoned timed-out lookup can't inject a stale one.
- The **folder batch** records the same near misses and reports them as `result.unmatched`; new `POST /api/provider-issues` serves the issue list once per volume so a 20-file folder doesn't repeat the lookup 20 times.

### Frontend — `static/js/clu-metadata.js` (+ one `id` on the modal partial)

- **`_showCVIssueModal`** reuses `#comicVineVolumeModal`: same card layout, filter box matching issue number or title, refine row and sort buttons hidden, covers lazy-loaded. Routed from both the selection follow-up and the cascade response, so skip-to-next-provider and inline refine get it for free.
- Rendering is now swappable via `_cvRenderFn`, mirroring the `_cvFilterFn` override the GCD-API language filter already uses.
- **`CLU.resolveUnmatchedIssues`** walks a batch run's unmatched files one at a time after the run completes, caching the issue list per volume. `_whenModalsClosed` polls rather than listening for `hidden.bs.modal` — Bootstrap drops `.modal.show` at the *start* of the hide animation, so an event-driven advance opens the next picker mid-transition and strands a backdrop.
- Fixes a latent trap: the manga branch derived its issue from the filename's `vNN` and would have discarded a user-picked issue.

## Scope

Single-file path covers the four providers that already share this modal — Metron, ComicVine, ComicVine (Local DB), GCD API. The batch path additionally covers GCD MySQL. GCD API returns issue numbers with no titles/dates/covers, so its picker is a bare numbered list. The bulk-review wizard already has its own `issue_ambiguous` picker and is untouched.

## Testing

`TestIssueSelectionFallback`, `TestBatchUnmatchedIssues`, `TestProviderIssuesRoute`, `TestIssueOptionsFor` — covering the volume-pick → picker → apply round trip, the no-loop guard, both preserved 404 paths, the cascade near miss, and the `003 [23]` batch case end to end.

**Full suite: 3480 passed, 6 skipped** (the usual POSIX-only skips).

Not yet exercised against live providers — the Metron and GCD-API issue lists are covered by mocks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
