### PR TITLE
Fix CBR/RAR download race between api.py and monitor.py

### DIFF
--- a/api.py
+++ b/api.py
@@ -28,6 +28,7 @@ from urllib3.util.retry import Retry
 # Application logging and configuration (adjust these as needed)
 from models.getcomics import provider_label, is_unresolved_gc_redirect
 from core.app_logging import MONITOR_LOG
+from helpers import is_hidden
 from core.config import config, load_config, load_flask_config
 
 # Load config and initialize Flask app.
@@ -58,6 +59,11 @@ from core.download_utils import (
     is_cancel_requested as _is_cancel_requested,
     mark_cancelled as _mark_cancelled,
     set_error_status as _set_error_status,
+    monitor_enabled,
+    post_download_action,
+    watch_drain_timeout_seconds,
+    DEFER_TO_MONITOR,
+    FULL_POST_PROCESS,
 )
 
 
@@ -232,6 +238,67 @@ def resolve_final_url(url: str, *, hdrs=headers, max_hops: int = 6) -> str:
 # -------------------------------
 download_queue = Queue()
 
+def _finish_download_in_watch(file_path, full_pipeline=True):
+    """Convert a completed download, and when we own it, move + rename it too.
+
+    ``full_pipeline=False`` means monitor.py owns WATCH: convert only, and leave
+    the rename and the move to TARGET to it, so the two processes can never both
+    move the same comic and produce a " (1)" duplicate.
+    """
+    # Auto-convert CBR/RAR to CBZ and move to TARGET after download
+    if file_path and file_path.lower().endswith(('.cbr', '.rar')):
+        _autoconvert = config.getboolean("SETTINGS", "AUTOCONVERT", fallback=False)
+        if _autoconvert:
+            if not os.path.exists(file_path):
+                monitor_logger.info(f"Downloaded file already moved by monitor, skipping api conversion: {file_path}")
+            else:
+                try:
+                    from cbz_ops.single_file import convert_to_cbz
+
+                    # Convert CBR/RAR to CBZ
+                    monitor_logger.info(f"Auto-converting downloaded file: {file_path}")
+                    convert_to_cbz(file_path)
+                    cbz_path = os.path.splitext(file_path)[0] + '.cbz'
+                    if os.path.exists(cbz_path):
+                        file_path = cbz_path
+                        monitor_logger.info(f"Post-download conversion complete: {cbz_path}")
+
+                        if full_pipeline:
+                            # Move converted file to TARGET directory
+                            target_dir = config.get("SETTINGS", "TARGET", fallback="/processed")
+                            target_path = os.path.join(target_dir, os.path.basename(cbz_path))
+                            os.makedirs(target_dir, exist_ok=True)
+                            if os.path.abspath(cbz_path) != os.path.abspath(target_path):
+                                if os.path.exists(target_path):
+                                    base, ext = os.path.splitext(target_path)
+                                    counter = 1
+                                    while os.path.exists(target_path):
+                                        target_path = f"{base} ({counter}){ext}"
+                                        counter += 1
+                                shutil.move(cbz_path, target_path)
+                                file_path = target_path
+                                monitor_logger.info(f"Moved converted file to: {target_path}")
+                    else:
+                        monitor_logger.warning(f"Conversion did not produce expected file: {cbz_path}")
+                except Exception as e:
+                    monitor_logger.error(f"Post-download auto-conversion failed for {file_path}: {e}")
+
+    # Apply AUTO_RENAME_MONITOR so extension/API-queued downloads are
+    # renamed consistently with files picked up by monitor.py.
+    if full_pipeline and file_path and os.path.exists(file_path) and file_path.lower().endswith(('.cbz', '.cbr')):
+        if config.getboolean("SETTINGS", "AUTO_RENAME_MONITOR", fallback=True):
+            try:
+                from cbz_ops.rename import rename_file
+                renamed = rename_file(file_path)
+                if renamed and renamed != file_path:
+                    file_path = renamed
+                    monitor_logger.info(f"Renamed File: {file_path}")
+            except Exception as e:
+                monitor_logger.error(f"Post-download rename failed for {file_path}: {e}")
+
+    return file_path
+
+
 def process_download(task):
     download_id = task['download_id']
     original_url  = task['url']
@@ -332,55 +399,30 @@ def process_download(task):
                 monitor_logger.debug(f"Routing to: download_getcomics (fallback)")
                 file_path = download_getcomics(final_url, download_id, hdrs=use_headers, source_url=(source_page_url or try_url))
 
-            # Auto-convert CBR/RAR to CBZ and move to TARGET after download
-            if file_path and file_path.lower().endswith(('.cbr', '.rar')):
-                _autoconvert = config.getboolean("SETTINGS", "AUTOCONVERT", fallback=False)
-                if _autoconvert:
-                    if not os.path.exists(file_path):
-                        monitor_logger.info(f"Downloaded file already moved by monitor, skipping api conversion: {file_path}")
-                    else:
-                        try:
-                            from cbz_ops.single_file import convert_to_cbz
-
-                            # Convert CBR/RAR to CBZ
-                            monitor_logger.info(f"Auto-converting downloaded file: {file_path}")
-                            convert_to_cbz(file_path)
-                            cbz_path = os.path.splitext(file_path)[0] + '.cbz'
-                            if os.path.exists(cbz_path):
-                                file_path = cbz_path
-                                monitor_logger.info(f"Post-download conversion complete: {cbz_path}")
-
-                                # Move converted file to TARGET directory
-                                target_dir = config.get("SETTINGS", "TARGET", fallback="/processed")
-                                target_path = os.path.join(target_dir, os.path.basename(cbz_path))
-                                os.makedirs(target_dir, exist_ok=True)
-                                if os.path.abspath(cbz_path) != os.path.abspath(target_path):
-                                    if os.path.exists(target_path):
-                                        base, ext = os.path.splitext(target_path)
-                                        counter = 1
-                                        while os.path.exists(target_path):
-                                            target_path = f"{base} ({counter}){ext}"
-                                            counter += 1
-                                    shutil.move(cbz_path, target_path)
-                                    file_path = target_path
-                                    monitor_logger.info(f"Moved converted file to: {target_path}")
-                            else:
-                                monitor_logger.warning(f"Conversion did not produce expected file: {cbz_path}")
-                        except Exception as e:
-                            monitor_logger.error(f"Post-download auto-conversion failed for {file_path}: {e}")
-
-            # Apply AUTO_RENAME_MONITOR so extension/API-queued downloads are
-            # renamed consistently with files picked up by monitor.py.
-            if file_path and os.path.exists(file_path) and file_path.lower().endswith(('.cbz', '.cbr')):
-                if config.getboolean("SETTINGS", "AUTO_RENAME_MONITOR", fallback=True):
-                    try:
-                        from cbz_ops.rename import rename_file
-                        renamed = rename_file(file_path)
-                        if renamed and renamed != file_path:
-                            file_path = renamed
-                            monitor_logger.info(f"Renamed File: {file_path}")
-                    except Exception as e:
-                        monitor_logger.error(f"Post-download rename failed for {file_path}: {e}")
+            # WATCH has two writers with no shared lock: this worker thread and
+            # monitor.py, a separate process. When the monitor is running it owns
+            # the file from here -- the same hand-off DC++ and Usenet already do --
+            # otherwise both convert it, both move it into TARGET, and the
+            # extraction scratch dir gets strip-mined mid-conversion. See
+            # core.download_utils.post_download_action for the full contract.
+            action = post_download_action(
+                file_path,
+                monitor_running=monitor_enabled(),
+                ignored_extensions=config.get(
+                    "SETTINGS", "IGNORED_EXTENSIONS", fallback=".crdownload"),
+                auto_unpack=config.getboolean(
+                    "SETTINGS", "AUTO_UNPACK", fallback=False),
+            )
+            if action == DEFER_TO_MONITOR:
+                if file_path:
+                    monitor_logger.info(
+                        f"Monitor owns WATCH - leaving {file_path} in place for "
+                        f"monitor.py to rename/convert/move"
+                    )
+            else:
+                file_path = _finish_download_in_watch(
+                    file_path, full_pipeline=(action == FULL_POST_PROCESS)
+                )
 
             # Success – but honour a cancellation that arrived while downloading
             if is_cancel_requested(download_id):
@@ -411,11 +453,23 @@ def process_download(task):
                     ignored_exts = config.get("SETTINGS", "IGNORED_EXTENSIONS", fallback=".crdownload")
                     ignored = set(ext.strip().lower() for ext in ignored_exts.split(",") if ext.strip())
 
-                    # Poll for up to 5 minutes (30 checks * 10 seconds)
-                    for _ in range(30):
+                    # When the monitor owns WATCH, a file that missed its
+                    # watchdog event waits for the next reconciliation sweep --
+                    # so the budget has to outlast that, not the old flat 5
+                    # minutes (which the sweep interval alone can consume).
+                    budget = watch_drain_timeout_seconds(
+                        config.getint("SETTINGS", "RECONCILE_INTERVAL_MINUTES",
+                                      fallback=5)
+                    )
+                    for _ in range(budget // 10):
                         time.sleep(10)
                         total = 0
-                        for root, _, files in os.walk(watch_dir):
+                        for root, dirs, files in os.walk(watch_dir):
+                            # Prune hidden dirs, or the pages inside an
+                            # in-flight .temp_* extraction (and .clu_unwrap)
+                            # read as "WATCH still busy" for the whole conversion.
+                            dirs[:] = [d for d in dirs
+                                       if not is_hidden(os.path.join(root, d))]
                             for f in files:
                                 if f.startswith('.') or f.startswith('_'):
                                     continue
@@ -427,7 +481,9 @@ def process_download(task):
                             from app import process_incoming_wanted_issues
                             process_incoming_wanted_issues()
                             return
-                    monitor_logger.warning("Timeout waiting for WATCH folder to empty")
+                    monitor_logger.warning(
+                        f"Timeout waiting for WATCH folder to empty after {budget}s"
+                    )
                 except Exception as e:
                     monitor_logger.error(f"Error checking wanted issues: {e}")
 

--- a/api.py
+++ b/api.py
@@ -86,9 +86,36 @@ watch = config.get("SETTINGS", "WATCH", fallback="watch")
 from core.database import get_user_preference
 custom_headers_str = get_user_preference("custom_headers", "")
 
+# Import-time bootstrap only -- WATCH is editable at runtime from Settings, so
+# every download must resolve it through _download_dir() instead of this constant.
 DOWNLOAD_DIR = watch
 if not os.path.exists(DOWNLOAD_DIR):
     os.makedirs(DOWNLOAD_DIR)
+
+
+def _download_dir():
+    """WATCH resolved per call.
+
+    WATCH lives in user_preferences and can be changed from Settings without a
+    restart; monitor.py re-reads it on every event via get_watch_dir(). Holding
+    the import-time snapshot here would keep writing downloads into a folder the
+    monitor no longer watches -- and since the monitor now owns post-processing,
+    those files would never be converted or moved at all.
+    """
+    try:
+        from core.config import get_watch_dir
+        resolved = get_watch_dir()
+    except Exception:
+        resolved = None
+    if not resolved:
+        resolved = config.get("SETTINGS", "WATCH", fallback=DOWNLOAD_DIR)
+    if resolved and not os.path.exists(resolved):
+        try:
+            os.makedirs(resolved, exist_ok=True)
+        except OSError as e:
+            monitor_logger.error(f"Could not create WATCH directory {resolved}: {e}")
+            return DOWNLOAD_DIR
+    return resolved or DOWNLOAD_DIR
 
 # Default headers for HTTP requests.
 default_headers = {
@@ -681,12 +708,13 @@ def download_getcomics(url, download_id, hdrs=None, source_url=None):
                     filename = unquote(fname_match.group(1))
                     monitor_logger.info(f"Filename from Content-Disposition: {filename}")
 
-            file_path = os.path.join(DOWNLOAD_DIR, filename)
+            dl_dir = _download_dir()
+            file_path = os.path.join(dl_dir, filename)
             base, ext = os.path.splitext(filename)
             counter = 1
             while os.path.exists(file_path):
                 filename = f"{base}_{counter}{ext}"
-                file_path = os.path.join(DOWNLOAD_DIR, filename)
+                file_path = os.path.join(dl_dir, filename)
                 counter += 1
 
             download_progress[download_id]['filename'] = file_path
@@ -948,7 +976,7 @@ def download_pixeldrain(url: str, download_id: str, dest_name: Optional[str] = N
     download_progress[download_id] |= {"filename": filename_fs, "progress": 0}
 
     # 3) choose output path
-    out_path = os.path.join(DOWNLOAD_DIR, filename_fs)
+    out_path = os.path.join(_download_dir(), filename_fs)
     base, ext = os.path.splitext(out_path)
     n = 1
     while os.path.exists(out_path):
@@ -1122,7 +1150,7 @@ def download_comicbookplus(url: str, download_id: str, dest_name: Optional[str] 
     session = _requests_session()
 
     # Choose output path
-    out_path = os.path.join(DOWNLOAD_DIR, filename)
+    out_path = os.path.join(_download_dir(), filename)
     base, ext = os.path.splitext(out_path)
     n = 1
     while os.path.exists(out_path):
@@ -1153,7 +1181,7 @@ def download_comicbookplus(url: str, download_id: str, dest_name: Optional[str] 
                     cd_filename = secure_filename(unquote(m.group(1)))
                     if cd_filename:
                         # Update path with new filename
-                        out_path = os.path.join(DOWNLOAD_DIR, cd_filename)
+                        out_path = os.path.join(_download_dir(), cd_filename)
                         base, ext = os.path.splitext(out_path)
                         n = 1
                         while os.path.exists(out_path):
@@ -1239,7 +1267,7 @@ def download_mega(url: str, download_id: str, dest_name: Optional[str] = None, h
         monitor_logger.info(f"MEGA file: {filename} ({total_size / 1024 / 1024:.2f} MB)")
 
         # Resolve output path (handle duplicates)
-        out_path = os.path.join(DOWNLOAD_DIR, filename)
+        out_path = os.path.join(_download_dir(), filename)
         base, ext = os.path.splitext(out_path)
         n = 1
         while os.path.exists(out_path):
@@ -1269,9 +1297,10 @@ def download_mega(url: str, download_id: str, dest_name: Optional[str] = None, h
             download_progress[download_id]['progress'] = int(percent)
             return True  # Continue download
 
-        # Download to DOWNLOAD_DIR, MegaDownloader handles decryption
-        monitor_logger.debug(f"Starting MEGA download to {DOWNLOAD_DIR}")
-        result_path = mega_dl.download(DOWNLOAD_DIR, progress_callback=progress_callback)
+        # Download into WATCH, MegaDownloader handles decryption
+        _watch_dir = _download_dir()
+        monitor_logger.debug(f"Starting MEGA download to {_watch_dir}")
+        result_path = mega_dl.download(_watch_dir, progress_callback=progress_callback)
         monitor_logger.debug(f"Download returned path: {result_path}")
 
         # If dest_name was specified, rename the file

--- a/cbz_ops/convert.py
+++ b/cbz_ops/convert.py
@@ -184,7 +184,7 @@ def convert_rar_directory(directory, force_recursive=False):
                     processed_files += 1
                     
                     rar_path = file_path
-                    temp_extraction_dir = os.path.join(root, f"temp_{file_name[:-4]}")
+                    temp_extraction_dir = os.path.join(root, f".temp_{file_name[:-4]}")
                     zip_path = os.path.join(root, f"{file_name[:-4]}.cbz")
 
                     app_logger.info(f"Processing file: {file_name} ({processed_files}/{total_files})")
@@ -210,7 +210,7 @@ def convert_rar_directory(directory, force_recursive=False):
                 processed_files += 1
                 
                 rar_path = file_path
-                temp_extraction_dir = os.path.join(directory, f"temp_{file_name[:-4]}")
+                temp_extraction_dir = os.path.join(directory, f".temp_{file_name[:-4]}")
                 zip_path = os.path.join(directory, f"{file_name[:-4]}.cbz")
 
                 app_logger.info(f"Processing file: {file_name} ({processed_files}/{total_files})")

--- a/cbz_ops/rebuild.py
+++ b/cbz_ops/rebuild.py
@@ -258,7 +258,7 @@ def rebuild_single_cbz_file(cbz_path, directory):
                 shutil.rmtree(folder_path)
             
             # Try to convert as RAR file
-            temp_extraction_dir = os.path.join(directory, f"temp_{base_name}")
+            temp_extraction_dir = os.path.join(directory, f".temp_{base_name}")
             zip_path = os.path.join(directory, base_name + '.cbz')
             
             app_logger.info(f"Attempting to convert {base_name}.rar as RAR file...")
@@ -307,7 +307,7 @@ def convert_rar_to_zip_in_directory(directory, total_files=None, processed_files
                 processed_files[0] += 1
             
             rar_path = file_path
-            temp_extraction_dir = os.path.join(directory, f"temp_{file_name[:-4]}")
+            temp_extraction_dir = os.path.join(directory, f".temp_{file_name[:-4]}")
             zip_path = os.path.join(directory, file_name[:-4] + '.cbz')
 
             app_logger.info(f"Processing file: {file_name} ({processed_files[0] if processed_files else '?'}/{total_files if total_files else '?'})")

--- a/cbz_ops/single_file.py
+++ b/cbz_ops/single_file.py
@@ -342,7 +342,7 @@ def rebuild_single_cbz_file(cbz_path):
                 shutil.rmtree(folder_name)
 
             # Try to convert as RAR file
-            temp_extraction_dir = os.path.join(directory, f"temp_{base_name}")
+            temp_extraction_dir = os.path.join(directory, f".temp_{base_name}")
             final_cbz_path = os.path.join(directory, base_name + '.cbz')
 
             app_logger.info(f"Attempting to convert {base_name}.rar as RAR file...")
@@ -415,7 +415,13 @@ def convert_to_cbz(file_path):
         base_name = os.path.splitext(file_path)[0]  # Removes the extension
         parent_dir = os.path.dirname(file_path)
         base_only = os.path.splitext(os.path.basename(file_path))[0]
-        temp_extraction_dir = os.path.join(parent_dir, f"temp_{base_only}")
+        # Hidden ("." prefix) so helpers.is_hidden() skips it. This dir is a
+        # sibling of the file being converted, so when api.py converts a fresh
+        # download it lands *inside* WATCH -- and monitor.py's recursive sweep
+        # would otherwise treat each extracted page as a completed download and
+        # move it to TARGET, strip-mining the conversion still in progress.
+        # Same reasoning as monitor.py's ".clu_unwrap" staging root.
+        temp_extraction_dir = os.path.join(parent_dir, f".temp_{base_only}")
         cbz_file_path = base_name + '.cbz'
 
         # Get parent directory for cache invalidation

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -253,3 +253,98 @@ def reconcile_weekly_pack_history(progress=None, stale_after_seconds=900):
             )
 
     return changed
+
+
+# ---------------------------------------------------------------------------
+# Post-download ownership of WATCH
+#
+# WATCH has two independent writers: this app's download workers (threads in the
+# Gunicorn process) and monitor.py (a separate OS process, started by app.py when
+# MONITOR=yes). monitor.py's _processing_lock/_in_flight guard is per-process, so
+# neither side can see the other's claim. Left to race, both convert the file and
+# both move it, so TARGET gains a "Foo.cbz" *and* a "Foo (1).cbz" -- with loose
+# extraction pages alongside them, because the monitor's recursive sweep descends
+# into the conversion scratch dir while it is still being filled.
+#
+# The resolution is the contract DC++ and Usenet already follow: put the finished
+# file in WATCH and stop (models/dcpp.py, models/usenet.py). The one wrinkle is
+# that the monitor refuses some extensions outright, so "hand it over" is only
+# correct for files it will actually claim.
+# ---------------------------------------------------------------------------
+
+DEFER_TO_MONITOR = "defer"           # leave in WATCH; monitor renames/converts/moves
+CONVERT_IN_PLACE = "convert_only"    # convert only, so the monitor will claim the result
+FULL_POST_PROCESS = "full"           # no monitor: convert + move to TARGET + rename here
+
+_CONVERTIBLE_EXTS = ('.cbr', '.rar')
+
+
+def monitor_enabled(env=None) -> bool:
+    """True when monitor.py owns WATCH. Mirrors app.py's MONITOR env check."""
+    env = os.environ if env is None else env
+    return (env.get("MONITOR", "") or "").strip().lower() == "yes"
+
+
+def parse_ignored_extensions(value) -> set:
+    """IGNORED_EXTENSIONS config string -> {'.ext', ...}.
+
+    Tolerates spacing, casing and a missing leading dot, so a hand-edited
+    config.ini can't silently desync this from monitor.py's own parse.
+    """
+    out = set()
+    for part in (value or "").split(","):
+        part = part.strip().lower()
+        if part:
+            out.add(part if part.startswith(".") else "." + part)
+    return out
+
+
+def monitor_claims(file_path, ignored_extensions, auto_unpack=False) -> bool:
+    """Whether monitor.py would import *file_path* as-is.
+
+    Mirror of ``DownloadCompleteHandler._handle_file_if_complete``: everything
+    except an ignored extension, plus ``.zip`` when AUTO_UNPACK is on. Note that
+    ``.rar`` is in the shipped IGNORED_EXTENSIONS default -- which is exactly why
+    deferring every file unconditionally would strand RAR downloads in WATCH.
+    Kept in lockstep by tests/unit/test_monitor.py::test_monitor_ignores_rar_extension.
+    """
+    ext = os.path.splitext(file_path or "")[1].lower()
+    if not ext:
+        return False
+    if ext not in parse_ignored_extensions(ignored_extensions):
+        return True
+    return ext == ".zip" and bool(auto_unpack)
+
+
+def post_download_action(file_path, *, monitor_running,
+                         ignored_extensions, auto_unpack=False) -> str:
+    """Decide who finishes a completed download sitting in WATCH."""
+    if not file_path:
+        return DEFER_TO_MONITOR
+    if not monitor_running:
+        # Nothing else drains WATCH in this configuration.
+        return FULL_POST_PROCESS
+    if monitor_claims(file_path, ignored_extensions, auto_unpack):
+        return DEFER_TO_MONITOR
+    # The monitor will never touch this extension (.rar by default). Convert it
+    # into something it does claim, but still leave the rename and the move to it
+    # so only one process ever writes into TARGET.
+    if os.path.splitext(file_path)[1].lower() in _CONVERTIBLE_EXTS:
+        return CONVERT_IN_PLACE
+    return DEFER_TO_MONITOR
+
+
+def watch_drain_timeout_seconds(reconcile_interval_minutes=5) -> int:
+    """How long to wait for monitor.py to drain WATCH before giving up.
+
+    Must cover a fully missed watchdog event, where the file waits for the next
+    reconciliation sweep: two sweep intervals plus conversion headroom, never
+    less than the historical 5 minutes. Capped at an hour so a long sweep
+    interval can't leave a poller thread alive per download indefinitely -- this
+    only gates an opportunistic wanted-issue check, which is also scheduled.
+    """
+    try:
+        minutes = int(reconcile_interval_minutes)
+    except (TypeError, ValueError):
+        minutes = 5
+    return max(300, min(3600, minutes * 60 * 2 + 120))

--- a/monitor.py
+++ b/monitor.py
@@ -77,6 +77,19 @@ def strip_comic_extension(name):
     return name
 
 
+# Conversion scratch directories written by cbz_ops next to the file being
+# converted: ".temp_<name>" today, bare "temp_<name>" from older CLU versions and
+# from conversions that died before their rmtree. Their contents are extracted
+# pages, not downloads -- moving them both litters TARGET with loose images and
+# strip-mines the CBZ still being assembled from them.
+_SCRATCH_DIR_RE = re.compile(r"^\.?temp_", re.IGNORECASE)
+
+
+def is_scratch_dir(name):
+    """True if *name* is a conversion scratch directory (hidden or legacy)."""
+    return bool(_SCRATCH_DIR_RE.match(os.path.basename(name or "")))
+
+
 class DownloadCompleteHandler(FileSystemEventHandler):
     def __init__(self, directory, target_directory, ignored_extensions):
         """
@@ -375,7 +388,8 @@ class DownloadCompleteHandler(FileSystemEventHandler):
     def _scan_directory(self, directory):
         for root, dirs, files in os.walk(directory):
             # Skip hidden directories from being traversed.
-            dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
+            dirs[:] = [d for d in dirs
+                       if not is_hidden(os.path.join(root, d)) and not is_scratch_dir(d)]
             for file in files:
                 file_path = os.path.join(root, file)
                 # Skip hidden files.
@@ -385,7 +399,43 @@ class DownloadCompleteHandler(FileSystemEventHandler):
                 monitor_logger.info(f"Scanning directory - found file: {file_path}")
 
 
+    def _is_in_ignored_dir(self, filepath):
+        """True when any folder between WATCH and *filepath* is hidden or a
+        conversion scratch dir.
+
+        ``is_hidden()`` only inspects a basename, and PollingObserver snapshots
+        hidden directories too -- so without this check a live ``on_created`` for
+        "WATCH/.temp_Foo/page001.jpg" (or "WATCH/.clu_unwrap/...") reaches the
+        code below, where the page's own name looks perfectly ordinary, and gets
+        moved to TARGET. The ``dirs[:]`` prunes in the walks only protect the
+        sweep path, never the live-event path.
+        """
+        try:
+            rel = os.path.relpath(os.path.abspath(filepath),
+                                  os.path.abspath(self.directory))
+        except ValueError:
+            # Different drive on Windows -- not under WATCH, nothing to prune.
+            return False
+        parts = rel.split(os.sep)
+        if parts and parts[0] == os.pardir:
+            return False
+        # Rebuild each ancestor as a real path: is_hidden() stats the path on
+        # Windows and only guards AttributeError, so a bare component name would
+        # raise FileNotFoundError.
+        current = os.path.abspath(self.directory)
+        for part in parts[:-1]:
+            current = os.path.join(current, part)
+            if is_scratch_dir(part) or is_hidden(current):
+                return True
+        return False
+
+
     def _handle_file_if_complete(self, filepath):
+        # Skip anything living under a hidden or conversion-scratch folder.
+        if self._is_in_ignored_dir(filepath):
+            monitor_logger.debug(f"Skipping file under ignored directory: {filepath}")
+            return
+
         # Skip hidden files.
         if is_hidden(filepath):
             monitor_logger.info(f"Skipping hidden file: {filepath}")
@@ -485,8 +535,9 @@ class DownloadCompleteHandler(FileSystemEventHandler):
             total_size_cleaned = 0
             
             for root, dirs, files in os.walk(self.directory):
-                # Skip hidden directories
-                dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
+                # Skip hidden directories and conversion scratch dirs
+                dirs[:] = [d for d in dirs
+                           if not is_hidden(os.path.join(root, d)) and not is_scratch_dir(d)]
                 
                 for file in files:
                     file_path = os.path.join(root, file)
@@ -540,8 +591,9 @@ class DownloadCompleteHandler(FileSystemEventHandler):
 
             monitor_logger.info(f"Running reconciliation sweep of: {self.directory}")
             for root, dirs, files in os.walk(self.directory):
-                # Skip hidden directories from being traversed.
-                dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
+                # Skip hidden directories and conversion scratch dirs.
+                dirs[:] = [d for d in dirs
+                           if not is_hidden(os.path.join(root, d)) and not is_scratch_dir(d)]
                 # Offer each subfolder to the multipart unwrapper first; prune any
                 # it claims so the per-file loop never sees the obfuscated parts.
                 kept = []

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -307,7 +307,7 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
 
             # Convert RAR to CBZ
             app_logger.info(f"Converting {base_name}.rar to CBZ format...")
-            temp_conversion_dir = os.path.join(file_dir, f"temp_{base_name}")
+            temp_conversion_dir = os.path.join(file_dir, f".temp_{base_name}")
             success = convert_single_rar_file(rar_file, file_path, temp_conversion_dir)
 
             if success:

--- a/tests/mocked/test_convert.py
+++ b/tests/mocked/test_convert.py
@@ -114,3 +114,65 @@ class TestConvertRarDirectory:
 
         result = convert_rar_directory(str(tmp_path))
         assert result == []
+
+
+class TestConvertDirectoryScratchDirs:
+    """cbz_ops/convert.py must use the same hidden scratch-dir name."""
+
+    def test_scratch_dir_is_hidden(self, tmp_path):
+        from unittest.mock import patch
+        from helpers import is_hidden
+        from cbz_ops.convert import convert_rar_directory
+
+        (tmp_path / "Batman 001.cbr").write_bytes(b"fake rar")
+        seen = {}
+
+        def fake_convert(rar_path, zip_path, temp_extraction_dir):
+            seen["dir"] = temp_extraction_dir
+            with open(zip_path, "wb") as f:
+                f.write(b"fake cbz")
+            return True
+
+        with patch("cbz_ops.convert.convert_single_rar_file", side_effect=fake_convert):
+            convert_rar_directory(str(tmp_path))
+
+        assert seen.get("dir") is not None, "convert_single_rar_file was never called"
+        assert os.path.basename(seen["dir"]).startswith(".")
+        assert is_hidden(seen["dir"]) is True
+
+
+class TestConversionWorksFromAHiddenExtractionRoot:
+    """The zip-building walk must still see pages under a dot-prefixed root.
+
+    Both walks in convert_single_rar_file prune hidden *sub*directories. The
+    extraction root is now dot-prefixed itself, and os.walk never applies that
+    filter to its own root -- but if that ever changed, every conversion would
+    silently produce an empty CBZ. This pins it down with the real walk/zip code
+    (only the unar call is faked).
+    """
+
+    def test_pages_under_a_hidden_root_are_zipped(self, tmp_path):
+        from unittest.mock import patch
+        from cbz_ops.convert import convert_single_rar_file
+
+        rar = tmp_path / "Batman 001.cbr"
+        rar.write_bytes(b"fake rar")
+        cbz = tmp_path / "Batman 001.cbz"
+        scratch = tmp_path / ".temp_Batman 001"
+
+        def fake_extract(rar_path, output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+            for n in (1, 2, 3):
+                with open(os.path.join(output_dir, f"page{n:03}.jpg"), "wb") as f:
+                    f.write(b"jpeg-bytes")
+            return True, 0
+
+        with patch("cbz_ops.convert.extract_rar_with_unar", side_effect=fake_extract):
+            ok = convert_single_rar_file(str(rar), str(cbz), str(scratch))
+
+        assert ok is True
+        assert cbz.exists(), "conversion must produce a CBZ"
+        with zipfile.ZipFile(str(cbz)) as zf:
+            names = sorted(zf.namelist())
+        assert names == ["page001.jpg", "page002.jpg", "page003.jpg"], \
+            f"all pages must be archived, got {names}"

--- a/tests/mocked/test_single_file.py
+++ b/tests/mocked/test_single_file.py
@@ -265,3 +265,70 @@ class TestConvertToCbz:
 
         convert_to_cbz(str(cbz))
         mock_handle.assert_called_once_with(str(cbz))
+
+
+class TestConvertToCbzScratchDir:
+    """The extraction scratch dir must be a *hidden* sibling of the source.
+
+    convert_to_cbz extracts next to the file it is converting, so when api.py
+    converts a fresh download the scratch dir lands inside WATCH. If it is
+    visible, monitor.py's recursive sweep walks in, treats each extracted page as
+    a completed download and moves it to TARGET -- littering the library with
+    loose JPGs and strip-mining the CBZ still being built from those pages.
+    helpers.is_hidden() is the mechanism every monitor walk already prunes on.
+    """
+
+    @staticmethod
+    def _capture(tmp_path, source_name="Batman 001.cbr", succeed=True):
+        """Run convert_to_cbz and return the scratch dir it asked for."""
+        from unittest.mock import patch
+        from cbz_ops.single_file import convert_to_cbz
+
+        cbr = tmp_path / source_name
+        cbr.write_bytes(b"fake rar")
+        seen = {}
+
+        def fake_convert(rar_path, cbz_path, temp_extraction_dir):
+            seen["dir"] = temp_extraction_dir
+            os.makedirs(temp_extraction_dir, exist_ok=True)
+            with open(os.path.join(temp_extraction_dir, "page001.jpg"), "wb") as f:
+                f.write(b"jpeg-bytes")
+            if succeed:
+                with open(cbz_path, "wb") as f:
+                    f.write(b"fake cbz")
+            return succeed
+
+        with patch("cbz_ops.single_file.convert_single_rar_file", side_effect=fake_convert), \
+                patch("core.database.invalidate_browse_cache"), \
+                patch("core.database.delete_file_index_entry"), \
+                patch("core.database.add_file_index_entry"), \
+                patch("core.database.move_reading_data"):
+            convert_to_cbz(str(cbr))
+
+        return seen.get("dir"), str(cbr)
+
+    def test_scratch_dir_is_a_hidden_sibling(self, tmp_path):
+        from helpers import is_hidden
+
+        scratch, source = self._capture(tmp_path)
+
+        assert scratch is not None, "convert_single_rar_file was never called"
+        assert os.path.dirname(os.path.abspath(scratch)) == \
+            os.path.dirname(os.path.abspath(source)), "must be a sibling"
+        assert os.path.basename(scratch).startswith("."), \
+            "scratch dir must be dot-prefixed"
+        assert is_hidden(scratch) is True, \
+            "monitor.py prunes on is_hidden(); the scratch dir must satisfy it"
+
+    def test_scratch_dir_removed_after_successful_conversion(self, tmp_path):
+        scratch, _source = self._capture(tmp_path)
+        assert not os.path.exists(scratch), "cleanup must still fire"
+
+    def test_scratch_dir_left_by_a_failed_conversion_is_still_hidden(self, tmp_path):
+        """A crashed conversion leaves cruft -- it must at least be invisible to
+        the monitor, or the next sweep harvests its pages into TARGET."""
+        from helpers import is_hidden
+
+        scratch, _source = self._capture(tmp_path, succeed=False)
+        assert os.path.basename(scratch).startswith(".")
+        assert is_hidden(scratch) is True

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -39,6 +39,13 @@ class TestIsHidden:
         from helpers import is_hidden
         assert is_hidden("/path/.DS_Store") is True
 
+    def test_conversion_scratch_dir(self):
+        """cbz_ops names its extraction dir ".temp_<base>" precisely so this
+        returns True -- that is what keeps monitor.py's sweep out of a
+        conversion in progress. Contract lock between the two."""
+        from helpers import is_hidden
+        assert is_hidden("/downloads/temp/.temp_Batman 001") is True
+
     def test_macosx_dir(self):
         from helpers import is_hidden
         assert is_hidden("/path/_MACOSX") is True

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -358,3 +358,244 @@ def test_file_under_in_flight_dir_is_skipped(handler, monkeypatch):
 
     assert called == [], "file under in-flight unwrap dir must not be processed"
     assert os.path.exists(part), "part must stay put"
+
+
+# ---------------------------------------------------------------------------
+# Conversion scratch dirs
+#
+# cbz_ops writes its extraction dir next to the file being converted, so when
+# api.py converts a fresh download it lands inside WATCH. Those are extracted
+# pages, not downloads: moving them litters TARGET with loose images *and*
+# strip-mines the CBZ still being assembled. ".temp_*" is the current name,
+# bare "temp_*" survives from older versions and crashed conversions.
+# ---------------------------------------------------------------------------
+
+def _jpgs_under(root):
+    found = []
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            if f.lower().endswith(".jpg"):
+                found.append(os.path.join(dirpath, f))
+    return found
+
+
+def test_reconcile_never_moves_pages_from_conversion_scratch_dir(handler):
+    """The headline regression: extraction pages must never reach TARGET.
+
+    Covers both the current hidden name and the legacy bare one, and proves a
+    real comic sitting beside them is still drained.
+    """
+    h, watch, target = handler
+
+    hidden_scratch = os.path.join(watch, ".temp_Series 007 (2024)")
+    legacy_scratch = os.path.join(watch, "temp_Series 008 (2024)")
+    os.makedirs(hidden_scratch)
+    os.makedirs(legacy_scratch)
+    hidden_page = os.path.join(hidden_scratch, "page001.jpg")
+    legacy_page = os.path.join(legacy_scratch, "page001.jpg")
+    _write(hidden_page, b"jpeg-bytes")
+    _write(legacy_page, b"jpeg-bytes")
+
+    real = "Series 009 (2024).cbz"
+    _write(os.path.join(watch, real))
+
+    h.reconcile_directory()
+
+    assert os.path.exists(hidden_page), "page in .temp_* must stay put"
+    assert os.path.exists(legacy_page), "page in legacy temp_* must stay put"
+    assert _jpgs_under(target) == [], "no loose images may reach TARGET"
+    assert os.path.exists(_moved_path(target, real)), "real comic still drains"
+
+
+def test_live_event_inside_scratch_dir_is_ignored(handler, monkeypatch):
+    """Guards the live-event path, which the dirs[:] prunes do not cover.
+
+    PollingObserver snapshots hidden directories, and is_hidden() only inspects a
+    basename -- so on_created for ".temp_Foo/page001.jpg" arrives here with a
+    perfectly ordinary-looking filename.
+    """
+    h, watch, target = handler
+    scratch = os.path.join(watch, ".temp_Series 007 (2024)")
+    os.makedirs(scratch)
+    page = os.path.join(scratch, "page001.jpg")
+    _write(page, b"jpeg-bytes")
+
+    called = []
+    monkeypatch.setattr(h, "_process_file", lambda fp: called.append(fp))
+
+    h._handle_file_if_complete(page)
+
+    assert called == [], "page under a scratch dir must not be processed"
+    assert os.path.exists(page)
+
+
+def test_live_event_inside_legacy_scratch_dir_is_ignored(handler, monkeypatch):
+    """Same guard for the pre-fix, non-hidden scratch name."""
+    h, watch, target = handler
+    scratch = os.path.join(watch, "temp_Series 008 (2024)")
+    os.makedirs(scratch)
+    page = os.path.join(scratch, "page001.jpg")
+    _write(page, b"jpeg-bytes")
+
+    called = []
+    monkeypatch.setattr(h, "_process_file", lambda fp: called.append(fp))
+
+    h._handle_file_if_complete(page)
+
+    assert called == [], "page under a legacy scratch dir must not be processed"
+    assert os.path.exists(page)
+
+
+def test_live_event_inside_hidden_dir_is_ignored(handler, monkeypatch):
+    """The unwrap staging root (.clu_unwrap) had the same hole."""
+    h, watch, target = handler
+    staging = os.path.join(watch, ".clu_unwrap", "job1")
+    os.makedirs(staging)
+    page = os.path.join(staging, "page001.jpg")
+    _write(page, b"jpeg-bytes")
+
+    called = []
+    monkeypatch.setattr(h, "_process_file", lambda fp: called.append(fp))
+
+    h._handle_file_if_complete(page)
+
+    assert called == [], "file under a hidden dir must not be processed"
+    assert os.path.exists(page)
+
+
+def test_scan_directory_prunes_scratch_dirs(handler, monkeypatch):
+    """The READ_SUBDIRECTORIES walk must not descend into scratch dirs."""
+    h, watch, target = handler
+    scratch = os.path.join(watch, ".temp_Series 007 (2024)")
+    os.makedirs(scratch)
+    _write(os.path.join(scratch, "page001.jpg"), b"jpeg-bytes")
+
+    seen = []
+    monkeypatch.setattr(h, "_handle_file_if_complete", lambda fp: seen.append(fp))
+
+    h._scan_directory(watch)
+
+    assert seen == [], "scan must not surface scratch-dir contents"
+
+
+def test_ordinary_subdirectory_is_still_processed(handler):
+    """The scratch-dir prune must not swallow normal release folders."""
+    h, watch, target = handler
+    sub = os.path.join(watch, "Series 010 (2024)")
+    os.makedirs(sub)
+    name = "Series 010 (2024).cbz"
+    _write(os.path.join(sub, name))
+
+    h.reconcile_directory()
+
+    assert not os.path.exists(os.path.join(sub, name)), "file should leave WATCH"
+    assert os.path.exists(_moved_path(target, name))
+
+
+def test_is_scratch_dir_matching():
+    """Prefix-only, case-insensitive, hidden or not."""
+    import monitor
+
+    assert monitor.is_scratch_dir("temp_Batman 001") is True
+    assert monitor.is_scratch_dir(".temp_Batman 001") is True
+    assert monitor.is_scratch_dir("TEMP_Batman 001") is True
+    assert monitor.is_scratch_dir(os.path.join("a", "b", ".temp_x")) is True
+    # Not scratch: the word has to be the prefix.
+    assert monitor.is_scratch_dir("Temperature Rising 001") is False
+    assert monitor.is_scratch_dir("my_temp_folder") is False
+    assert monitor.is_scratch_dir("") is False
+    assert monitor.is_scratch_dir(None) is False
+
+
+def test_monitor_ignores_rar_extension(handler):
+    """.rar ships on IGNORED_EXTENSIONS, so the monitor never imports one.
+
+    This is the assumption core.download_utils.post_download_action encodes when
+    it returns CONVERT_IN_PLACE instead of deferring a .rar; the two must not
+    drift apart.
+    """
+    from core.download_utils import monitor_claims
+
+    h, watch, target = handler
+    h.ignored_extensions = {".crdownload", ".rar", ".zip"}
+    name = "Series 011 (2024).rar"
+    _write(os.path.join(watch, name))
+
+    h.reconcile_directory()
+
+    assert os.path.exists(os.path.join(watch, name)), "monitor must leave .rar alone"
+    assert monitor_claims(name, ".crdownload,.rar,.zip") is False
+
+
+# ---------------------------------------------------------------------------
+# The CBR -> CBZ conversion branch (previously untested: the base fixture
+# disables autoconvert).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def converting_handler(handler, monkeypatch):
+    """handler with autoconvert on and convert_to_cbz faked.
+
+    The fake records the path it was handed and performs the real observable
+    effect (write <base>.cbz, drop the .cbr) so no unar binary is needed.
+    """
+    import monitor
+
+    h, watch, target = handler
+    h.autoconvert = True
+    calls = []
+
+    def fake_convert(path):
+        calls.append(path)
+        cbz = os.path.splitext(path)[0] + ".cbz"
+        _write(cbz, b"converted")
+        if os.path.exists(path):
+            os.remove(path)
+
+    monkeypatch.setattr(monitor, "convert_to_cbz", fake_convert)
+    return h, watch, target, calls
+
+
+def test_cbr_converted_after_move_into_target(converting_handler):
+    """The monitor converts in TARGET, never in WATCH.
+
+    This is why the monitor's own conversion was never part of the race: its
+    scratch dir lands in TARGET, which nothing watches.
+    """
+    h, watch, target, calls = converting_handler
+    name = "Series 012 (2024).cbr"
+    _write(os.path.join(watch, name))
+
+    h.reconcile_directory()
+
+    assert len(calls) == 1, "must convert exactly once"
+    converted = os.path.abspath(calls[0])
+    assert not converted.startswith(os.path.abspath(watch) + os.sep), \
+        "conversion must not run inside WATCH"
+    assert os.path.exists(_moved_path(target, "Series 012 (2024).cbz"))
+    assert not os.path.exists(os.path.join(watch, name)), "WATCH should drain"
+
+
+def test_existing_cbz_in_target_skips_conversion(converting_handler):
+    """If the CBZ is already there, don't convert again."""
+    h, watch, target, calls = converting_handler
+    name = "Series 013 (2024).cbr"
+    _write(os.path.join(watch, name))
+    from cbz_ops.rename import clean_directory_name
+    os.makedirs(clean_directory_name(target), exist_ok=True)
+    _write(_moved_path(target, "Series 013 (2024).cbz"), b"already-there")
+
+    h.reconcile_directory()
+
+    assert calls == [], "must not re-convert an existing CBZ"
+
+
+def test_empty_cbr_not_converted(converting_handler):
+    """A zero-byte CBR is skipped rather than fed to the converter."""
+    h, watch, target, calls = converting_handler
+    name = "Series 014 (2024).cbr"
+    _write(os.path.join(watch, name), b"")
+
+    h.reconcile_directory()
+
+    assert calls == [], "must not convert an empty file"

--- a/tests/unit/test_post_download_policy.py
+++ b/tests/unit/test_post_download_policy.py
@@ -1,0 +1,142 @@
+"""
+Unit tests for the post-download ownership policy in core/download_utils.py.
+
+WATCH has two writers -- api.py's download workers (threads in the Gunicorn
+process) and monitor.py (a separate OS process) -- and no lock between them.
+These tests pin down which of the two finishes a completed download, which is
+what stops the pair from both converting it, both moving it into TARGET, and
+littering TARGET with the extraction pages in between.
+
+The policy lives here rather than in api.py because api.py cannot be imported by
+the suite at all (tests/routes/conftest.py substitutes a MagicMock for it).
+"""
+import pytest
+
+from core.download_utils import (
+    CONVERT_IN_PLACE,
+    DEFER_TO_MONITOR,
+    FULL_POST_PROCESS,
+    monitor_claims,
+    monitor_enabled,
+    parse_ignored_extensions,
+    post_download_action,
+    watch_drain_timeout_seconds,
+)
+
+# The shipped default (core/config.py). Note .rar is on it -- that is the whole
+# reason CONVERT_IN_PLACE exists.
+DEFAULT_IGNORED = ".crdownload,.torrent,.tmp,.mega,.rar,.bak,.zip"
+
+
+class TestMonitorEnabled:
+    """Mirrors app.py's `os.environ.get("MONITOR","").strip().lower() == "yes"`."""
+
+    @pytest.mark.parametrize("value", ["yes", "YES", "Yes", " yes "])
+    def test_truthy_values(self, value):
+        assert monitor_enabled({"MONITOR": value}) is True
+
+    @pytest.mark.parametrize("value", ["no", "", "  ", "true", "1"])
+    def test_falsy_values(self, value):
+        assert monitor_enabled({"MONITOR": value}) is False
+
+    def test_missing_key(self):
+        assert monitor_enabled({}) is False
+
+    def test_reads_real_environ_by_default(self, monkeypatch):
+        monkeypatch.setenv("MONITOR", "yes")
+        assert monitor_enabled() is True
+        monkeypatch.setenv("MONITOR", "no")
+        assert monitor_enabled() is False
+
+
+class TestParseIgnoredExtensions:
+    def test_normalizes_case_spacing_and_missing_dot(self):
+        assert parse_ignored_extensions(".crdownload, .RAR ,zip") == {
+            ".crdownload", ".rar", ".zip",
+        }
+
+    @pytest.mark.parametrize("value", ["", None, ",,  ,"])
+    def test_empty_inputs(self, value):
+        assert parse_ignored_extensions(value) == set()
+
+
+class TestMonitorClaims:
+    """Must stay in lockstep with monitor.py's _handle_file_if_complete."""
+
+    @pytest.mark.parametrize("name", ["Batman 001.cbz", "Batman 001.cbr"])
+    def test_claims_comics_not_on_the_ignore_list(self, name):
+        assert monitor_claims(name, DEFAULT_IGNORED) is True
+
+    def test_does_not_claim_rar(self):
+        # .rar ships on IGNORED_EXTENSIONS, so the monitor never imports one.
+        assert monitor_claims("Batman 001.rar", DEFAULT_IGNORED) is False
+
+    def test_zip_depends_on_auto_unpack(self):
+        assert monitor_claims("pack.zip", DEFAULT_IGNORED, auto_unpack=False) is False
+        assert monitor_claims("pack.zip", DEFAULT_IGNORED, auto_unpack=True) is True
+
+    def test_extensionless_is_not_claimed(self):
+        assert monitor_claims("no_extension_here", DEFAULT_IGNORED) is False
+
+    def test_empty_path(self):
+        assert monitor_claims("", DEFAULT_IGNORED) is False
+
+
+class TestPostDownloadAction:
+    def _act(self, name, monitor_running, ignored=DEFAULT_IGNORED, auto_unpack=False):
+        return post_download_action(
+            name,
+            monitor_running=monitor_running,
+            ignored_extensions=ignored,
+            auto_unpack=auto_unpack,
+        )
+
+    @pytest.mark.parametrize("name", ["a.cbr", "a.rar", "a.cbz", "a.zip"])
+    def test_no_monitor_means_api_does_everything(self, name):
+        # Nothing else drains WATCH in this configuration, so api.py must keep
+        # its convert -> move -> rename behaviour unchanged.
+        assert self._act(name, monitor_running=False) == FULL_POST_PROCESS
+
+    @pytest.mark.parametrize("name", ["a.cbr", "a.cbz"])
+    def test_monitor_claims_it_so_api_defers(self, name):
+        assert self._act(name, monitor_running=True) == DEFER_TO_MONITOR
+
+    def test_rar_is_converted_in_place_not_deferred(self):
+        # Deferring a .rar would strand it in WATCH forever: the monitor's
+        # ignore list means it will never pick one up.
+        assert self._act("a.rar", monitor_running=True) == CONVERT_IN_PLACE
+
+    def test_zip_defers_regardless_of_auto_unpack(self):
+        assert self._act("a.zip", monitor_running=True, auto_unpack=False) == DEFER_TO_MONITOR
+        assert self._act("a.zip", monitor_running=True, auto_unpack=True) == DEFER_TO_MONITOR
+
+    def test_user_ignoring_cbr_falls_back_to_converting_in_place(self):
+        assert self._act("a.cbr", monitor_running=True,
+                         ignored=".cbr,.rar") == CONVERT_IN_PLACE
+
+    def test_unconvertible_ignored_file_is_left_alone(self):
+        assert self._act("notes.bak", monitor_running=True) == DEFER_TO_MONITOR
+
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_missing_path_defers(self, value):
+        assert self._act(value, monitor_running=True) == DEFER_TO_MONITOR
+        assert self._act(value, monitor_running=False) == DEFER_TO_MONITOR
+
+
+class TestWatchDrainTimeout:
+    def test_covers_two_reconciliation_sweeps_plus_headroom(self):
+        assert watch_drain_timeout_seconds(5) == 720
+        assert watch_drain_timeout_seconds(15) == 1920
+
+    def test_capped_at_an_hour(self):
+        # A long sweep interval must not keep a poller thread alive per download.
+        assert watch_drain_timeout_seconds(30) == 3600
+        assert watch_drain_timeout_seconds(600) == 3600
+
+    @pytest.mark.parametrize("value", [0, 1, -5])
+    def test_never_below_the_historical_five_minutes(self, value):
+        assert watch_drain_timeout_seconds(value) == 300
+
+    @pytest.mark.parametrize("value", [None, "abc"])
+    def test_bad_input_falls_back_to_the_default_interval(self, value):
+        assert watch_drain_timeout_seconds(value) == 720


### PR DESCRIPTION
## The bug

With `MONITOR=yes` and `AUTOCONVERT=on`, a downloaded CBR/RAR was processed by **two actors at once, with no lock between them**:

- **api.py's download worker** — a thread inside the Gunicorn process. It converted the file in place, then moved it to TARGET.
- **monitor.py** — a **separate OS process** (spawned by `app.py`). It moved the file to TARGET, then converted.

monitor.py's `_processing_lock`/`_in_flight` guard is per-process, so neither side could see the other's claim. The two existence checks that appeared to coordinate them (`api.py`'s "already moved by monitor" and `monitor.py`'s "CBZ already exists") are unsynchronised TOCTOU guards.

Symptoms: loose page images dumped into `/downloads/processed`, duplicate `Foo.cbz` + `Foo (1).cbz`, and truncated CBZs.

### Why loose JPGs reached the library

`convert_to_cbz` built its extraction dir as a **sibling of the file being converted** (`cbz_ops/single_file.py`), so an api.py conversion created `WATCH/temp_Foo/`. That name isn't hidden, `.jpg` isn't an ignored extension, and an already-extracted page is size-stable — so the monitor treated every page as a completed download and moved it to TARGET. That also **strip-mined the conversion still assembling those same pages**, so `convert_single_rar_file` hit `FileNotFoundError` and left the CBR behind for the next sweep.

monitor.py's *own* conversion was never part of this: it converts **after** moving, so its scratch dir lands in TARGET, which nothing watches.

## The fix

Give WATCH a single owner. When `MONITOR=yes`, api.py leaves the finished file in place and monitor.py does the rename, convert and move — the contract `models/dcpp.py` and `models/usenet.py` already followed. The policy lives in `core/download_utils.py` because **api.py cannot be imported by the test suite at all** (`tests/routes/conftest.py` substitutes a `MagicMock`).

| Area | Change |
|---|---|
| `core/download_utils.py` | New `post_download_action` ownership policy + helpers |
| `api.py` | Post-download block lifted verbatim into `_finish_download_in_watch`, dispatched by the policy |
| `monitor.py` | Ancestor-aware `_is_in_ignored_dir` guard; `is_scratch_dir` prunes on three walks |
| `cbz_ops/{single_file,convert,rebuild}.py`, `routes/metadata.py` | All 7 scratch dirs → hidden `.temp_<name>` |
| `api.py` | `check_wanted_after_watch_empty` prunes directories; budget derived from the sweep interval |

## Three findings that shaped the fix

**`.rar` ships on `IGNORED_EXTENSIONS`**, so monitor.py never claims one. Deferring unconditionally would have stranded every RAR download in WATCH forever — invisible in manual testing, because GetComics serves `.cbr`. Hence the third outcome, `CONVERT_IN_PLACE`: api.py converts, the monitor claims the resulting `.cbz`.

**Hiding the scratch dir was necessary but not sufficient.** `is_hidden()` inspects only a basename, and `PollingObserver` snapshots hidden directories — so a live `on_created` for `.temp_Foo/page001.jpg` still reached the handler looking like an ordinary file. The `dirs[:]` prunes only ever protected the sweeps, never the live-event path. Confirmed by disabling the guard: four regression tests fail, **including the `.clu_unwrap` one — that hole pre-existed this PR**.

**Legacy scratch dirs.** The walk prunes also skip bare `temp_*`, so folders left by older versions or crashed conversions aren't harvested after upgrade.

## Behaviour matrix

| MONITOR | file | action | who moves to TARGET |
|---|---|---|---|
| unset/no | any | `FULL_POST_PROCESS` | api.py (**unchanged**) |
| yes | `.cbr`, `.cbz` | `DEFER_TO_MONITOR` | monitor.py |
| yes | `.rar` | `CONVERT_IN_PLACE` | monitor.py (claims the `.cbz`) |
| yes | `.zip` | `DEFER_TO_MONITOR` | monitor.py / nobody — same as today |

## Tests

**3658 passed, 6 skipped** (baseline 3601 / 6). 57 new tests:

- `tests/unit/test_post_download_policy.py` (new) — the full ownership matrix
- `tests/unit/test_monitor.py` — the headline regression (pages in a scratch dir never reach TARGET, via both the sweep and the live-event path), plus the CBR conversion branch that the existing fixture had **always disabled**
- `tests/mocked/test_single_file.py`, `test_convert.py` — scratch dir is a hidden sibling; cleanup still fires; a *failed* conversion still leaves it hidden
- A check that conversion still archives **every** page now that the extraction root is hidden — both zip-building walks prune hidden *sub*directories, and had either ever applied that to its own root, every conversion would have silently produced an empty CBZ

## Reviewer notes

- **Second commit is separable.** `api.py` read WATCH once at import while monitor.py re-reads it live, so changing WATCH in Settings desynced them until restart. Survivable before; **not** survivable once the monitor owns post-processing, since a download written to the stale path would never be processed at all.
- **New failure mode:** if `MONITOR=yes` but monitor.py crashed, downloads accumulate in WATCH instead of being rescued by api.py. This is already the exposure DC++ and Usenet users have; it's visible in the log, and monitor.py's startup sweep drains the backlog on restart.
- **Accepted downside:** a failed conversion now leaves *invisible* cruft rather than a user-deletable `temp_Foo` folder.

## Not fixed (flagged for follow-up)

- monitor.py moves the `.cbr` to TARGET then converts, and `process_incoming_wanted_issues` treats `.cbr` as a comic — so it can move the file mid-conversion. Pre-existing for every DC++/Usenet/manual drop; this PR routes more files through it. Clean fix: stage under a hidden name in TARGET, convert, publish with one rename.
- `cbz_ops/single_file.py` builds `<base>_folder` as rebuild scratch — `"Batman 001_folder"` doesn't start with `_`, so it isn't hidden. Same class of mistake, but that path never runs against WATCH today.

## Verification still to do

Docker end-to-end with `MONITOR=yes`: a real CBR (expect one conversion under TARGET, one `.cbz`, no loose `.jpg`, no ` (1)`, empty WATCH), a real `.rar` (expect `CONVERT_IN_PLACE`), a legacy bare `temp_Foo/` dropped into WATCH (expect it left alone), and a `MONITOR` unset run to confirm the old path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
