### PR TITLE
Stop spin-offs outranking and displacing the series they spun off from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ gunicorn -w 1 --threads 8 -b 0.0.0.0:5577 --timeout 120 app:app
 ### Routes
 | Module | Purpose |
 |--------|---------|
-| `routes/downloads.py` | GetComics search/download, auto-download schedules, weekly packs |
+| `routes/downloads.py` | GetComics search/download (search is scored server-side via `score_getcomics_result`), auto-download schedules, weekly packs |
 | `routes/files.py` | File ops — rename, delete, move, crop, combine CBZ, upload, cleanup |
 | `routes/collection.py` | File browsing — directory listing, search, thumbnails, metadata browse |
 | `routes/metadata.py` | ComicInfo.xml management — provider search, batch processing, field updates |
@@ -246,6 +246,20 @@ Key configurable lists (in `config.ini` under `[SETTINGS]`):
 |---------|---------|---------|
 | `VARIANT_TYPES` | Publication format keywords | annual,quarterly,tpB,oneshot,... |
 | `PUBLICATION_TYPES` | Series type keywords — also keeps annuals/specials from matching as regular issues in `helpers/collection.py` | annual,quarterly |
+
+> **Never reuse `VARIANT_TYPES` for filename matching.** It carries adjectives
+> ("absolute", "deluxe", "prestige", "gallery") that are ordinary words in real
+> issue titles (`Nightwing 117 - Absolute Power.cbz`), so filtering on it would
+> report owned issues as missing and re-download them. `helpers/collection.py`
+> keeps its own narrower `_COLLECTED_EDITION_TYPES` for that reason.
+>
+> Spin-offs are blocked structurally instead, by `_STRICT_GAP`: with
+> `strict_gap=True`, `generate_filename_pattern()` forbids letters between the
+> series name and the issue number, so `TMNT - Nightwatcher 003` cannot satisfy
+> TMNT #3 while `Nightwing 117 - Absolute Power` still matches (its subtitle
+> comes *after* the number). Only `match_wanted_issues_to_files` opts in — it
+> is the one matcher that moves and renames files. `match_issues_to_collection`
+> stays loose deliberately.
 | `SEQUEL_KEYWORDS` | Volume/sequel keywords | season,volume,book,part,chapter |
 | `CROSSOVER_KEYWORDS` | Crossover detection keywords | meets,vs,versus,x-over,crossover |
 

--- a/docs/getcomics.md
+++ b/docs/getcomics.md
@@ -18,6 +18,22 @@ GetComics (`models/getcomics.py`) provides search and download functionality for
 2. **Search**: `search_getcomics_for_issue()` queries the scrape index first, falls back to live search
 3. **Scoring**: `score_getcomics_result()` evaluates how well a title matches a wanted issue
 
+### Manual Search
+
+The search modal on the Wanted and Series pages goes through the **same scorer**:
+`/api/getcomics/search` (`routes/downloads.py`) calls `search_getcomics()`, then
+`score_getcomics_result()` + `accept_result()` on every hit, and returns them
+sorted best-first with a `score` and a `decision` per result — the response
+shape `/api/usenet/search` and `/api/dcpp/search` already use. The modal shows
+ACCEPT/FALLBACK results and collapses the rest behind a toggle.
+
+Scoring needs the issue context (`series`, `issue`, `issue_year`). A bare `q`,
+or a query the user has retyped to a different series, returns `scored: false`
+and the site's own ordering — scoring against a stale context would reject
+everything. Aliases are consulted when deciding whether the query still refers
+to the series, because `series.html` seeds the query box with the first
+configured alias rather than the canonical name.
+
 ## Scoring System
 
 The scoring system (`score_comic()` in `models/getcomics.py`) evaluates how well a GetComics title matches a wanted issue.
@@ -61,6 +77,27 @@ The scoring system (`score_comic()` in `models/getcomics.py`) evaluates how well
 1. **Variants**: Annual, TPB, Quarterly, etc. - penalized unless accepted via `SEARCH_VARIANTS`
 2. **Arcs**: Dash notation (e.g., "Batman - Court of Owls") - penalized, arcs have separate numbering
 3. **Sequels**: Season/Volume/Book/Part/Chapter keywords - treated as arc-type sub-series
+
+Dash notation means any of `-`, `–` (en dash), `—` (em dash) or `:` — GetComics
+titles use the en dash, and `_normalize_separators()` folds the rest onto it.
+
+#### Worked example
+
+Searching `Teenage Mutant Ninja Turtles 3 2024` returns four spin-offs sharing
+the parent name, issue number and year:
+
+| Title | Score | Why |
+|-------|-------|-----|
+| `Teenage Mutant Ninja Turtles #3 (2024)` | **95** | series +30, issue +30, year +20, tightness +15 |
+| `Teenage Mutant Ninja Turtles – Nightwatcher #3 (2024)` | 10 | arc -30, no issue bonus, tightness -10 |
+| `Teenage Mutant Ninja Turtles – Saturday Morning Adventures Vol. 3` | -20 | arc -30, no year |
+
+The spin-offs score 10 rather than 40 because `_score_series_match()` marks the
+dash subtitle as an `arc`, which both costs -30 and clears `allow_issue_match`
+— so the +30 issue bonus never applies even though `#3` is present and correct.
+That gate is what separates a spin-off from the series it spun off from; a
+substring heuristic cannot, since all five titles contain the series name, the
+issue number and the year.
 
 ### Configurable Keywords
 
@@ -126,8 +163,15 @@ The sitemap index maps series names to their GetComics sitemap URLs for pre-filt
 
 ## Key Functions
 
+### `score_getcomics_result(result_title, series_name, issue_number, year, ...) -> tuple`
+The public entry point every caller uses — auto-download (`app.py`), the dry-run
+simulation and the manual search route (`routes/downloads.py`), Usenet
+(`models/usenet.py`) and DC++ (`models/dcpp.py`). Scores the title once per
+series alias and keeps the best, returning `(score, range_contains_target,
+series_match)`. Pair it with `accept_result()` to get ACCEPT/FALLBACK/REJECT.
+
 ### `score_comic(result_title, search) -> ComicScore`
-Pure functional scoring composition. Returns `ComicScore` with score, series_match, sub_series_type, variant_accepted, and remaining analysis.
+Pure functional scoring composition behind `score_getcomics_result`. Returns `ComicScore` with score, series_match, sub_series_type, variant_accepted, and remaining analysis.
 
 ### `search_getcomics_for_issue(series_name, issue_num, ...)`
 Main search function. Queries scrape index first, then falls back to live GetComics search. Returns list of matched results.

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -192,7 +192,30 @@ def _word_regex(word):
     return re.escape(word)
 
 
-def generate_filename_pattern(custom_pattern, series_name, issue_number):
+# What may sit between the series name and the issue number when strict_gap is
+# on. A spin-off writes its subtitle THERE ("TMNT - Nightwatcher 003"); a real
+# issue title comes AFTER the number ("Nightwing 117 - Absolute Power"), so
+# banning letters from the gap separates the two without touching the tail.
+#
+# This is deliberately structural rather than keyword-based: it never asks
+# WHICH words appear, so the trap described above _COLLECTED_EDITION_TYPES —
+# that "absolute"/"deluxe" are ordinary issue-title words — cannot apply.
+#
+# The alternatives are mutually exclusive (the final class excludes letters and
+# brackets), which keeps a failed lazy match from backtracking exponentially.
+_STRICT_GAP = (
+    r"(?:"
+    r"\([^()]*\)"                                              # (2024) (Digital) (Zone-Empire)
+    r"|\[[^\[\]]*\]"                                           # [2016] [c2c]
+    # Volume/issue markers, but only when digits follow: this lets
+    # "Batman No. 5" through while still rejecting "Batman - No Mans Land 005".
+    r"|(?:volume|vol|v|issues|issue|numbers|number|nos|no|num)\.?(?=[\s._\-]*\d)"
+    r"|[^A-Za-z]"                                              # space, dash, dot, #, digits
+    r")*?"
+)
+
+
+def generate_filename_pattern(custom_pattern, series_name, issue_number, strict_gap=False):
     """
     Convert CUSTOM_RENAME_PATTERN to a precise regex for matching a specific issue.
 
@@ -209,6 +232,9 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         custom_pattern: The rename pattern from config (e.g., "{series_name} {issue_number} ({volume_year})")
         series_name: The series name to match
         issue_number: The issue number to match
+        strict_gap: Forbid letters between the series name and the issue number,
+            so a spin-off ("TMNT - Nightwatcher 003") cannot satisfy the parent
+            series' pattern. Off by default — see ``_STRICT_GAP``.
 
     Returns:
         Compiled regex pattern or None if pattern is invalid
@@ -306,7 +332,8 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number):
         # The separator may be empty: with the (?<!\d) guard on the issue pattern
         # above it can no longer swallow leading digits, and ".+?" would otherwise
         # regress "Nightwing001.cbz" (no separator at all) to a non-match.
-        pattern = pattern.replace(') (', r").*?(" )
+        gap = _STRICT_GAP if strict_gap else r".*?"
+        pattern = pattern.replace(') (', ")" + gap + "(")
 
         # Defensive: drop any unrecognized {token} (and an empty "()" it may
         # leave behind) so a stray placeholder never becomes a literal regex
@@ -337,6 +364,49 @@ _COLLECTED_EDITION_TYPES = (
     'tpb', 'trade paperback', 'omnibus', 'hardcover', 'one-shot', 'oneshot',
     'giant-size',
 )
+
+
+# What may follow the wanted series name inside a ComicInfo <Series> value and
+# still be the same series: a volume marker or a bracketed year/tag. Same
+# structural rule as _STRICT_GAP — anything with letters of its own is a
+# subtitle, and a subtitle means a different series.
+_BENIGN_SERIES_EXTRA = re.compile(
+    r"^(?:"
+    r"\([^()]*\)"
+    r"|\[[^\[\]]*\]"
+    r"|(?:volume|vol|v)\.?(?=[\s._\-]*\d)"
+    r"|[^A-Za-z]"
+    r")*$",
+    re.IGNORECASE,
+)
+
+
+def _comicinfo_series_matches(meta_series, wanted_name):
+    """True when a file's ComicInfo <Series> names the series we want.
+
+    The ComicInfo tier is the filename guard's blind spot: it never looks at
+    the filename, so a plain two-way substring test let every spin-off through.
+    "Teenage Mutant Ninja Turtles: Nightwatcher" *contains* "Teenage Mutant
+    Ninja Turtles", so a Nightwatcher issue satisfied the parent's wanted entry
+    and was moved into (and renamed inside) the parent's folder.
+
+    The two directions are not symmetric:
+
+    - ``meta_series`` shorter — the file says "Ultimates", the DB says "The
+      Ultimates". Dropped words are how real libraries differ; accept.
+    - ``meta_series`` longer — the file says the wanted name PLUS something.
+      That something is either a volume/year tag (same series) or a subtitle
+      (a spin-off), so it has to earn the match.
+    """
+    wanted = (wanted_name or "").lower().strip()
+    meta = (meta_series or "").lower().strip()
+    if not wanted or not meta:
+        return False
+    if meta in wanted:
+        return True
+    if wanted not in meta:
+        return False
+    return bool(_BENIGN_SERIES_EXTRA.match(meta.replace(wanted, " ", 1)))
 
 
 def _publication_type_keywords():
@@ -528,8 +598,11 @@ def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None
         for name in match_names:
             rk = (name, str(issue_number))
             if rk not in regex_cache:
+                # strict_gap: this matcher feeds shutil.move + a rename, so a
+                # spin-off claiming the parent's issue is destructive. The
+                # collection-status matcher deliberately stays loose.
                 regex_cache[rk] = generate_filename_pattern(
-                    match_pattern, name, issue_number
+                    match_pattern, name, issue_number, strict_gap=True
                 )
             r = regex_cache[rk]
             if r:
@@ -567,7 +640,7 @@ def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None
                     if meta_num == check_num:
                         meta_series = (ci.get("series") or "").lower()
                         if meta_series and any(
-                            n.lower() in meta_series or meta_series in n.lower()
+                            _comicinfo_series_matches(meta_series, n)
                             for n in match_names
                         ):
                             match_result = True

--- a/models/download_sources.py
+++ b/models/download_sources.py
@@ -156,3 +156,22 @@ def build_queries(series_name, issue_num) -> list:
         variants.append("")
     base = series_name.strip()
     return [f"{base} {v}".strip() for v in variants]
+
+
+def as_year(value):
+    """Coerce a request value to a 4-digit year int, or None.
+
+    Scoring compares the year numerically (``int(y) != search.year``), so a
+    string year would never match and would penalize every result. Accepts a
+    bare year or anything starting with one (e.g. a "2026-01-14" store date).
+
+    Shared by every manual-search route — GetComics, Usenet and DC++ all take
+    the year straight off a request, so the coercion rule lives in one place.
+    """
+    if value is None:
+        return None
+    try:
+        year = int(str(value).strip()[:4])
+    except (TypeError, ValueError):
+        return None
+    return year if 1900 <= year <= 2100 else None

--- a/routes/download_clients.py
+++ b/routes/download_clients.py
@@ -397,20 +397,10 @@ def list_usenet_downloads():
         return jsonify({"error": str(e)}), 500
 
 
-def _as_year(value):
-    """Coerce a request value to a 4-digit year int, or None.
-
-    Scoring compares the year numerically (``int(y) != search.year``), so a
-    string year would never match and would penalize every result. Accepts a
-    bare year or anything starting with one (e.g. a "2026-01-14" store date).
-    """
-    if value is None:
-        return None
-    try:
-        year = int(str(value).strip()[:4])
-    except (TypeError, ValueError):
-        return None
-    return year if 1900 <= year <= 2100 else None
+# The year coercion is shared with the GetComics search route, so it lives in
+# models/download_sources.py. Kept under the old private name here so the
+# existing call sites (and their tests) read unchanged.
+from models.download_sources import as_year as _as_year
 
 
 @download_clients_bp.route('/api/usenet/search', methods=['POST'])

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -82,18 +82,102 @@ def _weekly_pack_history_with_live_status(limit=20):
 # GetComics Search & Download
 # =============================================================================
 
+def _query_mentions_series(query, series_name, aliases):
+    """True when ``query`` still refers to ``series_name`` (or one of its aliases).
+
+    The modal seeds the query box from the clicked row but leaves the user free
+    to retype it. If they search a different series, the page-level
+    series/issue context goes stale — scoring against it would REJECT every
+    result and collapse the whole list, which is worse than not scoring at all.
+    So scoring is gated on the query and the context still agreeing.
+
+    Aliases matter here: series.html seeds the query with the first configured
+    alias rather than the canonical name, so a canonical "2000 AD" is not a
+    substring of the alias-seeded query "2000AD 100 2024".
+    """
+    from models.getcomics import normalize_series_for_compare
+
+    haystack = normalize_series_for_compare(query)
+    if not haystack:
+        return False
+    for name in [series_name] + list(aliases or []):
+        needle = normalize_series_for_compare(name or "")
+        if needle and needle in haystack:
+            return True
+    return False
+
+
 @downloads_bp.route('/api/getcomics/search')
 def api_getcomics_search():
-    """Search getcomics.org for comics."""
+    """Search getcomics.org for comics, scored against the wanted issue.
+
+    GetComics returns raw page hits in site order, which puts spin-offs above
+    the series being searched for ("TMNT - Nightwatcher #3" before "TMNT #3").
+    When the caller supplies the issue context, every result is run through the
+    same scorer the auto-download uses so the modal ranks them the way the
+    scheduler would, and the response mirrors /api/usenet/search: each result
+    carries ``score`` and ``decision``, best first.
+
+    Without that context (a bare ``q``, or a query the user retyped to a
+    different series) the response keeps its original unscored shape, flagged
+    by ``scored: false``.
+    """
     from models.getcomics import search_getcomics
+    from models.download_sources import as_year
 
     query = request.args.get('q', '')
     if not query:
         return jsonify({"success": False, "error": "Query required"}), 400
 
+    series_name = (request.args.get('series') or '').strip()
+    issue_num = str(request.args.get('issue') or '').strip()
+    issue_year = as_year(request.args.get('issue_year'))
+    series_volume = request.args.get('series_volume') or None
+
     try:
         results = search_getcomics(query)
-        return jsonify({"success": True, "results": results})
+
+        series_aliases = get_series_alias_list(series_name) if series_name else []
+        if not (series_name and _query_mentions_series(query, series_name, series_aliases)):
+            return jsonify({"success": True, "scored": False, "results": results})
+
+        search_variants_str = config.get("SETTINGS", "VARIANT_TYPES", fallback="")
+        search_variants = [v.strip().lower() for v in search_variants_str.split(",") if v.strip()]
+
+        scored = []
+        for result in results:
+            score, is_range, series_match = score_getcomics_result(
+                result.get("title", ""), series_name, issue_num, issue_year,
+                accept_variants=search_variants,
+                series_volume=series_volume,
+                series_aliases=series_aliases,
+            )
+            scored.append({
+                "title": result.get("title", ""),
+                "link": result.get("link", ""),
+                "image": result.get("image", ""),
+                "score": score,
+                "range_contains_target": is_range,
+                "series_match": series_match,
+            })
+
+        # Sort before deciding, unlike models/usenet.py which decides in scrape
+        # order. `accept_result` threads `single_issue_found` so a range pack
+        # only falls back once a single issue has been accepted — deciding in
+        # scrape order would make that depend on how the site happened to
+        # order its hits. For a list a human picks from, determinism wins.
+        scored.sort(key=lambda r: r["score"], reverse=True)
+
+        single_found = False
+        for r in scored:
+            r["decision"] = accept_result(
+                r["score"], r["range_contains_target"], r["series_match"],
+                single_issue_found=single_found,
+            )
+            if r["decision"] == "ACCEPT":
+                single_found = True
+
+        return jsonify({"success": True, "scored": True, "results": scored})
     except Exception as e:
         app_logger.error(f"Error searching getcomics: {e}")
         return jsonify({"success": False, "error": str(e)}), 500

--- a/static/js/clu-source-search.js
+++ b/static/js/clu-source-search.js
@@ -62,29 +62,6 @@
     }
 
     /**
-     * Sort GetComics results by how well the title matches the wanted issue.
-     * GetComics returns raw page hits with no server-side scoring, unlike the
-     * Usenet and DC++ endpoints which score before responding.
-     */
-    function scoreGetComicsResults(results, ctx) {
-        return results.map(r => {
-            let score = 0;
-            const title = String(r.title || '').toLowerCase();
-            const series = String(ctx.series || '').toLowerCase();
-            const issue = ctx.issue;
-
-            if (series && title.includes(series)) score += 10;
-            if (title.includes(`#${issue}`) || title.includes(` ${issue} `) ||
-                title.endsWith(` ${issue}`)) score += 5;
-            // A matching year separates this volume's issue from every reprint
-            // and reboot that shares the number.
-            if (ctx.year && title.includes(String(ctx.year))) score += 8;
-
-            return Object.assign({}, r, { score: score });
-        }).sort((a, b) => b.score - a.score);
-    }
-
-    /**
      * Render a scored result list with the low-scoring tail behind a toggle.
      *
      * Indexers and hubs can return 50+ hits for one issue; an unfiltered list
@@ -162,13 +139,16 @@
     }
 
     /**
-     * A card for a scored (Usenet/DC++) result. `buttons` is the pre-built
-     * grabButtons() pair for it.
+     * A card for a scored result. `buttons` is the pre-built grabButtons()
+     * pair for it. `thumb` is an optional cover URL — GetComics posts carry
+     * one, Usenet and DC++ releases do not, so it is a trailing argument and
+     * those two call sites stay as they were.
      */
-    function scoredCard(r, subtitle, buttons) {
+    function scoredCard(r, subtitle, buttons, thumb) {
         return `
         <div class="card mb-2">
             <div class="card-body d-flex align-items-center gap-3 py-2">
+                ${thumb ? `<img src="${escapeHtml(thumb)}" style="width:50px;height:75px;object-fit:cover;" class="rounded flex-shrink-0" onerror="this.style.display='none'">` : ''}
                 <div class="flex-grow-1 overflow-hidden">
                     <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}${decisionBadge(r.decision)}</div>
                     <small class="text-muted text-truncate d-block">${subtitle}</small>
@@ -191,27 +171,39 @@
             label: 'GetComics',
             icon: 'globe',
             async build(ctx) {
-                const resp = await fetch(`/api/getcomics/search?q=${encodeURIComponent(ctx.query)}`);
+                // The issue context is what lets the server score: getcomics
+                // returns page hits in site order, which puts spin-offs
+                // ("TMNT - Nightwatcher #3") above the series being searched
+                // for. Sending it opts into the same scorer the scheduled
+                // auto-download uses.
+                const params = new URLSearchParams({ q: ctx.query });
+                if (ctx.series) params.set('series', ctx.series);
+                if (ctx.issue !== '' && ctx.issue !== null && ctx.issue !== undefined) {
+                    params.set('issue', ctx.issue);
+                }
+                if (ctx.year) params.set('issue_year', ctx.year);
+
+                const resp = await fetch(`/api/getcomics/search?${params.toString()}`);
                 const data = await resp.json();
                 if (!data.success) {
                     return alertBox('alert-danger', 'exclamation-octagon', escapeHtml(data.error));
                 }
                 if (!data.results || !data.results.length) return '';
 
-                const cards = scoreGetComicsResults(data.results, ctx).map((r, idx) => `
-                <div class="card mb-2 ${idx === 0 && r.score > 5 ? 'border-success' : ''}">
-                    <div class="card-body d-flex align-items-center gap-3 py-2">
-                        ${r.image ? `<img src="${escapeHtml(r.image)}" style="width:50px;height:75px;object-fit:cover;" class="rounded" onerror="this.style.display='none'">` : '<div style="width:50px"></div>'}
-                        <div class="flex-grow-1 overflow-hidden">
-                            <div class="fw-bold text-truncate" title="${escapeHtml(r.title)}">${escapeHtml(r.title)}</div>
-                            <small class="text-muted text-truncate d-block">${escapeHtml(r.link)}</small>
-                        </div>
-                        ${grabButtons('getcomics', 'bi-download',
-                    `data-link="${escapeHtml(r.link)}" data-title="${escapeHtml(r.title)}"`,
-                    r.link, true)}
-                    </div>
-                </div>`).join('');
-                return sectionHeader('GetComics', 'globe') + cards;
+                const card = (r) => scoredCard(
+                    r, escapeHtml(r.link),
+                    grabButtons('getcomics', 'bi-download',
+                        `data-link="${escapeHtml(r.link)}" data-title="${escapeHtml(r.title)}"`,
+                        r.link, true),
+                    r.image);
+
+                const header = sectionHeader('GetComics', 'globe');
+                // Unscored means the server had no usable issue context (a
+                // hand-typed query, or one edited to a different series). There
+                // is nothing to rank by, so show the site's own order rather
+                // than guessing a winner.
+                if (!data.scored) return header + data.results.map(card).join('');
+                return header + scoredResultList('getcomics', data.results, card);
             },
             async queue(btn, ctx) {
                 // GetComics names the file after the post title, not the wanted

--- a/tests/routes/test_downloads_routes.py
+++ b/tests/routes/test_downloads_routes.py
@@ -3,6 +3,29 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+# The five titles getcomics.org returns for "Teenage Mutant Ninja Turtles 3
+# 2024", in the order the site returns them. Four of the five are spin-offs
+# that carry the parent series name, an en dash, a subtitle and the same issue
+# number and year -- indistinguishable to a substring heuristic, which is why
+# the correct result used to rank fourth.
+TMNT_TITLES = [
+    "Teenage Mutant Ninja Turtles – Saturday Morning Adventures Vol. 3",
+    "Teenage Mutant Ninja Turtles – Nightwatcher #3 (2024)",
+    "Teenage Mutant Ninja Turtles #3 (2024)",
+    "Teenage Mutant Ninja Turtles – The Last Ronin II – Re-Evolution #3 (2024)",
+    "Teenage Mutant Ninja Turtles – Black, White, & Green #3 (2024)",
+]
+TMNT_RESULTS = [
+    {"title": t, "link": f"https://getcomics.org/{i}", "image": ""}
+    for i, t in enumerate(TMNT_TITLES)
+]
+TMNT_CORRECT = "Teenage Mutant Ninja Turtles #3 (2024)"
+TMNT_QUERY = (
+    "/api/getcomics/search?q=Teenage+Mutant+Ninja+Turtles+3+2024"
+    "&series=Teenage+Mutant+Ninja+Turtles&issue=3&issue_year=2024"
+)
+
+
 class TestGetcomicsSearch:
 
     @patch("models.getcomics.search_getcomics", return_value=[
@@ -23,6 +46,84 @@ class TestGetcomicsSearch:
     def test_search_error(self, mock_search, client):
         resp = client.get("/api/getcomics/search?q=batman")
         assert resp.status_code == 500
+
+
+class TestGetcomicsSearchScoring:
+    """The search modal ranks by the same scorer the auto-download uses."""
+
+    @patch("routes.downloads.get_series_alias_list", return_value=[])
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS)
+    def test_correct_issue_is_ranked_first(self, mock_search, mock_alias, client):
+        """The regression: getcomics returns the wanted issue fourth of five."""
+        data = client.get(TMNT_QUERY).get_json()
+        assert data["results"][0]["title"] == TMNT_CORRECT
+        assert data["results"][0]["decision"] == "ACCEPT"
+
+    @patch("routes.downloads.get_series_alias_list", return_value=[])
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS)
+    def test_only_the_parent_series_is_accepted(self, mock_search, mock_alias, client):
+        """Every en-dash spin-off is a different series, not a variant."""
+        results = client.get(TMNT_QUERY).get_json()["results"]
+        accepted = [r for r in results if r["decision"] == "ACCEPT"]
+        assert [r["title"] for r in accepted] == [TMNT_CORRECT]
+        spin_offs = [r for r in results if r["title"] != TMNT_CORRECT]
+        assert all(r["decision"] == "REJECT" for r in spin_offs)
+
+    @patch("routes.downloads.get_series_alias_list", return_value=[])
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS)
+    def test_scores_are_attached_and_sorted_desc(self, mock_search, mock_alias, client):
+        data = client.get(TMNT_QUERY).get_json()
+        assert data["scored"] is True
+        scores = [r["score"] for r in data["results"]]
+        assert len(scores) == len(TMNT_TITLES)
+        assert scores == sorted(scores, reverse=True)
+
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS)
+    def test_q_only_stays_unscored_and_unordered(self, mock_search, client):
+        """A bare ``q`` keeps the pre-scoring response shape."""
+        data = client.get("/api/getcomics/search?q=Teenage+Mutant+Ninja+Turtles+3+2024").get_json()
+        assert data["scored"] is False
+        assert [r["title"] for r in data["results"]] == TMNT_TITLES
+        assert "score" not in data["results"][0]
+        assert "decision" not in data["results"][0]
+
+    @patch("routes.downloads.get_series_alias_list", return_value=[])
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS)
+    def test_query_that_diverges_from_series_is_unscored(self, mock_search, mock_alias, client):
+        """A retyped query leaves the page context stale; don't score against it."""
+        data = client.get(
+            "/api/getcomics/search?q=Teenage+Mutant+Ninja+Turtles+3&series=Batman&issue=3"
+        ).get_json()
+        assert data["scored"] is False
+
+    @patch("routes.downloads.get_series_alias_list", return_value=["TMNT"])
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS)
+    def test_alias_seeded_query_still_scores(self, mock_search, mock_alias, client):
+        """series.html seeds the query with the alias, not the canonical name."""
+        data = client.get(
+            "/api/getcomics/search?q=TMNT+3+2024"
+            "&series=Teenage+Mutant+Ninja+Turtles&issue=3&issue_year=2024"
+        ).get_json()
+        assert data["scored"] is True
+        assert data["results"][0]["title"] == TMNT_CORRECT
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("2024", 2024),
+        ("2024-05-01", 2024),
+        ("", None),
+        ("not-a-year", None),
+        ("1492", None),
+    ])
+    @patch("routes.downloads.get_series_alias_list", return_value=[])
+    @patch("routes.downloads.score_getcomics_result", return_value=(95, False, True))
+    @patch("models.getcomics.search_getcomics", return_value=TMNT_RESULTS[2:3])
+    def test_issue_year_coercion(self, mock_search, mock_score, mock_alias,
+                                 raw, expected, client):
+        client.get(
+            "/api/getcomics/search?q=Teenage+Mutant+Ninja+Turtles+3"
+            f"&series=Teenage+Mutant+Ninja+Turtles&issue=3&issue_year={raw}"
+        )
+        assert mock_score.call_args.args[3] == expected
 
 
 class TestGetcomicsDownload:

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -554,3 +554,43 @@ class TestNamesOtherPublicationType:
         assert not names_other_publication_type(
             "Nightwing Annualized 001 (2023).cbz", "Nightwing"
         )
+
+
+class TestStrictGap:
+    """The spin-off guard is opt-in, so only the move path changes.
+
+    generate_filename_pattern also backs match_issues_to_collection, which only
+    paints owned/missing and runs on files the user has already filed. Keeping
+    the default loose confines the behaviour change to the one caller that
+    moves and renames files.
+    """
+
+    PATTERN = "{series_name} {issue_number}"
+    SPINOFF = "Teenage Mutant Ninja Turtles - Nightwatcher 003.cbz"
+    SERIES = "Teenage Mutant Ninja Turtles"
+
+    def test_default_still_allows_a_subtitle_in_the_gap(self):
+        regex = generate_filename_pattern(self.PATTERN, self.SERIES, "3")
+        assert regex.match(self.SPINOFF)
+
+    def test_strict_gap_rejects_a_subtitle_in_the_gap(self):
+        regex = generate_filename_pattern(
+            self.PATTERN, self.SERIES, "3", strict_gap=True
+        )
+        assert not regex.match(self.SPINOFF)
+
+    def test_strict_gap_keeps_the_issue_as_group_one(self):
+        # The gap must not introduce a capture group -- callers read group 1
+        # as the issue number.
+        regex = generate_filename_pattern(
+            self.PATTERN, self.SERIES, "3", strict_gap=True
+        )
+        assert regex.match("Teenage Mutant Ninja Turtles 003 (2024).cbz").group(1) == "003"
+
+    def test_strict_gap_does_not_blow_up_on_a_long_non_match(self):
+        # The alternatives are mutually exclusive, so a failed lazy match
+        # cannot backtrack exponentially.
+        regex = generate_filename_pattern(
+            self.PATTERN, self.SERIES, "3", strict_gap=True
+        )
+        assert not regex.match(self.SERIES + " " + "- x " * 60 + ".cbz")

--- a/tests/unit/test_match_wanted_to_files.py
+++ b/tests/unit/test_match_wanted_to_files.py
@@ -250,3 +250,171 @@ class TestExtractComicInfoCached:
         cache = {}
         assert extract_comicinfo_cached(f, cache) == {}
         assert cache[f] == {}
+
+
+# ---- spin-off guard -----------------------------------------------------
+
+class TestSpinOffSubtitleGuard:
+    """A spin-off must not be filed as an issue of the series it spun off from.
+
+    Every matching tier used to allow arbitrary text between the series name
+    and the issue number, so "Teenage Mutant Ninja Turtles - Nightwatcher 003"
+    satisfied the wanted entry for TMNT #3. Unlike the collection-status
+    matcher, this one drives shutil.move plus a rename, so the mistake is
+    destructive: the wrong comic lands in the folder wearing the right name.
+
+    The discriminator is position. A spin-off puts its subtitle BEFORE the
+    issue number; a real issue title comes AFTER it.
+    """
+
+    TMNT = "Teenage Mutant Ninja Turtles"
+
+    def _match_one(self, tmp_path, filenames, series=None, issue="3"):
+        series = series or self.TMNT
+        series_dir = tmp_path / series.replace("/", "-")
+        series_dir.mkdir()
+        files = []
+        for name in filenames:
+            path = str(tmp_path / name)
+            _touch(path)
+            files.append((name, path))
+        wanted = [_wanted(series, issue, str(series_dir))]
+        return match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+
+    def test_dash_subtitled_spinoff_is_not_moved_into_the_parent_series(self, tmp_path):
+        """The reported case: four spin-offs and the real issue, all #3 (2024)."""
+        matches = self._match_one(tmp_path, [
+            "Teenage Mutant Ninja Turtles - Saturday Morning Adventures 003.cbz",
+            "Teenage Mutant Ninja Turtles - Nightwatcher 003 (2024).cbz",
+            "Teenage Mutant Ninja Turtles 003 (2024).cbz",
+            "Teenage Mutant Ninja Turtles - The Last Ronin II - Re-Evolution 003 (2024).cbz",
+            "Teenage Mutant Ninja Turtles - Black, White, & Green 003 (2024).cbz",
+        ])
+        assert len(matches) == 1
+        assert matches[0]["filename"] == "Teenage Mutant Ninja Turtles 003 (2024).cbz"
+
+    def test_spinoff_alone_yields_no_match(self, tmp_path):
+        """With the real issue absent, the spin-off must not stand in for it."""
+        matches = self._match_one(
+            tmp_path, ["Teenage Mutant Ninja Turtles - Nightwatcher 003 (2024).cbz"]
+        )
+        assert matches == []
+
+    def test_dashless_getcomics_filename_is_still_rejected(self, tmp_path):
+        r"""The filename CLU actually writes for a GetComics grab.
+
+        clu-source-search.js sanitises the post title with
+        /[^a-zA-Z0-9\s\-#]/g, which strips the en dash getcomics.org uses --
+        so the file arrives with no separator at all. A dash-based guard would
+        miss this; the rule is "no letters in the gap", not "no dash".
+        """
+        matches = self._match_one(
+            tmp_path, ["Teenage Mutant Ninja Turtles  Nightwatcher 3 2024.cbz"]
+        )
+        assert matches == []
+
+    def test_en_dash_spinoff_is_rejected(self, tmp_path):
+        matches = self._match_one(
+            tmp_path,
+            ["Teenage Mutant Ninja Turtles \u2013 Black, White, & Green 003 (2024).cbz"],
+        )
+        assert matches == []
+
+    def test_nested_spinoff_is_rejected(self, tmp_path):
+        matches = self._match_one(
+            tmp_path,
+            ["Teenage Mutant Ninja Turtles - The Last Ronin II - Re-Evolution 003 (2024).cbz"],
+        )
+        assert matches == []
+
+    def test_comicinfo_cannot_smuggle_a_spinoff_in(self, tmp_path):
+        """The ComicInfo tier never sees the filename, so it needs its own guard."""
+        series_dir = tmp_path / "Teenage Mutant Ninja Turtles"
+        series_dir.mkdir()
+        f = str(tmp_path / "Nightwatcher 003.cbz")
+        _make_cbz_with_comicinfo(
+            f, "Teenage Mutant Ninja Turtles: Nightwatcher", "3"
+        )
+        wanted = [_wanted(self.TMNT, "3", str(series_dir))]
+        matches = match_wanted_issues_to_files(
+            wanted, [("Nightwatcher 003.cbz", f)], PATTERN, alias_lookup=_no_aliases
+        )
+        assert matches == []
+
+    # -- non-regression: everything the guard must NOT break ---------------
+
+    def test_issue_subtitle_after_the_number_still_matches(self, tmp_path):
+        """A story-arc title following the issue number is normal and fine."""
+        matches = self._match_one(
+            tmp_path, ["Nightwing 117 - Absolute Power.cbz"],
+            series="Nightwing", issue="117",
+        )
+        assert len(matches) == 1
+
+    def test_no_separator_still_matches(self, tmp_path):
+        matches = self._match_one(
+            tmp_path, ["Nightwing001.cbz"], series="Nightwing", issue="1"
+        )
+        assert len(matches) == 1
+
+    def test_punctuated_series_name_still_matches(self, tmp_path):
+        matches = self._match_one(
+            tmp_path, ["K.O. 003.cbz"], series="K.O.", issue="3"
+        )
+        assert len(matches) == 1
+
+    @pytest.mark.parametrize("filename", [
+        "Batman v3 005 (2016).cbz",
+        "Batman Vol. 3 005 (2016).cbz",
+        "Batman No. 5 (2016).cbz",
+        "Batman Issue 5.cbz",
+    ])
+    def test_volume_marker_between_series_and_issue_still_matches(self, tmp_path, filename):
+        matches = self._match_one(
+            tmp_path, [filename], series="Batman", issue="5"
+        )
+        assert len(matches) == 1, filename
+
+    @pytest.mark.parametrize("filename", [
+        "Batman (2016) 005.cbz",
+        "Batman [2016] #005.cbz",
+        "Batman 2024 005.cbz",
+    ])
+    def test_release_tags_between_series_and_issue_still_match(self, tmp_path, filename):
+        matches = self._match_one(
+            tmp_path, [filename], series="Batman", issue="5"
+        )
+        assert len(matches) == 1, filename
+
+    def test_words_that_are_not_volume_markers_still_block(self, tmp_path):
+        """"No" is only a marker when digits follow it."""
+        matches = self._match_one(
+            tmp_path, ["Batman - No Mans Land 005.cbz"], series="Batman", issue="5"
+        )
+        assert matches == []
+
+    def test_comicinfo_shorter_series_still_matches(self, tmp_path):
+        """DB "The Ultimates" vs ComicInfo "Ultimates" -- the safe direction."""
+        series_dir = tmp_path / "The Ultimates"
+        series_dir.mkdir()
+        f = str(tmp_path / "unhelpful.cbz")
+        _make_cbz_with_comicinfo(f, "Ultimates", "5")
+        wanted = [_wanted("The Ultimates", "5", str(series_dir))]
+        matches = match_wanted_issues_to_files(
+            wanted, [("unhelpful.cbz", f)], PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1
+
+    def test_comicinfo_volume_tagged_series_still_matches(self, tmp_path):
+        """ComicInfo "Batman (2016)" is Batman, not a spin-off."""
+        series_dir = tmp_path / "Batman"
+        series_dir.mkdir()
+        f = str(tmp_path / "unhelpful.cbz")
+        _make_cbz_with_comicinfo(f, "Batman (2016)", "5")
+        wanted = [_wanted("Batman", "5", str(series_dir))]
+        matches = match_wanted_issues_to_files(
+            wanted, [("unhelpful.cbz", f)], PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1

--- a/tests/unit/test_source_search_ui.py
+++ b/tests/unit/test_source_search_ui.py
@@ -122,3 +122,31 @@ class TestReadingListMigration:
         # rights has no #getcomicsResults to bind to.
         assert "function ensureSourceSearch(" in source
         assert "function ensureGetComicsModal(" in source
+
+
+class TestGetComicsUsesServerScoring:
+    """GetComics ranks server-side, like the other two sources.
+
+    It used to rank client-side with a substring heuristic that scored every
+    "TMNT ... #3 (2024)" title identically -- a tie a stable sort resolved by
+    keeping getcomics.org's own order, so a spin-off took the top slot and the
+    wanted issue sat below it.
+    """
+
+    def test_getcomics_uses_the_shared_scored_list(self, module_js):
+        assert "scoredResultList('getcomics'" in module_js
+
+    def test_client_side_scoring_is_gone(self, module_js):
+        # Keeping it as a fallback would re-add the tie: in unscored mode the
+        # series context is by definition absent or stale.
+        assert "scoreGetComicsResults" not in module_js
+
+    def test_top_result_highlight_is_gone(self, module_js):
+        # decisionBadge() marks the real match now; a positional highlight
+        # asserts a winner the client can no longer identify.
+        assert "border-success" not in module_js
+
+    def test_search_sends_the_issue_context(self, module_js):
+        # Without these the server cannot score and falls back to site order.
+        for param in ("'series'", "'issue'", "'issue_year'"):
+            assert "params.set(%s" % param in module_js


### PR DESCRIPTION
## The report

Searching `Teenage Mutant Ninja Turtles 3 2024` returns five titles, and the correct one is neither highlighted nor first:

1. `Teenage Mutant Ninja Turtles – Saturday Morning Adventures Vol. 3`
2. `Teenage Mutant Ninja Turtles – Nightwatcher #3 (2024)`
3. `Teenage Mutant Ninja Turtles #3 (2024)` ← correct
4. `Teenage Mutant Ninja Turtles – The Last Ronin II – Re-Evolution #3 (2024)`
5. `Teenage Mutant Ninja Turtles – Black, White, & Green #3 (2024)`

One symptom, two unrelated causes — and the second one is destructive.

## The scorer was innocent

`score_getcomics_result` already ranks these correctly. Verified by running it:

| # | Score | Decision |
|---|-------|----------|
| 1 | -20 | REJECT |
| 2 | 10 | REJECT |
| **3** | **95** | **ACCEPT** |
| 4 | 10 | REJECT |
| 5 | 10 | REJECT |

It marks the en-dash subtitle as an `arc`, which costs -30 *and* clears `allow_issue_match`, so the +30 issue bonus never lands even though `#3` is present and correct. That gate is what separates a spin-off from its parent — a substring heuristic cannot, since all five titles contain the series name, the issue number and the year.

## Cause A — the modal never called it

`/api/getcomics/search` returned raw scraped hits. Ranking happened client-side in `scoreGetComicsResults`, which scored results 2–5 at **23 each**. `Array.prototype.sort` is stable, so the four-way tie preserved getcomics.org's own ordering and Nightwatcher landed at index 0 with the `border-success` highlight.

Usenet and DC++ have scored server-side all along. GetComics was the only source that didn't.

The route now scores every hit and returns `score`/`decision` sorted best-first — the shape `/api/usenet/search` and `/api/dcpp/search` already use — so all three sources share `scoredResultList` and its Match/Pack badges. The client-side scorer and the positional highlight are gone.

Scoring is gated on the query still mentioning the series, aliases included (`series.html` seeds the query box with the first configured alias, not the canonical name). A query the user retypes to a different series leaves the page context stale, and scoring against it would REJECT everything and collapse the whole list — strictly worse than not scoring. That case returns `scored: false` and the original shape, so a bare `q` behaves exactly as before.

## Cause B — the move matcher, which is the one that hurts

`generate_filename_pattern` compiles the series↔issue separator to a lazy wildcard, so **all four** spin-off filenames satisfy the wanted regex for TMNT #3. This path drives `shutil.move` **plus a rename** — the wrong comic lands in the folder wearing the right name. `names_other_publication_type` doesn't help; its list is tpb/omnibus/annual, not "Nightwatcher".

The discriminator is position: a spin-off puts its subtitle **before** the issue number, a real issue title **after** it. So `strict_gap` bans letters from the gap. That keeps `Nightwing 117 - Absolute Power.cbz` matching, and sidesteps the trap already documented above `_COLLECTED_EDITION_TYPES` — "absolute"/"deluxe" are ordinary title words, so a keyword list would report owned issues as missing and re-download them.

**Deliberately not dash-based.** `clu-source-search.js` sanitises the post title with `/[^a-zA-Z0-9\s\-#]/g`, which strips the en dash — the file actually lands as `Teenage Mutant Ninja Turtles  Nightwatcher 3 2024.cbz` with no separator at all. There's a test locking that specific case.

Opt-in, and only `match_wanted_issues_to_files` takes it. `match_issues_to_collection` stays loose: it's non-destructive, it runs on files the user already filed, and changing it would touch collection status library-wide and need a cache purge + forced re-match.

### The ComicInfo route into the same bug

Fixing only the regex leaves it reachable. That tier never reads the filename, and `n in meta_series or meta_series in n` is true precisely when ComicInfo says the wanted name **plus extra text** — i.e. a spin-off. `Series="Teenage Mutant Ninja Turtles: Nightwatcher"` matched outright.

The directions aren't symmetric, so they're no longer treated as such: ComicInfo *shorter* than the DB name (`"Ultimates"` vs `"The Ultimates"`) still matches freely; *longer* now has to earn it — a volume/year tag is the same series, a subtitle is not.

## Verification

- **3696 passed, 6 skipped** (the known POSIX-only skips) — full suite, clean.
- Guard checked across 26 filename cases and 6 ComicInfo cases, including `Nightwing001.cbz` (empty separator), `K.O. 003.cbz` (punctuation), `Batman v3 005` / `Batman Vol. 3 005` / `Batman No. 5`, `Batman (2016) 005`, `Batman [2016] #005`, and `Batman - No Mans Land 005` (rejected — "No" only counts as a marker when digits follow). Pathological input: 0 ms, no backtracking blowup.
- `tests/unit/test_filename_pattern.py::TestStrictGap` locks the blast radius by asserting the **default** still matches the spin-off, proving every other caller is untouched.

### Manual check for the move half

Drop `Teenage Mutant Ninja Turtles - Nightwatcher 003 (2024).cbz` and `Teenage Mutant Ninja Turtles 003 (2024).cbz` into TARGET with TMNT #3 wanted, then `POST /api/scan-downloads`. Only the second should move into `/data/Teenage Mutant Ninja Turtles`; the Nightwatcher file should be left where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
