### PR TITLE
Auto-generate folder thumbnails, fix card art sizing, add a card size picker

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,6 +96,7 @@ from core.database import (
     save_file_index_to_db,
     update_file_index_entry,
     add_file_index_entry,
+    set_directory_has_thumbnail,
     delete_file_index_entry,
     sync_file_index_incremental,
     get_rebuild_schedule,
@@ -3578,12 +3579,11 @@ def _build_file_index_locked():
     # Track comic files for recent files database
     comic_files = []
 
-    # Helper function to check for folder thumbnail
+    # Helper function to check for folder thumbnail. Shares find_folder_thumbnail's
+    # extension list so an uploaded folder.gif / folder.webp indexes as art rather
+    # than reading as "no thumbnail".
     def check_has_thumbnail(folder_path):
-        for ext in [".png", ".jpg", ".jpeg"]:
-            if os.path.exists(os.path.join(folder_path, f"folder{ext}")):
-                return 1
-        return 0
+        return 1 if find_folder_thumbnail(folder_path) else 0
 
     try:
         # Iterate over all configured library roots
@@ -3755,10 +3755,7 @@ def scan_filesystem_for_sync():
             return normalized_path.startswith(normalized_target_dir)
 
     def check_has_thumbnail(folder_path):
-        for ext in [".png", ".jpg", ".jpeg"]:
-            if os.path.exists(os.path.join(folder_path, f"folder{ext}")):
-                return 1
-        return 0
+        return 1 if find_folder_thumbnail(folder_path) else 0
 
     # Get all library roots to scan
     library_roots = get_library_roots()
@@ -4764,6 +4761,7 @@ def resize_upload(file_path, target_dir):
 
 
 from helpers import find_folder_thumbnail  # noqa: E402  (re-export for callers)
+from helpers import match_parent_permissions  # noqa: E402
 
 
 def find_folder_thumbnails_batch(folder_paths):
@@ -5690,43 +5688,6 @@ def get_thumbnail():
     return redirect(url_for("static", filename="images/loading.svg"))
 
 
-def create_nested_folder_thumbnail(
-    comic_stack_img, folder_icon_path, canvas_size=(200, 300)
-):
-    """Composite the comic stack behind a folder icon for nested folder thumbnails."""
-    folder_icon = Image.open(folder_icon_path).convert("RGBA")
-
-    stack = comic_stack_img.convert("RGBA")
-
-    # Scale stack to 175px wide with proportionate height
-    new_w = 190
-    aspect_ratio = stack.height / stack.width
-    new_h = int(new_w * aspect_ratio)
-
-    stack_resized = stack.resize((new_w, new_h), Image.Resampling.LANCZOS)
-
-    # Position stack: centered horizontally, 20px from bottom
-    x_pos = (canvas_size[0] - new_w) // 2
-    y_pos = canvas_size[1] - new_h - 20  # 20px from bottom
-
-    # Create final canvas
-    final_thumb = Image.new("RGBA", canvas_size, (0, 0, 0, 0))
-
-    # Paste stack FIRST (behind)
-    final_thumb.paste(stack_resized, (x_pos, y_pos), mask=stack_resized)
-
-    # Paste folder icon ON TOP (in front)
-    final_thumb.paste(folder_icon, (0, 0), mask=folder_icon)
-
-    # Resize final image to 167px width with proportionate height
-    final_w = 167
-    aspect = final_thumb.height / final_thumb.width
-    final_h = int(final_w * aspect)
-    final_thumb = final_thumb.resize((final_w, final_h), Image.Resampling.LANCZOS)
-
-    return final_thumb
-
-
 @app.route("/api/generate-folder-thumbnail", methods=["POST"])
 def generate_folder_thumbnail():
     """Generate a fanned stack thumbnail for a folder using cached thumbnails."""
@@ -5740,228 +5701,39 @@ def generate_folder_thumbnail():
         return jsonify({"error": "Invalid folder path"}), 400
 
     try:
-        # Get cache directory
-        cache_dir = config.get("SETTINGS", "CACHE_DIR", fallback="/cache")
-        thumbnails_dir = os.path.join(cache_dir, "thumbnails")
-
-        # Define excluded extensions
-        excluded_extensions = {
-            ".png",
-            ".jpg",
-            ".jpeg",
-            ".gif.html",
-            ".css",
-            ".ds_store",
-            "cvinfo",
-            ".json",
-            ".db",
-            ".xml",
-        }
-
-        # Find comic files in the folder
-        comic_files = []
-        is_nested = False  # Track if we're using nested folder comics
-
-        # First, check for direct comic files
-        for item in sorted(os.listdir(folder_path)):
-            item_path = os.path.join(folder_path, item)
-            if os.path.isfile(item_path):
-                _, ext = os.path.splitext(item.lower())
-                if ext not in excluded_extensions and not item.startswith(
-                    (".", "-", "_")
-                ):
-                    if ext in [".cbz", ".cbr", ".zip"]:
-                        comic_files.append(item_path)
-
-        # If no direct comics, scan subfolders
-        if not comic_files:
-            is_nested = True
-            subfolder_comics = {}  # {subfolder_path: [comic_files]}
-
-            for item in sorted(os.listdir(folder_path)):
-                item_path = os.path.join(folder_path, item)
-                if os.path.isdir(item_path) and not item.startswith((".", "_")):
-                    folder_comics = []
-                    for subitem in sorted(os.listdir(item_path)):
-                        subitem_path = os.path.join(item_path, subitem)
-                        if os.path.isfile(subitem_path):
-                            _, ext = os.path.splitext(subitem.lower())
-                            if ext in [".cbz", ".cbr", ".zip"]:
-                                folder_comics.append(subitem_path)
-                    if folder_comics:
-                        subfolder_comics[item_path] = folder_comics
-
-            if not subfolder_comics:
-                return jsonify(
-                    {"error": "No comic files found in folder or subfolders"}
-                ), 400
-
-            # Distribute 4 slots across subfolders
-            MAX_COVERS = 4
-            subfolders = list(subfolder_comics.keys())
-            num_folders = len(subfolders)
-
-            if num_folders >= MAX_COVERS:
-                # 4+ folders: 1 from each of first 4
-                for i in range(MAX_COVERS):
-                    comic_files.append(subfolder_comics[subfolders[i]][0])
-            else:
-                # Fewer than 4 folders: distribute evenly with extras going to earlier folders
-                per_folder = MAX_COVERS // num_folders
-                remainder = MAX_COVERS % num_folders
-
-                for i, folder in enumerate(subfolders):
-                    count = per_folder + (1 if i < remainder else 0)
-                    comic_files.extend(subfolder_comics[folder][:count])
-
-        # Get cached thumbnail paths for the first 4 comics
-        MAX_COVERS = 4
-        selected_files = comic_files[:MAX_COVERS]
-        cached_thumbs = []
-
-        for file_path in selected_files:
-            # Calculate cache path using same method as get_thumbnail
-            path_hash = hashlib.md5(
-                file_path.encode("utf-8"), usedforsecurity=False
-            ).hexdigest()
-            shard_dir = path_hash[:2]
-            filename = f"{path_hash}.jpg"
-            cache_path = os.path.join(thumbnails_dir, shard_dir, filename)
-
-            if os.path.exists(cache_path):
-                cached_thumbs.append(cache_path)
-            else:
-                # Generate thumbnail synchronously if missing
-                try:
-                    if generate_thumbnail_sync(file_path, cache_path):
-                        cached_thumbs.append(cache_path)
-                except Exception as e:
-                    app_logger.warning(
-                        f"Failed to generate thumbnail for {file_path}: {e}"
-                    )
-
-        if not cached_thumbs:
+        # Single source of truth for the rendering itself — see
+        # generate_folder_thumbnail_internal below. This route is the explicit
+        # user action, so it overwrites any existing folder image.
+        if generate_folder_thumbnail_internal(folder_path):
             return jsonify(
-                {"error": "Could not generate any thumbnails for comics in this folder"}
-            ), 400
-
-        # Create fanned stack thumbnail
-        CANVAS_SIZE = (200, 300)
-        THUMB_SIZE = (150, 245)
-        ROTATION_LIMIT = 10
-        Y_OFFSET = 0
-
-        final_canvas = Image.new("RGBA", CANVAS_SIZE, (0, 0, 0, 0))
-
-        # Reverse cached_thumbs so we paste from back to front (001 pasted last/on top)
-        reversed_thumbs = list(reversed(cached_thumbs))
-
-        # --- 3. Define Angles ---
-        angles = []
-        for i in range(len(reversed_thumbs)):
-            if i == len(reversed_thumbs) - 1:
-                angles.append(0)
-            else:
-                # Randomize rotation for background images
-                angles.append(random.randint(-ROTATION_LIMIT, ROTATION_LIMIT))
-
-        for i, thumb_path in enumerate(reversed_thumbs):
-            try:
-                # Open and resize cached thumbnail
-                img = Image.open(thumb_path).convert("RGBA")
-
-                # Fit to thumb size
-                img.thumbnail(THUMB_SIZE, Image.Resampling.LANCZOS)
-
-                # Create centered image
-                fitted_img = Image.new("RGBA", THUMB_SIZE, (0, 0, 0, 0))
-                paste_x = (THUMB_SIZE[0] - img.width) // 2
-                paste_y = (THUMB_SIZE[1] - img.height) // 2
-                fitted_img.paste(
-                    img, (paste_x, paste_y), img if img.mode == "RGBA" else None
-                )
-
-                # Create layer for rotation and shadow
-                layer_size = (int(THUMB_SIZE[0] * 1.5), int(THUMB_SIZE[1] * 1.5))
-                layer = Image.new("RGBA", layer_size, (0, 0, 0, 0))
-
-                # Calculate center position
-                layer_paste_x = (layer_size[0] - THUMB_SIZE[0]) // 2
-                layer_paste_y = (layer_size[1] - THUMB_SIZE[1]) // 2
-
-                # Add drop shadow
-                shadow = Image.new("RGBA", layer_size, (0, 0, 0, 0))
-                shadow_box = (
-                    layer_paste_x + 4,
-                    layer_paste_y + 4,
-                    layer_paste_x + THUMB_SIZE[0] + 4,
-                    layer_paste_y + THUMB_SIZE[1] + 4,
-                )
-
-                d = ImageDraw.Draw(shadow)
-                d.rectangle(shadow_box, fill=(0, 0, 0, 120))
-                shadow = shadow.filter(ImageFilter.GaussianBlur(radius=5))
-
-                # Composite shadow + image
-                layer = Image.alpha_composite(layer, shadow)
-                layer.paste(fitted_img, (layer_paste_x, layer_paste_y), fitted_img)
-
-                # Rotate the layer
-                angle = angles[i]
-                rotated_layer = layer.rotate(
-                    angle, resample=Image.Resampling.BICUBIC, expand=False
-                )
-
-                # Position on canvas with Y_OFFSET to move stack down
-                final_x = (CANVAS_SIZE[0] - rotated_layer.width) // 2
-                final_y = ((CANVAS_SIZE[1] - rotated_layer.height) // 2) + Y_OFFSET
-
-                final_canvas.paste(rotated_layer, (final_x, final_y), rotated_layer)
-
-            except Exception as e:
-                app_logger.error(f"Error processing thumbnail {thumb_path}: {e}")
-
-        # Remove any existing folder thumbnail files to allow regeneration
-        for ext in ["folder.png", "folder.jpg", "folder.jpeg", "folder.gif"]:
-            existing_thumb = os.path.join(folder_path, ext)
-            if os.path.exists(existing_thumb):
-                try:
-                    os.remove(existing_thumb)
-                    app_logger.info(f"Removed existing thumbnail: {existing_thumb}")
-                except Exception as e:
-                    app_logger.error(
-                        f"Error removing existing thumbnail {existing_thumb}: {e}"
-                    )
-
-        # If using nested folder comics, overlay on folder icon
-        if is_nested:
-            folder_icon_path = os.path.join(
-                app.static_folder, "images", "folder-fill-200x300.png"
+                {
+                    "success": True,
+                    "thumbnail_path": os.path.join(folder_path, "folder.png"),
+                }
             )
-            if os.path.exists(folder_icon_path):
-                final_canvas = create_nested_folder_thumbnail(
-                    final_canvas, folder_icon_path
-                )
 
-        # Save to folder
-        output_path = os.path.join(folder_path, "folder.png")
-        final_canvas.save(output_path, "PNG")
-
-        app_logger.info(f"Generated folder thumbnail: {output_path}")
-
-        # Invalidate cache to show new thumbnail
-        invalidate_cache_for_path(folder_path)
-
-        return jsonify({"success": True, "thumbnail_path": output_path})
+        return jsonify(
+            {"error": "No comic files found in folder or subfolders"}
+        ), 400
 
     except Exception as e:
         app_logger.error(f"Error generating folder thumbnail: {e}")
         return jsonify({"error": str(e)}), 500
 
 
-def generate_folder_thumbnail_internal(folder_path):
-    """Internal function to generate folder thumbnail. Returns True on success, False on failure."""
+def generate_folder_thumbnail_internal(folder_path, overwrite=True):
+    """Generate a folder's cover art. Returns True on success, False on failure.
+
+    With ``overwrite=False`` an existing ``folder.*`` image is left alone and
+    False is returned — that is the contract the background auto-generator
+    relies on so it can never replace art the user uploaded themselves.
+    """
     try:
+        from core.folder_thumbnails import create_nested_folder_thumbnail, may_write
+
+        if not may_write(folder_path, overwrite):
+            return False
+
         # Get cache directory
         cache_dir = config.get("SETTINGS", "CACHE_DIR", fallback="/cache")
         thumbnails_dir = os.path.join(cache_dir, "thumbnails")
@@ -6145,8 +5917,15 @@ def generate_folder_thumbnail_internal(folder_path):
 
         output_path = os.path.join(folder_path, "folder.png")
         final_canvas.save(output_path, "PNG")
+        # Without this the image lands with the process umask (root:0600 when
+        # the container fell back to root at startup) and cannot be read back
+        # out to serve the thumbnail.
+        match_parent_permissions(output_path)
 
         app_logger.info(f"Generated folder thumbnail: {output_path}")
+        # /api/browse serves folder art off this cached flag, so a stale 0 here
+        # hides the image until the next full library scan.
+        set_directory_has_thumbnail(folder_path, True)
         invalidate_cache_for_path(folder_path)
 
         return True
@@ -6873,6 +6652,11 @@ def save_file_processing_config():
             str(data.get("smartRenameExcludeTerms", "Annual,Special") or ""),
             category="file_processing",
         )
+        set_user_preference(
+            "auto_folder_thumbnails",
+            bool(data.get("autoFolderThumbnails", True)),
+            category="file_processing",
+        )
         app.config["SMART_RENAME_PREVIEW_ENABLED"] = bool(
             data.get("smartRenamePreviewEnabled", True)
         )
@@ -7448,6 +7232,9 @@ def config_page():
         skippedFiles=settings.get("SKIPPED_FILES", ""),
         deletedFiles=settings.get("DELETED_FILES", ""),
         hiddenDirectories=get_user_preference("hidden_directories", ["@eaDir"]),
+        autoFolderThumbnails=get_user_preference(
+            "auto_folder_thumbnails", default=True
+        ),
         customHeaders=get_user_preference("custom_headers", ""),
         operationTimeout=settings.get("OPERATION_TIMEOUT", "3600"),
         largeFileThreshold=settings.get("LARGE_FILE_THRESHOLD", "500"),

--- a/core/database.py
+++ b/core/database.py
@@ -25,6 +25,10 @@ from core.metadata_normalize import (
 #       file_index, file_metadata_tags and issues_read.
 CURRENT_DATA_MIGRATION_VERSION = 1
 
+# The ANALYZE thread init_db() spawns. Kept so callers can wait for it to
+# finish -- see wait_for_background_analyze().
+_analyze_thread = None
+
 
 def get_db_path():
     target_dir = CONFIG_DIR
@@ -1686,7 +1690,9 @@ def init_db():
             except Exception as e:
                 app_logger.debug(f"Background ANALYZE skipped: {e}")
 
-        threading.Thread(target=_background_analyze, daemon=True).start()
+        global _analyze_thread
+        _analyze_thread = threading.Thread(target=_background_analyze, daemon=True)
+        _analyze_thread.start()
 
         if _needs_tag_backfill or _needs_credit_normalization:
             app_logger.info(
@@ -1717,6 +1723,24 @@ def get_db_connection():
     except Exception as e:
         app_logger.error(f"Failed to connect to database: {e}")
         return None
+
+
+def wait_for_background_analyze(timeout: float = 10.0) -> bool:
+    """Block until the ANALYZE thread ``init_db()`` started has finished.
+
+    That thread keeps writing to the database after ``init_db()`` returns, and
+    an open connection committing after the file has been replaced flushes its
+    cached pages back over the new contents. Anything that swaps the file out
+    or inspects it for corruption has to be able to wait for quiet first.
+
+    Returns True when no ANALYZE thread is still running (including the case
+    where none was ever started), False if it outlived ``timeout``.
+    """
+    thread = _analyze_thread
+    if thread is None:
+        return True
+    thread.join(timeout)
+    return not thread.is_alive()
 
 
 def check_integrity(db_path: Optional[str] = None, quick: bool = True):

--- a/core/database.py
+++ b/core/database.py
@@ -2989,6 +2989,39 @@ def update_file_index_entry(path, name=None, new_path=None, parent=None, size=No
         return False
 
 
+def set_directory_has_thumbnail(path, has_thumbnail=True):
+    """Flip the cached ``has_thumbnail`` flag for an indexed directory.
+
+    ``/api/browse`` reads this flag rather than stat-ing the filesystem, so a
+    folder.png created after the last index pass stays invisible until the flag
+    is updated. Every folder-thumbnail write calls this so the art shows up on
+    the next page load instead of the next full scan.
+
+    Returns True when a row was updated (False when the directory is not
+    indexed yet — harmless, the next scan will pick it up).
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return False
+
+        c = conn.cursor()
+        c.execute(
+            "UPDATE file_index SET has_thumbnail = ?, "
+            "last_updated = CURRENT_TIMESTAMP "
+            "WHERE path = ? AND type = 'directory'",
+            (1 if has_thumbnail else 0, path),
+        )
+        rows_affected = c.rowcount
+        conn.commit()
+        conn.close()
+        return rows_affected > 0
+
+    except Exception as e:
+        app_logger.error(f"Failed to set has_thumbnail for {path}: {e}")
+        return False
+
+
 def add_file_index_entry(
     name, path, entry_type, size=None, parent=None, has_thumbnail=0, modified_at=None
 ):

--- a/core/folder_thumbnails.py
+++ b/core/folder_thumbnails.py
@@ -1,0 +1,228 @@
+"""Background auto-generation of folder cover art.
+
+Folders get their `folder.png` from three places: a user-uploaded image, the
+per-folder "Generate Thumbnail" menu action, or the recursive "Generate All
+Missing Thumbnails" sweep. The first is manual by nature; the other two mean a
+new series sits behind a generic folder icon until someone remembers to run
+them.
+
+This module closes that gap by generating art lazily for folders the user
+actually looks at. `/api/browse-thumbnails` — the endpoint the collection grid
+already calls for every folder it cannot show art for — hands those paths to
+`enqueue()`, and a single background worker fills them in. Browsing is the hook
+because it is reliable: unlike filesystem events, it fires for exactly the
+folders on screen and re-fires on every visit, so a folder that failed to
+render once gets another chance the next time it matters.
+
+Two rules keep this from becoming a nuisance:
+
+* An existing `folder.*` image is never touched. Uploaded art always wins.
+* A folder that cannot produce art (no comics in it or below it) is remembered
+  as failed and not retried for `FAILURE_TTL_SECONDS`, so a library full of
+  empty folders does not re-attempt generation on every page view.
+
+Generation is single-threaded on purpose: it opens comic archives to build
+missing cover thumbnails, and the pre-existing `thumbnail_executor` already
+competes for the same disk.
+"""
+
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from PIL import Image
+
+from core.app_logging import app_logger
+
+# Folders whose generation failed are not retried for this long. Long enough
+# that browsing back and forth costs nothing, short enough that adding comics
+# to a previously empty folder is picked up the same day.
+FAILURE_TTL_SECONDS = 6 * 60 * 60
+
+# Upper bound on paths waiting in the queue. A user paging through a large
+# library can enqueue faster than one worker drains; past this point new
+# requests are dropped and picked up on a later visit rather than growing the
+# backlog without limit.
+MAX_QUEUED = 250
+
+# Ceiling on remembered failures before expired ones are pruned.
+MAX_FAILED_TRACKED = 5000
+
+_executor = None
+_executor_lock = threading.Lock()
+
+_state_lock = threading.Lock()
+_queued = set()        # paths queued or in flight
+_failed = {}           # path -> monotonic timestamp of last failure
+
+
+def is_enabled():
+    """True when auto-generation is turned on (default) in preferences."""
+    try:
+        from core.database import get_user_preference
+
+        return bool(get_user_preference("auto_folder_thumbnails", default=True))
+    except Exception:
+        return True
+
+
+def create_nested_folder_thumbnail(
+    comic_stack_img, folder_icon_path, canvas_size=(200, 300)
+):
+    """Composite the comic stack behind a folder icon for nested folder thumbnails.
+
+    Returns an image at ``canvas_size`` — the same dimensions as the plain
+    fanned stack, and the same 300px height every comic cover thumbnail is
+    normalized to. The two folder variants sit side by side in the grid, so a
+    composite of a different size reads as a different-sized card.
+    """
+    folder_icon = Image.open(folder_icon_path).convert("RGBA")
+
+    stack = comic_stack_img.convert("RGBA")
+
+    # Scale stack to 190px wide with proportionate height
+    new_w = 190
+    aspect_ratio = stack.height / stack.width
+    new_h = int(new_w * aspect_ratio)
+
+    stack_resized = stack.resize((new_w, new_h), Image.Resampling.LANCZOS)
+
+    # Position stack: centered horizontally, 20px from bottom
+    x_pos = (canvas_size[0] - new_w) // 2
+    y_pos = canvas_size[1] - new_h - 20  # 20px from bottom
+
+    # Create final canvas
+    final_thumb = Image.new("RGBA", canvas_size, (0, 0, 0, 0))
+
+    # Paste stack FIRST (behind)
+    final_thumb.paste(stack_resized, (x_pos, y_pos), mask=stack_resized)
+
+    # Paste folder icon ON TOP (in front)
+    final_thumb.paste(folder_icon, (0, 0), mask=folder_icon)
+
+    return final_thumb
+
+
+def may_write(folder_path, overwrite):
+    """Whether generation is allowed to write ``folder.png`` into a folder.
+
+    The explicit menu actions pass ``overwrite=True`` — the user asked for new
+    art and expects the old image replaced. Auto-generation passes False, and
+    any existing ``folder.*`` (including formats we generate but never produce,
+    like an uploaded .gif) makes this the user's image to keep.
+    """
+    if overwrite:
+        return True
+
+    from helpers import find_folder_thumbnail
+
+    return find_folder_thumbnail(folder_path) is None
+
+
+def _get_executor():
+    global _executor
+    with _executor_lock:
+        if _executor is None:
+            _executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="folder-thumb"
+            )
+        return _executor
+
+
+def reset_state():
+    """Clear queue bookkeeping. Test-support only."""
+    with _state_lock:
+        _queued.clear()
+        _failed.clear()
+
+
+def _should_queue(folder_path):
+    """Decide whether to accept a path, and claim it if so."""
+    with _state_lock:
+        if folder_path in _queued:
+            return False
+        if len(_queued) >= MAX_QUEUED:
+            return False
+
+        failed_at = _failed.get(folder_path)
+        if failed_at is not None:
+            if (time.monotonic() - failed_at) < FAILURE_TTL_SECONDS:
+                return False
+            del _failed[folder_path]
+
+        _queued.add(folder_path)
+        return True
+
+
+def _record_result(folder_path, succeeded):
+    with _state_lock:
+        _queued.discard(folder_path)
+        if succeeded:
+            _failed.pop(folder_path, None)
+        else:
+            _failed[folder_path] = time.monotonic()
+            # A library can hold more art-less folders than we want to remember
+            # forever. Expired entries are dead weight, so drop them once the
+            # record grows past the point of being a useful short-term memory.
+            if len(_failed) > MAX_FAILED_TRACKED:
+                cutoff = time.monotonic() - FAILURE_TTL_SECONDS
+                for path in [p for p, t in _failed.items() if t < cutoff]:
+                    del _failed[path]
+
+
+def _generate(folder_path):
+    """Worker body: generate art for one folder, never raising."""
+    succeeded = False
+    try:
+        # Imported here: app imports this module's enqueue(), so a module-level
+        # import would be circular.
+        from app import generate_folder_thumbnail_internal
+
+        succeeded = generate_folder_thumbnail_internal(folder_path, overwrite=False)
+        if succeeded:
+            app_logger.info(f"Auto-generated folder thumbnail for {folder_path}")
+        else:
+            app_logger.debug(
+                f"No folder thumbnail could be generated for {folder_path}"
+            )
+    except Exception as e:
+        app_logger.warning(f"Auto folder-thumbnail generation failed for {folder_path}: {e}")
+    finally:
+        _record_result(folder_path, succeeded)
+
+
+def enqueue(folder_path):
+    """Queue a folder for background art generation.
+
+    Returns True when the path was accepted (it was a real directory, is not
+    already queued, has not recently failed, and auto-generation is enabled).
+    Callers treat the return value as advisory — a False costs the user
+    nothing beyond the generic folder icon they already have.
+    """
+    if not folder_path or not is_enabled():
+        return False
+
+    try:
+        if not os.path.isdir(folder_path):
+            return False
+    except OSError:
+        return False
+
+    if not _should_queue(folder_path):
+        return False
+
+    try:
+        _get_executor().submit(_generate, folder_path)
+        return True
+    except Exception as e:
+        # Executor rejected the work (shutdown, thread exhaustion). Release the
+        # claim so a later visit can retry.
+        _record_result(folder_path, False)
+        app_logger.warning(f"Could not queue folder thumbnail for {folder_path}: {e}")
+        return False
+
+
+def enqueue_many(folder_paths):
+    """Queue several folders. Returns the number accepted."""
+    return sum(1 for path in folder_paths if enqueue(path))

--- a/routes/collection.py
+++ b/routes/collection.py
@@ -23,6 +23,8 @@ from PIL import Image
 from core.app_logging import app_logger
 from core.config import config
 from core.metadata_normalize import strip_provider_ids
+from core import folder_thumbnails
+from helpers import find_folder_thumbnail
 from helpers.library import get_library_roots, get_default_library, is_valid_library_path
 from core.auth import (
     enforce_path_access,
@@ -423,12 +425,17 @@ def api_browse():
                 'file_count': None
             }
 
+            # find_folder_thumbnail, not a local extension list: the indexer sets
+            # has_thumbnail from that same helper, so a narrower list here would
+            # report "has art" while never producing a URL for it, and the client
+            # only re-checks folders it was told have none.
             if d.get('has_thumbnail'):
-                for ext in ['.png', '.jpg', '.jpeg', '.webp']:
-                    thumb_path = os.path.join(d['path'], f'folder{ext}')
-                    if os.path.exists(thumb_path):
-                        dir_info['thumbnail_url'] = url_for('.serve_folder_thumbnail', path=thumb_path)
-                        break
+                thumb_path = find_folder_thumbnail(d['path'])
+                if thumb_path:
+                    dir_info['thumbnail_url'] = url_for('.serve_folder_thumbnail', path=thumb_path)
+                else:
+                    # Indexed flag is stale (art deleted since the last scan).
+                    dir_info['has_thumbnail'] = False
 
             processed_directories.append(dir_info)
 
@@ -561,10 +568,7 @@ def api_scan_directory():
         file_count = 0
 
         def check_has_thumbnail(folder_path):
-            for ext in ['.png', '.jpg', '.jpeg']:
-                if os.path.exists(os.path.join(folder_path, f'folder{ext}')):
-                    return 1
-            return 0
+            return 1 if find_folder_thumbnail(folder_path) else 0
 
         parent_dir = os.path.dirname(path)
         add_file_index_entry(
@@ -707,6 +711,7 @@ def api_browse_thumbnails():
         folder_thumbs = find_folder_thumbnails_batch(paths)
 
         results = {}
+        missing = []
         for path, thumb in folder_thumbs.items():
             if thumb:
                 results[path] = {
@@ -718,6 +723,22 @@ def api_browse_thumbnails():
                     'has_thumbnail': False,
                     'thumbnail_url': None
                 }
+                missing.append(path)
+
+        # Browsing is the trigger for auto-generation: these are exactly the
+        # folders the grid is about to draw a bare icon for. The queue dedupes,
+        # skips folders that recently failed, and never overwrites existing art,
+        # so re-visiting a folder costs nothing. The client polls this endpoint
+        # again shortly to pick up whatever finished.
+        try:
+            queued = folder_thumbnails.enqueue_many(missing)
+            if queued:
+                app_logger.debug(f"Queued {queued} folder thumbnail(s) for generation")
+        except Exception as e:
+            # Generation is a nicety layered on top of the lookup. Losing it
+            # must never cost the caller the thumbnail data it actually asked
+            # for, which is what an escaping exception here would do.
+            app_logger.warning(f"Could not queue folder thumbnails: {e}")
 
         return jsonify({"thumbnails": results})
 

--- a/static/css/collection.css
+++ b/static/css/collection.css
@@ -35,6 +35,18 @@
     scroll-margin-top: 1rem;
 }
 
+/* Large cards: roughly 15% wider than standard.
+   Columns are whole numbers, so raising the floor alone drops a column and the
+   cards absorb every pixel it freed -- around +38% at tablet widths, far past
+   "a bit bigger". Capping the track at 190px instead lets the leftover become
+   margin, which holds the increase near 15% from 992px up (+13%/+15%/+15%) and
+   caps the worst case at +22%. Below ~500px the floor still fits two columns,
+   so phones are left alone. */
+.file-grid.cards-lg {
+    grid-template-columns: repeat(auto-fill, minmax(173px, 190px));
+    justify-content: center;
+}
+
 .grid-item {
     cursor: pointer;
     transition: transform 0.2s;
@@ -108,14 +120,14 @@
     transition: opacity 0.3s;
 }
 
-/* Apply width/height to files (comics) so they scale to fit */
-.grid-item.file .thumbnail {
-    width: 100%;
-    height: 100%;
-}
-
-/* Apply width/height to root-level folder thumbnails */
-.grid-item.root-folder .thumbnail {
+/* Every card's art fills its frame, whatever the source pixel dimensions.
+   Without width/height the <img> is a flex item sized from its intrinsic size --
+   and min-width:auto forbids it shrinking -- so a 200x300 folder.png overflows
+   and is centre-cropped while a 167x250 one sits inside the frame at 1:1. Same
+   2:3 art, two apparent sizes. Sizing from the container makes the source
+   dimensions irrelevant: comic covers, both generated folder variants, and
+   user-supplied folder.png/jpg/gif/webp of any size in any folder. */
+.grid-item .thumbnail {
     width: 100%;
     height: 100%;
 }
@@ -142,25 +154,6 @@
 .grid-item.folder .thumbnail {
     display: none;
 }
-
-/* Folders with custom thumbnails */
-/*
-.grid-item.folder.has-thumbnail .thumbnail {
-    display: block;
-    object-fit: contain;
-    max-width: 100%;
-    max-height: 100%;
-}
-
-.grid-item.folder.has-thumbnail .thumbnail-container {
-    overflow: visible;
-    background-color: transparent;
-}
-
-.grid-item.folder.has-thumbnail .icon-overlay {
-    opacity: 0;
-    display: none;
-} */
 
 .grid-item.folder .icon-overlay i {
     font-size: 3rem;

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initItemsPerPageMirror();
     // Restore saved items-per-page preference before the first directory load
     restoreItemsPerPage();
+    restoreCardSize();
     initPaginationStickyObserver();
 
     // Initialize with path from URL: prefer clean URL path, fallback to query param
@@ -480,18 +481,29 @@ async function loadMetadataInBatches(paths, signal) {
     }));
 }
 
+// Requesting thumbnails for a folder that has none asks the server to generate
+// art for it in the background. These are the delays, in ms, at which we look
+// again for the result — spaced out because generation opens comic archives to
+// build the covers it stacks. Running out of entries ends the chase; whatever
+// was generated shows up on the next visit.
+const AUTO_THUMBNAIL_RETRY_DELAYS_MS = [4000, 10000, 20000];
+
 /**
  * Load folder thumbnails in parallel batches.
  * @param {Array<string>} paths - Directory paths that need thumbnails loaded
  * @param {AbortSignal} signal - AbortController signal for cancellation
+ * @param {number} attempt - Retry round; 0 is the initial load
  */
-async function loadThumbnailsInBatches(paths, signal) {
+async function loadThumbnailsInBatches(paths, signal, attempt = 0) {
     const BATCH_SIZE = 50; // Backend max is 50
 
     const batches = [];
     for (let i = 0; i < paths.length; i += BATCH_SIZE) {
         batches.push(paths.slice(i, i + BATCH_SIZE));
     }
+
+    // Folders the server reported no art for — candidates for auto-generation.
+    const stillMissing = [];
 
     await Promise.all(batches.map(async (batch) => {
         try {
@@ -529,6 +541,8 @@ async function loadThumbnailsInBatches(paths, signal) {
                             }
                         }
                     }
+                } else {
+                    stillMissing.push(path);
                 }
             });
         } catch (error) {
@@ -536,6 +550,32 @@ async function loadThumbnailsInBatches(paths, signal) {
             console.error('Error loading thumbnails batch:', error);
         }
     }));
+
+    scheduleAutoThumbnailRetry(stillMissing, signal, attempt);
+}
+
+/**
+ * Look again for folders the server is generating art for.
+ * @param {Array<string>} paths - Folders that came back without a thumbnail
+ * @param {AbortSignal} signal - Cancelled when the user navigates elsewhere
+ * @param {number} attempt - Round that just completed
+ */
+function scheduleAutoThumbnailRetry(paths, signal, attempt) {
+    const delay = AUTO_THUMBNAIL_RETRY_DELAYS_MS[attempt];
+    if (!paths.length || delay === undefined) return;
+    if (signal && signal.aborted) return;
+
+    setTimeout(() => {
+        if (signal && signal.aborted) return;
+        // Only chase folders still on screen. Navigating away or paging on
+        // makes the request pointless, and loadDirectory aborts the signal
+        // only on a fresh directory load, not on a page change.
+        const onScreen = paths.filter(
+            path => document.querySelector(`[data-path="${CSS.escape(path)}"]`)
+        );
+        if (!onScreen.length) return;
+        loadThumbnailsInBatches(onScreen, signal, attempt + 1);
+    }, delay);
 }
 
 /**
@@ -2505,6 +2545,72 @@ function restoreItemsPerPage() {
         itemsPerPage = parsed;
         syncItemsPerPageSelects(saved);
     }
+}
+
+// Grid card sizes. The value is the class appended to #file-grid ('' = the
+// stylesheet default), and doubles as the allowlist for the saved preference.
+const CARD_SIZES = { standard: '', large: 'cards-lg' };
+const CARD_SIZE_STORAGE_KEY = 'collectionCardSize';
+
+/**
+ * Switch the grid between card sizes and remember the choice.
+ *
+ * Purely presentational -- the page contents and pagination are unchanged, so
+ * this only swaps a class rather than re-rendering.
+ * @param {string} size - A key of CARD_SIZES.
+ */
+function changeCardSize(size) {
+    if (!Object.prototype.hasOwnProperty.call(CARD_SIZES, size)) return;
+
+    applyCardSize(size);
+    try {
+        localStorage.setItem(CARD_SIZE_STORAGE_KEY, size);
+    } catch (e) {
+        // Ignore storage errors (e.g. private mode / quota)
+    }
+}
+
+/**
+ * Put the grid into a card size and reflect it on the toggle buttons.
+ * @param {string} size - A key of CARD_SIZES.
+ */
+function applyCardSize(size) {
+    const grid = document.getElementById('file-grid');
+    if (grid) {
+        // The class lives on the container, which survives the innerHTML
+        // rewrites in renderGrid() -- so this holds across page changes.
+        Object.values(CARD_SIZES).forEach(cls => {
+            if (cls) grid.classList.remove(cls);
+        });
+        if (CARD_SIZES[size]) grid.classList.add(CARD_SIZES[size]);
+    }
+
+    const buttons = {
+        standard: document.getElementById('cardSizeStandardBtn'),
+        large: document.getElementById('cardSizeLargeBtn'),
+    };
+    Object.entries(buttons).forEach(([key, btn]) => {
+        if (!btn) return;
+        const active = key === size;
+        btn.classList.toggle('active', active);
+        btn.setAttribute('aria-pressed', String(active));
+    });
+}
+
+/**
+ * Restore the saved card size from localStorage so the choice survives
+ * navigation and reloads, the same way the per-page preference does.
+ */
+function restoreCardSize() {
+    let saved;
+    try {
+        saved = localStorage.getItem(CARD_SIZE_STORAGE_KEY);
+    } catch (e) {
+        saved = null;
+    }
+    // Anything unrecognised (including a value from an older build) falls back
+    // to the stylesheet default rather than leaving the toggle out of step.
+    applyCardSize(Object.prototype.hasOwnProperty.call(CARD_SIZES, saved) ? saved : 'standard');
 }
 
 /**

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -97,6 +97,18 @@
                 <!-- Search input will be dynamically populated by JS -->
             </div>
             <div class="d-flex align-items-center" style="flex: 0 0 auto;">
+                <div class="btn-group btn-group-sm" role="group" aria-label="Card size">
+                    <button type="button" class="btn btn-outline-secondary" id="cardSizeStandardBtn"
+                        onclick="changeCardSize('standard')" title="Standard card size" aria-pressed="true">
+                        <i class="bi bi-grid-3x3-gap-fill"></i>
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary" id="cardSizeLargeBtn"
+                        onclick="changeCardSize('large')" title="Large card size" aria-pressed="false">
+                        <i class="bi bi-grid-fill"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="d-flex align-items-center" style="flex: 0 0 auto;">
                 <div class="input-group input-group-sm">
                     <label class="input-group-text bg-body border-0" for="itemsPerPage">Per page</label>
                     <select class="form-select border-0 shadow-none bg-body" id="itemsPerPage" onchange="changeItemsPerPage(this.value)">

--- a/templates/config.html
+++ b/templates/config.html
@@ -365,6 +365,22 @@
                                 hidden by default.
                             </small>
                         </div>
+                        <div class="col-md-6">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" role="switch"
+                                    id="autoFolderThumbnails" name="autoFolderThumbnails"
+                                    {% if autoFolderThumbnails %}checked{% endif %}>
+                                <label class="form-check-label" for="autoFolderThumbnails">
+                                    Auto-Generate Folder Thumbnails
+                                </label>
+                                <small class="form-text text-muted d-block">
+                                    As you browse, folders without cover art get a stacked-cover
+                                    <code>folder.png</code> generated in the background. An image you
+                                    uploaded yourself is never replaced. Turn this off to generate
+                                    them only from the folder three-dots menu.
+                                </small>
+                            </div>
+                        </div>
                     </div>
 
                 </div>
@@ -1802,7 +1818,8 @@
             trashEnabled: document.getElementById('trashEnabled')?.checked || false,
             trashDir: document.getElementById('trashDir')?.value || '',
             trashMaxSizeMb: document.getElementById('trashMaxSizeMb')?.value || '1024',
-            hiddenDirectories: document.getElementById('hiddenDirectories')?.value || '@eaDir'
+            hiddenDirectories: document.getElementById('hiddenDirectories')?.value || '@eaDir',
+            autoFolderThumbnails: document.getElementById('autoFolderThumbnails')?.checked ?? true
         };
 
         try {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,9 +126,18 @@ def db_connection(db_path):
     Patches get_db_path() so all database.py functions use this test DB.
     """
     with patch("core.database.get_db_path", return_value=db_path):
-        from core.database import init_db, get_db_connection
+        from core.database import (
+            init_db, get_db_connection, wait_for_background_analyze,
+        )
 
         init_db()
+        # init_db() kicks ANALYZE off in a daemon thread that keeps writing to
+        # this DB after it returns. Left running it races the test body: a
+        # commit landing after a test overwrites the file flushes cached pages
+        # back over the garbage, erasing corruption the test just staged (and
+        # the thread would outlive the get_db_path patch above, writing to
+        # whatever DB the next test is using). Wait for quiet first.
+        wait_for_background_analyze()
         conn = get_db_connection()
         yield conn
         conn.close()
@@ -160,6 +169,29 @@ def create_cbz(tmp_path):
         return str(cbz_path)
 
     return _create_cbz
+
+
+# ---------------------------------------------------------------------------
+# Fixture: Background ANALYZE containment (autouse)
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _contain_background_analyze():
+    """Stop init_db()'s ANALYZE thread from outliving the test that spawned it.
+
+    Every init_db() call starts a daemon thread that writes to whatever
+    get_db_path() resolved to. Tests patch that path per-test, so a thread
+    still running when a test ends writes into the *next* test's database --
+    and a commit landing after a file has been replaced flushes cached pages
+    back over the new contents. The db_connection fixture waits before handing
+    the connection over; this catches the tests that call init_db() themselves.
+    """
+    yield
+    try:
+        from core.database import wait_for_background_analyze
+
+        wait_for_background_analyze(timeout=5)
+    except ImportError:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/factories/db_factories.py
+++ b/tests/factories/db_factories.py
@@ -61,6 +61,7 @@ def create_directory_entry(
     name=None,
     path=None,
     parent="/data",
+    has_thumbnail=0,
 ):
     """Convenience wrapper for directory entries."""
     n = _next("dir")
@@ -72,6 +73,7 @@ def create_directory_entry(
         entry_type="directory",
         size=None,
         parent=parent,
+        has_thumbnail=has_thumbnail,
     )
 
 

--- a/tests/integration/test_database_file_index.py
+++ b/tests/integration/test_database_file_index.py
@@ -241,6 +241,47 @@ class TestGetDirectoryChildren:
         assert files[0]["size"] == 999
 
 
+class TestSetDirectoryHasThumbnail:
+    """Browse reads folder art off this cached flag rather than the filesystem,
+    so art written after the last scan stays invisible until the flag moves."""
+
+    def test_marks_a_directory_as_having_art(self, db_connection):
+        from core.database import get_directory_children, set_directory_has_thumbnail
+
+        create_directory_entry(name="Batman", path="/data/T/Batman", parent="/data/T",
+                               has_thumbnail=0)
+
+        assert set_directory_has_thumbnail("/data/T/Batman", True) is True
+
+        dirs, _ = get_directory_children("/data/T")
+        assert dirs[0]["has_thumbnail"] is True
+
+    def test_clears_the_flag(self, db_connection):
+        from core.database import get_directory_children, set_directory_has_thumbnail
+
+        create_directory_entry(name="Batman", path="/data/U/Batman", parent="/data/U",
+                               has_thumbnail=1)
+
+        assert set_directory_has_thumbnail("/data/U/Batman", False) is True
+
+        dirs, _ = get_directory_children("/data/U")
+        assert dirs[0]["has_thumbnail"] is False
+
+    def test_unindexed_directory_is_a_no_op(self, db_connection):
+        from core.database import set_directory_has_thumbnail
+
+        assert set_directory_has_thumbnail("/data/never/indexed", True) is False
+
+    def test_does_not_touch_file_entries(self, db_connection):
+        """The flag is directory-only; a file sharing the path must be left be."""
+        from core.database import set_directory_has_thumbnail
+
+        create_file_index_entry(name="Batman.cbz", path="/data/V/Batman.cbz",
+                                parent="/data/V")
+
+        assert set_directory_has_thumbnail("/data/V/Batman.cbz", True) is False
+
+
 class TestSyncFileIndexIncremental:
 
     def test_adds_new_entries(self, db_connection):

--- a/tests/routes/test_collection_routes.py
+++ b/tests/routes/test_collection_routes.py
@@ -132,6 +132,22 @@ class TestCollectionPage:
         assert b'"/manga/Naruto"' in resp.data
         assert b'"/data/Marvel"' not in resp.data
 
+    @patch("routes.collection.get_dashboard_sections", return_value=[])
+    @patch("routes.collection.config")
+    def test_collection_offers_both_card_sizes(
+            self, mock_config, mock_sections, client):
+        """The card-size toggle drives collection.js's changeCardSize(), whose
+        allowlist is keyed on these exact size names."""
+        mock_config.get.return_value = "True"
+        html = client.get("/collection").get_data(as_text=True)
+
+        for button_id, size in (
+            ("cardSizeStandardBtn", "standard"),
+            ("cardSizeLargeBtn", "large"),
+        ):
+            assert f'id="{button_id}"' in html
+            assert f"changeCardSize('{size}')" in html
+
 
 class TestToReadPage:
 
@@ -180,6 +196,133 @@ class TestApiBrowse:
         with patch.dict("sys.modules", {"app": MagicMock(DATA_DIR=str(tmp_path))}):
             resp = client.get("/api/browse")
         assert resp.status_code == 500
+
+    @pytest.mark.parametrize("thumb_name", [
+        "folder.png", "folder.jpg", "folder.jpeg", "folder.gif", "folder.webp",
+    ])
+    @patch("routes.collection.get_directory_children")
+    def test_browse_serves_every_supported_thumbnail_format(
+        self, mock_children, client, tmp_path, thumb_name
+    ):
+        """Uploaded folder art must resolve whatever extension the user used.
+
+        The indexer sets has_thumbnail from find_folder_thumbnail, so a narrower
+        list here would report art the client is never given a URL for -- and
+        the client only re-checks folders reported as having none.
+        """
+        data_dir = tmp_path / "data"
+        series = data_dir / "Batman"
+        series.mkdir(parents=True)
+        (series / thumb_name).write_bytes(b"image")
+
+        mock_children.return_value = (
+            [{"name": "Batman", "path": str(series), "has_thumbnail": True}], [],
+        )
+
+        with patch.dict("sys.modules", {"app": MagicMock(DATA_DIR=str(data_dir))}):
+            resp = client.get(f"/api/browse?path={data_dir}")
+
+        directory = resp.get_json()["directories"][0]
+        assert directory["has_thumbnail"] is True
+        assert thumb_name in directory["thumbnail_url"]
+
+    @patch("routes.collection.get_directory_children")
+    def test_browse_corrects_a_stale_thumbnail_flag(
+        self, mock_children, client, tmp_path
+    ):
+        """Art deleted since the last scan must report as missing.
+
+        Leaving the indexed flag set would strand the folder: no URL to draw and
+        no re-check from the client, so it shows a bare icon until a full rescan.
+        """
+        data_dir = tmp_path / "data"
+        series = data_dir / "Batman"
+        series.mkdir(parents=True)
+
+        mock_children.return_value = (
+            [{"name": "Batman", "path": str(series), "has_thumbnail": True}], [],
+        )
+
+        with patch.dict("sys.modules", {"app": MagicMock(DATA_DIR=str(data_dir))}):
+            resp = client.get(f"/api/browse?path={data_dir}")
+
+        directory = resp.get_json()["directories"][0]
+        assert directory["has_thumbnail"] is False
+        assert "thumbnail_url" not in directory
+
+
+class TestApiBrowseThumbnails:
+    """Folder art lookups, and the auto-generation they trigger."""
+
+    def _post(self, client, tmp_path, paths, thumbs):
+        mock_app = MagicMock(DATA_DIR=str(tmp_path))
+        mock_app.find_folder_thumbnails_batch = MagicMock(return_value=thumbs)
+        with patch.dict("sys.modules", {"app": mock_app}):
+            return client.post("/api/browse-thumbnails", json={"paths": paths})
+
+    @patch("routes.collection.folder_thumbnails.enqueue_many", return_value=0)
+    def test_returns_urls_for_existing_art(self, mock_enqueue, client, tmp_path):
+        series = tmp_path / "Batman"
+        series.mkdir()
+        thumb = series / "folder.png"
+        thumb.write_bytes(b"png")
+
+        resp = self._post(client, tmp_path, [str(series)], {str(series): str(thumb)})
+
+        assert resp.status_code == 200
+        entry = resp.get_json()["thumbnails"][str(series)]
+        assert entry["has_thumbnail"] is True
+        assert entry["thumbnail_url"]
+
+    @patch("routes.collection.folder_thumbnails.enqueue_many", return_value=1)
+    def test_queues_generation_for_folders_without_art(
+        self, mock_enqueue, client, tmp_path
+    ):
+        """Browsing is the trigger: these are the folders about to draw a bare
+        icon, so they are exactly the ones worth generating art for."""
+        series = tmp_path / "Batman"
+        series.mkdir()
+
+        resp = self._post(client, tmp_path, [str(series)], {str(series): None})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["thumbnails"][str(series)]["has_thumbnail"] is False
+        mock_enqueue.assert_called_once_with([str(series)])
+
+    @patch("routes.collection.folder_thumbnails.enqueue_many", return_value=0)
+    def test_does_not_queue_folders_that_already_have_art(
+        self, mock_enqueue, client, tmp_path
+    ):
+        series = tmp_path / "Batman"
+        series.mkdir()
+        thumb = series / "folder.png"
+        thumb.write_bytes(b"png")
+
+        self._post(client, tmp_path, [str(series)], {str(series): str(thumb)})
+
+        mock_enqueue.assert_called_once_with([])
+
+    @patch("routes.collection.folder_thumbnails.enqueue_many",
+           side_effect=RuntimeError("queue exploded"))
+    def test_queue_failure_does_not_break_the_response(
+        self, mock_enqueue, client, tmp_path
+    ):
+        """Auto-generation is a nicety; it must never cost the user their grid."""
+        series = tmp_path / "Batman"
+        series.mkdir()
+
+        resp = self._post(client, tmp_path, [str(series)], {str(series): None})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["thumbnails"][str(series)]["has_thumbnail"] is False
+
+    def test_rejects_oversized_batches(self, client, tmp_path):
+        resp = self._post(client, tmp_path, [f"/data/s{i}" for i in range(51)], {})
+        assert resp.status_code == 400
+
+    def test_rejects_empty_batches(self, client, tmp_path):
+        resp = self._post(client, tmp_path, [], {})
+        assert resp.status_code == 400
 
 
 class TestApiMissingXml:

--- a/tests/routes/test_database.py
+++ b/tests/routes/test_database.py
@@ -1,6 +1,8 @@
 """Route tests for the Database settings page (/api/database/*)."""
 import os
+import threading
 import zipfile
+from unittest.mock import patch
 
 import pytest
 
@@ -239,6 +241,53 @@ class TestCheckIntegrity:
         ok, msg = check_integrity(db_path)
         assert ok is False
         assert msg  # non-empty SQLite error text
+
+
+class TestWaitForBackgroundAnalyze:
+    """init_db() leaves a thread writing to the DB after it returns.
+
+    Anything that replaces the file or inspects it for corruption has to be
+    able to wait: a commit from that thread landing after the file is
+    overwritten flushes its cached pages back and undoes the overwrite.
+    """
+
+    def test_no_thread_is_already_quiet(self):
+        from core import database
+
+        with patch.object(database, "_analyze_thread", None):
+            assert database.wait_for_background_analyze() is True
+
+    def test_waits_for_a_running_thread(self):
+        from core import database
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _work():
+            started.set()
+            release.wait(5)
+
+        thread = threading.Thread(target=_work, daemon=True)
+        thread.start()
+        started.wait(5)
+        try:
+            with patch.object(database, "_analyze_thread", thread):
+                # Still working -- reported as not settled rather than hanging.
+                assert database.wait_for_background_analyze(timeout=0.1) is False
+                release.set()
+                assert database.wait_for_background_analyze(timeout=5) is True
+        finally:
+            release.set()
+            thread.join(5)
+
+    def test_init_db_leaves_nothing_running(self, db_path):
+        """The fixture already waits, so a caller that just ran init_db()
+        should find the DB quiet."""
+        from core import database
+
+        with patch("core.database.get_db_path", return_value=db_path):
+            assert database.init_db() is True
+            assert database.wait_for_background_analyze(timeout=10) is True
 
 
 class TestBackupIntegrityGuard:

--- a/tests/unit/test_folder_thumbnails.py
+++ b/tests/unit/test_folder_thumbnails.py
@@ -1,0 +1,324 @@
+"""Tests for core/folder_thumbnails.py -- the background auto-generation queue
+and the nested-folder composite.
+
+The queue's whole job is to be cheap to call from a hot path: browsing a folder
+enqueues every child that has no cover art, so the guards that stop it from
+re-doing work (dedupe, failure back-off, size cap) are what these cover.
+"""
+import os
+import time
+import pytest
+from unittest.mock import patch, MagicMock
+from PIL import Image
+
+from core import folder_thumbnails
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+FOLDER_ICON = os.path.join(PROJECT_ROOT, "static", "images", "folder-fill-200x300.png")
+
+
+@pytest.fixture(autouse=True)
+def clean_queue_state():
+    folder_thumbnails.reset_state()
+    yield
+    folder_thumbnails.reset_state()
+
+
+@pytest.fixture
+def fake_executor():
+    """Executor that records submissions without running them.
+
+    Leaving the work unfinished is deliberate: it holds paths in the in-flight
+    set, which is the state the dedupe guard is meant to react to.
+    """
+    executor = MagicMock()
+    with patch.object(folder_thumbnails, "_get_executor", return_value=executor):
+        yield executor
+
+
+class TestEnqueue:
+
+    def test_accepts_a_directory(self, fake_executor, tmp_path):
+        assert folder_thumbnails.enqueue(str(tmp_path)) is True
+        assert fake_executor.submit.call_count == 1
+
+    def test_rejects_empty_path(self, fake_executor):
+        assert folder_thumbnails.enqueue("") is False
+        assert folder_thumbnails.enqueue(None) is False
+        fake_executor.submit.assert_not_called()
+
+    def test_rejects_missing_directory(self, fake_executor, tmp_path):
+        assert folder_thumbnails.enqueue(str(tmp_path / "nope")) is False
+        fake_executor.submit.assert_not_called()
+
+    def test_rejects_a_file(self, fake_executor, tmp_path):
+        target = tmp_path / "folder.png"
+        target.write_bytes(b"png")
+        assert folder_thumbnails.enqueue(str(target)) is False
+        fake_executor.submit.assert_not_called()
+
+    def test_dedupes_while_in_flight(self, fake_executor, tmp_path):
+        assert folder_thumbnails.enqueue(str(tmp_path)) is True
+        assert folder_thumbnails.enqueue(str(tmp_path)) is False
+        assert fake_executor.submit.call_count == 1
+
+    def test_requeues_after_completion(self, fake_executor, tmp_path):
+        assert folder_thumbnails.enqueue(str(tmp_path)) is True
+        folder_thumbnails._record_result(str(tmp_path), True)
+        assert folder_thumbnails.enqueue(str(tmp_path)) is True
+        assert fake_executor.submit.call_count == 2
+
+    def test_honours_the_queue_cap(self, fake_executor, tmp_path):
+        for i in range(folder_thumbnails.MAX_QUEUED):
+            folder = tmp_path / f"series{i}"
+            folder.mkdir()
+            assert folder_thumbnails.enqueue(str(folder)) is True
+
+        overflow = tmp_path / "one-too-many"
+        overflow.mkdir()
+        assert folder_thumbnails.enqueue(str(overflow)) is False
+
+    def test_releases_the_claim_when_submit_fails(self, tmp_path):
+        executor = MagicMock()
+        executor.submit.side_effect = RuntimeError("shutting down")
+        with patch.object(folder_thumbnails, "_get_executor", return_value=executor):
+            assert folder_thumbnails.enqueue(str(tmp_path)) is False
+
+        # Rejected work must not leave the path wedged in the in-flight set, or
+        # it could never be generated again for the life of the process.
+        assert str(tmp_path) not in folder_thumbnails._queued
+
+
+class TestFailureBackoff:
+
+    def test_recent_failure_is_not_retried(self, fake_executor, tmp_path):
+        folder_thumbnails._failed[str(tmp_path)] = time.monotonic()
+        assert folder_thumbnails.enqueue(str(tmp_path)) is False
+        fake_executor.submit.assert_not_called()
+
+    def test_expired_failure_is_retried(self, fake_executor, tmp_path):
+        folder_thumbnails._failed[str(tmp_path)] = (
+            time.monotonic() - folder_thumbnails.FAILURE_TTL_SECONDS - 1
+        )
+        assert folder_thumbnails.enqueue(str(tmp_path)) is True
+        assert str(tmp_path) not in folder_thumbnails._failed
+
+    def test_success_clears_a_previous_failure(self, tmp_path):
+        folder_thumbnails._failed[str(tmp_path)] = time.monotonic()
+        folder_thumbnails._record_result(str(tmp_path), True)
+        assert str(tmp_path) not in folder_thumbnails._failed
+
+    def test_expired_records_are_pruned_once_the_ledger_grows(self):
+        """A library of art-less folders must not grow the record without end."""
+        stale = time.monotonic() - folder_thumbnails.FAILURE_TTL_SECONDS - 1
+        for i in range(folder_thumbnails.MAX_FAILED_TRACKED + 1):
+            folder_thumbnails._failed[f"/data/stale{i}"] = stale
+        fresh = time.monotonic()
+        folder_thumbnails._failed["/data/fresh"] = fresh
+
+        folder_thumbnails._record_result("/data/trigger", False)
+
+        assert "/data/stale0" not in folder_thumbnails._failed
+        # Still-valid back-off entries survive the prune.
+        assert "/data/fresh" in folder_thumbnails._failed
+        assert "/data/trigger" in folder_thumbnails._failed
+
+    def test_prune_leaves_unexpired_records_alone(self):
+        fresh = time.monotonic()
+        for i in range(folder_thumbnails.MAX_FAILED_TRACKED + 1):
+            folder_thumbnails._failed[f"/data/recent{i}"] = fresh
+
+        folder_thumbnails._record_result("/data/trigger", False)
+
+        assert len(folder_thumbnails._failed) > folder_thumbnails.MAX_FAILED_TRACKED
+
+
+class TestPreferenceGate:
+
+    def test_disabled_preference_blocks_enqueue(self, fake_executor, tmp_path):
+        with patch("core.database.get_user_preference", return_value=False):
+            assert folder_thumbnails.enqueue(str(tmp_path)) is False
+        fake_executor.submit.assert_not_called()
+
+    def test_enabled_by_default(self, tmp_path):
+        with patch("core.database.get_user_preference",
+                   side_effect=lambda key, default=None: default):
+            assert folder_thumbnails.is_enabled() is True
+
+    def test_database_error_leaves_it_enabled(self):
+        with patch("core.database.get_user_preference",
+                   side_effect=Exception("no db")):
+            assert folder_thumbnails.is_enabled() is True
+
+
+class TestEnqueueMany:
+
+    def test_counts_only_accepted_paths(self, fake_executor, tmp_path):
+        real = tmp_path / "series"
+        real.mkdir()
+        paths = [str(real), str(tmp_path / "missing"), str(real)]
+        assert folder_thumbnails.enqueue_many(paths) == 1
+
+    def test_empty_list(self, fake_executor):
+        assert folder_thumbnails.enqueue_many([]) == 0
+
+
+class TestCreateNestedFolderThumbnail:
+    """Geometry of the folder-of-folders composite.
+
+    This art sits next to the plain fanned stack in the same grid row, so its
+    dimensions are not cosmetic: they decide whether the two variants read as
+    the same size on screen.
+    """
+
+    # The canvas generate_folder_thumbnail_internal renders the stack on, and
+    # the size it saves the files-only variant at.
+    STACK_CANVAS = (200, 300)
+
+    @pytest.fixture
+    def stack(self):
+        """Stand-in for the fanned cover stack, at the size app.py renders it."""
+        img = Image.new("RGBA", self.STACK_CANVAS, (0, 0, 0, 0))
+        # Opaque block in the middle, mimicking covers on a transparent canvas.
+        img.paste(Image.new("RGBA", (150, 245), (200, 30, 30, 255)), (25, 27))
+        return img
+
+    def test_matches_the_files_only_variant(self, stack):
+        """The whole point: both folder variants save at identical dimensions.
+
+        A downscale here is what made folder-of-folders art render ~20% smaller
+        than a sibling folder-of-files card.
+        """
+        result = folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+        assert result.size == self.STACK_CANVAS
+
+    def test_is_300px_tall(self, stack):
+        """generate_thumbnail_sync normalizes every comic cover to 300px tall;
+        folder art follows the same convention."""
+        result = folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+        assert result.height == 300
+
+    def test_honours_a_custom_canvas_size(self, stack):
+        result = folder_thumbnails.create_nested_folder_thumbnail(
+            stack, FOLDER_ICON, canvas_size=(400, 600)
+        )
+        assert result.size == (400, 600)
+
+    def test_folder_glyph_is_not_clipped(self, stack):
+        """The icon's art runs to y=297 of 300. Any resize that shortens the
+        canvas would cut the bottom off the folder."""
+        icon_bottom = Image.open(FOLDER_ICON).convert("RGBA").getchannel("A").getbbox()[3]
+        result = folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+
+        assert result.getchannel("A").getbbox()[3] >= icon_bottom
+
+    def test_result_is_two_by_three(self, stack):
+        """The grid frame is aspect-ratio 2/3, so art at that ratio fills it
+        under object-fit: cover without cropping anything."""
+        result = folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+        assert result.width / result.height == pytest.approx(2 / 3, abs=0.01)
+
+    def test_stack_shows_through_the_folder_glyph(self, stack):
+        """The glyph is translucent (peak alpha 216), so covers pasted behind it
+        must tint it. If the paste order flipped, the glyph would read flat."""
+        icon = Image.open(FOLDER_ICON).convert("RGBA")
+        glyph_box = icon.getchannel("A").getbbox()
+
+        with_covers = folder_thumbnails.create_nested_folder_thumbnail(
+            stack, FOLDER_ICON
+        ).crop(glyph_box)
+        without_covers = folder_thumbnails.create_nested_folder_thumbnail(
+            Image.new("RGBA", self.STACK_CANVAS, (0, 0, 0, 0)), FOLDER_ICON
+        ).crop(glyph_box)
+
+        assert with_covers.tobytes() != without_covers.tobytes()
+
+    def test_folder_glyph_is_drawn_over_the_stack(self, stack):
+        """...and the glyph is still on top, not buried under the covers."""
+        icon = Image.open(FOLDER_ICON).convert("RGBA")
+        glyph_box = icon.getchannel("A").getbbox()
+
+        result = folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+
+        # The same stack placed with no icon over it -- what the glyph region
+        # would look like if the paste order were reversed.
+        resized = stack.resize((190, int(190 * (stack.height / stack.width))),
+                               Image.Resampling.LANCZOS)
+        bare = Image.new("RGBA", self.STACK_CANVAS, (0, 0, 0, 0))
+        bare.paste(resized, ((200 - 190) // 2, 300 - resized.height - 20), resized)
+
+        assert result.crop(glyph_box).tobytes() != bare.crop(glyph_box).tobytes()
+
+    def test_stack_is_visible_above_the_glyph(self, stack):
+        """...but the covers must still show, or the composite is just an icon."""
+        icon = Image.open(FOLDER_ICON).convert("RGBA")
+        top_of_glyph = icon.getchannel("A").getbbox()[1]
+        result = folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+
+        # Above the glyph, only the stack can be contributing opaque pixels.
+        band = result.crop((0, 0, result.width, top_of_glyph))
+        assert band.getchannel("A").getbbox() is not None
+
+    def test_leaves_the_source_stack_untouched(self, stack):
+        """The caller may keep using its canvas; compositing must not mutate it."""
+        before = stack.tobytes()
+        folder_thumbnails.create_nested_folder_thumbnail(stack, FOLDER_ICON)
+        assert stack.tobytes() == before
+
+
+class TestMayWrite:
+    """The guard that stops auto-generation from clobbering uploaded art."""
+
+    @pytest.mark.parametrize("existing", [
+        "folder.png", "folder.jpg", "folder.jpeg", "folder.gif", "folder.webp",
+    ])
+    def test_refuses_when_art_exists(self, tmp_path, existing):
+        (tmp_path / existing).write_bytes(b"image")
+        assert folder_thumbnails.may_write(str(tmp_path), overwrite=False) is False
+
+    def test_allows_when_folder_has_no_art(self, tmp_path):
+        (tmp_path / "Batman 001.cbz").write_bytes(b"cbz")
+        assert folder_thumbnails.may_write(str(tmp_path), overwrite=False) is True
+
+    @pytest.mark.parametrize("existing", ["folder.png", "folder.gif"])
+    def test_explicit_overwrite_replaces_existing_art(self, tmp_path, existing):
+        """The menu action means "make me a new one" -- it may replace art."""
+        (tmp_path / existing).write_bytes(b"image")
+        assert folder_thumbnails.may_write(str(tmp_path), overwrite=True) is True
+
+    def test_unrelated_images_are_not_folder_art(self, tmp_path):
+        (tmp_path / "cover.png").write_bytes(b"image")
+        (tmp_path / "header.jpg").write_bytes(b"image")
+        assert folder_thumbnails.may_write(str(tmp_path), overwrite=False) is True
+
+
+class TestWorker:
+
+    def _run(self, folder, returns=True, raises=None):
+        fake_app = MagicMock()
+        if raises is not None:
+            fake_app.generate_folder_thumbnail_internal.side_effect = raises
+        else:
+            fake_app.generate_folder_thumbnail_internal.return_value = returns
+        with patch.dict("sys.modules", {"app": fake_app}):
+            folder_thumbnails._generate(folder)
+        return fake_app
+
+    def test_never_overwrites_existing_art(self, tmp_path):
+        fake_app = self._run(str(tmp_path))
+        _, kwargs = fake_app.generate_folder_thumbnail_internal.call_args
+        assert kwargs["overwrite"] is False
+
+    def test_success_leaves_no_failure_record(self, tmp_path):
+        self._run(str(tmp_path), returns=True)
+        assert str(tmp_path) not in folder_thumbnails._queued
+        assert str(tmp_path) not in folder_thumbnails._failed
+
+    def test_failure_is_recorded_for_backoff(self, tmp_path):
+        self._run(str(tmp_path), returns=False)
+        assert str(tmp_path) in folder_thumbnails._failed
+
+    def test_exception_is_swallowed_and_recorded(self, tmp_path):
+        self._run(str(tmp_path), raises=OSError("disk gone"))
+        assert str(tmp_path) in folder_thumbnails._failed
+        assert str(tmp_path) not in folder_thumbnails._queued


### PR DESCRIPTION
## Auto-generate folder thumbnails

Folder cover art only appeared if you uploaded it or ran **Generate Thumbnail** / **Generate All Missing Thumbnails** by hand, so a new series sat behind a generic folder icon until someone remembered to do it.

Browsing is now the trigger. `/api/browse-thumbnails` — the endpoint the grid already calls for every folder it can't draw art for — hands those paths to a background queue (`core/folder_thumbnails.py`), and the client re-checks at 4s/10s/20s so art appears while you're still looking at the folder.

The queue is deliberately conservative:

- **Never replaces existing art.** `may_write()` refuses when any `folder.{png,jpg,jpeg,gif,webp}` exists; only the explicit menu action passes `overwrite=True`.
- **One worker**, since generation opens comic archives to build the covers it stacks.
- **6h back-off** on folders that can't produce art, so a library full of empty folders doesn't retry on every page view. Queue capped at 250 pending.
- **Off switch** in Settings → Directory & File Processing (default on).

## Bugs fixed along the way

- **Generated thumbnails vanished on reload.** Nothing updated `file_index.has_thumbnail` after writing `folder.png`, and `/api/browse` reads folder art off that flag rather than the disk — so art stayed invisible until the next full scan. The manual menu action only patched the `<img>` in the DOM. Every write now calls `set_directory_has_thumbnail()`.
- **`folder.gif` was never indexed as art.** Three copies of `check_has_thumbnail` probed only `.png/.jpg/.jpeg`. All three now share `find_folder_thumbnail`, and `/api/browse` resolves the same list instead of its own narrower one.
- **`folder.png` was saved without `match_parent_permissions()`**, so on a root-fallback start it landed `root:0600` and couldn't be read back to serve.
- **`/api/generate-folder-thumbnail` was a ~215-line copy** of `generate_folder_thumbnail_internal` that had drifted (its exclusion set had `".gif.html"` where the other has `".gif", ".html"`). It now delegates.

## Card art sizing

Two folder art variants sat side by side at visibly different scales: a fanned stack (200×300) and a folder-icon composite (167×250).

Only `.grid-item.file` and `.grid-item.root-folder` had `width/height` on the thumbnail — nothing matched a **non-root folder**, so its `<img>` kept `width/height: auto`. As a flex item, a replaced element's `min-width: auto` resolves to its intrinsic width and forbids shrinking, so the 200×300 art overflowed the ~166px frame and was centre-cropped while the 167×250 one sat inside it at 1:1. Same 2:3 art, ~20% apparent size difference.

One rule on `.grid-item .thumbnail` now sizes every card's art from its frame. That also covers user-supplied art of arbitrary dimensions in **any** folder — a 1000×1500 `folder.jpg` dropped into a nested series folder previously showed only its centre ~16%.

`create_nested_folder_thumbnail` moves to `core/folder_thumbnails.py` (it's pure PIL, and `app.py` isn't importable under the test harness) and drops its final downscale, so both variants now emit 200×300 — matching the 300px-tall convention `generate_thumbnail_sync` uses for every comic cover. No migration needed: once art is sized from the container, existing 167×250 files render identically.

Also deleted a dead commented-out `.has-thumbnail` block that proposed `overflow: visible` on `.thumbnail-container` — which the info/favorite/to-read buttons and the bulk-selected outline all depend on being clipped.

## Card size picker

A Standard/Large toggle in the Browse Library filter bar, persisted in `localStorage` like the per-page control. Purely presentational — it swaps a class on `#file-grid` rather than re-rendering.

Raising the `minmax()` floor alone doesn't work: columns are whole numbers, so a higher floor drops one and the remaining cards absorb every pixel it freed. Any floor between 170–196px behaves identically at **+19% (xxl) / +23% (xl) / +29% (lg) / +38% (tablet)**. Capping the track at 190px instead turns the leftover into margin:

| viewport | standard | large | gain |
|---|---|---|---|
| 1400 (xxl) | 164.6px × 7 | 190px × 6 | +15.5% |
| 1200 (xl) | 166px × 6 | 190px × 5 | +14.5% |
| 992 (lg) | 168px × 5 | 190px × 4 | +13.1% |
| 720 (tablet) | 156px × 4 | 190px × 3 | +21.8% |
| 400 (mobile) | 176px × 2 | 176px × 2 | unchanged |

Only the Browse Library grid is affected; the metadata browser has its own `.file-grid` override.

## Testing

`pytest` — **3564 passed, 6 skipped** (baseline before this branch: 3552 passed, 6 skipped).

New coverage:
- `tests/unit/test_folder_thumbnails.py` — queue dedupe, failure back-off and pruning, queue cap, preference gate, worker contract, the never-overwrite guard, and the nested composite's geometry (dimensions match the files-only variant, glyph isn't clipped, custom canvas size, paste order).
- `tests/routes/test_collection_routes.py` — `/api/browse-thumbnails` queues folders without art and skips those with it, a queue failure can't 500 the grid, `/api/browse` serves every supported thumbnail extension and clears a stale flag, and the card-size toggle renders.
- `tests/integration/test_database_file_index.py` — `set_directory_has_thumbnail` sets/clears the flag, no-ops on unindexed paths, and won't touch file entries.

Not covered by automated tests: the CSS itself (no browser harness in this repo). Worth a manual check of the two folder variants side by side, a wrong-sized `folder.jpg` in a nested folder, and both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up commit: fix an `init_db` race that broke CI

The first CI run failed on `tests/routes/test_database.py::TestCheckIntegrity::test_corrupt_db_detected` with `assert True is False` — the integrity check found a *healthy* database after the test had deliberately corrupted it.

`init_db()` starts `ANALYZE` in a fire-and-forget daemon thread that keeps writing after it returns. When it still holds a connection as a test overwrites the file, its `commit()` flushes cached pages back over the garbage and restores a valid database:

```python
bg = sqlite3.connect(p); bg.execute("CREATE TABLE t (a)")   # the thread's conn
open(p, "wb").write(b"not a database" * 64)                 # test corrupts it
sqlite3.connect(p).execute("PRAGMA quick_check")            # -> malformed
bg.commit()                                                 # thread commits
sqlite3.connect(p).execute("PRAGMA quick_check")            # -> ("ok",)
```

The thread predates this branch — it has been on `main` since #255 — and the extra tests here only shifted timing enough to surface it. It also outlives the per-test `get_db_path` patch, so a late commit can land in the *next* test's database.

`init_db()` now keeps a handle on the thread and `wait_for_background_analyze()` joins it. The `db_connection` fixture waits before yielding, closing the in-test race; an autouse fixture waits on teardown to catch the tests that call `init_db()` themselves. Three tests cover the new helper.

**Worth a reviewer's eye:** the same race exists in production. `restore_database()` replaces the DB file, and a background `ANALYZE` commit landing mid-restore could write stale pages over the restored database. I left that alone as out of scope for this PR, but it's the reason `wait_for_background_analyze()` is written as a general helper rather than a test hook.
