### PR TITLE
Bring reading list cover art onto the 2:3 sizing convention

### DIFF
--- a/static/css/reading_lists.css
+++ b/static/css/reading_lists.css
@@ -1,7 +1,14 @@
 /* Reading Lists Premium Redesign */
 
 :root {
-    --card-height: 400px;
+    /* Tall enough to hold the 2:3 art below plus the text block, including the
+       actions row, whose space is reserved (see .card-actions) so nothing
+       reflows on hover. */
+    --card-height: 440px;
+    /* Height of the cover art box; its width follows from the 2:3 ratio below.
+       Fixed rather than a percentage of the stack container, so the art is one
+       size in every card regardless of what the text block below it does. */
+    --card-cover-height: 280px;
     --card-border-radius: 16px;
     --card-transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     --hover-scale: 1.02;
@@ -10,7 +17,12 @@
 
 .reading-list-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    /* Capped track, like the collection grid: with a 1fr maximum a single
+       column stretches to the full container on narrow viewports, stranding
+       the fixed-width cover art in a very wide card. Leftover space becomes
+       margin instead. */
+    grid-template-columns: repeat(auto-fill, minmax(280px, 300px));
+    justify-content: center;
     gap: 2rem;
     padding: 1rem 0;
 }
@@ -30,9 +42,19 @@
 }
 
 .card-stack-container {
+    /* Positioning context for the select checkbox and completion badge, which
+       are absolute and so are not grid items. */
     position: relative;
     flex: 1;
     min-height: 0;
+    /* Every cover shares one grid cell, so they stack and the fan transforms
+       below spread them out. This replaces absolute positioning, which cannot
+       centre a box whose width is derived from its aspect ratio.
+       Top-anchored, not centred: this container shrinks when the actions row
+       expands on hover, and centring would slide the art upwards as it did. */
+    display: grid;
+    place-items: start center;
+    padding-top: 12px;
 }
 
 .reading-list-card:hover {
@@ -57,18 +79,28 @@
 */
 
 .card-stack-item {
-    position: absolute;
-    top: 3%;
-    left: 18%;
-    width: 65%;
-    height: 90%;
+    /* All items in one cell -> they stack on top of each other. */
+    grid-area: 1 / 1;
+    /* Normally the fixed height, but never taller than the space available.
+       The app ships 26 Bootswatch themes and they do not agree on font size or
+       line height, so the text block below is not exactly the height computed
+       here -- the clamp turns a too-tall theme into slightly smaller art
+       instead of art overlapping the title. */
+    height: min(var(--card-cover-height), 100%);
+    /* Comic covers are 2:3. Sizing the box to that ratio -- rather than to
+       whatever space is left over after the card's text -- is what stops
+       background-size: cover from cropping the art, and matches the 2:3
+       thumbnail frame the collection grid uses. The old box was a percentage
+       of both the card width and the leftover height, so its shape (and how
+       much of each cover survived) changed with the viewport, with the card's
+       tag row, and again on hover. */
+    aspect-ratio: 2 / 3;
     background-size: cover;
-    /* background-position: center; */
+    /* Anchor the crop centrally, as object-fit: cover does everywhere else.
+       The default of 0% 0% pinned art to the top-left corner. */
+    background-position: center;
     transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
     transform-origin: center bottom;
-    /* box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3); */
-    /* border-radius: var(--card-border-radius); */
-    /* Add radius to items */
 }
 
 /* Stacking Order */
@@ -176,16 +208,21 @@
 .card-actions {
     display: flex;
     gap: 0.5rem;
+    /* The row's space is reserved even while it is hidden. Animating it open
+       used to grow the text block, which shrank the art area underneath it and
+       resized the cover art mid-hover -- fighting the fan's scale(1.05) lift
+       and re-cropping the art. Only opacity moves now, so the hover is pure
+       transform and the art holds still. */
     opacity: 0;
-    max-height: 0;
-    overflow: hidden;
-    transition: all 0.3s ease;
+    margin-top: 0.5rem;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
 }
 
-.reading-list-card:hover .card-actions {
+.reading-list-card:hover .card-actions,
+.reading-list-card:focus-within .card-actions {
     opacity: 1;
-    max-height: 50px;
-    margin-top: 0.5rem;
+    pointer-events: auto;
 }
 
 /* Empty State / Fallback */

--- a/templates/files.html
+++ b/templates/files.html
@@ -4,7 +4,7 @@
 {% block title %}CLU (Comic Library Utilities){% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/files.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/files.css') }}?v={{ range(1, 10000) | random }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/insights.html
+++ b/templates/insights.html
@@ -3,7 +3,7 @@
 {% block title %}Library Insights{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/insights.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/insights.css') }}?v={{ range(1, 10000) | random }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/reading_list_view.html
+++ b/templates/reading_list_view.html
@@ -7,7 +7,14 @@
 <style>
     .reading-list-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        /* 187px = the 280px cover height on the Reading Lists index (its
+           --card-cover-height) at 2:3, so a cover is exactly the same size on
+           both pages -- it was ~165x247 here against 187x280 there. Capping
+           rather than raising the floor alone keeps the leftover space as
+           margin; an uncapped 1fr hands every pixel freed by dropping a
+           column straight back to the cards. */
+        grid-template-columns: repeat(auto-fill, minmax(173px, 187px));
+        justify-content: center;
         gap: 1.5rem;
     }
 
@@ -25,8 +32,20 @@
 
     .book-cover {
         aspect-ratio: 2/3;
-        background-color: #f8f9fa;
-        background-size: cover;
+        /* Theme-aware: contain leaves a few px at the sides of each cover, and
+           a hardcoded light grey there reads as a bright frame on dark themes. */
+        background-color: var(--bs-tertiary-bg, #f8f9fa);
+        /* contain, not cover: the collection grid shows a cover whole -- its
+           .thumbnail-container is a flex item, so min-height:auto lets the box
+           grow past the 2:3 it asks for and the art is never trimmed. A
+           background image has no intrinsic size to grow this box, so `cover`
+           was cropping ~3% off the top and bottom of every cover here.
+           `contain` keeps the whole cover visible; a comic is slightly
+           narrower than 2:3, so it leaves ~3px at each side instead. */
+        background-size: contain;
+        /* Required with contain -- the default `repeat` would tile slivers of
+           the cover into those side gaps. */
+        background-repeat: no-repeat;
         background-position: center;
         border-radius: 4px;
         position: relative;

--- a/templates/reading_lists.html
+++ b/templates/reading_lists.html
@@ -2,7 +2,7 @@
 {% block title %}Reading Lists{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/reading_lists.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/reading_lists.css') }}?v={{ range(1, 10000) | random }}">
 {% endblock %}
 
 {% block content %}
@@ -133,13 +133,11 @@
             onclick="window.location.href='{{ url_for('reading_lists.view_list', list_id=list.id) }}'">
 
             <!-- Background / Stack -->
+            {# The covers come first so the fan effect's :nth-child(1..5) rules
+               line up with them. Anything else in here must stay after them:
+               it is absolutely positioned, so DOM order does not move it, but
+               it does shift every cover's child index. #}
             <div class="card-stack-container">
-                {% if _can_manage %}
-                <div class="card-select-checkbox" onclick="event.stopPropagation();">
-                    <input type="checkbox" class="form-check-input list-select-cb"
-                           data-list-id="{{ list.id }}" onchange="onListCheckboxChange(this)">
-                </div>
-                {% endif %}
                 {% if list.covers and list.covers|length > 0 %}
                 {% for cover in list.covers %}
                 <div class="card-stack-item"
@@ -151,6 +149,12 @@
                     <div class="no-image-placeholder">
                         <i class="bi bi-journal-album placeholder-icon"></i>
                     </div>
+                </div>
+                {% endif %}
+                {% if _can_manage %}
+                <div class="card-select-checkbox" onclick="event.stopPropagation();">
+                    <input type="checkbox" class="form-check-input list-select-cb"
+                           data-list-id="{{ list.id }}" onchange="onListCheckboxChange(this)">
                 </div>
                 {% endif %}
                 {% if list.entry_count > 0 and list.read_count == list.entry_count %}

--- a/templates/series.html
+++ b/templates/series.html
@@ -3,7 +3,7 @@
 {% block title %}{{ series.name }} - Series{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/files.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/files.css') }}?v={{ range(1, 10000) | random }}">
 {% endblock %}
 
 {% block content %}

--- a/templates/to_read.html
+++ b/templates/to_read.html
@@ -4,7 +4,7 @@
 {% block title %}To Read - Comic Library Utilities{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/collection.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/collection.css') }}?v={{ range(1, 10000) | random }}">
 <style>
   .to-read-container {
     max-width: 1400px;

--- a/tests/routes/test_reading_lists_routes.py
+++ b/tests/routes/test_reading_lists_routes.py
@@ -4,12 +4,72 @@ from unittest.mock import patch, MagicMock
 from io import BytesIO
 
 
+def _list_with_covers(covers, **overrides):
+    """A reading list row shaped like get_all_reading_lists() returns."""
+    row = {
+        "id": 1,
+        "name": "Batman Essentials",
+        "tags": [],
+        "created_at": "2026-01-01",
+        "covers": covers,
+        "entry_count": len(covers),
+        "read_count": 0,
+        "source": None,
+        "thumbnail_path": None,
+    }
+    row.update(overrides)
+    return [row]
+
+
 class TestReadingListIndex:
 
     @patch("routes.reading_lists.get_all_reading_lists", return_value=[])
     def test_index_page(self, mock_get, client):
         resp = client.get("/reading-lists")
         assert resp.status_code == 200
+
+    def test_covers_precede_the_select_checkbox(self, client):
+        """The fan effect keys off :nth-child(1..5) of .card-stack-container.
+
+        The checkbox is absolutely positioned, so moving it in the DOM does not
+        move it on screen -- but it does shift every cover's child index. With
+        it first, :nth-child(1) matched nothing and the last cover fell off the
+        end of the rules, so managers saw a different stack from readers.
+        """
+        covers = [f"/data/Batman {i:03}.cbz" for i in range(1, 6)]
+        with patch("routes.reading_lists.get_all_reading_lists",
+                   return_value=_list_with_covers(covers)):
+            html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert "card-select-checkbox" in html, "expected manager controls"
+        assert html.index("card-stack-item") < html.index("card-select-checkbox")
+
+    def test_covers_precede_the_completion_badge(self, client):
+        """Same contract for the other absolutely-positioned sibling."""
+        covers = [f"/data/Batman {i:03}.cbz" for i in range(1, 6)]
+        with patch("routes.reading_lists.get_all_reading_lists",
+                   return_value=_list_with_covers(covers, read_count=len(covers))):
+            html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert "completion-badge" in html, "expected a badge on a finished list"
+        assert html.index("card-stack-item") < html.index("completion-badge")
+
+    def test_every_cover_renders_a_stack_item(self, client):
+        covers = [f"/data/Batman {i:03}.cbz" for i in range(1, 6)]
+        with patch("routes.reading_lists.get_all_reading_lists",
+                   return_value=_list_with_covers(covers)):
+            html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert html.count('class="card-stack-item"') == len(covers)
+
+    def test_list_without_covers_falls_back_to_a_placeholder(self, client):
+        with patch("routes.reading_lists.get_all_reading_lists",
+                   return_value=_list_with_covers([])):
+            html = client.get("/reading-lists").get_data(as_text=True)
+
+        assert "no-image-placeholder" in html
+        # The placeholder occupies the same 2:3 box as real art.
+        assert html.count('class="card-stack-item"') == 1
 
     @patch("routes.reading_lists.get_reading_list", return_value=None)
     def test_view_nonexistent_list(self, mock_get, client):


### PR DESCRIPTION
Follow-up to #495, which updated the collection grid but not the reading list pages — they have their own stylesheets and were left behind.

## Reading Lists index — `.card-stack-item`

The fanned cover stack was sized from *leftover space* (65% of the card's width × 90% of whatever the text block didn't use) rather than from the covers' own 2:3 ratio. `background-size: cover` then discarded a different slice of every cover at every viewport:

| viewport | old box | art lost | new box | art lost |
|---|---|---|---|---|
| sm | 335×267 | **46.9%** | 187×280 | 0% |
| md | 216×267 | 17.4% | 187×280 | 0% |
| lg | 189×267 | 5.7% | 187×280 | 0% |
| xl | 228×267 | 21.8% | 187×280 | 0% |
| xxl | 195×267 | 8.6% | 187×280 | 0% |

`background-position` was also commented out, so what survived was anchored **top-left** rather than centred the way `object-fit: cover` is everywhere else.

Covers now sit in a 2:3 box whose width derives from its height, stacked in a single grid cell so the **fan transforms are untouched**. Height is `min(280px, 100%)` — the app ships 26 Bootswatch themes that disagree on font metrics, so a too-tall theme yields slightly smaller art instead of art overlapping the title.

**Hover was fighting itself.** The actions row expanded the text block, shrinking the art area ~20% mid-hover — the front cover's `scale(1.05)` lift was landing at a net **0.84**, so it got *smaller* on hover. Its space is now reserved and only opacity animates, making the hover pure transform. The card grows 400→440px to fit the taller art plus that reserved row.

**Bug fixed along the way:** the select checkbox was the first child of `.card-stack-container`, shifting every cover's index — so the fan's `:nth-child(1)` matched nothing and the 5th cover fell off the end of the rules. Managers saw a different stack from readers. It's absolutely positioned, so moving it after the covers changes nothing on screen.

## Reading list detail — `.book-cover`

Its grid was an uncapped `minmax(150px, 1fr)`, giving ~165×247 covers against 187×280 on the index. Capped at `minmax(173px, 187px)` so a cover is the same size on both pages.

Measured in a headless browser, `.book-cover` also **cropped where the collection grid doesn't**:

| cover shape | `img.thumbnail` | `.book-cover` before | after |
|---|---|---|---|
| standard comic | 0% cut | 2.65% cut | **0% cut** |
| tall / manga | 0% cut | ~5% cut | **0% cut** |
| 2:3 exactly | 0% cut | 0% cut | **0% cut** |
| wide / wraparound | 0% cut | heavier | **0% cut** |

`img.thumbnail` never crops: its `.thumbnail-container` is a flex item, so `min-height: auto` lets the box grow past the 2:3 it asks for — measured **165×254**, not the 165×247 the CSS requests — and the whole cover shows. A background image has no intrinsic size to grow its box, so `cover` was trimming ~3% off the top and bottom of every cover here.

Switched to `contain` (with `no-repeat`, or the gaps would tile slivers of the cover). A comic is slightly narrower than 2:3, so it leaves ~3px at each side instead of cutting the height. `background-color` now follows the theme, since those gaps make it visible.

## Stylesheet cache-busting

`reading_lists.css` was loaded with **no `?v=` query**, so browsers served a stale copy and none of the above was visible in the app. Four other templates had the same gap:

| template | stylesheet |
|---|---|
| `reading_lists.html` | `reading_lists.css` |
| `to_read.html` | **`collection.css`** |
| `files.html` / `series.html` | `files.css` |
| `insights.html` | `insights.css` |

`to_read.html` matters beyond this change — it loads `collection.css`, so it wasn't picking up #495 either.

## Testing

`pytest` — **3571 passed, 6 skipped**.

Three new tests in `tests/routes/test_reading_lists_routes.py` cover the DOM-order contract the fan depends on (covers before the checkbox and before the completion badge), that every cover renders a stack item, and the no-covers placeholder fallback. I verified the ordering test fails without the template fix and passes with it.

Cropping and box geometry were verified by measurement in headless Chromium rather than by eye — the numbers in the tables above are rendered `getBoundingClientRect()` values, not estimates. That isn't part of the suite (no browser harness in this repo), so a manual look at both reading list pages in light and dark themes is still worthwhile.

**Note:** a hard refresh is needed once to clear the stylesheet cached before the buster fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
