### PR TITLE
Make the series page Refresh button actually refresh from Metron

### DIFF
--- a/models/metron.py
+++ b/models/metron.py
@@ -277,6 +277,72 @@ def invalidate_session_cache() -> None:
     _metron_pacer.reset()
 
 
+def purge_series_cache(series_id, api=None) -> int:
+    """Drop mokkari's cached responses for one series so the next call re-fetches.
+
+    ``Session._get`` consults ``SqliteCache`` *before* dispatching, and
+    ``SqliteCache.get()`` never checks the ``expire`` column (see
+    ``_metron_cache``), so a user-initiated "refresh from Metron" that only
+    bypasses CLU's own database still gets whatever Metron returned the first
+    time this process asked. A Summary edited on Metron would then never appear.
+    Worse, ``store()`` is a plain INSERT and ``get()`` returns the first row, so
+    a later fetch cannot overwrite the stale one -- it has to be deleted.
+
+    Args:
+        series_id: Metron series id whose cached responses should be dropped.
+        api: Optional Session to purge; defaults to every cached session.
+
+    Returns:
+        Number of cached rows removed.
+    """
+    try:
+        series_id = int(series_id)
+    except (TypeError, ValueError):
+        return 0
+
+    # The series detail response, plus the paged issue lists filtered by it.
+    detail_re = re.compile(rf"/series/{series_id}/?(?:\?|$)")
+    issues_re = re.compile(rf"[?&]series_id={series_id}(?:&|$)")
+
+    removed = 0
+    seen: List[Any] = []
+    for session in [api] if api is not None else _cached_sessions():
+        cache = getattr(session, "cache", None)
+        con = getattr(cache, "con", None)
+        if con is None or any(cache is c for c in seen):
+            continue
+        seen.append(cache)
+        lock = getattr(cache, "_lock", None) or threading.Lock()
+        try:
+            with lock:
+                rows = con.execute(
+                    "SELECT key FROM responses WHERE key LIKE ? OR key LIKE ?",
+                    (f"%/series/{series_id}%", f"%series_id={series_id}%"),
+                ).fetchall()
+                # LIKE can't tell 8859 from 88591; the regexes decide.
+                keys = [
+                    row[0]
+                    for row in rows
+                    if detail_re.search(row[0]) or issues_re.search(row[0])
+                ]
+                if keys:
+                    con.executemany(
+                        "DELETE FROM responses WHERE key = ?", [(k,) for k in keys]
+                    )
+                    con.commit()
+            removed += len(keys)
+        except Exception as e:
+            app_logger.warning(
+                f"Could not purge Metron response cache for series {series_id}: {e}"
+            )
+
+    if removed:
+        app_logger.info(
+            f"Purged {removed} cached Metron responses for series {series_id}"
+        )
+    return removed
+
+
 def _handle_rate_limit(e: "RateLimitError", attempt: int, context: str) -> bool:
     """Sleep and signal whether to retry after a RateLimitError.
 

--- a/routes/series.py
+++ b/routes/series.py
@@ -672,6 +672,13 @@ def series_view(slug):
                 flash("Metron API not configured", "error")
                 return redirect(url_for(".releases"))
 
+    # Skipping CLU's own cache isn't enough: mokkari answers api.series() from
+    # its response cache, which never expires on read, so the refetch below
+    # would replay the same body and fields edited on Metron (the Summary most
+    # visibly) would never change. Drop this series' cached responses first.
+    if force_refresh and api is not None:
+        metron.purge_series_cache(series_id, api=api)
+
     try:
         if use_cache and cached_series:
             app_logger.info(f"Loading series {series_id} from cache")
@@ -1587,16 +1594,21 @@ def sync_series(series_id):
         series_mapping = get_series_by_id(series_id)
         mapped_path = series_mapping.get("mapped_path") if series_mapping else None
 
+        # An explicit sync must reach Metron, not mokkari's response cache,
+        # which serves stale bodies until the process restarts.
+        metron.purge_series_cache(series_id, api=api)
+
         series_info = api.series(series_id)
         if not series_info:
             return jsonify({"error": "Series not found"}), 404
 
-        # Check if API has desc and database desc is blank - update if so
+        # Take the API's description whenever it differs — a Summary edited on
+        # Metron has to land here, not only fill a blank one.
         api_desc = getattr(series_info, "desc", None) or (
             series_info.get("desc") if isinstance(series_info, dict) else None
         )
         db_desc = series_mapping.get("desc") if series_mapping else None
-        if api_desc and not db_desc:
+        if api_desc and api_desc != db_desc:
             update_series_desc(series_id, api_desc)
             app_logger.info(f"Updated description for series {series_id}")
 

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -136,6 +136,99 @@ class TestSessionCache:
         invalidate_session_cache()  # must not raise
 
 
+class TestPurgeSeriesCache:
+    """A user-initiated refresh has to reach Metron, not mokkari's cache.
+
+    ``SqliteCache.get()`` never checks the expire column and ``store()`` is a
+    plain INSERT whose row ``get()`` returns first, so a body cached once is
+    replayed for the life of the process unless its rows are deleted.
+    """
+
+    SERIES_URL = "https://metron.cloud/api/series/8859/"
+    ISSUES_URL = "https://metron.cloud/api/issue/?page=1&series_id=8859"
+
+    def _session_with_cache(self, tmp_path):
+        from mokkari.sqlite_cache import SqliteCache
+
+        cache = SqliteCache(db_name=str(tmp_path / "mokkari_cache.db"), expire=1)
+        return SimpleNamespace(cache=cache), cache
+
+    def test_drops_series_and_issue_rows(self, tmp_path):
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.SERIES_URL, {"desc": "old summary"})
+        cache.store(self.ISSUES_URL, {"results": []})
+
+        assert purge_series_cache(8859, api=session) == 2
+        assert cache.get(self.SERIES_URL) is None
+        assert cache.get(self.ISSUES_URL) is None
+
+    def test_leaves_other_series_alone(self, tmp_path):
+        """LIKE '%series_id=8859%' also matches 88591 -- only the regex saves us."""
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        other_detail = "https://metron.cloud/api/series/88591/"
+        other_issues = "https://metron.cloud/api/issue/?page=1&series_id=88591"
+        cache.store(self.SERIES_URL, {"desc": "old summary"})
+        cache.store(other_detail, {"desc": "different series"})
+        cache.store(other_issues, {"results": []})
+
+        assert purge_series_cache(8859, api=session) == 1
+        assert cache.get(other_detail) == {"desc": "different series"}
+        assert cache.get(other_issues) == {"results": []}
+
+    def test_drops_every_duplicate_row_for_a_key(self, tmp_path):
+        """store() appends, so one leftover row keeps serving the stale body."""
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.SERIES_URL, {"desc": "old summary"})
+        cache.store(self.SERIES_URL, {"desc": "older still"})
+
+        assert purge_series_cache(8859, api=session) == 2
+        assert cache.get(self.SERIES_URL) is None
+
+    def test_next_fetch_sees_the_new_body(self, tmp_path):
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.SERIES_URL, {"desc": "old summary"})
+        purge_series_cache(8859, api=session)
+        cache.store(self.SERIES_URL, {"desc": "new summary"})
+
+        assert cache.get(self.SERIES_URL) == {"desc": "new summary"}
+
+    def test_session_without_a_cache_is_a_no_op(self):
+        from models.metron import purge_series_cache
+
+        assert purge_series_cache(8859, api=SimpleNamespace(cache=None)) == 0
+
+    def test_non_numeric_series_id_is_a_no_op(self, tmp_path):
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.SERIES_URL, {"desc": "old summary"})
+
+        assert purge_series_cache("not-an-id", api=session) == 0
+        assert cache.get(self.SERIES_URL) == {"desc": "old summary"}
+
+    @patch("models.metron.MokkariSession")
+    def test_defaults_to_every_cached_session(self, mock_session_class, tmp_path):
+        from models.metron import get_api, invalidate_session_cache, purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.SERIES_URL, {"desc": "old summary"})
+        mock_session_class.return_value = session
+        invalidate_session_cache()
+        get_api("user", "pass")
+
+        assert purge_series_cache(8859) == 1
+        assert cache.get(self.SERIES_URL) is None
+        invalidate_session_cache()
+
+
 class TestIsConnectionError:
 
     def test_timeout_detected(self):

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -637,6 +637,101 @@ class TestSeriesPageSearchYear:
         assert "searchGetComics(this.dataset.series, this.dataset.issue, this.dataset.year)" in html
 
 
+class _MetronSeries:
+    """Stand-in for the mokkari Series model the route gets back from Metron."""
+
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+    def model_dump(self, mode=None):
+        return dict(self.__dict__)
+
+
+class TestSeriesPageForceRefresh:
+    """The page's Refresh button (?refresh=1) has to show what Metron holds now.
+
+    Skipping CLU's own cache isn't enough: mokkari answers api.series() from its
+    own SQLite response cache, which never expires on read, so without a purge
+    the refetch replays the old body and an edited Summary never appears.
+    """
+
+    @staticmethod
+    def _register_slug_global(app):
+        app.jinja_env.globals["generate_series_slug"] = (
+            lambda name, sid, volume=None: f"{sid}-slug"
+        )
+
+    @patch("routes.series.metron")
+    def test_purges_response_cache_before_refetching(
+        self, mock_metron, app, client_with_data
+    ):
+        self._register_slug_global(app)
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+
+        calls = []
+        mock_api = MagicMock()
+
+        def _series(series_id):
+            calls.append("fetch")
+            return _MetronSeries(
+                id=series_id,
+                name="Batman",
+                desc="Summary edited on Metron",
+                volume=2020,
+                status="Ongoing",
+                issue_count=3,
+                year_began=2020,
+                year_end=None,
+            )
+
+        mock_api.series.side_effect = _series
+        mock_metron.get_flask_api.return_value = mock_api
+        mock_metron.is_connection_error.return_value = False
+        mock_metron.get_all_issues_for_series.return_value = []
+        mock_metron.purge_series_cache.side_effect = lambda *a, **k: calls.append("purge")
+
+        resp = client_with_data.get("/series/batman-v2020-100?refresh=1")
+
+        assert resp.status_code == 200
+        mock_metron.purge_series_cache.assert_called_once_with(100, api=mock_api)
+        # Purging after the fetch would be useless.
+        assert calls == ["purge", "fetch"]
+        assert "Summary edited on Metron" in resp.get_data(as_text=True)
+
+    @patch("routes.series.metron")
+    def test_normal_load_keeps_the_cache(self, mock_metron, app, client_with_data):
+        """Without ?refresh=1 the page serves the DB copy and touches neither
+        Metron nor its cache."""
+        self._register_slug_global(app)
+
+        resp = client_with_data.get("/series/batman-v2020-100")
+
+        assert resp.status_code == 200
+        mock_metron.purge_series_cache.assert_not_called()
+
+
+class TestSyncSeriesDescription:
+
+    @patch("routes.series.metron")
+    def test_sync_purges_cache_and_updates_changed_desc(
+        self, mock_metron, client_with_data
+    ):
+        from core.database import get_series_by_id
+
+        mock_api = MagicMock()
+        mock_api.series.return_value = {"id": 100, "desc": "Rewritten summary"}
+        mock_metron.get_flask_api.return_value = mock_api
+        mock_metron.get_all_issues_for_series.return_value = []
+
+        resp = client_with_data.post("/api/sync/series/100")
+
+        assert resp.status_code == 200
+        mock_metron.purge_series_cache.assert_called_once_with(100, api=mock_api)
+        # The seeded row already had a description; a changed one must still land.
+        assert get_series_by_id(100)["desc"] == "Rewritten summary"
+
+
 class TestWantedPage:
     """The /wanted page seeds each search with the issue's own year — without
     it "Iron Man 8" matches every volume that ever had an #8."""


### PR DESCRIPTION
## Problem

On a series page, **Refresh** calls `forceRefresh()`, which sets `?refresh=1` and reloads — but the description in `<p class="lead">` never picked up a Summary edited on Metron.

`?refresh=1` only bypasses *CLU's* cache (`get_series_by_id`). The refetch then goes through `mokkari.Session._get`, which consults its own SQLite response cache **before** dispatching. That cache is stale-forever in practice:

- `SqliteCache.get()` never checks the `expire` column — expiry only runs in `cleanup()`, which mokkari calls once, in `__init__`. With CLU's process-shared session the effective TTL is `expire + process uptime`.
- `store()` is a plain `INSERT` and `get()` returns the first row, so a later fetch can't even overwrite the stale body.

So `api.series(id)` replayed whatever Metron returned the first time this process asked.

**API Sync** had a second, independent version of the same symptom: it only wrote the description `if api_desc and not db_desc` — it filled a *blank* description and never updated a changed one.

## Changes

- `models/metron.py` — new `purge_series_cache(series_id, api=None)`: deletes the cached rows for a series' detail endpoint and its `series_id=`-filtered issue lists. SQL `LIKE` narrows the scan, regexes decide (`LIKE '%series_id=8859%'` also matches `88591`). Degrades to a logged warning, never raises.
- `routes/series.py` — the series page purges before refetching when `force_refresh` is set.
- `routes/series.py` — API Sync purges too, and takes the API's description whenever it differs from the stored one.

## Tests

7 new in `tests/mocked/test_metron_model.py`, against a real `SqliteCache`:
- series detail + issue-list rows dropped
- lookalike ids (`88591` vs `8859`) left alone
- every duplicate row for a key removed, so the next `store()` is what `get()` returns
- no-cache session and non-numeric id are no-ops
- defaults to purging every cached session

3 new in `tests/routes/test_series_routes.py`:
- `?refresh=1` purges *before* the fetch (call order asserted) and the new summary renders
- a normal load touches neither Metron nor its cache
- sync purges and updates an already-populated description

Full suite: 3490 passed, 6 skipped (the usual POSIX skips).

## Note

`forceRefresh()` leaves `?refresh=1` in the address bar, so reloading that URL keeps burning a real Metron request. Left as-is — happy to make it redirect back to the clean URL in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
