### PR TITLE
Surface reading lists in Want to Read and On the Stack

### DIFF
--- a/app.py
+++ b/app.py
@@ -4258,14 +4258,36 @@ def api_continue_reading():
 
 @app.route("/api/on-the-stack", methods=["GET"])
 def api_on_the_stack():
-    """Get next unread issues for subscribed series."""
+    """Get next unread issues for subscribed series and bookmarked reading lists."""
     try:
-        from core.database import get_on_the_stack_items
+        from core.database import (
+            get_on_the_stack_items, get_reading_list_stack_items
+        )
 
         limit = request.args.get("limit", 10, type=int)
         if limit > 100:
             limit = 100
+
+        # Two sources, one section. Each is already limited and sorted; merging
+        # here (rather than in the client) keeps the folder-scope filter below
+        # covering both.
         items = get_on_the_stack_items(limit=limit)
+        items += get_reading_list_stack_items(limit=limit)
+
+        # A bookmarked list and a subscribed series can point at the same next
+        # issue — show it once, keeping whichever source sorts higher.
+        items.sort(
+            key=lambda x: x.get("last_read_at") or x.get("added_at") or "",
+            reverse=True,
+        )
+        deduped, seen = [], set()
+        for item in items:
+            if item["file_path"] in seen:
+                continue
+            seen.add(item["file_path"])
+            deduped.append(item)
+        items = deduped[:limit]
+
         # Folder-scope: hide next-up issues in folders the user can't access.
         items = filter_paths_for_user(current_user(), items, key='file_path')
         return jsonify({"success": True, "items": items, "total_count": len(items)})

--- a/core/database.py
+++ b/core/database.py
@@ -677,6 +677,26 @@ def init_db():
         """)
         c.execute("CREATE INDEX IF NOT EXISTS idx_to_read_path ON to_read(path)")
 
+        # Create reading_list_to_read table (reading lists marked "want to read").
+        # Separate from to_read because that table is keyed on a filesystem path
+        # and a reading list has none — a synthetic path would leak into every
+        # path-keyed consumer (folder-scope filtering, /to-read, OPDS, api_v1).
+        # Born user-scoped, so no _rebuild_add_user_scope migration is needed.
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS reading_list_to_read (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL DEFAULT 1,
+                reading_list_id INTEGER NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(user_id, reading_list_id),
+                FOREIGN KEY (reading_list_id) REFERENCES reading_lists (id) ON DELETE CASCADE
+            )
+        """)
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_rl_to_read_user "
+            "ON reading_list_to_read(user_id)"
+        )
+
         # Create stats_cache table (cache computed statistics)
         c.execute("""
             CREATE TABLE IF NOT EXISTS stats_cache (
@@ -7346,6 +7366,184 @@ def is_to_read(path, user_id=None):
 
 
 # =============================================================================
+# To Read — Reading Lists
+# =============================================================================
+
+
+def reading_list_exists(list_id):
+    """Cheap existence check for a reading list id."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+
+    try:
+        c = conn.cursor()
+        c.execute("SELECT 1 FROM reading_lists WHERE id = ?", (list_id,))
+        return c.fetchone() is not None
+
+    except Exception as e:
+        app_logger.error(f"Failed to check reading list {list_id} exists: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def add_reading_list_to_read(list_id, user_id=None):
+    """
+    Bookmark a reading list into the current (or given) user's 'want to read'.
+
+    Also the opt-in that surfaces the list's next unread issue in On the Stack
+    (see get_reading_list_stack_items).
+
+    Returns:
+        True on success, False on error
+    """
+    conn = get_db_connection()
+    if not conn:
+        return False
+
+    # try/finally: an unknown list_id trips the foreign key (OR IGNORE does not
+    # swallow FK violations), and a connection left open by the error path holds
+    # the database file on Windows.
+    try:
+        uid = _resolve_user_id(user_id)
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT OR IGNORE INTO reading_list_to_read (user_id, reading_list_id)
+            VALUES (?, ?)
+        """,
+            (uid, list_id),
+        )
+
+        conn.commit()
+
+        app_logger.info(f"Added reading list {list_id} to 'want to read'")
+        return True
+
+    except Exception as e:
+        app_logger.error(f"Failed to add reading list {list_id} to 'want to read': {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def remove_reading_list_to_read(list_id, user_id=None):
+    """
+    Remove a reading list from the current (or given) user's 'want to read'.
+
+    Returns:
+        True on success, False on error
+    """
+    conn = get_db_connection()
+    if not conn:
+        return False
+
+    try:
+        uid = _resolve_user_id(user_id)
+        c = conn.cursor()
+        c.execute(
+            "DELETE FROM reading_list_to_read WHERE reading_list_id = ? AND user_id = ?",
+            (list_id, uid),
+        )
+
+        conn.commit()
+
+        app_logger.info(f"Removed reading list {list_id} from 'want to read'")
+        return True
+
+    except Exception as e:
+        app_logger.error(
+            f"Failed to remove reading list {list_id} from 'want to read': {e}"
+        )
+        return False
+    finally:
+        conn.close()
+
+
+def get_to_read_reading_lists(user_id=None):
+    """
+    Get the reading lists the current (or given) user has bookmarked, shaped for
+    the Want to Read dashboard cards.
+
+    Same aggregate as get_all_reading_lists() so the card matches the Reading
+    Lists page: entry_count/read_count (read_count scoped to this user) plus a
+    cover stack.
+
+    Returns:
+        List of dicts with id, name, covers, entry_count, read_count, added_at
+    """
+    conn = get_db_connection()
+    if not conn:
+        return []
+
+    try:
+        uid = _resolve_user_id(user_id)
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT rl.id, rl.name, rl.thumbnail_path, rl.tags,
+                   COUNT(DISTINCT rle.id) as entry_count,
+                   COUNT(DISTINCT ir.id) as read_count,
+                   t.created_at as added_at
+            FROM reading_list_to_read t
+            JOIN reading_lists rl ON rl.id = t.reading_list_id
+            LEFT JOIN reading_list_entries rle ON rl.id = rle.reading_list_id
+            LEFT JOIN issues_read ir
+                   ON COALESCE(rle.manual_override_path, rle.matched_file_path) = ir.issue_path
+                  AND ir.user_id = ?
+            WHERE t.user_id = ?
+            GROUP BY rl.id
+            ORDER BY t.created_at DESC
+        """,
+            (uid, uid),
+        )
+
+        lists = [dict(row) for row in c.fetchall()]
+
+        import json
+
+        for lst in lists:
+            lst["covers"] = _reading_list_covers(c, lst["id"], lst["thumbnail_path"])
+            try:
+                lst["tags"] = json.loads(lst.get("tags") or "[]")
+            except (json.JSONDecodeError, TypeError):
+                lst["tags"] = []
+
+        return lists
+
+    except Exception as e:
+        app_logger.error(f"Failed to get 'want to read' reading lists: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def is_reading_list_to_read(list_id, user_id=None):
+    """Check whether a reading list is in the user's 'want to read'."""
+    conn = get_db_connection()
+    if not conn:
+        return False
+
+    try:
+        uid = _resolve_user_id(user_id)
+        c = conn.cursor()
+        c.execute(
+            "SELECT 1 FROM reading_list_to_read WHERE reading_list_id = ? AND user_id = ?",
+            (list_id, uid),
+        )
+        return c.fetchone() is not None
+
+    except Exception as e:
+        app_logger.error(
+            f"Failed to check 'want to read' status for reading list {list_id}: {e}"
+        )
+        return False
+    finally:
+        conn.close()
+
+
+# =============================================================================
 # Stats Cache Functions
 # =============================================================================
 
@@ -8835,6 +9033,115 @@ def get_on_the_stack_items(limit=10, user_id=None):
         return []
 
 
+def get_reading_list_stack_items(limit=10, user_id=None):
+    """
+    Get the next unread issue for each reading list the user has bookmarked into
+    'want to read', for the current (or given) user's read history.
+
+    Unlike the series-based get_on_the_stack_items(), a list does NOT have to be
+    started: the next issue is simply the first entry in the list's own
+    sort_order that is unread and has a matched file. Entries with no matched
+    file are skipped rather than treated as unread, so a list whose next entry
+    isn't in the library advances to the next one that is.
+
+    Returns list of dicts shaped like get_on_the_stack_items() so both the
+    dashboard swiper and the full-page view render them unchanged, plus
+    source/reading_list_id/reading_list_name and added_at (the bookmark time)
+    for the caller's sort, since a never-started list has no last_read_at.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return []
+
+    try:
+        uid = _resolve_user_id(user_id)
+        c = conn.cursor()
+        # user_id lives in the LEFT JOIN condition so unread entries still appear.
+        c.execute("""
+            SELECT
+                rl.id as reading_list_id,
+                rl.name as reading_list_name,
+                t.created_at as added_at,
+                rle.id as entry_id,
+                rle.series,
+                rle.issue_number,
+                COALESCE(rle.manual_override_path, rle.matched_file_path) as file_path,
+                CASE WHEN ir.issue_path IS NOT NULL THEN 1 ELSE 0 END as is_read,
+                ir.read_at
+            FROM reading_list_to_read t
+            JOIN reading_lists rl ON rl.id = t.reading_list_id
+            JOIN reading_list_entries rle ON rle.reading_list_id = rl.id
+            LEFT JOIN issues_read ir
+                   ON COALESCE(rle.manual_override_path, rle.matched_file_path) = ir.issue_path
+                  AND ir.user_id = ?
+            WHERE t.user_id = ?
+              AND COALESCE(rle.manual_override_path, rle.matched_file_path) IS NOT NULL
+            ORDER BY rl.id, rle.sort_order ASC, rle.id ASC
+        """, (uid, uid))
+
+        rows = c.fetchall()
+
+        from collections import OrderedDict
+        list_groups = OrderedDict()
+        for row in rows:
+            row_dict = dict(row)
+            list_groups.setdefault(row_dict["reading_list_id"], []).append(row_dict)
+
+        results = []
+        for lid, entries in list_groups.items():
+            last_read_at = None
+            next_unread = None
+            for entry in entries:
+                if entry["is_read"]:
+                    if entry["read_at"] and (
+                        last_read_at is None or entry["read_at"] > last_read_at
+                    ):
+                        last_read_at = entry["read_at"]
+                elif next_unread is None:
+                    next_unread = entry
+
+            # Nothing left to read in this list.
+            if next_unread is None:
+                continue
+
+            file_path = next_unread["file_path"]
+            file_name = file_path.replace("\\", "/").split("/")[-1]
+
+            results.append({
+                "series_id": None,
+                # The card's subtitle line. Entries imported without a series
+                # name fall back to the list name so the card is never blank.
+                "series_name": next_unread["series"] or next_unread["reading_list_name"],
+                "issue_number": next_unread["issue_number"],
+                "file_path": file_path,
+                "file_name": file_name,
+                # Thumbnails come from /api/thumbnail?path=, not a remote cover.
+                "cover_image": None,
+                "last_read_at": last_read_at,
+                "series_status": None,
+                "source": "reading_list",
+                "reading_list_id": lid,
+                "reading_list_name": next_unread["reading_list_name"],
+                "added_at": next_unread["added_at"],
+            })
+
+        # Most recently read list first; a list with no reads yet falls back to
+        # when it was bookmarked so it can't sink below everything and get cut
+        # off by the limit.
+        results.sort(
+            key=lambda x: x["last_read_at"] or x["added_at"] or "",
+            reverse=True,
+        )
+
+        return results[:limit]
+
+    except Exception as e:
+        app_logger.error(f"Failed to get reading list stack items: {e}")
+        return []
+    finally:
+        conn.close()
+
+
 def set_series_subscription(series_id, enabled):
     """Set the On the Stack subscription status for a series."""
     try:
@@ -9115,28 +9422,7 @@ def get_reading_lists(user_id=None):
 
         # Get covers for each list
         for lst in lists:
-            c.execute(
-                """
-                SELECT COALESCE(manual_override_path, matched_file_path) as path
-                FROM reading_list_entries
-                WHERE reading_list_id = ?
-                AND COALESCE(manual_override_path, matched_file_path) IS NOT NULL
-                LIMIT 5
-            """,
-                (lst["id"],),
-            )
-
-            # Get valid covers from entries
-            covers = [row["path"] for row in c.fetchall() if row["path"]]
-
-            # If there's a specific thumbnail set, ensure it's first
-            if lst["thumbnail_path"]:
-                if lst["thumbnail_path"] in covers:
-                    covers.remove(lst["thumbnail_path"])
-                covers.insert(0, lst["thumbnail_path"])
-
-            # Limit to 5 covers
-            lst["covers"] = covers[:5]
+            lst["covers"] = _reading_list_covers(c, lst["id"], lst["thumbnail_path"])
 
             # Parse tags JSON
             try:
@@ -9149,6 +9435,33 @@ def get_reading_lists(user_id=None):
     except Exception as e:
         app_logger.error(f"Error getting reading lists: {str(e)}")
         return []
+
+
+def _reading_list_covers(cursor, list_id, thumbnail_path):
+    """Cover paths for a reading list's card stack, at most 5.
+
+    Uses the caller's open cursor. An explicitly-set thumbnail is forced to the
+    front so the card's top cover is the one the user picked.
+    """
+    cursor.execute(
+        """
+        SELECT COALESCE(manual_override_path, matched_file_path) as path
+        FROM reading_list_entries
+        WHERE reading_list_id = ?
+        AND COALESCE(manual_override_path, matched_file_path) IS NOT NULL
+        LIMIT 5
+    """,
+        (list_id,),
+    )
+
+    covers = [row["path"] for row in cursor.fetchall() if row["path"]]
+
+    if thumbnail_path:
+        if thumbnail_path in covers:
+            covers.remove(thumbnail_path)
+        covers.insert(0, thumbnail_path)
+
+    return covers[:5]
 
 
 def get_all_reading_lists(viewer_id=None):
@@ -9191,28 +9504,7 @@ def get_all_reading_lists(viewer_id=None):
 
         # Get covers for each list
         for lst in lists:
-            c.execute(
-                """
-                SELECT COALESCE(manual_override_path, matched_file_path) as path
-                FROM reading_list_entries
-                WHERE reading_list_id = ?
-                AND COALESCE(manual_override_path, matched_file_path) IS NOT NULL
-                LIMIT 5
-            """,
-                (lst["id"],),
-            )
-
-            # Get valid covers from entries
-            covers = [row["path"] for row in c.fetchall() if row["path"]]
-
-            # If there's a specific thumbnail set, ensure it's first
-            if lst["thumbnail_path"]:
-                if lst["thumbnail_path"] in covers:
-                    covers.remove(lst["thumbnail_path"])
-                covers.insert(0, lst["thumbnail_path"])
-
-            # Limit to 5 covers
-            lst["covers"] = covers[:5]
+            lst["covers"] = _reading_list_covers(c, lst["id"], lst["thumbnail_path"])
 
             # Parse tags JSON
             try:

--- a/routes/favorites.py
+++ b/routes/favorites.py
@@ -16,6 +16,8 @@ from core.database import (
     get_issues_read, is_issue_read, get_issue_read_date,
     hide_issue_from_history,
     add_to_read, remove_to_read, get_to_read_items, is_to_read,
+    add_reading_list_to_read, remove_reading_list_to_read,
+    get_to_read_reading_lists, is_reading_list_to_read, reading_list_exists,
     clear_stats_cache_keys, clear_stats_cache_prefix, current_user_id
 )
 from core.auth import current_user, filter_paths_for_user
@@ -283,4 +285,85 @@ def remove_to_read_item():
             return jsonify({"success": False, "error": "Failed to remove from 'to read'"}), 500
     except Exception as e:
         app_logger.error(f"Error removing from 'to read': {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+# =============================================================================
+# To Read — Reading Lists
+# =============================================================================
+# Deliberately hung off /api/favorites rather than /api/reading-lists: the
+# former is in core.auth._READER_WRITE_PREFIXES, so a Reader can bookmark a list
+# for themselves. Under /api/reading-lists these would fall through to the
+# "mutation -> clerk" default and 403.
+
+
+def _list_id_from_body():
+    """Pull and validate ``list_id`` from a JSON body. Returns (id, error)."""
+    data = request.get_json() or {}
+    raw = data.get('list_id')
+    if raw is None:
+        return None, "Missing list_id in request body"
+    try:
+        return int(raw), None
+    except (TypeError, ValueError):
+        return None, "list_id must be an integer"
+
+
+@favorites_bp.route('/to-read/reading-lists', methods=['GET'])
+def get_to_read_lists():
+    """Get the reading lists the current user has bookmarked as 'want to read'."""
+    try:
+        return jsonify({"success": True, "lists": get_to_read_reading_lists()})
+    except Exception as e:
+        app_logger.error(f"Error getting 'to read' reading lists: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@favorites_bp.route('/to-read/reading-lists/check', methods=['GET'])
+def check_to_read_list():
+    """Check whether a reading list is in the current user's 'want to read'."""
+    list_id = request.args.get('list_id', type=int)
+    if list_id is None:
+        return jsonify({"success": False, "error": "Missing list_id parameter"}), 400
+
+    try:
+        return jsonify({"success": True, "is_to_read": is_reading_list_to_read(list_id)})
+    except Exception as e:
+        app_logger.error(f"Error checking reading list 'to read' status: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@favorites_bp.route('/to-read/reading-lists', methods=['POST'])
+def add_to_read_list():
+    """Add a reading list to the current user's 'want to read'."""
+    list_id, error = _list_id_from_body()
+    if error:
+        return jsonify({"success": False, "error": error}), 400
+
+    try:
+        # The FK would reject an unknown id anyway, but as a 500. Check first so
+        # a list deleted in another tab reports itself honestly.
+        if not reading_list_exists(list_id):
+            return jsonify({"success": False, "error": "Reading list not found"}), 404
+        if add_reading_list_to_read(list_id):
+            return jsonify({"success": True})
+        return jsonify({"success": False, "error": "Failed to add reading list to 'to read'"}), 500
+    except Exception as e:
+        app_logger.error(f"Error adding reading list to 'to read': {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@favorites_bp.route('/to-read/reading-lists', methods=['DELETE'])
+def remove_to_read_list():
+    """Remove a reading list from the current user's 'want to read'."""
+    list_id, error = _list_id_from_body()
+    if error:
+        return jsonify({"success": False, "error": error}), 400
+
+    try:
+        if remove_reading_list_to_read(list_id):
+            return jsonify({"success": True})
+        return jsonify({"success": False, "error": "Failed to remove reading list from 'to read'"}), 500
+    except Exception as e:
+        app_logger.error(f"Error removing reading list from 'to read': {e}")
         return jsonify({"success": False, "error": str(e)}), 500

--- a/static/css/reading_lists.css
+++ b/static/css/reading_lists.css
@@ -377,10 +377,66 @@
 }
 
 /* Completion Badge */
-.completion-badge {
+/* Want to Read Bookmark Toggle
+   Mirrors .to-read-button on the collection grid (static/css/collection.css):
+   hidden until hover, always visible once marked. Duplicated rather than
+   linking collection.css here, which would pull the whole file-grid stylesheet
+   into this page. */
+.want-to-read-button {
     position: absolute;
     top: 10px;
     right: 10px;
+    background: rgba(0, 0, 0, 0.6);
+    border: none;
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 11;
+    opacity: 0;
+    transition: opacity 0.2s ease, background 0.2s ease;
+}
+
+.want-to-read-button i {
+    color: white;
+    font-size: 16px;
+}
+
+.reading-list-card:hover .want-to-read-button,
+.want-to-read-button:focus {
+    opacity: 1;
+}
+
+.want-to-read-button:hover {
+    background: rgba(0, 0, 0, 0.9);
+}
+
+.want-to-read-button:focus {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
+}
+
+.want-to-read-button.marked {
+    opacity: 1;
+    background: rgba(255, 193, 7, 0.9);
+}
+
+.want-to-read-button.marked i {
+    color: #212529;
+}
+
+.want-to-read-button.marked:hover {
+    background: rgba(255, 193, 7, 1);
+}
+
+/* Shifted left of the bookmark toggle, which occupies the top-right corner. */
+.completion-badge {
+    position: absolute;
+    top: 10px;
+    right: 48px;
     background: #28a745;
     color: white;
     width: 28px;

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -3904,15 +3904,67 @@ async function loadDashboardMetadata(paths) {
 }
 
 /**
+ * Build a Want to Read slide for a bookmarked reading list.
+ *
+ * Reading lists have no path, so they render from their own card data
+ * (cover stack + read progress) and open the list page rather than navigating
+ * the collection tree.
+ */
+function renderWantToReadListSlide(list) {
+    const name = list.name || 'Untitled list';
+    const escapedName = name.replace(/'/g, "\\'").replace(/"/g, '&quot;');
+    const cover = (list.covers && list.covers.length) ? list.covers[0] : null;
+    const thumbnailUrl = cover ? `/api/thumbnail?path=${encodeURIComponent(cover)}` : '';
+    const total = list.entry_count || 0;
+    const read = list.read_count || 0;
+    const percent = total > 0 ? Math.round((read / total) * 100) : 0;
+
+    return `
+    <div class="swiper-slide">
+        <div class="dashboard-card${cover ? ' has-thumbnail' : ''}" data-reading-list-id="${list.id}"
+             onclick="window.location.href='/reading-lists/${list.id}'">
+            <div class="dashboard-card-img-container">
+                <img src="${thumbnailUrl}" alt="${escapedName}" class="thumbnail" style="${cover ? '' : 'display: none;'}">
+                <div class="icon-overlay" style="${cover ? 'display: none;' : ''}">
+                    <i class="bi bi-journal-album"></i>
+                </div>
+                <div class="progress" style="height: 4px; position: absolute; bottom: 0; left: 0; width: 100%; border-radius: 0;">
+                    <div class="progress-bar bg-warning" role="progressbar" style="width: ${percent}%"
+                         aria-valuenow="${percent}" aria-valuemin="0" aria-valuemax="100"></div>
+                </div>
+                <button class="to-read-button marked"
+                        onclick="event.stopPropagation(); removeReadingListFromWantToRead(${list.id}, '${escapedName}', this)"
+                        title="Remove from Want to Read">
+                    <i class="bi bi-bookmark"></i>
+                </button>
+            </div>
+            <div class="dashboard-card-body">
+                <div class="text-truncate item-name" title="${escapedName}">${name}</div>
+                <small class="text-muted">Reading List &bull; ${read}/${total}</small>
+            </div>
+        </div>
+    </div>`;
+}
+
+/**
  * Load 'Want to Read' items for the dashboard swiper.
+ *
+ * Two sources: path-based files/folders (to_read) and bookmarked reading lists
+ * (reading_list_to_read). Lists render first, as one card each.
  */
 async function loadWantToRead() {
     const swiper = document.querySelector('#wantToReadSwiper .swiper-wrapper');
     if (!swiper) return;
 
     try {
-        const response = await fetch('/api/favorites/to-read');
+        const [response, listResponse] = await Promise.all([
+            fetch('/api/favorites/to-read'),
+            fetch('/api/favorites/to-read/reading-lists')
+        ]);
         const data = await response.json();
+        const listData = await listResponse.json().catch(() => ({}));
+
+        const readingLists = (listData.success && listData.lists) ? listData.lists : [];
 
         // Store to-read paths globally for grid item sync
         window.toReadPaths = new Set(
@@ -3920,10 +3972,14 @@ async function loadWantToRead() {
                 ? data.items.map(item => item.path)
                 : []
         );
+        // Same idea for reading lists, keyed by id — used by the Reading Lists page.
+        window.toReadListIds = new Set(readingLists.map(l => l.id));
+
+        const listSlides = readingLists.map(renderWantToReadListSlide).join('');
 
         if (!data.success || !data.items.length) {
-            // Show empty state
-            swiper.innerHTML = `
+            // Show empty state only when neither source has anything
+            swiper.innerHTML = listSlides || `
                 <div class="swiper-slide">
                     <div class="dashboard-card text-center p-4">
                         <i class="bi bi-bookmark-plus text-muted" style="font-size: 3rem;"></i>
@@ -3931,6 +3987,7 @@ async function loadWantToRead() {
                     </div>
                 </div>
             `;
+            if (listSlides) initNameTooltips(swiper);
             return;
         }
 
@@ -3954,8 +4011,8 @@ async function loadWantToRead() {
             }
         }
 
-        // Render slides
-        swiper.innerHTML = data.items.map(item => {
+        // Render slides — reading lists first, then the path-based items
+        swiper.innerHTML = listSlides + data.items.map(item => {
             const name = item.name || item.path.split('/').pop();
             const escapedName = name.replace(/'/g, "\\'").replace(/"/g, '&quot;');
             const escapedPath = item.path.replace(/'/g, "\\'").replace(/"/g, '&quot;');
@@ -4182,6 +4239,11 @@ async function loadOnTheStackSwiper() {
         swiper.innerHTML = data.items.map(item => {
             const thumbnailUrl = `/api/thumbnail?path=${encodeURIComponent(item.file_path)}`;
             const timeAgo = formatReadTimeAgo(item.last_read_at);
+            // Make it obvious when a next-up issue came from a bookmarked
+            // reading list rather than a series subscription.
+            const listBadge = item.source === 'reading_list'
+                ? `<span class="badge bg-warning text-dark mt-1 text-truncate mw-100 d-inline-block" title="${item.reading_list_name}"><i class="bi bi-journal-bookmark me-1"></i>${item.reading_list_name}</span>`
+                : '';
             return `
             <div class="swiper-slide">
                 <div class="dashboard-card has-thumbnail" data-path="${item.file_path}"
@@ -4192,6 +4254,7 @@ async function loadOnTheStackSwiper() {
                     <div class="dashboard-card-body">
                         <div class="text-truncate item-name" title="${item.file_name}">${item.file_name}</div>
                         <small class="text-muted">${item.series_name} #${item.issue_number}<br/>${timeAgo}</small>
+                        ${listBadge}
                     </div>
                 </div>
             </div>`;
@@ -4382,6 +4445,37 @@ function removeFromWantToRead(path, name, button) {
         .catch(error => {
             console.error('Error removing from To Read:', error);
             CLU.showError('Failed to remove from To Read');
+        });
+}
+
+/**
+ * Remove a reading list from 'Want to Read' via the dashboard swiper
+ * @param {number} listId - Reading list id
+ * @param {string} name - Name of the list
+ * @param {HTMLElement} button - The button element
+ */
+function removeReadingListFromWantToRead(listId, name, button) {
+    fetch('/api/favorites/to-read/reading-lists', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ list_id: listId })
+    })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                const slide = button.closest('.swiper-slide');
+                if (slide) slide.remove();
+
+                window.toReadListIds?.delete(listId);
+
+                CLU.showSuccess(`${name} removed from Want to Read`);
+            } else {
+                CLU.showError('Failed to remove from Want to Read: ' + (data.error || 'Unknown error'));
+            }
+        })
+        .catch(error => {
+            console.error('Error removing reading list from Want to Read:', error);
+            CLU.showError('Failed to remove from Want to Read');
         });
 }
 

--- a/static/js/reading_list.js
+++ b/static/js/reading_list.js
@@ -100,6 +100,87 @@ function applySort(btn) {
 
 document.addEventListener('DOMContentLoaded', initSortButtons);
 
+// ==========================================
+// Want to Read (dashboard bookmark)
+// ==========================================
+// Bookmarking a reading list puts it in the Want to Read section of Browse
+// Library, and is also the opt-in that surfaces the list's next unread issue in
+// On the Stack. The endpoints live under /api/favorites so Readers can use them.
+
+// .want-to-read-toggle is the JS hook shared by both variants: the round
+// overlay on the grid cards (.want-to-read-button) and the labelled button in
+// the list detail header.
+function _wantToReadButtons(listId) {
+    return document.querySelectorAll(`.want-to-read-toggle[data-list-id="${listId}"]`);
+}
+
+function _paintWantToReadButton(button, marked) {
+    const icon = button.querySelector('i');
+    const label = button.querySelector('.want-to-read-label');
+    const title = marked ? 'Remove from Want to Read' : 'Add to Want to Read';
+    button.classList.toggle('marked', marked);
+    if (icon) {
+        icon.className = (marked ? 'bi bi-bookmark-fill' : 'bi bi-bookmark-plus')
+            + (label ? ' me-1' : '');
+    }
+    if (label) label.textContent = marked ? 'In Want to Read' : 'Want to Read';
+    button.title = title;
+    button.setAttribute('aria-label', title);
+}
+
+// Seed the bookmark buttons from the server so they render in the right state
+// on load. Silently leaves them unmarked if the fetch fails.
+function loadWantToReadState() {
+    const buttons = document.querySelectorAll('.want-to-read-toggle');
+    if (!buttons.length) return;
+
+    fetch('/api/favorites/to-read/reading-lists')
+        .then(r => r.json())
+        .then(data => {
+            if (!data.success) return;
+            const marked = new Set((data.lists || []).map(l => String(l.id)));
+            buttons.forEach(btn => {
+                if (marked.has(btn.dataset.listId)) _paintWantToReadButton(btn, true);
+            });
+        })
+        .catch(err => console.error('Error loading Want to Read state:', err));
+}
+
+document.addEventListener('DOMContentLoaded', loadWantToReadState);
+
+function toggleReadingListWantToRead(listId, name, button) {
+    const marked = button.classList.contains('marked');
+    const buttons = _wantToReadButtons(listId);
+
+    // Optimistic update — reverted below if the request fails.
+    buttons.forEach(btn => _paintWantToReadButton(btn, !marked));
+
+    fetch('/api/favorites/to-read/reading-lists', {
+        method: marked ? 'DELETE' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ list_id: listId })
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                showToast(
+                    marked
+                        ? `${name} removed from Want to Read`
+                        : `${name} added to Want to Read`,
+                    'success'
+                );
+            } else {
+                buttons.forEach(btn => _paintWantToReadButton(btn, marked));
+                showToast('Error: ' + (data.error || 'Unknown error'), 'error');
+            }
+        })
+        .catch(err => {
+            console.error('Error updating Want to Read:', err);
+            buttons.forEach(btn => _paintWantToReadButton(btn, marked));
+            showToast('Failed to update Want to Read', 'error');
+        });
+}
+
 // Toast notification system
 let currentProgressToast = null;
 

--- a/templates/reading_list_view.html
+++ b/templates/reading_list_view.html
@@ -5,6 +5,15 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/reader.css') }}?v={{ range(1, 10000) | random }}">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
 <style>
+    /* Bookmarked state for the header's Want to Read toggle — the outline
+       button fills in, matching how .want-to-read-button.marked reads on the
+       Reading Lists grid. */
+    .want-to-read-toggle.marked {
+        background-color: var(--bs-warning);
+        border-color: var(--bs-warning);
+        color: #212529;
+    }
+
     .reading-list-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -173,6 +182,14 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 id="reading-list-title">{{ reading_list.name }}</h2>
         <div class="d-flex align-items-center gap-2">
+            {# Outside the _can_manage gate on purpose — bookmarking is personal
+               data, so Readers get it too. #}
+            <button type="button" class="btn btn-outline-warning btn-sm want-to-read-toggle"
+                data-list-id="{{ reading_list.id }}"
+                onclick='toggleReadingListWantToRead({{ reading_list.id }}, {{ reading_list.name|tojson }}, this)'
+                title="Add to Want to Read" aria-label="Add to Want to Read">
+                <i class="bi bi-bookmark-plus me-1"></i><span class="want-to-read-label">Want to Read</span>
+            </button>
             {% if _can_manage %}
             <button class="btn btn-success btn-sm" onclick="openAddIssueModal()">
                 <i class="bi bi-plus-lg me-1"></i>Add Issue

--- a/templates/reading_lists.html
+++ b/templates/reading_lists.html
@@ -140,6 +140,16 @@
                            data-list-id="{{ list.id }}" onchange="onListCheckboxChange(this)">
                 </div>
                 {% endif %}
+                {# Outside the _can_manage gate on purpose: bookmarking a list is
+                   personal data, so Readers get it too (the endpoint sits under
+                   /api/favorites, which core/auth.py allows Readers to write). #}
+                {# Single-quoted onclick: tojson escapes ' but not ", so a list
+                   name containing a quote would break a double-quoted attribute. #}
+                <button type="button" class="want-to-read-button want-to-read-toggle" data-list-id="{{ list.id }}"
+                    onclick='event.stopPropagation(); toggleReadingListWantToRead({{ list.id }}, {{ list.name|tojson }}, this)'
+                    title="Add to Want to Read" aria-label="Add to Want to Read">
+                    <i class="bi bi-bookmark-plus"></i>
+                </button>
                 {% if list.covers and list.covers|length > 0 %}
                 {% for cover in list.covers %}
                 <div class="card-stack-item"

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -337,14 +337,33 @@ def app(db_connection, tmp_path):
         except FileNotFoundError as e:
             return jsonify({"success": False, "error": f"Backup not found: {e}"}), 404
 
+    # Mirrors app.py's api_on_the_stack(). Keep the merge/dedupe/sort logic in
+    # step with the real route or these tests stop meaning anything.
     @test_app.route("/api/on-the-stack")
     def api_on_the_stack():
         from flask import jsonify, request as flask_request
-        from core.database import get_on_the_stack_items
+        from core.database import (
+            get_on_the_stack_items, get_reading_list_stack_items
+        )
         limit = flask_request.args.get('limit', 10, type=int)
         if limit > 100:
             limit = 100
+
         items = get_on_the_stack_items(limit=limit)
+        items += get_reading_list_stack_items(limit=limit)
+
+        items.sort(
+            key=lambda x: x.get("last_read_at") or x.get("added_at") or "",
+            reverse=True,
+        )
+        deduped, seen = [], set()
+        for item in items:
+            if item["file_path"] in seen:
+                continue
+            seen.add(item["file_path"])
+            deduped.append(item)
+        items = deduped[:limit]
+
         return jsonify({"success": True, "items": items, "total_count": len(items)})
 
     # Inject mock ``app`` module so ``from app import X`` works in routes ---

--- a/tests/routes/test_collection_routes.py
+++ b/tests/routes/test_collection_routes.py
@@ -563,6 +563,82 @@ class TestApiOnTheStack:
         mock_items.assert_called_once_with(limit=5)
 
 
+def _series_item(name, path, last_read_at):
+    return {
+        "series_id": 100, "series_name": name, "issue_number": "4",
+        "file_path": path, "file_name": path.rsplit("/", 1)[-1],
+        "cover_image": None, "last_read_at": last_read_at,
+        "series_status": "Ongoing",
+    }
+
+
+def _list_item(list_name, path, last_read_at, added_at="2024-01-01 00:00:00"):
+    return {
+        "series_id": None, "series_name": "Batman", "issue_number": "3",
+        "file_path": path, "file_name": path.rsplit("/", 1)[-1],
+        "cover_image": None, "last_read_at": last_read_at,
+        "series_status": None, "source": "reading_list",
+        "reading_list_id": 7, "reading_list_name": list_name,
+        "added_at": added_at,
+    }
+
+
+class TestApiOnTheStackReadingLists:
+    """/api/on-the-stack merges subscribed series with bookmarked reading lists."""
+
+    @patch("core.database.get_reading_list_stack_items")
+    @patch("core.database.get_on_the_stack_items")
+    def test_returns_both_sources(self, mock_series, mock_lists, client):
+        mock_series.return_value = [
+            _series_item("Absolute Batman", "/data/DC/AB 004.cbz", "2024-12-01 10:00:00")
+        ]
+        mock_lists.return_value = [
+            _list_item("Bat Arc", "/data/DC/Batman 003.cbz", "2024-11-01 10:00:00")
+        ]
+        data = client.get("/api/on-the-stack").get_json()
+        assert data["total_count"] == 2
+        sources = [i.get("source") for i in data["items"]]
+        assert sources == [None, "reading_list"]  # most recently read first
+
+    @patch("core.database.get_reading_list_stack_items")
+    @patch("core.database.get_on_the_stack_items")
+    def test_dedupes_shared_file_path(self, mock_series, mock_lists, client):
+        """A list and a series pointing at the same next issue show once."""
+        shared = "/data/DC/Batman 003.cbz"
+        mock_series.return_value = [_series_item("Batman", shared, "2024-12-01 10:00:00")]
+        mock_lists.return_value = [_list_item("Bat Arc", shared, "2024-11-01 10:00:00")]
+        data = client.get("/api/on-the-stack").get_json()
+        assert data["total_count"] == 1
+        # The higher-sorting entry (more recent read) survives.
+        assert data["items"][0].get("source") is None
+
+    @patch("core.database.get_reading_list_stack_items")
+    @patch("core.database.get_on_the_stack_items")
+    def test_unstarted_list_sorts_by_added_at(self, mock_series, mock_lists, client):
+        """A never-started list uses its bookmark time, not the bottom."""
+        mock_series.return_value = [
+            _series_item("Old Series", "/data/DC/Old 004.cbz", "2023-01-01 10:00:00")
+        ]
+        mock_lists.return_value = [
+            _list_item("Fresh Arc", "/data/DC/Fresh 001.cbz", None,
+                       added_at="2025-06-01 00:00:00")
+        ]
+        data = client.get("/api/on-the-stack").get_json()
+        assert data["items"][0]["reading_list_name"] == "Fresh Arc"
+
+    @patch("core.database.get_reading_list_stack_items")
+    @patch("core.database.get_on_the_stack_items")
+    def test_limit_applies_after_merge(self, mock_series, mock_lists, client):
+        mock_series.return_value = [
+            _series_item("A", "/data/a.cbz", "2024-12-01 10:00:00")
+        ]
+        mock_lists.return_value = [
+            _list_item("Bat Arc", "/data/b.cbz", "2024-11-01 10:00:00")
+        ]
+        data = client.get("/api/on-the-stack?limit=1").get_json()
+        assert data["total_count"] == 1
+
+
 # =============================================================================
 # /api/browse-recursive (All Books) — server-side pagination
 # =============================================================================

--- a/tests/routes/test_favorites_routes.py
+++ b/tests/routes/test_favorites_routes.py
@@ -189,3 +189,78 @@ class TestToReadEndpoints:
     def test_remove_to_read_missing_path(self, client):
         resp = client.delete("/api/favorites/to-read", json={})
         assert resp.status_code == 400
+
+
+class TestToReadReadingListEndpoints:
+
+    @patch("routes.favorites.get_to_read_reading_lists", return_value=[
+        {"id": 7, "name": "Bat Arc", "covers": [], "entry_count": 4, "read_count": 1},
+    ])
+    def test_get_to_read_lists(self, mock_get, client):
+        resp = client.get("/api/favorites/to-read/reading-lists")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["lists"][0]["name"] == "Bat Arc"
+
+    @patch("routes.favorites.get_to_read_reading_lists", side_effect=Exception("db error"))
+    def test_get_to_read_lists_error(self, mock_get, client):
+        resp = client.get("/api/favorites/to-read/reading-lists")
+        assert resp.status_code == 500
+        assert resp.get_json()["success"] is False
+
+    @patch("routes.favorites.is_reading_list_to_read", return_value=True)
+    def test_check_to_read_list(self, mock_check, client):
+        resp = client.get("/api/favorites/to-read/reading-lists/check?list_id=7")
+        assert resp.status_code == 200
+        assert resp.get_json()["is_to_read"] is True
+
+    def test_check_to_read_list_missing_param(self, client):
+        resp = client.get("/api/favorites/to-read/reading-lists/check")
+        assert resp.status_code == 400
+
+    @patch("routes.favorites.reading_list_exists", return_value=True)
+    @patch("routes.favorites.add_reading_list_to_read", return_value=True)
+    def test_add_to_read_list(self, mock_add, mock_exists, client):
+        resp = client.post("/api/favorites/to-read/reading-lists", json={"list_id": 7})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_add.assert_called_once_with(7)
+
+    @patch("routes.favorites.reading_list_exists", return_value=True)
+    @patch("routes.favorites.add_reading_list_to_read", return_value=True)
+    def test_add_to_read_list_coerces_string_id(self, mock_add, mock_exists, client):
+        resp = client.post("/api/favorites/to-read/reading-lists", json={"list_id": "7"})
+        assert resp.status_code == 200
+        mock_add.assert_called_once_with(7)
+
+    def test_add_to_read_list_missing_id(self, client):
+        resp = client.post("/api/favorites/to-read/reading-lists", json={})
+        assert resp.status_code == 400
+
+    def test_add_to_read_list_bad_id(self, client):
+        resp = client.post("/api/favorites/to-read/reading-lists", json={"list_id": "abc"})
+        assert resp.status_code == 400
+
+    @patch("routes.favorites.reading_list_exists", return_value=False)
+    def test_add_to_read_list_unknown_list(self, mock_exists, client):
+        """A list deleted in another tab reports 404, not 500."""
+        resp = client.post("/api/favorites/to-read/reading-lists", json={"list_id": 999})
+        assert resp.status_code == 404
+
+    @patch("routes.favorites.reading_list_exists", return_value=True)
+    @patch("routes.favorites.add_reading_list_to_read", return_value=False)
+    def test_add_to_read_list_failure(self, mock_add, mock_exists, client):
+        resp = client.post("/api/favorites/to-read/reading-lists", json={"list_id": 7})
+        assert resp.status_code == 500
+
+    @patch("routes.favorites.remove_reading_list_to_read", return_value=True)
+    def test_remove_to_read_list(self, mock_rm, client):
+        resp = client.delete("/api/favorites/to-read/reading-lists", json={"list_id": 7})
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        mock_rm.assert_called_once_with(7)
+
+    def test_remove_to_read_list_missing_id(self, client):
+        resp = client.delete("/api/favorites/to-read/reading-lists", json={})
+        assert resp.status_code == 400

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -34,6 +34,13 @@ class TestRolePolicy:
         ("POST", "/api/browse-thumbnails", "reader"),  # read-only batch (POST body)
         ("POST", "/api/browse-metadata", "reader"),    # read-only batch (POST body)
         ("GET", "/api/continue-reading", "reader"),
+        # Bookmarking a reading list is personal data. These live under
+        # /api/favorites precisely so _READER_WRITE_PREFIXES classifies them as
+        # reader-writable; moving them under /api/reading-lists/* would fall
+        # through to the "mutation → clerk" default and 403 every Reader.
+        ("GET", "/api/favorites/to-read/reading-lists", "reader"),
+        ("POST", "/api/favorites/to-read/reading-lists", "reader"),
+        ("DELETE", "/api/favorites/to-read/reading-lists", "reader"),
         ("POST", "/rename", "clerk"),                 # default: mutation → clerk
         ("DELETE", "/api/delete-file", "clerk"),
         ("GET", "/api/getcomics/search", "clerk"),    # clerk-only read area

--- a/tests/unit/test_on_the_stack.py
+++ b/tests/unit/test_on_the_stack.py
@@ -172,6 +172,203 @@ class TestGetOnTheStackItems:
         assert "series_status" in item
 
 
+@pytest.fixture
+def rl_stack_db(db_connection):
+    """Reading lists bookmarked into Want to Read, for On the Stack tests.
+
+    - "Bat Arc"      : 4 entries, #1 read, #2 unmatched, #3-4 unread  -> next #3
+    - "Fresh Arc"    : 2 entries, nothing read                        -> next #1
+    - "Done Arc"     : 2 entries, both read                           -> excluded
+    - "Not Bookmarked": 2 entries, nothing read, NOT in want-to-read  -> excluded
+    """
+    from core.database import (
+        create_reading_list, add_reading_list_entry,
+        add_reading_list_to_read, mark_issue_read,
+    )
+
+    def build(name, entries, bookmarked=True):
+        list_id = create_reading_list(name)
+        for entry in entries:
+            add_reading_list_entry(list_id, entry)
+        if bookmarked:
+            add_reading_list_to_read(list_id)
+        return list_id
+
+    bat_id = build("Bat Arc", [
+        {"series": "Batman", "issue_number": "1",
+         "matched_file_path": "/data/DC/Batman/Batman 001.cbz"},
+        # No matched file: skipped, not treated as the next unread.
+        {"series": "Batman", "issue_number": "2", "matched_file_path": None},
+        {"series": "Batman", "issue_number": "3",
+         "matched_file_path": "/data/DC/Batman/Batman 003.cbz"},
+        {"series": "Batman", "issue_number": "4",
+         "matched_file_path": "/data/DC/Batman/Batman 004.cbz"},
+    ])
+    mark_issue_read(issue_path="/data/DC/Batman/Batman 001.cbz",
+                    read_at="2024-12-01 10:00:00", page_count=24, time_spent=600)
+
+    fresh_id = build("Fresh Arc", [
+        {"series": "Saga", "issue_number": "1",
+         "matched_file_path": "/data/Image/Saga/Saga 001.cbz"},
+        {"series": "Saga", "issue_number": "2",
+         "matched_file_path": "/data/Image/Saga/Saga 002.cbz"},
+    ])
+
+    build("Done Arc", [
+        {"series": "Y The Last Man", "issue_number": "1",
+         "matched_file_path": "/data/DC/Y/Y 001.cbz"},
+    ])
+    mark_issue_read(issue_path="/data/DC/Y/Y 001.cbz",
+                    read_at="2024-11-01 10:00:00", page_count=24, time_spent=600)
+
+    build("Not Bookmarked", [
+        {"series": "Hellboy", "issue_number": "1",
+         "matched_file_path": "/data/DH/Hellboy/Hellboy 001.cbz"},
+    ], bookmarked=False)
+
+    return {"bat_id": bat_id, "fresh_id": fresh_id}
+
+
+class TestGetReadingListStackItems:
+
+    def test_returns_first_unread_in_list_order(self, rl_stack_db):
+        """#1 read, #2 unmatched, #3 unread -> returns #3."""
+        from core.database import get_reading_list_stack_items
+        items = get_reading_list_stack_items(limit=10)
+        bat = [i for i in items if i["reading_list_name"] == "Bat Arc"]
+        assert len(bat) == 1
+        assert bat[0]["issue_number"] == "3"
+        assert bat[0]["file_path"] == "/data/DC/Batman/Batman 003.cbz"
+
+    def test_unstarted_list_still_appears(self, rl_stack_db):
+        """A list with nothing read still surfaces its first entry."""
+        from core.database import get_reading_list_stack_items
+        items = get_reading_list_stack_items(limit=10)
+        fresh = [i for i in items if i["reading_list_name"] == "Fresh Arc"]
+        assert len(fresh) == 1
+        assert fresh[0]["issue_number"] == "1"
+        assert fresh[0]["last_read_at"] is None
+
+    def test_fully_read_list_excluded(self, rl_stack_db):
+        """A list with every matched entry read drops out."""
+        from core.database import get_reading_list_stack_items
+        items = get_reading_list_stack_items(limit=10)
+        assert not [i for i in items if i["reading_list_name"] == "Done Arc"]
+
+    def test_unbookmarked_list_excluded(self, rl_stack_db):
+        """A list that isn't in Want to Read never appears."""
+        from core.database import get_reading_list_stack_items
+        items = get_reading_list_stack_items(limit=10)
+        assert not [i for i in items if i["reading_list_name"] == "Not Bookmarked"]
+
+    def test_removing_bookmark_removes_list(self, rl_stack_db):
+        """Un-bookmarking a list takes it out of the stack."""
+        from core.database import (
+            get_reading_list_stack_items, remove_reading_list_to_read
+        )
+        remove_reading_list_to_read(rl_stack_db["bat_id"])
+        items = get_reading_list_stack_items(limit=10)
+        assert not [i for i in items if i["reading_list_name"] == "Bat Arc"]
+
+    def test_read_state_is_per_user(self, rl_stack_db):
+        """Another user hasn't read #1, so their next issue is #1."""
+        from core.database import get_reading_list_stack_items, add_reading_list_to_read
+        add_reading_list_to_read(rl_stack_db["bat_id"], user_id=2)
+        items = get_reading_list_stack_items(limit=10, user_id=2)
+        bat = [i for i in items if i["reading_list_name"] == "Bat Arc"]
+        assert len(bat) == 1
+        assert bat[0]["issue_number"] == "1"
+
+    def test_sorted_started_lists_first(self, rl_stack_db):
+        """A read at 2024-12-01 outranks a list bookmarked just now... or not.
+
+        Sorting is by last_read_at, falling back to the bookmark time for
+        never-started lists. Both lists must be present either way.
+        """
+        from core.database import get_reading_list_stack_items
+        names = [i["reading_list_name"] for i in get_reading_list_stack_items(limit=10)]
+        assert set(names) == {"Bat Arc", "Fresh Arc"}
+
+    def test_limit_parameter(self, rl_stack_db):
+        """Respects the limit parameter."""
+        from core.database import get_reading_list_stack_items
+        assert len(get_reading_list_stack_items(limit=1)) == 1
+
+    def test_return_format_matches_series_items(self, rl_stack_db):
+        """Same keys as get_on_the_stack_items so the renderers are shared."""
+        from core.database import get_reading_list_stack_items
+        item = get_reading_list_stack_items(limit=10)[0]
+        for key in ("series_id", "series_name", "issue_number", "file_path",
+                    "file_name", "cover_image", "last_read_at", "series_status"):
+            assert key in item
+        assert item["source"] == "reading_list"
+        assert item["reading_list_id"] is not None
+        # series_name carries the entry's series for the card subtitle.
+        assert item["series_name"] in ("Batman", "Saga")
+        assert "/" not in item["file_name"]
+
+    def test_deleting_list_cascades(self, rl_stack_db):
+        """Deleting a reading list removes its want-to-read bookmark."""
+        from core.database import (
+            delete_reading_list, get_reading_list_stack_items,
+            get_to_read_reading_lists,
+        )
+        delete_reading_list(rl_stack_db["bat_id"])
+        assert not [i for i in get_reading_list_stack_items(limit=10)
+                    if i["reading_list_name"] == "Bat Arc"]
+        assert not [l for l in get_to_read_reading_lists()
+                    if l["name"] == "Bat Arc"]
+
+
+class TestToReadReadingLists:
+
+    def test_returns_bookmarked_lists_with_progress(self, rl_stack_db):
+        """Card data carries entry/read counts and a cover stack."""
+        from core.database import get_to_read_reading_lists
+        lists = {l["name"]: l for l in get_to_read_reading_lists()}
+        assert set(lists) == {"Bat Arc", "Fresh Arc", "Done Arc"}
+        # 4 entries, 1 of them read.
+        assert lists["Bat Arc"]["entry_count"] == 4
+        assert lists["Bat Arc"]["read_count"] == 1
+        # Only entries with a matched file can supply a cover.
+        assert lists["Bat Arc"]["covers"] == [
+            "/data/DC/Batman/Batman 001.cbz",
+            "/data/DC/Batman/Batman 003.cbz",
+            "/data/DC/Batman/Batman 004.cbz",
+        ]
+        assert lists["Fresh Arc"]["read_count"] == 0
+
+    def test_read_count_is_per_user(self, rl_stack_db):
+        """Another user sees their own progress, not the owner's."""
+        from core.database import get_to_read_reading_lists, add_reading_list_to_read
+        add_reading_list_to_read(rl_stack_db["bat_id"], user_id=2)
+        lists = {l["name"]: l for l in get_to_read_reading_lists(user_id=2)}
+        assert lists["Bat Arc"]["entry_count"] == 4
+        assert lists["Bat Arc"]["read_count"] == 0
+
+    def test_add_is_idempotent(self, rl_stack_db):
+        """Bookmarking twice doesn't duplicate the card."""
+        from core.database import get_to_read_reading_lists, add_reading_list_to_read
+        assert add_reading_list_to_read(rl_stack_db["bat_id"]) is True
+        names = [l["name"] for l in get_to_read_reading_lists()]
+        assert names.count("Bat Arc") == 1
+
+    def test_is_reading_list_to_read(self, rl_stack_db):
+        from core.database import is_reading_list_to_read, remove_reading_list_to_read
+        assert is_reading_list_to_read(rl_stack_db["bat_id"]) is True
+        remove_reading_list_to_read(rl_stack_db["bat_id"])
+        assert is_reading_list_to_read(rl_stack_db["bat_id"]) is False
+
+    def test_unknown_list_rejected(self, rl_stack_db):
+        """The FK keeps a bogus id out rather than storing a dangling row."""
+        from core.database import (
+            add_reading_list_to_read, get_to_read_reading_lists, reading_list_exists
+        )
+        assert reading_list_exists(99999) is False
+        add_reading_list_to_read(99999)
+        assert not [l for l in get_to_read_reading_lists() if l["id"] == 99999]
+
+
 class TestSeriesSubscription:
 
     def test_set_and_get_subscription_enabled(self, stack_db):


### PR DESCRIPTION
Reading lists were a dead end: you could build or import one, but nothing about it reached the Browse Library dashboard, so a list only existed if you deliberately navigated to it.

## What this does

**Want to Read** — bookmarking a reading list adds it as a single card (cover stack, `read/total`, progress bar) that opens the list page. The toggle sits on the `/reading-lists` grid cards and in the list detail header.

**On the Stack** — the same bookmark is the opt-in that surfaces the list's next unread issue: the first entry in the list's own `sort_order` that is unread and has a matched file. A list you have never started still shows up. Entries with no matched file are skipped rather than treated as unread, so a list whose next entry isn't in the library advances to the next one that is.

## Design notes

**A separate table, not a synthetic path.** `to_read` is keyed on a filesystem path (`UNIQUE(user_id, path)`) and a reading list has none. Storing one as `reading_list:12` would leak a fake path into every path-keyed consumer — `filter_paths_for_user`, `compute_display_name`, `/to-read`, `static/js/files.js`, `/api/v1/library/to-read` and OPDS. The new `reading_list_to_read` table is born user-scoped (no `_rebuild_add_user_scope` migration) and cascades on list deletion, and `to_read` is untouched.

**Endpoints hang off `/api/favorites` deliberately.** That prefix is in `core/auth.py:_READER_WRITE_PREFIXES`, so a Reader can bookmark a list for themselves with no auth.py change. Under `/api/reading-lists` they would fall through to the `mutation → clerk` default and 403. `tests/routes/test_rbac.py` pins this.

**Merging happens in the route.** `/api/on-the-stack` concatenates both sources, dedupes by `file_path` (a bookmarked list and a subscribed series can point at the same next issue), sorts, slices, and keeps the existing `filter_paths_for_user` call — which now covers reading-list issues for free. A never-started list sorts by its bookmark time rather than sinking below everything and getting cut off by `limit=10`.

`get_reading_list_stack_items()` returns the same dict shape as `get_on_the_stack_items()`, so `loadOnTheStackSwiper()` and `loadOnTheStack()` render it unchanged apart from a list-name badge.

## Cleanup carried along

- `get_reading_lists()` and `get_all_reading_lists()` each had a verbatim copy of the covers-fetch loop. Both now call a shared `_reading_list_covers()`, which the new card query reuses — so the Want to Read card and the Reading Lists page can't drift apart.
- The `/api/on-the-stack` stub in `tests/routes/conftest.py` now mirrors the real route's merge logic. It is a hand-maintained copy and will go stale silently if that endpoint changes again.

## Worth flagging

One full-suite failure during development looked like the known Windows `test_restore_round_trip` flake (`WinError 5`, passes in isolation), but the mechanism pointed elsewhere: the new `test_unknown_list_rejected` deliberately trips the foreign key, and that error path left a SQLite connection open — the pattern every neighbouring `to_read` function uses. All six new DB functions now use `try/finally`.

## Not included

The `/to-read` "View All" page still shows paths only; bookmarked lists appear in the dashboard section but not there.

## Testing

`pytest`: **3601 passed, 6 skipped, 0 failed.**

New coverage: first-unread-in-sort_order selection, unstarted lists appearing, fully-read lists dropping out, unmatched entries being skipped, un-bookmarked lists never appearing, per-user read state, FK cascade on list deletion, the three endpoints (including a 404 for a list deleted in another tab), Reader RBAC classification, and the merge/dedupe/sort behaviour of `/api/on-the-stack`.

Not yet exercised in a running container — the dashboard rendering is verified by tests and template parsing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
