### PR TITLE
Keep the Browse Library pager reachable without scrolling to the bottom

### DIFF
--- a/static/css/collection.css
+++ b/static/css/collection.css
@@ -31,6 +31,8 @@
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
     gap: 1.5rem;
     padding: 1rem 0;
+    /* Breathing room when changePage() jumps the viewport back to the first row */
+    scroll-margin-top: 1rem;
 }
 
 .grid-item {
@@ -291,6 +293,122 @@
 
     to {
         opacity: 0;
+    }
+}
+
+/* ---- Sticky pagination bar (Browse Library) ----
+   #pagination-controls is the last in-flow child of the tall #library-section, so a
+   bottom-sticky nav pins itself to the viewport for exactly as long as there is grid
+   left to scroll, then lands inline at the true bottom. No JS drives the position —
+   the .is-floating class below is purely cosmetic (see initPaginationStickyObserver). */
+body {
+    --clu-bulkbar-h: 0px;
+}
+
+/* The bulk action bar is position:fixed with nothing reserving its space, so it used
+   to cover the pager and the last grid row. Reserve its measured height instead. */
+body.collection-select-mode {
+    padding-bottom: var(--clu-bulkbar-h, 0px);
+}
+
+#pagination-controls {
+    position: sticky;
+    bottom: var(--clu-bulkbar-h, 0px);
+    /* Above .grid-item:hover (10); below .collection-bulk-action-bar (1050) and modals */
+    z-index: 1020;
+    padding: 0.5rem 0;
+}
+
+/* The pager reads as a raised control surface rather than a patch of page.
+   Both the fill and the edge are mixed from the theme's own body colour and
+   background, which is the one pair every Bootswatch theme guarantees to be
+   high-contrast. Deriving them beats using --bs-tertiary-bg / --bs-border-color
+   directly, which several themes leave all but identical to --bs-body-bg
+   (cyborg 1.01:1, simplex 1.03:1; borders on cyborg, minty and pulse).
+   The plain declarations come first as the pre-color-mix() fallback. */
+#pagination-controls .collection-pager-inner {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    background: var(--bs-tertiary-bg);
+    background: color-mix(in srgb, var(--bs-body-color) 8%, var(--bs-body-bg));
+    border: 1px solid var(--bs-border-color);
+    border-color: color-mix(in srgb, var(--bs-body-color) 26%, var(--bs-body-bg));
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* Detached state — add lift on top of the surface while the bar is pinned.
+   The inset highlight is what reads as "raised" on dark themes, where a black
+   drop shadow has almost nothing to darken. */
+#pagination-controls.is-floating .collection-pager-inner {
+    border-color: color-mix(in srgb, var(--bs-body-color) 34%, var(--bs-body-bg));
+    box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.18),
+                inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    animation: slideUp 0.3s ease-out;
+}
+
+#pagination-controls .pager-perpage {
+    width: auto;
+}
+
+/* Full body colour, not --bs-secondary-color: any mix toward the background can
+   only lose contrast, and several themes (minty, morph, quartz, spacelab) start
+   muted enough that the result fell to 1.8-2.8:1. Hierarchy comes from the
+   smaller type instead, and legibility then matches the theme's own body text. */
+#pagination-controls .pager-readout {
+    color: var(--bs-body-color);
+}
+
+/* Soft busy state for in-place page changes: the bar dims but never moves or vanishes */
+#pagination-controls.is-busy {
+    opacity: 0.65;
+}
+
+#pagination-controls.is-busy .page-link,
+#pagination-controls.is-busy #itemsPerPageFloating {
+    pointer-events: none;
+}
+
+.file-grid.grid-busy {
+    opacity: 0.55;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+#pagination-sentinel {
+    width: 100%;
+    height: 1px;
+    margin: 0;
+}
+
+@media (pointer: coarse) {
+    #pagination-controls .page-link {
+        min-width: 2.75rem;
+        min-height: 2.75rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 575.98px) {
+    #pagination-controls .collection-pager-inner {
+        padding: 0.4rem 0.5rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    #pagination-controls .collection-pager-inner,
+    #pagination-controls.is-floating .collection-pager-inner {
+        animation: none;
+        transition: none;
+    }
+}
+
+@supports not (position: sticky) {
+    #pagination-controls {
+        /* Degrade to the previous inline-only behaviour */
+        position: static;
     }
 }
 

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -8,8 +8,12 @@
 // Update XML – field config and current path now in clu-update-xml.js
 
 document.addEventListener('DOMContentLoaded', () => {
+    // Mirror the per-page options into the sticky pager before restoring the saved
+    // preference, so both selects land on the same value.
+    initItemsPerPageMirror();
     // Restore saved items-per-page preference before the first directory load
     restoreItemsPerPage();
+    initPaginationStickyObserver();
 
     // Initialize with path from URL: prefer clean URL path, fallback to query param
     const initialPath = window.INITIAL_PATH ||
@@ -698,8 +702,14 @@ async function loadAllBooks(preservePage = false) {
  * Uses currentPath, currentPage, itemsPerPage, currentFilter, gridSearchTerm
  * as inputs. Cancels any in-flight previous fetch.
  */
-async function fetchAllBooksPage() {
+async function fetchAllBooksPage(opts) {
     if (!isAllBooksMode) return;
+
+    // A "soft" load is an in-place page change: dim the grid rather than tearing it down,
+    // so the sticky pager doesn't disappear and the page doesn't jump. Only meaningful
+    // when a grid is already on screen — the first load still gets the full spinner.
+    const gridEl = document.getElementById('file-grid');
+    const soft = !!(opts && opts.soft) && !!gridEl && gridEl.childElementCount > 0;
 
     const offset = Math.max(0, (currentPage - 1) * itemsPerPage);
     const params = new URLSearchParams({
@@ -722,7 +732,7 @@ async function fetchAllBooksPage() {
     allBooksAbort = ctrl;
     const timeoutId = setTimeout(() => ctrl.abort(), 30000);
 
-    setLoading(true);
+    if (soft) setPageBusy(true); else setLoading(true);
     try {
         const response = await fetch(`/api/browse-recursive?${params.toString()}`, { signal: ctrl.signal });
         if (!response.ok) {
@@ -762,8 +772,13 @@ async function fetchAllBooksPage() {
         updateViewButtons(currentPath);
     } finally {
         clearTimeout(timeoutId);
-        if (allBooksAbort === ctrl) allBooksAbort = null;
-        setLoading(false);
+        // Rapid clicks supersede this fetch; let the newest one own the loading state
+        // rather than clearing the indicator a newer request just set.
+        const isCurrent = allBooksAbort === ctrl;
+        if (isCurrent) allBooksAbort = null;
+        if (isCurrent || !soft) {
+            if (soft) setPageBusy(false); else setLoading(false);
+        }
     }
 }
 
@@ -1821,9 +1836,28 @@ function updateCollectionBulkActionBar() {
         bar.style.display = '';
         if (countEl) countEl.textContent = `${selectedFiles.size} file${selectedFiles.size === 1 ? '' : 's'} selected`;
         if (grid) grid.classList.add('selection-active');
+        syncBulkBarHeight(bar);
     } else {
         bar.style.display = 'none';
         if (grid) grid.classList.remove('selection-active');
+        document.body.style.removeProperty('--clu-bulkbar-h');
+    }
+}
+
+/**
+ * Publish the fixed bulk action bar's height so the sticky pager sits above it and the
+ * page reserves space for it. Measured rather than hardcoded because the bar's buttons
+ * wrap onto extra rows at narrow widths.
+ * @param {HTMLElement} bar - The bulk action bar element.
+ */
+let _bulkBarResizeObserver = null;
+function syncBulkBarHeight(bar) {
+    const apply = () => document.body.style.setProperty('--clu-bulkbar-h', bar.offsetHeight + 'px');
+    // After the slide-up animation has laid the bar out
+    requestAnimationFrame(apply);
+    if (!_bulkBarResizeObserver && 'ResizeObserver' in window) {
+        _bulkBarResizeObserver = new ResizeObserver(apply);
+        _bulkBarResizeObserver.observe(bar);
     }
 }
 
@@ -2291,56 +2325,102 @@ document.addEventListener('DOMContentLoaded', () => {
 function renderPagination(totalItems) {
     const paginationNav = document.getElementById('pagination-controls');
     const paginationList = document.getElementById('pagination-list');
+    const readout = document.getElementById('pagination-readout');
+    if (!paginationNav || !paginationList) return;
 
     // Use totalItems parameter, or default to allItems.length for backward compatibility
     const itemCount = totalItems !== undefined ? totalItems : allItems.length;
 
     if (itemCount <= itemsPerPage) {
         paginationNav.style.display = 'none';
+        // Leave .is-floating alone: the observer only fires when the sentinel's
+        // intersection actually changes, so clearing it here can leave a pinned bar
+        // without its chrome the next time the pager is shown at the same scroll spot.
         return;
     }
 
     paginationNav.style.display = 'block';
+
+    const totalPages = Math.max(1, Math.ceil(itemCount / itemsPerPage));
+
+    // The bar is permanently visible now, so wiping innerHTML would steal keyboard focus
+    // mid-navigation. Remember which control was focused and restore it after the rebuild.
+    const active = document.activeElement;
+    const focusKey = (active && paginationList.contains(active)) ? active.dataset.pagerKey : null;
+
     paginationList.innerHTML = '';
 
-    const totalPages = Math.ceil(itemCount / itemsPerPage);
-
-    // Previous Button
-    const prevLi = document.createElement('li');
-    prevLi.className = `page-item ${currentPage === 1 ? 'disabled' : ''}`;
-    prevLi.innerHTML = `<a class="page-link" href="#" onclick="changePage(${currentPage - 1}); return false;">Previous</a>`;
-    paginationList.appendChild(prevLi);
-
-    // Page Info (e.g., "Page 1 of 5")
-    const infoLi = document.createElement('li');
-    infoLi.className = 'page-item disabled';
-    infoLi.innerHTML = `<span class="page-link text-dark">Page ${currentPage} of ${totalPages}</span>`;
-    paginationList.appendChild(infoLi);
-
-    // Next Button
-    const nextLi = document.createElement('li');
-    nextLi.className = `page-item ${currentPage === totalPages ? 'disabled' : ''}`;
-    nextLi.innerHTML = `<a class="page-link" href="#" onclick="changePage(${currentPage + 1}); return false;">Next</a>`;
-    paginationList.appendChild(nextLi);
-
-    // Jump To dropdown (only show if there are multiple pages)
-    if (totalPages > 1) {
-        const jumpLi = document.createElement('li');
-        jumpLi.className = 'page-item';
-
-        // Create select dropdown with all pages
-        let optionsHtml = '';
-        for (let i = 1; i <= totalPages; i++) {
-            optionsHtml += `<option value="${i}" ${i === currentPage ? 'selected' : ''}>Page ${i}</option>`;
+    const addItem = (label, page, opts) => {
+        const o = opts || {};
+        const li = document.createElement('li');
+        li.className = 'page-item' + (o.disabled ? ' disabled' : '') + (o.active ? ' active' : '');
+        const a = document.createElement('a');
+        a.className = 'page-link';
+        a.href = '#';
+        a.textContent = label;
+        if (o.key) a.dataset.pagerKey = o.key;
+        if (o.ariaLabel) a.setAttribute('aria-label', o.ariaLabel);
+        if (o.active) a.setAttribute('aria-current', 'page');
+        if (o.disabled) {
+            a.setAttribute('aria-disabled', 'true');
+            a.tabIndex = -1;
         }
+        a.onclick = (e) => {
+            e.preventDefault();
+            if (o.disabled || o.active) return;
+            changePage(page);
+        };
+        li.appendChild(a);
+        paginationList.appendChild(li);
+    };
 
-        jumpLi.innerHTML = `
-            <select class="form-select form-select-sm" onchange="jumpToPage(this.value)" style="width: auto; border-radius: 0.375rem; margin: 0 0.25rem;">
-                ${optionsHtml}
-            </select>
-        `;
-        paginationList.appendChild(jumpLi);
+    addItem('‹', currentPage - 1, {
+        disabled: currentPage === 1, key: 'prev', ariaLabel: 'Previous page'
+    });
+
+    // Windowed page numbers with ellipsis gaps (same approach as metadata_browser.js)
+    const span = window.matchMedia('(max-width: 575.98px)').matches ? 1 : 2;
+    const pages = new Set([1, totalPages, currentPage]);
+    for (let i = 1; i <= span; i++) {
+        if (currentPage - i >= 1) pages.add(currentPage - i);
+        if (currentPage + i <= totalPages) pages.add(currentPage + i);
     }
+    let previous = 0;
+    Array.from(pages).sort((a, b) => a - b).forEach(p => {
+        if (p - previous > 1) addItem('…', 0, { disabled: true });
+        addItem(String(p), p, { active: p === currentPage, key: 'p' + p, ariaLabel: `Page ${p}` });
+        previous = p;
+    });
+
+    addItem('›', currentPage + 1, {
+        disabled: currentPage === totalPages, key: 'next', ariaLabel: 'Next page'
+    });
+
+    if (readout) {
+        const first = (currentPage - 1) * itemsPerPage + 1;
+        const last = Math.min(currentPage * itemsPerPage, itemCount);
+        readout.textContent = `Showing ${first.toLocaleString()}–${last.toLocaleString()} of ` +
+            `${itemCount.toLocaleString()} · page ${currentPage} of ${totalPages}`;
+    }
+
+    if (focusKey) {
+        // Fall back down the chain for the case where the previously focused control is
+        // now disabled (e.g. clicking Next onto the last page).
+        const target = paginationList.querySelector(`[data-pager-key="${focusKey}"]:not([aria-disabled])`)
+            || paginationList.querySelector('[data-pager-key="next"]:not([aria-disabled])')
+            || paginationList.querySelector('[data-pager-key="prev"]:not([aria-disabled])');
+        if (target) target.focus({ preventScroll: true });
+    }
+}
+
+/**
+ * Jump the viewport back to the first row of the grid.
+ * Instant rather than smooth: the pager is always reachable now, so there is nothing to
+ * chase, and animating past 250 tiles fights the lazy-load observer.
+ */
+function scrollGridToTop() {
+    const grid = document.getElementById('file-grid');
+    if (grid) grid.scrollIntoView({ behavior: 'auto', block: 'start' });
 }
 
 /**
@@ -2348,12 +2428,16 @@ function renderPagination(totalItems) {
  * @param {number} page - The page number to switch to.
  */
 function changePage(page) {
+    page = parseInt(page, 10);
+    if (Number.isNaN(page)) return;
+
     if (isAllBooksMode) {
         const totalPages = Math.max(1, Math.ceil((allBooksTotal || 0) / itemsPerPage));
         if (page < 1 || page > totalPages) return;
         currentPage = page;
-        fetchAllBooksPage();
-        document.getElementById('file-grid').scrollIntoView({ behavior: 'smooth' });
+        // Soft load: keep the grid mounted so the sticky pager holds its position
+        fetchAllBooksPage({ soft: true });
+        scrollGridToTop();
         return;
     }
 
@@ -2365,8 +2449,7 @@ function changePage(page) {
     renderPage();
     loadVisiblePageData();
 
-    // Scroll to top of grid
-    document.getElementById('file-grid').scrollIntoView({ behavior: 'smooth' });
+    scrollGridToTop();
 }
 
 /**
@@ -2388,6 +2471,7 @@ function changeItemsPerPage(value) {
     } catch (e) {
         // Ignore storage errors (e.g. private mode / quota)
     }
+    syncItemsPerPageSelects(String(value));
     currentPage = 1;
     if (isAllBooksMode) {
         fetchAllBooksPage();
@@ -2419,8 +2503,70 @@ function restoreItemsPerPage() {
     const parsed = parseInt(saved);
     if (!Number.isNaN(parsed)) {
         itemsPerPage = parsed;
-        if (selector) selector.value = saved;
+        syncItemsPerPageSelects(saved);
     }
+}
+
+/**
+ * Keep the filter-bar per-page select and its mirror in the sticky pager in step.
+ * @param {string} value - The option value to select on both controls.
+ */
+function syncItemsPerPageSelects(value) {
+    ['itemsPerPage', 'itemsPerPageFloating'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el && el.value !== value) el.value = value;
+    });
+}
+
+/**
+ * Populate the sticky pager's per-page select from the filter-bar one.
+ *
+ * The options are cloned rather than duplicated in the template on purpose:
+ * restoreItemsPerPage() validates the saved preference against #itemsPerPage's options,
+ * so that control has to stay the single source of truth for the allowed values.
+ */
+function initItemsPerPageMirror() {
+    const source = document.getElementById('itemsPerPage');
+    const mirror = document.getElementById('itemsPerPageFloating');
+    if (!source || !mirror) return;
+
+    mirror.innerHTML = '';
+    Array.from(source.options).forEach(opt => mirror.appendChild(opt.cloneNode(true)));
+    mirror.value = source.value;
+}
+
+/**
+ * Toggle a cosmetic "detached" class while the sticky pager is pinned to the viewport.
+ * Positioning is pure CSS — this only drives the pill background and shadow, so losing
+ * IntersectionObserver costs nothing but the resting-state polish.
+ */
+function initPaginationStickyObserver() {
+    const sentinel = document.getElementById('pagination-sentinel');
+    const nav = document.getElementById('pagination-controls');
+    if (!nav) return;
+
+    if (!sentinel || !('IntersectionObserver' in window)) {
+        nav.classList.add('is-floating');
+        return;
+    }
+
+    new IntersectionObserver(([entry]) => {
+        nav.classList.toggle('is-floating', !entry.isIntersecting);
+    }, { threshold: 0 }).observe(sentinel);
+}
+
+/**
+ * Soft loading state for in-place page changes: keeps the grid mounted so the sticky
+ * pager holds its position instead of vanishing and re-appearing on every click.
+ * @param {boolean} busy
+ */
+function setPageBusy(busy) {
+    const grid = document.getElementById('file-grid');
+    const nav = document.getElementById('pagination-controls');
+    if (grid) grid.classList.toggle('grid-busy', busy);
+    if (!nav) return;
+    nav.classList.toggle('is-busy', busy);
+    nav.setAttribute('aria-busy', busy ? 'true' : 'false');
 }
 
 /**
@@ -2843,10 +2989,19 @@ function setLoading(loading) {
     const empty = document.getElementById('empty-state');
     const pagination = document.getElementById('pagination-controls');
 
+    // A hard load always supersedes a soft one, so never leave the dimmed state stuck
+    if (grid) grid.classList.remove('grid-busy');
+    if (pagination) {
+        pagination.classList.remove('is-busy');
+        pagination.removeAttribute('aria-busy');
+    }
+
     if (loading) {
         indicator.style.display = 'block';
         grid.style.display = 'none';
         empty.style.display = 'none';
+        // Hidden only for full view swaps, which collapse the grid anyway — an in-place
+        // page change goes through setPageBusy() instead so the pager stays put.
         if (pagination) pagination.style.display = 'none';
     } else {
         indicator.style.display = 'none';
@@ -3528,7 +3683,7 @@ async function loadFavoritePublishers() {
                         </button>
                     </div>
                     <div class="dashboard-card-body">
-                        <div class="text-truncate text-dark item-name" title="${pub.name}">${pub.name}</div>
+                        <div class="text-truncate item-name" title="${pub.name}">${pub.name}</div>
                         <small class="text-muted item-meta${pub.folderCount === null ? ' metadata-loading' : ''}">${pub.folderCount === null ? 'Loading...' :
                     [
                         pub.folderCount > 0 ? `${pub.folderCount} folder${pub.folderCount !== 1 ? 's' : ''}` : '',
@@ -3728,7 +3883,7 @@ async function loadWantToRead() {
                         </button>
                     </div>
                     <div class="dashboard-card-body">
-                        <div class="text-truncate text-dark item-name" title="${name}">${name}</div>
+                        <div class="text-truncate item-name" title="${name}">${name}</div>
                         <small class="text-muted">${item.type === 'folder' ? 'Folder' : 'Comic'}</small>
                     </div>
                 </div>
@@ -3794,7 +3949,7 @@ async function loadRecentlyAddedSwiper() {
                         <img src="/static/images/loading.svg" data-thumbnail="${thumbnailUrl}" alt="${name}" class="thumbnail">
                     </div>
                     <div class="dashboard-card-body">
-                        <div class="text-truncate text-dark item-name" title="${name}">${name}</div>
+                        <div class="text-truncate item-name" title="${name}">${name}</div>
                         <small class="text-muted">${timeAgo}</small>
                     </div>
                 </div>
@@ -3866,7 +4021,7 @@ async function loadContinueReadingSwiper() {
                         </button>
                     </div>
                     <div class="dashboard-card-body">
-                        <div class="text-truncate text-dark item-name" title="${name}">${name}</div>
+                        <div class="text-truncate item-name" title="${name}">${name}</div>
                         <small class="text-muted">${pageInfo}<br/>${timeAgo}</small>
                     </div>
                 </div>
@@ -3929,7 +4084,7 @@ async function loadOnTheStackSwiper() {
                         <img src="/static/images/loading.svg" data-thumbnail="${thumbnailUrl}" alt="${item.file_name}" class="thumbnail">
                     </div>
                     <div class="dashboard-card-body">
-                        <div class="text-truncate text-dark item-name" title="${item.file_name}">${item.file_name}</div>
+                        <div class="text-truncate item-name" title="${item.file_name}">${item.file_name}</div>
                         <small class="text-muted">${item.series_name} #${item.issue_number}<br/>${timeAgo}</small>
                     </div>
                 </div>

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -131,10 +131,27 @@
                 <i class="bi bi-folder2-open display-1 text-muted"></i>
                 <p class="lead text-muted mt-3">This folder is empty</p>
             </div>
-            <nav id="pagination-controls" aria-label="File browser pagination" class="mt-4" style="display: none;">
-                <ul class="pagination justify-content-center" id="pagination-list">
-                </ul>
+            <nav id="pagination-controls" aria-label="File browser pagination" class="collection-pager mt-4"
+                style="display: none;">
+                <div
+                    class="collection-pager-inner d-flex flex-column flex-md-row align-items-center justify-content-between gap-2">
+                    {# Muting is done in collection.css, not with .text-body-secondary:
+                       that utility is `!important` and is already below AA on several
+                       Bootswatch themes (minty, morph, quartz, spacelab). #}
+                    <div class="pager-readout small d-none d-md-block" id="pagination-readout"
+                        aria-live="polite" aria-atomic="true"></div>
+                    <ul class="pagination pagination-sm justify-content-center flex-wrap mb-0" id="pagination-list">
+                    </ul>
+                    <div class="pager-perpage input-group input-group-sm d-none d-md-flex">
+                        <label class="input-group-text" for="itemsPerPageFloating">Per page</label>
+                        <select class="form-select" id="itemsPerPageFloating"
+                            onchange="changeItemsPerPage(this.value)"></select>
+                    </div>
+                </div>
             </nav>
+            {# Sticky-pager state probe: when this scrolls out of view the pager is pinned,
+               which is what toggles its detached (pill + shadow) treatment. Must stay last. #}
+            <div id="pagination-sentinel" aria-hidden="true"></div>
         </section>
         {% elif section.id == 'discover' %}
         <!-- Discover / Recommendations -->
@@ -222,12 +239,15 @@
         </div>
         <div class="item-info d-flex justify-content-between align-items-start mt-2">
             <div class="item-details text-truncate flex-grow-1">
-                <div class="item-name text-truncate text-dark" title=""></div>
+                {# No .text-dark here: it is `color: … !important`, which beats the
+                   theme-aware .item-name rules in collection.css and leaves filenames
+                   invisible on dark themes. #}
+                <div class="item-name text-truncate" title=""></div>
                 <div class="item-meta text-muted small"></div>
             </div>
             {% if _can_manage %}
             <div class="item-actions dropdown ms-2">
-                <button class="btn btn-link btn-sm p-0 text-dark no-propagation" type="button" data-bs-toggle="dropdown"
+                <button class="btn btn-link btn-sm p-0 text-body no-propagation" type="button" data-bs-toggle="dropdown"
                     aria-expanded="false">
                     <i class="bi bi-three-dots-vertical"></i>
                 </button>


### PR DESCRIPTION
## Problem

The pagination control on `/collection` was rendered below the grid and nowhere else. At **Per page 100 or 250**, reaching *Next* meant scrolling past every cover on the page — and since `changePage()` scrolled back to the top of the grid, the next page cost the same trip again. The effort of paging scaled with the page size, penalising exactly the users who chose a large one.

## Approach

The nav is now `position: sticky; bottom: 0`. It is the last in-flow child of the tall `#library-section`, and a bottom-sticky box is shifted *up* toward the viewport (clamped to its containing block) — so it pins for as long as there is grid left to scroll, and lands inline at the true bottom. No JavaScript drives the position.

The ancestor chain was checked for the properties that silently disable sticky (`overflow`, `contain`, `transform`, `filter`, `will-change`) — none are present.

Rejected alternatives:
- **`position: fixed` + sentinel** — leaves flow, so it needs a hand-managed width, a spacer to stop the content jump, and left-offset recalculation on resize; also breaks DOM/tab order.
- **Scroll listener** — per-frame work on a 250-tile grid, no `throttle` helper in `clu-utils.js`, and throttled anyway during iOS momentum scroll.

`#pagination-sentinel` drives only the cosmetic "detached" class. Without `IntersectionObserver` the chrome just stays on.

## The bar itself

| Slot | Content | Mobile |
|---|---|---|
| Left | `Showing 1–252 of 1,842 · page 1 of 8` | hidden |
| Centre | `‹ 1 … 4 5 6 … 19 ›` | ±1 window |
| Right | mirrored **Per page** | hidden |

- Windowing is **ported from `metadata_browser.js:406`**, not reimplemented.
- The per-page mirror clones its options from `#itemsPerPage`, which stays the single source of truth — `restoreItemsPerPage()` validates the saved preference against them, and the `21/49/98/252` values must not change or every user's `localStorage` resets.
- Removed the jump `<select>`, which emitted one `<option>` per page on every render.
- Built with `createElement`/`textContent` instead of interpolating page numbers into `onclick=""` strings inside `innerHTML`.

## Three adjacent bugs fixed

1. **Bulk action bar covered the pager.** `.collection-bulk-action-bar` is `position: fixed` with nothing reserving its space, so paging was impossible while Multi-Select was on. Both now clear it via `--clu-bulkbar-h`, measured with a `ResizeObserver` (its buttons wrap at narrow widths). This also uncovered the last grid row.
2. **`.text-dark` made text invisible on dark themes.** `collection.css:218` already had the correct theme-aware rule for `.item-name` — it lost because the utility is `color: … !important`. Removed from the pager label, the grid tile **filenames**, the five dashboard swiper card titles, and the tile actions button (→ `.text-body`). Comic filenames were unreadable on all six dark themes.
3. **Pager vanished mid-navigation.** `setLoading()` hid the nav outright. Full view swaps still hide it (they collapse the grid anyway), but in-place page changes now use `setPageBusy()`, which dims in place.

`changePage()` also drops the smooth scroll — animating 500ms over 250 tiles fights the lazy-load observer, and with the control pinned it reads as the page sliding under a stationary bar.

## Accessibility

`renderPagination()` wipes `innerHTML`, which destroyed keyboard focus on *Next* — tolerable when the control was off-screen, not now that it is always visible. Links carry `data-pager-key` and focus is restored after the rebuild, falling back `same key → next → prev`. Plus `aria-current`, `aria-disabled` + `tabIndex -1`, `aria-live` on the readout **only** (never the nav or list, which would re-announce every link), 44px targets under `pointer: coarse`, and `prefers-reduced-motion`.

## Bootswatch compatibility

Measuring all 27 offered themes showed **no Bootstrap surface variable is usable**:

| Variable | Fails on |
|---|---|
| `--bs-tertiary-bg` | cyborg **1.01:1**, simplex 1.03:1 (~1.054:1 on most light themes) |
| `--bs-secondary-bg` | cyborg 1.03:1, morph 1.00:1 |
| `--bs-border-color` | cyborg 1.046:1, minty 1.16:1, pulse 1.17:1 |

So the fill and edge are mixed from each theme's own `--bs-body-color`/`--bs-body-bg` pair — the one pairing every theme guarantees to be high-contrast. Plain declarations precede each `color-mix()` as the fallback. Result: bar-vs-page **1.07–1.24:1**, border **1.25–2.20:1** on all 27.

The readout uses `--bs-body-color` at full strength — mixing toward the background can only *lose* contrast, and an earlier 72% mix dropped minty/morph to 1.8–2.5:1.

## Testing

`pytest`: **3490 passed, 6 skipped** — unchanged from baseline. No Python is touched and no routes are added.

This repo has no JS test infrastructure, so the frontend was verified by driving the running app with Playwright: pinning at the viewport edge, window recentring, landing inline at the bottom, focus surviving the re-render, hidden entirely below one page, zero overlap with the bulk bar, no horizontal overflow at 390px, and computed-colour contrast on all 27 themes.

**Known limitation:** on minty, morph, quartz and spacelab the readout sits below 4.5:1 — that is those themes' own body-text ceiling, so it is now exactly as legible as ordinary text there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
