### PR TITLE
Add a Publisher filter to Weekly Releases

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -359,6 +359,7 @@ _CLERK_PREFIXES = (
     "/api/usenet",
     "/api/dcpp",
     "/api/pull-list",
+    "/api/releases",           # publisher map behind the Clerk-only /releases page
     "/api/bulk-metadata",
     "/api/source-wall",
     "/api/weekly-packs",

--- a/core/database.py
+++ b/core/database.py
@@ -837,6 +837,25 @@ def init_db():
             c.execute("ALTER TABLE series ADD COLUMN monitored INTEGER DEFAULT 1")
             app_logger.info("Added monitored column to series table")
 
+        # Create metron_series_publishers table (series_id -> publisher name).
+        # Metron's /issue/ list endpoint returns BaseIssue objects, which carry
+        # the series but NOT the publisher, so the Weekly Releases publisher
+        # filter has no publisher to group on. This is a standalone cache that
+        # fills in the background; it is deliberately NOT the `series` table,
+        # which holds the user's tracked/mapped series and would be polluted by
+        # every series that happens to ship in a given week.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS metron_series_publishers (
+                series_id INTEGER PRIMARY KEY,
+                publisher_name TEXT NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_metron_series_publishers_name"
+            " ON metron_series_publishers(publisher_name)"
+        )
+
         # Create issues table (Metron issues cached for tracked series)
         c.execute("""
             CREATE TABLE IF NOT EXISTS issues (
@@ -9837,6 +9856,151 @@ def get_all_publishers():
     except Exception as e:
         app_logger.error(f"Failed to get all publishers: {e}")
         return []
+
+
+def get_series_publishers(series_ids=None):
+    """
+    Get the cached Metron series_id -> publisher name map.
+
+    Backs the Weekly Releases publisher filter: Metron's issue-list endpoint
+    returns the series but not the publisher, so releases are grouped through
+    this cache instead.
+
+    Args:
+        series_ids: Optional iterable of Metron series IDs to restrict to.
+                    None returns the whole cache.
+
+    Returns:
+        Dict of {series_id: publisher_name}, empty on error
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return {}
+
+        c = conn.cursor()
+        if series_ids is None:
+            c.execute("SELECT series_id, publisher_name FROM metron_series_publishers")
+            rows = c.fetchall()
+        else:
+            ids = [int(sid) for sid in series_ids if sid is not None]
+            if not ids:
+                return {}
+            rows = []
+            # Chunked to stay under SQLite's variable limit on a big week.
+            for start in range(0, len(ids), 500):
+                chunk = ids[start:start + 500]
+                placeholders = ",".join("?" * len(chunk))
+                c.execute(
+                    "SELECT series_id, publisher_name FROM metron_series_publishers"
+                    f" WHERE series_id IN ({placeholders})",
+                    chunk,
+                )
+                rows.extend(c.fetchall())
+
+        return {row["series_id"]: row["publisher_name"] for row in rows}
+
+    except Exception as e:
+        app_logger.error(f"Failed to get series publishers: {e}")
+        return {}
+
+    finally:
+        if conn:
+            conn.close()
+
+
+def save_series_publishers(mapping):
+    """
+    Upsert Metron series_id -> publisher name pairs into the cache.
+
+    Args:
+        mapping: Dict of {series_id: publisher_name} (falsy names are skipped)
+
+    Returns:
+        Number of rows written, 0 on error
+    """
+    if not mapping:
+        return 0
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return 0
+
+        rows = [
+            (int(sid), str(name))
+            for sid, name in mapping.items()
+            if sid is not None and name
+        ]
+        if not rows:
+            return 0
+
+        c = conn.cursor()
+        c.executemany(
+            """
+            INSERT INTO metron_series_publishers (series_id, publisher_name, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(series_id) DO UPDATE SET
+                publisher_name = excluded.publisher_name,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            rows,
+        )
+        conn.commit()
+        return len(rows)
+
+    except Exception as e:
+        app_logger.error(f"Failed to save series publishers: {e}")
+        return 0
+
+    finally:
+        if conn:
+            conn.close()
+
+
+def get_known_publisher_names(limit=40):
+    """
+    Get publisher names already seen in the series->publisher cache, most-used
+    first.
+
+    These are the cheap bulk-resolution candidates for the releases warm pass:
+    one filtered issue-list call per known publisher resolves every one of that
+    publisher's series in the window at once.
+
+    Args:
+        limit: Maximum number of names to return
+
+    Returns:
+        List of publisher names, empty on error
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT publisher_name, COUNT(*) AS series_count
+            FROM metron_series_publishers
+            GROUP BY publisher_name
+            ORDER BY series_count DESC, publisher_name
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        return [row["publisher_name"] for row in c.fetchall()]
+
+    except Exception as e:
+        app_logger.error(f"Failed to get known publisher names: {e}")
+        return []
+
+    finally:
+        if conn:
+            conn.close()
 
 
 def delete_publisher(publisher_id):

--- a/models/metron.py
+++ b/models/metron.py
@@ -1076,7 +1076,12 @@ def calculate_comic_week(date_obj=None):
     return start_of_week, end_of_week
 
 
-def get_releases(api, date_after: str, date_before: Optional[str] = None) -> List[Any]:
+def get_releases(
+    api,
+    date_after: str,
+    date_before: Optional[str] = None,
+    publisher_name: Optional[str] = None,
+) -> List[Any]:
     """
     Fetch releases from Metron API within a date range.
 
@@ -1084,6 +1089,9 @@ def get_releases(api, date_after: str, date_before: Optional[str] = None) -> Lis
         api: Mokkari API client
         date_after: Start date (YYYY-MM-DD)
         date_before: End date (YYYY-MM-DD), optional. If None, fetches everything after start date.
+        publisher_name: Optional publisher name to filter on server-side. The
+            returned issues carry no publisher of their own, so this is also how
+            the releases page learns which series belong to which publisher.
 
     Returns:
         List of issue objects
@@ -1094,6 +1102,8 @@ def get_releases(api, date_after: str, date_before: Optional[str] = None) -> Lis
     params = {"store_date_range_after": date_after}
     if date_before:
         params["store_date_range_before"] = date_before
+    if publisher_name:
+        params["publisher_name"] = publisher_name
     app_logger.info(f"Fetching releases with params: {params}")
     return (
         _api_call(lambda: api.issues_list(params), "getting releases", default=[]) or []

--- a/routes/series.py
+++ b/routes/series.py
@@ -47,6 +47,126 @@ series_bp = Blueprint("series", __name__)
 
 
 # =============================================================================
+# Weekly Releases publisher resolution
+# =============================================================================
+# Metron's issue-list endpoint returns BaseIssue objects, which carry the series
+# but no publisher, so the releases page can't group its own results. Publishers
+# come from a series->publisher cache that fills in the background:
+#
+#   Phase 1 (bulk)  - one publisher-filtered issue-list call per already-known
+#                     publisher resolves every series that publisher shipped in
+#                     the window at once.
+#   Phase 2 (tail)  - capped per-series lookups for whatever Phase 1 missed.
+#                     Each publisher discovered here becomes a Phase 1 candidate
+#                     on the next pass, so a cold cache converges in a few passes.
+
+_publisher_warm_lock = threading.Lock()
+_publisher_warm_active = set()
+_publisher_warm_state = {}
+
+# Bounds per pass, so a stubborn window can't sit on Metron's daily quota.
+_PUBLISHER_WARM_MAX_PASSES = 6
+_PUBLISHER_WARM_BULK_LIMIT = 25
+_PUBLISHER_WARM_SERIES_LIMIT = 20
+
+
+def _release_series_ids(releases_list):
+    """Collect the Metron series IDs referenced by a list of issues."""
+    ids = []
+    for issue in releases_list or []:
+        series = getattr(issue, "series", None)
+        series_id = getattr(series, "id", None)
+        if series_id is None and isinstance(series, dict):
+            series_id = series.get("id")
+        if series_id is not None:
+            ids.append(series_id)
+    return ids
+
+
+def _publisher_window_key(date_after, date_before):
+    return f"{date_after}|{date_before or ''}"
+
+
+def _warm_release_publishers(api, date_after, date_before, unknown_ids, key):
+    """Resolve series->publisher for a release window (runs in a thread)."""
+    from core.database import get_known_publisher_names, save_series_publishers
+
+    learned_total = 0
+    try:
+        state = _publisher_warm_state.setdefault(key, {"passes": 0, "swept": set()})
+        remaining = set(unknown_ids)
+
+        # Phase 1 is only worth its API calls when the tail is longer than the
+        # per-series cap; below that, resolving each series directly is cheaper.
+        if len(remaining) > _PUBLISHER_WARM_SERIES_LIMIT:
+            candidates = [
+                name
+                for name in get_known_publisher_names()
+                if name not in state["swept"]
+            ][:_PUBLISHER_WARM_BULK_LIMIT]
+            for name in candidates:
+                if not remaining:
+                    break
+                issues = metron.get_releases(
+                    api, date_after, date_before, publisher_name=name
+                )
+                state["swept"].add(name)
+                learned = {series_id: name for series_id in _release_series_ids(issues)}
+                if learned:
+                    save_series_publishers(learned)
+                    learned_total += len(set(learned) & remaining)
+                    remaining -= set(learned)
+
+        for series_id in list(remaining)[:_PUBLISHER_WARM_SERIES_LIMIT]:
+            details = metron.get_series_details(api, series_id)
+            publisher_name = (details or {}).get("publisher_name")
+            if publisher_name:
+                save_series_publishers({series_id: publisher_name})
+                learned_total += 1
+
+        # A pass that learns nothing means the rest is unresolvable right now
+        # (no data, or the rate-limit pacer is refusing calls). Stop retrying.
+        if not learned_total:
+            state["exhausted"] = True
+
+        app_logger.info(
+            f"Release publisher warm pass for {key}: resolved {learned_total} "
+            f"of {len(unknown_ids)} unknown series"
+        )
+    except Exception as e:
+        app_logger.error(f"Release publisher warm pass failed for {key}: {e}")
+        _publisher_warm_state.setdefault(key, {"passes": 0, "swept": set()})[
+            "exhausted"
+        ] = True
+    finally:
+        with _publisher_warm_lock:
+            _publisher_warm_active.discard(key)
+
+
+def _start_publisher_warm(api, date_after, date_before, unknown_ids):
+    """Start a background warm pass for a window. Returns True if one is running."""
+    if not api or not unknown_ids:
+        return False
+
+    key = _publisher_window_key(date_after, date_before)
+    with _publisher_warm_lock:
+        if key in _publisher_warm_active:
+            return True
+        state = _publisher_warm_state.setdefault(key, {"passes": 0, "swept": set()})
+        if state.get("exhausted") or state["passes"] >= _PUBLISHER_WARM_MAX_PASSES:
+            return False
+        state["passes"] += 1
+        _publisher_warm_active.add(key)
+
+    threading.Thread(
+        target=_warm_release_publishers,
+        args=(api, date_after, date_before, list(unknown_ids), key),
+        daemon=True,
+    ).start()
+    return True
+
+
+# =============================================================================
 # Pages
 # =============================================================================
 
@@ -57,7 +177,11 @@ def releases():
     Weekly Releases page integrated with Metron.
     Shows releases for a specific week or upcoming releases.
     """
-    from core.database import get_tracked_series_lookup, normalize_series_name
+    from core.database import (
+        get_series_publishers,
+        get_tracked_series_lookup,
+        normalize_series_name,
+    )
 
     # Get tracked series lookup for highlighting
     tracked_lookup = get_tracked_series_lookup()
@@ -72,6 +196,10 @@ def releases():
             view_mode="error",
             tracked_lookup=tracked_lookup,
             normalize_name=normalize_series_name,
+            publisher_map={},
+            publisher_pending=False,
+            query_after="",
+            query_before=None,
         )
 
     # Get query params
@@ -101,22 +229,31 @@ def releases():
 
         future_start = next_week_end
 
-        releases_list = metron.get_releases(
-            api, date_after=future_start.strftime(fmt), date_before=None
-        )
+        query_after = future_start.strftime(fmt)
+        query_before = None
 
-        display_date_range = f"Future (After {future_start.strftime(fmt)})"
+        display_date_range = f"Future (After {query_after})"
 
     else:
         # Weekly mode (default)
-        start_str = start_date.strftime(fmt)
-        end_str = end_date.strftime(fmt)
+        query_after = start_date.strftime(fmt)
+        query_before = end_date.strftime(fmt)
 
-        releases_list = metron.get_releases(
-            api, date_after=start_str, date_before=end_str
-        )
+        display_date_range = f"Week of {query_after} to {query_before}"
 
-        display_date_range = f"Week of {start_str} to {end_str}"
+    releases_list = metron.get_releases(
+        api, date_after=query_after, date_before=query_before
+    )
+
+    # Publisher filter data. The issues themselves carry no publisher, so group
+    # them through the series->publisher cache and warm the misses in the
+    # background; the page polls for the map as it fills.
+    series_ids = _release_series_ids(releases_list)
+    publisher_map = get_series_publishers(series_ids)
+    unknown_ids = [sid for sid in set(series_ids) if sid not in publisher_map]
+    publisher_pending = _start_publisher_warm(
+        api, query_after, query_before, unknown_ids
+    )
 
     # Navigation links
     prev_week_date = (start_date - timedelta(days=7)).strftime(fmt)
@@ -132,6 +269,58 @@ def releases():
         next_date=next_week_date,
         tracked_lookup=tracked_lookup,
         normalize_name=normalize_series_name,
+        publisher_map=publisher_map,
+        publisher_pending=publisher_pending,
+        query_after=query_after,
+        query_before=query_before,
+    )
+
+
+@series_bp.route("/api/releases/publishers", methods=["POST"])
+def api_release_publishers():
+    """
+    Return the cached publisher for each of the given Metron series IDs.
+
+    The Weekly Releases page polls this while its series->publisher cache is
+    still filling, so the publisher filter can appear without a page reload.
+    Unresolved IDs re-arm the background warm pass (bounded per window).
+    """
+    from core.database import get_series_publishers
+
+    data = request.get_json(silent=True) or {}
+
+    series_ids = []
+    for raw_id in data.get("series_ids") or []:
+        try:
+            series_ids.append(int(raw_id))
+        except (TypeError, ValueError):
+            continue
+
+    date_after = (data.get("date_after") or "").strip()
+    date_before = (data.get("date_before") or "").strip() or None
+    for value in (date_after, date_before):
+        if value:
+            try:
+                datetime.strptime(value, "%Y-%m-%d")
+            except ValueError:
+                return jsonify({"success": False, "error": "Invalid date"}), 400
+
+    publisher_map = get_series_publishers(series_ids)
+    unknown_ids = [sid for sid in set(series_ids) if sid not in publisher_map]
+
+    pending = False
+    if unknown_ids and date_after:
+        pending = _start_publisher_warm(
+            metron.get_flask_api(), date_after, date_before, unknown_ids
+        )
+
+    return jsonify(
+        {
+            "success": True,
+            "publishers": {str(sid): name for sid, name in publisher_map.items()},
+            "unknown": len(unknown_ids),
+            "pending": pending,
+        }
     )
 
 

--- a/templates/releases.html
+++ b/templates/releases.html
@@ -44,12 +44,28 @@
     {% endif %}
 
     {% if releases %}
+    <!-- Publisher Filter -->
+    <div class="publisher-filter mb-4 fade-in-down" id="publisher-filter" hidden>
+        <div class="d-flex align-items-center flex-wrap gap-2">
+            <span class="text-muted small text-uppercase fw-semibold me-1">
+                <i class="bi bi-building me-1"></i>Publisher
+            </span>
+            <div class="d-flex flex-wrap gap-2" id="publisher-pills"></div>
+            <span id="publisher-loading"
+                class="text-muted small ms-1{% if not publisher_pending %} d-none{% endif %}">
+                <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                Identifying publishers&hellip;
+            </span>
+        </div>
+    </div>
+
     <div class="releases-grid">
         {% for issue in releases %}
         {% set issue_slug = generate_series_slug(issue.series.name, issue.id, issue.series.volume) %}
         {% set is_tracked = (normalize_name(issue.series.name), issue.series.volume or 0) in tracked_lookup %}
         <a href="{% if issue_slug %}{{ url_for('series.issue_view', slug=issue_slug) }}{% else %}{{ issue.resource_url }}{% endif %}"
             {% if not series_slug %} {% endif %}
+            data-series-id="{{ issue.series.id }}"
             class="release-card stagger-load{% if is_tracked %} tracked{% endif %}">
             <!-- Cover Image -->
             <div class="release-cover">
@@ -110,6 +126,19 @@
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 1.5rem;
         padding: 1rem 0;
+    }
+
+    .publisher-pill {
+        border-radius: 999px;
+        font-size: 0.85rem;
+        padding: 0.25rem 0.85rem;
+        white-space: nowrap;
+    }
+
+    .publisher-pill .badge {
+        font-size: 0.7rem;
+        margin-left: 0.35rem;
+        opacity: 0.85;
     }
 
     .release-card {
@@ -387,6 +416,151 @@
 </style>
 
 <script>
+    // Publisher filter.
+    //
+    // Metron's issue-list payload has no publisher field, so the server groups
+    // releases through a series->publisher cache. That cache fills in the
+    // background, so the pills are built from whatever is known right now and
+    // re-rendered as the poll delivers more of the map.
+    document.addEventListener('DOMContentLoaded', function () {
+        const publisherMap = {{ publisher_map | tojson }};
+        const pendingWarm = {{ publisher_pending | tojson }};
+        const dateAfter = {{ (query_after or '') | tojson }};
+        const dateBefore = {{ (query_before or '') | tojson }};
+
+        const filterBar = document.getElementById('publisher-filter');
+        const pillsEl = document.getElementById('publisher-pills');
+        const loadingEl = document.getElementById('publisher-loading');
+        const cards = Array.from(document.querySelectorAll('.release-card'));
+        if (!filterBar || !pillsEl || !cards.length) return;
+
+        const UNKNOWN = '__unknown__';
+        let selected = new URLSearchParams(window.location.search).get('publisher') || '';
+
+        function publisherFor(card) {
+            return publisherMap[card.dataset.seriesId] || '';
+        }
+
+        function applyFilter() {
+            cards.forEach(function (card) {
+                const pub = publisherFor(card);
+                const match = !selected
+                    || (selected === UNKNOWN ? !pub : pub === selected);
+                card.classList.toggle('d-none', !match);
+            });
+        }
+
+        function syncUrl() {
+            const url = new URL(window.location.href);
+            if (selected) {
+                url.searchParams.set('publisher', selected);
+            } else {
+                url.searchParams.delete('publisher');
+            }
+            window.history.replaceState({}, '', url);
+        }
+
+        function render() {
+            const counts = new Map();
+            let unknown = 0;
+            cards.forEach(function (card) {
+                const pub = publisherFor(card);
+                if (pub) {
+                    counts.set(pub, (counts.get(pub) || 0) + 1);
+                } else {
+                    unknown += 1;
+                }
+            });
+
+            // Nothing resolved yet and nothing pending: no filter worth showing.
+            if (!counts.size) {
+                filterBar.hidden = !pendingWarm;
+                pillsEl.innerHTML = '';
+                return;
+            }
+            filterBar.hidden = false;
+
+            const options = [{ value: '', label: 'All', count: cards.length }];
+            Array.from(counts.entries())
+                .sort(function (a, b) {
+                    return b[1] - a[1] || a[0].localeCompare(b[0]);
+                })
+                .forEach(function (entry) {
+                    options.push({ value: entry[0], label: entry[0], count: entry[1] });
+                });
+            if (unknown) {
+                options.push({ value: UNKNOWN, label: 'Unidentified', count: unknown });
+            }
+
+            // Selection no longer exists (e.g. its last card got identified).
+            if (selected && !options.some(function (o) { return o.value === selected; })) {
+                selected = '';
+                syncUrl();
+            }
+
+            pillsEl.innerHTML = '';
+            options.forEach(function (opt) {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'btn btn-sm publisher-pill '
+                    + (opt.value === selected ? 'btn-primary' : 'btn-outline-secondary');
+                btn.dataset.publisher = opt.value;
+                btn.textContent = opt.label;
+
+                const badge = document.createElement('span');
+                badge.className = 'badge '
+                    + (opt.value === selected ? 'text-bg-light' : 'text-bg-secondary');
+                badge.textContent = opt.count;
+                btn.appendChild(badge);
+
+                btn.addEventListener('click', function () {
+                    selected = opt.value === selected ? '' : opt.value;
+                    syncUrl();
+                    applyFilter();
+                    render();
+                });
+                pillsEl.appendChild(btn);
+            });
+        }
+
+        render();
+        applyFilter();
+
+        // Poll for the rest of the map while the server is still resolving it.
+        if (pendingWarm) {
+            const seriesIds = Array.from(new Set(cards.map(function (c) {
+                return c.dataset.seriesId;
+            }).filter(Boolean)));
+
+            const handle = CLU.startPoll(function (signal) {
+                return fetch('/api/releases/publishers', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        series_ids: seriesIds,
+                        date_after: dateAfter,
+                        date_before: dateBefore
+                    }),
+                    signal: signal
+                })
+                    .then(function (res) { return res.json(); })
+                    .then(function (data) {
+                        if (!data.success) return;
+                        Object.assign(publisherMap, data.publishers || {});
+                        render();
+                        applyFilter();
+                        if (!data.pending) {
+                            clearInterval(handle);
+                            loadingEl.classList.add('d-none');
+                        }
+                    })
+                    .catch(function (err) {
+                        console.error('Publisher lookup failed:', err);
+                    });
+            }, 5000, { immediate: false });
+        }
+    });
+
     document.addEventListener('DOMContentLoaded', function () {
         // Add loading overlay to each card
         document.querySelectorAll('.release-card').forEach(function (card) {

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -881,6 +881,31 @@ class TestGetReleases:
         from models.metron import get_releases
         assert get_releases(None, "2024-01-01") == []
 
+    def test_passes_publisher_filter(self):
+        # The releases page filters by publisher server-side (and learns the
+        # series->publisher map from the result), so the name must reach Metron.
+        from models.metron import get_releases
+
+        mock_api = MagicMock()
+        mock_api.issues_list.return_value = []
+
+        get_releases(mock_api, "2024-01-01", "2024-01-07", publisher_name="Marvel")
+
+        params = mock_api.issues_list.call_args[0][0]
+        assert params["publisher_name"] == "Marvel"
+        assert params["store_date_range_after"] == "2024-01-01"
+        assert params["store_date_range_before"] == "2024-01-07"
+
+    def test_omits_publisher_filter_when_absent(self):
+        from models.metron import get_releases
+
+        mock_api = MagicMock()
+        mock_api.issues_list.return_value = []
+
+        get_releases(mock_api, "2024-01-01", "2024-01-07")
+
+        assert "publisher_name" not in mock_api.issues_list.call_args[0][0]
+
 
 class TestGetFlaskApi:
 

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -37,6 +37,8 @@ class TestRolePolicy:
         ("POST", "/rename", "clerk"),                 # default: mutation → clerk
         ("DELETE", "/api/delete-file", "clerk"),
         ("GET", "/api/getcomics/search", "clerk"),    # clerk-only read area
+        # Backs the clerk-only /releases page; must not be reader-visible.
+        ("POST", "/api/releases/publishers", "clerk"),
         ("POST", "/api/bulk-metadata/start", "clerk"),
         # Clerk-only browser pages (hidden from Readers in the nav + blocked by
         # direct URL). Enumerated so a Reader can't reach them via GET.

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -1161,3 +1161,272 @@ class TestPullListAddFolder:
 
         assert resp.status_code == 500
         assert resp.get_json()["success"] is False
+
+
+
+class TestReleasesPublisherFilter:
+    """
+    Weekly Releases publisher filter.
+
+    Metron's issue-list payload carries the series but no publisher, so the page
+    groups releases through the metron_series_publishers cache and fills the
+    misses in a bounded background pass.
+    """
+
+    ENDPOINT = "/api/releases/publishers"
+
+    @pytest.fixture(autouse=True)
+    def _reset_warm_state(self, db_connection):
+        from routes import series as series_routes
+
+        series_routes._publisher_warm_active.clear()
+        series_routes._publisher_warm_state.clear()
+        yield
+        series_routes._publisher_warm_active.clear()
+        series_routes._publisher_warm_state.clear()
+
+    @staticmethod
+    def _issue(issue_id, series_id):
+        issue = MagicMock()
+        issue.id = issue_id
+        issue.number = "1"
+        issue.cover_date = "2024-01-10"
+        issue.image = "http://example.test/cover.jpg"
+        issue.series = MagicMock()
+        issue.series.id = series_id
+        issue.series.name = f"Series {series_id}"
+        issue.series.volume = 1
+        return issue
+
+    def _releases_context(self, client, app, releases):
+        """Render /releases with Metron stubbed, returning the template context."""
+        from datetime import datetime
+
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+
+        captured = {}
+
+        def fake_render(template, **context):
+            captured.update(context)
+            captured["_template"] = template
+            return "ok"
+
+        with patch("routes.series.metron") as mock_metron, \
+                patch("routes.series.render_template", side_effect=fake_render):
+            mock_metron.get_flask_api.return_value = MagicMock()
+            mock_metron.calculate_comic_week.return_value = (
+                datetime(2024, 1, 7),
+                datetime(2024, 1, 13),
+            )
+            mock_metron.get_releases.return_value = releases
+            resp = client.get("/releases?date=2024-01-10")
+
+        assert resp.status_code == 200
+        return captured
+
+    # -- page context -----------------------------------------------------
+    def test_page_maps_series_to_cached_publishers(self, client, app):
+        from core.database import save_series_publishers
+
+        save_series_publishers({11: "Marvel", 22: "DC Comics"})
+
+        ctx = self._releases_context(
+            client, app, [self._issue(1, 11), self._issue(2, 22)]
+        )
+
+        assert ctx["publisher_map"] == {11: "Marvel", 22: "DC Comics"}
+        # Everything resolved -> no background work, no client polling.
+        assert ctx["publisher_pending"] is False
+        assert ctx["query_after"] == "2024-01-07"
+        assert ctx["query_before"] == "2024-01-13"
+
+    def test_page_starts_warm_pass_for_unknown_series(self, client, app):
+        from core.database import save_series_publishers
+
+        save_series_publishers({11: "Marvel"})
+
+        with patch("routes.series._start_publisher_warm",
+                   return_value=True) as mock_warm:
+            ctx = self._releases_context(
+                client, app, [self._issue(1, 11), self._issue(2, 99)]
+            )
+
+        assert ctx["publisher_pending"] is True
+        args = mock_warm.call_args[0]
+        assert args[1] == "2024-01-07" and args[2] == "2024-01-13"
+        assert list(args[3]) == [99]  # only the unresolved series
+
+    def test_page_survives_metron_being_unconfigured(self, client, app):
+        # The template always reads publisher_map/publisher_pending, so the
+        # error branch has to supply them too.
+        resp = client.get("/releases")
+        assert resp.status_code == 200
+
+    def test_page_renders_the_filter_and_tags_every_card(self, client, app):
+        # The pills are built client-side from these two things: the serialized
+        # map and a data-series-id on each card. If either stops rendering, the
+        # filter silently disappears.
+        from datetime import datetime
+        from core.database import save_series_publishers
+
+        app.config["METRON_USERNAME"] = "user"
+        app.config["METRON_PASSWORD"] = "pass"
+        app.jinja_env.globals["generate_series_slug"] = lambda *a, **k: "slug-1"
+        save_series_publishers({11: "Marvel"})
+
+        with patch("routes.series.metron") as mock_metron, \
+                patch("routes.series._start_publisher_warm", return_value=True):
+            mock_metron.get_flask_api.return_value = MagicMock()
+            mock_metron.calculate_comic_week.return_value = (
+                datetime(2024, 1, 7), datetime(2024, 1, 13),
+            )
+            mock_metron.get_releases.return_value = [
+                self._issue(1, 11), self._issue(2, 99),
+            ]
+            resp = client.get("/releases?date=2024-01-10")
+
+        html = resp.get_data(as_text=True)
+        assert resp.status_code == 200
+        assert 'id="publisher-filter"' in html
+        assert html.count("data-series-id=") == 2
+        # JSON keys are strings, matching the dataset lookup in the template.
+        assert 'const publisherMap = {"11": "Marvel"}' in html
+        assert "const pendingWarm = true" in html
+
+    # -- warm pass --------------------------------------------------------
+    def test_warm_pass_bulk_resolves_by_known_publisher(self, db_connection):
+        # One publisher-filtered call resolves every series that publisher
+        # shipped in the window -- the whole point of the bulk phase.
+        from core.database import get_series_publishers, save_series_publishers
+        from routes import series as series_routes
+
+        save_series_publishers({1: "Marvel"})
+        unknown = list(range(100, 130))  # > the per-series cap, so bulk runs
+
+        def fake_get_releases(api, date_after, date_before, publisher_name=None):
+            if publisher_name == "Marvel":
+                return [self._issue(i, sid) for i, sid in enumerate(unknown[:25])]
+            return []
+
+        with patch("routes.series.metron") as mock_metron:
+            mock_metron.get_releases.side_effect = fake_get_releases
+            mock_metron.get_series_details.return_value = {"publisher_name": "Image"}
+            series_routes._warm_release_publishers(
+                MagicMock(), "2024-01-07", "2024-01-13", unknown, "k"
+            )
+
+        cached = get_series_publishers(unknown)
+        assert cached[100] == "Marvel"
+        assert cached[124] == "Marvel"
+        # The bulk phase missed the tail; per-series lookups picked it up.
+        assert cached[125] == "Image"
+
+    def test_warm_pass_uses_series_lookup_for_small_tail(self, db_connection):
+        from core.database import get_series_publishers
+        from routes import series as series_routes
+
+        with patch("routes.series.metron") as mock_metron:
+            mock_metron.get_series_details.return_value = {"publisher_name": "Boom"}
+            series_routes._warm_release_publishers(
+                MagicMock(), "2024-01-07", "2024-01-13", [55], "k"
+            )
+            # A 1-series tail is not worth a bulk sweep.
+            mock_metron.get_releases.assert_not_called()
+
+        assert get_series_publishers([55]) == {55: "Boom"}
+
+    def test_warm_pass_that_learns_nothing_stops_retrying(self, db_connection):
+        from routes import series as series_routes
+
+        with patch("routes.series.metron") as mock_metron:
+            mock_metron.get_series_details.return_value = None
+            series_routes._warm_release_publishers(
+                MagicMock(), "2024-01-07", "2024-01-13", [55], "2024-01-07|2024-01-13"
+            )
+
+        assert series_routes._publisher_warm_state["2024-01-07|2024-01-13"]["exhausted"]
+        # Exhausted window -> no further passes are started.
+        with patch("routes.series.threading.Thread") as mock_thread:
+            started = series_routes._start_publisher_warm(
+                MagicMock(), "2024-01-07", "2024-01-13", [55]
+            )
+        assert started is False
+        mock_thread.assert_not_called()
+
+    def test_warm_pass_is_not_started_twice_for_a_window(self, db_connection):
+        from routes import series as series_routes
+
+        with patch("routes.series.threading.Thread") as mock_thread:
+            first = series_routes._start_publisher_warm(
+                MagicMock(), "2024-01-07", "2024-01-13", [55]
+            )
+            second = series_routes._start_publisher_warm(
+                MagicMock(), "2024-01-07", "2024-01-13", [55]
+            )
+
+        assert first is True and second is True
+        assert mock_thread.call_count == 1
+
+    def test_warm_pass_is_capped_per_window(self, db_connection):
+        from routes import series as series_routes
+
+        with patch("routes.series.threading.Thread"):
+            for _ in range(series_routes._PUBLISHER_WARM_MAX_PASSES):
+                series_routes._start_publisher_warm(
+                    MagicMock(), "2024-01-07", "2024-01-13", [55]
+                )
+                series_routes._publisher_warm_active.clear()
+
+            assert series_routes._start_publisher_warm(
+                MagicMock(), "2024-01-07", "2024-01-13", [55]
+            ) is False
+
+    # -- poll endpoint ----------------------------------------------------
+    def test_api_returns_cached_publishers(self, client):
+        from core.database import save_series_publishers
+
+        save_series_publishers({11: "Marvel"})
+
+        resp = client.post(self.ENDPOINT, json={"series_ids": [11]})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["publishers"] == {"11": "Marvel"}
+        assert data["unknown"] == 0
+        assert data["pending"] is False
+
+    def test_api_rearms_the_warm_pass_for_unknown_series(self, client):
+        with patch("routes.series._start_publisher_warm",
+                   return_value=True) as mock_warm:
+            resp = client.post(self.ENDPOINT, json={
+                "series_ids": [77],
+                "date_after": "2024-01-07",
+                "date_before": "2024-01-13",
+            })
+
+        data = resp.get_json()
+        assert data["unknown"] == 1
+        assert data["pending"] is True
+        assert mock_warm.call_args[0][1] == "2024-01-07"
+
+    def test_api_rejects_a_bad_date(self, client):
+        resp = client.post(self.ENDPOINT, json={
+            "series_ids": [1], "date_after": "not-a-date",
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+
+    def test_api_ignores_unusable_series_ids(self, client):
+        resp = client.post(self.ENDPOINT, json={"series_ids": ["abc", None, "12"]})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["unknown"] == 1  # only the coercible "12" counted
+
+    def test_api_handles_an_empty_body(self, client):
+        resp = client.post(self.ENDPOINT, json={})
+        assert resp.status_code == 200
+        assert resp.get_json()["publishers"] == {}


### PR DESCRIPTION
## What

Adds a Publisher filter to the Weekly Releases page.

## The constraint

Metron's issue-list endpoint (`api.issues_list`, behind `metron.get_releases`) returns `BaseIssue` objects — id, series `{id, name, volume, year_began}`, number, dates, image. **No publisher field**; only the full `Issue` schema has one. So the publishers aren't in the payload to group on, and `publisher_name` works as an *input* filter only.

Resolving publisher per series directly would be ~150 `api.series(id)` calls a week against the daily pacer in `models/metron.py`, so publishers come from a cache that warms itself instead.

## How

**Cache** — new `metron_series_publishers` table (`series_id` → `publisher_name`) with `get_series_publishers()`, `save_series_publishers()`, `get_known_publisher_names()`. Deliberately not the `series` table, which holds tracked/mapped series and would be polluted by every series that happens to ship in a given week.

**Warm pass** (`routes/series.py`), started in the background when a week has unresolved series:

1. *Bulk* — one `get_releases(..., publisher_name=X)` call per already-known publisher resolves every series X shipped in that window at once. This is where Mokkari's filter does the heavy lifting.
2. *Tail* — capped per-series lookups (20/pass) for what bulk missed. Each publisher discovered here becomes a bulk candidate on the next pass, so a cold cache converges in a few passes.

Bounded to 6 passes per week-window; a pass that learns nothing marks the window exhausted, so a stubborn week can't sit on Metron's daily quota.

**UI** — pills with live counts (`All 312 · Marvel 84 · DC 61 · Unidentified 30`), derived from the DOM so the counts are always truthful. Filtering is client-side and instant, with the selection mirrored into `?publisher=` for deep links. While the cache fills, the page polls `/api/releases/publishers` via `CLU.startPoll` (overlap guard + abort) and re-renders pills as publishers arrive, stopping when the server reports it's done.

**RBAC** — `/api/releases` added to `_CLERK_PREFIXES`, matching the Clerk-only `/releases` page it backs.

## Expected first-run behavior

The first visit with an empty cache shows mostly "Unidentified" and fills in over the following seconds and visits. Series repeat heavily week to week, so the cache is warm after a little browsing.

## Tests

- 16 new in `tests/routes/test_series_routes.py` — page context, a real HTML render (guards the serialized map and per-card `data-series-id`), both warm phases, exhaustion/dedup/pass-cap guards, endpoint happy path and bad input.
- `publisher_name` passthrough tests in `tests/mocked/test_metron_model.py`.
- RBAC classification case in `tests/routes/test_rbac.py`.

Full suite: **3507 passed, 6 skipped** (the usual POSIX-only skips on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
