### PR TITLE
Stop the TARGET empty-folder sweep from deleting configured directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ gunicorn -w 1 --threads 8 -b 0.0.0.0:5577 --timeout 120 app:app
 | `edit.py` | CBZ editing - image manipulation, file reordering, cropping |
 | `convert.py` | CBR to CBZ conversion using `unar` |
 | `wrapped.py` | Yearly reading stats image generation (Spotify Wrapped style) |
-| `helpers.py` | Utility functions — `is_hidden()`, `safe_image_open()`, `create_thumbnail_streaming()`, ZIP/RAR extraction |
+| `helpers/` | Utility functions — `is_hidden()`, `safe_image_open()`, `create_thumbnail_streaming()`, `prune_empty_dirs()`, ZIP/RAR extraction. `helpers/library.py` owns the path-safety predicates: `get_protected_roots()` (automated sweeps) and `is_critical_path()` (interactive routes) |
 | `recommendations.py` | AI-powered recommendations via OpenAI/Anthropic APIs |
 
 ### Models
@@ -121,6 +121,11 @@ tests/
 ### Data Flow
 1. Comics stored in `/data` (mounted volume)
 2. Downloads go to `/downloads/temp` then processed to `/downloads/processed`
+   - After files are moved *out* of TARGET, a debounced sweep (`schedule_target_cleanup`
+     → `helpers.prune_empty_dirs`) removes the empty wrapper folders left behind.
+     It never deletes — or descends into — WATCH, TARGET, TRASH or a library root,
+     and refuses to run at all if TARGET resolves inside a library. WATCH nested
+     inside TARGET is a supported layout.
 3. SQLite database in `CACHE_DIR` (default `/cache`)
 4. Config persisted in `/config/config.ini` - deprecated - all future settings should be stored in `user_preferences` table in the database
 
@@ -286,6 +291,12 @@ conn = get_db_connection()
 Use `helpers.py` functions: `safe_image_open()`, `create_thumbnail_streaming()` for memory-safe PIL operations.
 
 ## Project Rules
+
+- **Deleting directories:** any code that removes a directory it did not create must
+  first consult `helpers.library.get_protected_roots()` (automated/background work) or
+  `is_critical_path()` (user-initiated routes). A sweep that only checks its own root
+  is not enough — `is_hidden()` treats any name starting with `.` or `_` as junk, so a
+  configured folder can be destroyed via its *parent* without ever being visited.
 
 - Every new route in `routes/` must have a corresponding test in `tests/routes/`.
 - Any modification to `cbz_ops/` or file operations must include a pytest fixture check.

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -73,32 +73,101 @@ def prune_empty_dirs(root):
     (dotfiles, ``@eaDir`` subtrees, etc.) it contains is removed first. Walks
     bottom-up so nested and batch-emptied folders collapse in a single pass. Never
     removes ``root`` itself. Returns the number of directories removed.
+
+    Configured roots nested inside ``root`` are skipped, along with everything
+    under them — see :func:`helpers.library.get_protected_roots`. WATCH inside
+    TARGET is a supported layout, and this sweep used to delete it: the automated
+    trigger (``api.check_wanted_after_watch_empty``) waits for WATCH to be *empty*
+    before running the wanted match that schedules the sweep, so it fired on
+    precisely the condition that made WATCH deletable.
+
+    Interiors are skipped too, not just the roots themselves. A download client
+    creates its job folder before writing into it, so an empty folder inside WATCH
+    is usually a download about to start, not litter.
     """
-    root_abs = os.path.abspath(root)
-    if not os.path.isdir(root_abs):
+    from helpers.library import get_protected_roots, is_valid_library_path
+
+    if not os.path.isdir(root):
         return 0
+    root_real = os.path.realpath(root)
+
+    # Refuse outright rather than skip: a TARGET misconfigured to the collection
+    # would otherwise have every empty series folder swept. Mirrors the guard in
+    # app.process_incoming_wanted_issues.
+    try:
+        if is_valid_library_path(root_real):
+            app_logger.error(
+                f"Refusing to prune empty folders under {root_real}: it is a "
+                f"library root or inside one. Check the TARGET setting."
+            )
+            return 0
+    except Exception as e:
+        app_logger.debug(f"Library check skipped for {root_real}: {e}")
+
+    # Fail closed: if we cannot establish what is off-limits, skipping the sweep
+    # leaves wrapper folders to accumulate, while sweeping blind can delete WATCH.
+    try:
+        protected = get_protected_roots()
+    except Exception as e:
+        app_logger.error(
+            f"Skipping empty-folder sweep of {root_real}: could not resolve "
+            f"protected directories ({e})."
+        )
+        return 0
+    # Only roots *strictly inside* the sweep root make a subtree off-limits. The
+    # sweep root itself is normally TARGET, and a WATCH that is a parent of TARGET
+    # (WATCH=/downloads, TARGET=/downloads/processed — what the Unraid template
+    # nudges people toward) would otherwise mark the whole tree protected and
+    # silently turn the feature off.
+    blocked = tuple(sorted(
+        p for p in protected
+        if p != root_real and p.startswith(root_real + os.sep)
+    ))
+    if blocked:
+        app_logger.warning(
+            f"Empty-folder sweep of {root_real}: configured directories are nested "
+            f"inside it and will be left alone: {', '.join(blocked)}"
+        )
+
+    def _off_limits(path):
+        """True if *path* is a protected root or lives inside a nested one."""
+        if path in protected:
+            return True
+        return any(path.startswith(b + os.sep) for b in blocked)
+
     removed = 0
-    for cur, _dirs, _files in os.walk(root_abs, topdown=False):
-        cur_abs = os.path.abspath(cur)
-        if cur_abs == root_abs:
+    for cur, _dirs, _files in os.walk(root_real, topdown=False):
+        cur_real = os.path.realpath(cur)
+        if cur_real == root_real:
             continue  # never delete the root itself
+        if _off_limits(cur_real):
+            app_logger.debug(f"Sweep skipped protected directory: {cur_real}")
+            continue
         try:
-            entries = os.listdir(cur_abs)
+            entries = os.listdir(cur_real)
             # A single non-hidden entry keeps the folder alive.
-            if any(not is_hidden(os.path.join(cur_abs, e)) for e in entries):
+            if any(not is_hidden(os.path.join(cur_real, e)) for e in entries):
                 continue
-            # Only hidden junk (or nothing) remains — clear it, then the folder.
-            for e in entries:
-                p = os.path.join(cur_abs, e)
-                if os.path.isdir(p) and not os.path.islink(p):
-                    shutil.rmtree(p, ignore_errors=True)
+            # Only hidden entries remain — but a configured root can itself be
+            # hidden-named ("_incoming", ".staging") or sit under a hidden folder,
+            # and this branch deletes by rmtree without ever visiting it as `cur`.
+            # Re-check the entries or the parent's sweep takes the root out.
+            paths = [os.path.join(cur_real, e) for e in entries]
+            if any(_off_limits(os.path.realpath(pth)) for pth in paths):
+                app_logger.warning(
+                    f"Sweep kept {cur_real}: it holds a configured directory."
+                )
+                continue
+            for pth in paths:
+                if os.path.isdir(pth) and not os.path.islink(pth):
+                    shutil.rmtree(pth, ignore_errors=True)
                 else:
-                    os.remove(p)
-            os.rmdir(cur_abs)
+                    os.remove(pth)
+            os.rmdir(cur_real)
             removed += 1
-            app_logger.info(f"Deleted empty TARGET sub-directory: {cur_abs}")
+            app_logger.info(f"Pruned empty directory under {root_real}: {cur_real}")
         except Exception as e:
-            app_logger.error(f"Error pruning directory {cur_abs}: {e}")
+            app_logger.error(f"Error pruning directory {cur_real}: {e}")
     return removed
 
 #########################

--- a/helpers/library.py
+++ b/helpers/library.py
@@ -97,10 +97,70 @@ def get_library_for_path(path):
     return None
 
 
+def _resolve_trash_dir():
+    """TRASH path without needing a Flask app context.
+
+    ``helpers.trash.get_trash_dir`` reads ``current_app`` and also *creates* the
+    directory, so it is unusable from a scheduler thread. This mirrors its
+    fallback chain against the RawConfigParser instead.
+    """
+    from core.config import config
+
+    try:
+        trash_dir = config.get("SETTINGS", "TRASH_DIR", fallback="").strip()
+        if not trash_dir:
+            cache_dir = config.get("SETTINGS", "CACHE_DIR", fallback="/cache")
+            trash_dir = os.path.join(cache_dir, "trash")
+        return trash_dir
+    except Exception:
+        return ""
+
+
+def get_protected_roots():
+    """Configured roots an automated sweep must never delete or descend into.
+
+    WATCH, TARGET, TRASH and every enabled library root, as realpaths.
+
+    Deliberately separate from :func:`is_critical_path`, which answers the same
+    question for interactive routes. That one re-reads preferences from the DB on
+    every call and compares raw strings — fine for a single "can the user delete
+    this?" check, wrong inside a directory walk, where it would cost a DB hit per
+    directory and where a stored trailing slash ("/downloads/temp/") would defeat
+    the equality test. Callers resolve this set once and reuse it.
+
+    Keep the two in step: a new protected location belongs in both.
+    """
+    from core.config import get_watch_dir, get_target_dir
+
+    candidates = [
+        get_watch_dir() or "/downloads/temp",
+        get_target_dir() or "/downloads/processed",
+        _resolve_trash_dir(),
+    ]
+    try:
+        candidates.extend(get_library_roots())
+    except Exception as e:
+        # A library lookup failure must not silently shrink the protected set.
+        app_logger.error(f"Could not resolve library roots for protection: {e}")
+
+    roots = set()
+    for path in candidates:
+        if not path:
+            continue
+        try:
+            roots.add(os.path.realpath(path))
+        except Exception:
+            continue
+    return roots
+
+
 def is_critical_path(path):
     """
     Check if a path is a critical system path (WATCH, TARGET, or TRASH folders).
     Returns True if the path is critical, False otherwise.
+
+    For automated sweeps use :func:`get_protected_roots` instead — see its
+    docstring for why. A new protected location belongs in both.
     """
     from core.config import config, get_watch_dir, get_target_dir
 

--- a/tests/unit/test_prune_empty_dirs.py
+++ b/tests/unit/test_prune_empty_dirs.py
@@ -2,6 +2,8 @@
 
 import os
 
+import pytest
+
 from helpers import prune_empty_dirs
 
 
@@ -83,3 +85,205 @@ class TestPruneEmptyDirs:
 
     def test_missing_root_is_noop(self, tmp_path):
         assert prune_empty_dirs(str(tmp_path / "does-not-exist")) == 0
+
+
+class TestProtectedRoots:
+    """The sweep must never delete a directory that is configured as a root.
+
+    WATCH nested inside TARGET is a supported layout, and the sweep used to
+    delete it. The automated trigger (api.check_wanted_after_watch_empty) waits
+    for WATCH to be *empty* before running the wanted match that schedules the
+    sweep -- so it fired on exactly the condition that made WATCH deletable.
+    """
+
+    @pytest.fixture
+    def set_dirs(self, monkeypatch):
+        """Point WATCH/TARGET at test paths.
+
+        Patches core.config, which get_protected_roots imports lazily, so the
+        real resolution path (fallbacks, realpath normalization) is exercised
+        rather than stubbed out.
+        """
+        import core.config
+
+        def _set(watch="", target=""):
+            monkeypatch.setattr(core.config, "get_watch_dir", lambda: watch)
+            monkeypatch.setattr(core.config, "get_target_dir", lambda: target)
+        return _set
+
+    def test_never_removes_watch_nested_inside_target(self, tmp_path, set_dirs):
+        """The reported case: /downloads/processed/temp deleted for being empty."""
+        root = tmp_path / "processed"
+        watch = root / "temp"
+        watch.mkdir(parents=True)
+        set_dirs(watch=str(watch), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert watch.exists()
+
+    def test_watch_with_trailing_slash_is_still_protected(self, tmp_path, set_dirs):
+        """Nothing normalizes the stored preference, so the guard must.
+
+        This is the case a raw string comparison fails -- get_watch_dir()
+        preserves whatever the user typed.
+        """
+        root = tmp_path / "processed"
+        watch = root / "temp"
+        watch.mkdir(parents=True)
+        set_dirs(watch=str(watch) + os.sep, target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert watch.exists()
+
+    def test_does_not_delete_empty_folders_inside_watch(self, tmp_path, set_dirs):
+        """A download client creates its job folder before writing into it."""
+        root = tmp_path / "processed"
+        watch = root / "temp"
+        job = watch / "Batman 001"
+        job.mkdir(parents=True)
+        set_dirs(watch=str(watch), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert job.exists()
+
+    def test_hidden_named_watch_is_not_rmtree_as_junk(self, tmp_path, set_dirs):
+        """is_hidden() is true for any name starting with '_' or '.'.
+
+        A WATCH called "_incoming" reads as hidden junk, so its *parent* looks
+        empty and the rmtree branch deletes it without the walk ever visiting
+        WATCH as a directory of its own. A guard that only checks each walked
+        directory misses this entirely.
+        """
+        root = tmp_path / "processed"
+        watch = root / "Series" / "_incoming"
+        watch.mkdir(parents=True)
+        set_dirs(watch=str(watch), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert watch.exists()
+
+    def test_watch_under_hidden_ancestor_survives(self, tmp_path, set_dirs):
+        """Same hole one level up: the hidden ancestor is rmtree'd wholesale."""
+        root = tmp_path / "processed"
+        watch = root / "_staging" / "temp"
+        watch.mkdir(parents=True)
+        set_dirs(watch=str(watch), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert watch.exists()
+
+    def test_prunes_siblings_while_skipping_watch(self, tmp_path, set_dirs):
+        """The #423 behaviour still works alongside a protected sibling."""
+        root = tmp_path / "processed"
+        watch = root / "temp"
+        junk = root / "Emptied Wrapper"
+        watch.mkdir(parents=True)
+        junk.mkdir()
+        set_dirs(watch=str(watch), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert watch.exists()
+        assert not junk.exists()
+
+    def test_watch_above_the_sweep_root_does_not_disable_the_sweep(self, tmp_path, set_dirs):
+        """WATCH=/downloads with TARGET=/downloads/processed is a real layout.
+
+        The Unraid template maps the whole /downloads mount, so a user pointing
+        WATCH at the mount root is natural. Treating "inside WATCH" as protected
+        without qualification would mark the entire sweep tree off-limits and
+        silently turn the feature off.
+        """
+        root = tmp_path / "processed"
+        junk = root / "Emptied Wrapper"
+        junk.mkdir(parents=True)
+        set_dirs(watch=str(tmp_path), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert not junk.exists()
+
+    def test_target_nested_in_the_sweep_root_is_protected(self, tmp_path, set_dirs):
+        """Sweeping a parent of TARGET must not remove TARGET."""
+        target = tmp_path / "processed"
+        target.mkdir()
+        set_dirs(watch=str(tmp_path / "temp"), target=str(target))
+
+        assert prune_empty_dirs(str(tmp_path)) == 0
+        assert target.exists()
+
+    def test_trash_dir_under_the_root_is_protected(self, tmp_path, set_dirs, monkeypatch):
+        from core.config import config
+
+        root = tmp_path / "processed"
+        trash = root / "trash"
+        trash.mkdir(parents=True)
+        set_dirs(watch=str(tmp_path / "temp"), target=str(root))
+        monkeypatch.setitem(config["SETTINGS"], "TRASH_DIR", str(trash))
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert trash.exists()
+
+    def test_library_root_under_the_sweep_root_is_protected(self, tmp_path, set_dirs, monkeypatch):
+        import helpers.library
+
+        root = tmp_path / "processed"
+        lib = root / "library"
+        lib.mkdir(parents=True)
+        set_dirs(watch=str(tmp_path / "temp"), target=str(root))
+        monkeypatch.setattr(helpers.library, "get_library_roots", lambda: [str(lib)])
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert lib.exists()
+
+    def test_refuses_to_sweep_a_library_root(self, tmp_path, set_dirs, monkeypatch):
+        """A TARGET misconfigured to the collection would sweep every empty series folder."""
+        import helpers.library
+
+        root = tmp_path / "data"
+        series = root / "Batman"
+        series.mkdir(parents=True)
+        set_dirs(watch=str(tmp_path / "temp"), target=str(root))
+        monkeypatch.setattr(helpers.library, "get_library_roots", lambda: [str(root)])
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert series.exists()
+
+    def test_configured_root_that_does_not_exist_is_harmless(self, tmp_path, set_dirs):
+        root = tmp_path / "processed"
+        junk = root / "Emptied Wrapper"
+        junk.mkdir(parents=True)
+        set_dirs(watch=str(root / "never-created"), target=str(root))
+
+        assert prune_empty_dirs(str(root)) == 1
+        assert not junk.exists()
+
+    def test_config_read_failure_skips_the_sweep(self, tmp_path, monkeypatch):
+        """Fail closed when the protected set cannot be resolved.
+
+        Skipping leaves wrapper folders to accumulate until the next sweep;
+        sweeping blind can delete WATCH. Only one of those is recoverable.
+        """
+        import core.config
+
+        def boom():
+            raise RuntimeError("db gone")
+
+        monkeypatch.setattr(core.config, "get_watch_dir", boom)
+        root = tmp_path / "processed"
+        junk = root / "Emptied Wrapper"
+        junk.mkdir(parents=True)
+
+        assert prune_empty_dirs(str(root)) == 0
+        assert junk.exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="symlink creation needs privileges on Windows")
+    def test_symlinked_config_path_still_protects_watch(self, tmp_path, set_dirs):
+        """WATCH reached through a symlink must resolve to the same directory."""
+        real_root = tmp_path / "real" / "processed"
+        watch = real_root / "temp"
+        watch.mkdir(parents=True)
+        link = tmp_path / "link"
+        link.symlink_to(real_root, target_is_directory=True)
+        set_dirs(watch=str(link / "temp"), target=str(real_root))
+
+        assert prune_empty_dirs(str(real_root)) == 0
+        assert watch.exists()


### PR DESCRIPTION
## The report

`/downloads/processed/temp/` was automatically removed for being empty.

**It is not the monitor.** `monitor.py:813-836` walks up from the moved file's source folder and stops at `current_dir != watch_dir` — it only ever walks WATCH's own ancestry and cannot reach a folder under TARGET. That loop is unchanged here.

The culprit is `prune_empty_dirs`, added in `bc830bd` / #423. Its intent was narrow:

> Usenet downloads typically deliver a single comic zipped inside a same-named folder. When the file is later moved out of TARGET the wrapping folder is left behind empty and these accumulate.

The implementation deletes **every** empty descendant of TARGET, at any depth, guarded solely by `cur_abs == root_abs`.

## Why it was near-certain to fire

`api.py:476-518` `check_wanted_after_watch_empty()` **polls until WATCH is empty**, then calls `process_incoming_wanted_issues()`, which schedules the sweep (`app.py:928` → `2530-2556`). If WATCH lives under TARGET, the feature waits for exactly the condition that makes WATCH deletable, then deletes it.

Meanwhile `is_critical_path` has protected WATCH/TARGET/TRASH from *user-initiated* deletes at ~20 call sites in `routes/files.py` since long before #423. The File Manager won't let you delete WATCH. The background job never asked.

## The fix

Resolve the protected set once per sweep (`helpers.library.get_protected_roots`) and skip those directories wherever they appear — the roots and their interiors.

Two subtleties, both load-bearing and neither obvious:

**Guarding each walked directory is not enough.** `is_hidden()` returns True for any name starting with `.` or `_`. A WATCH called `_incoming` therefore reads as hidden junk: its *parent* looks empty and the `shutil.rmtree` branch destroys it without the walk ever visiting WATCH as a directory. The entries are now re-checked before that branch runs. Same for a WATCH sitting under a hidden ancestor like `_staging/`.

**Only roots strictly inside the sweep root make a subtree off-limits.** `WATCH=/downloads` with `TARGET=/downloads/processed` is a real layout — the Unraid template maps the whole `/downloads` mount, so pointing WATCH at the mount root is natural. Treating "inside WATCH" as protected without that qualification would mark the entire sweep tree off-limits and silently turn the feature off.

Interiors are skipped as well as the roots: a download client creates its job folder before writing into it, so an empty folder inside WATCH is usually a download about to start, not litter.

Also in scope:
- Refuse to sweep at all when the root resolves inside a library — a TARGET misconfigured to the collection would otherwise take out every empty series folder. Mirrors the guard at `app.py:672-679`.
- Fail closed if the protected set can't be resolved. Skipping leaves wrapper folders to accumulate; sweeping blind can delete WATCH. Only one of those is recoverable.
- `helpers/__init__.py:99` said "Deleted empty TARGET sub-directory" in a function that takes any root.

### Why not reuse `is_critical_path`

It compares raw strings, and `get_watch_dir()` returns the preference verbatim — nothing normalizes it, so a stored `/downloads/temp/` defeats the equality test. That is the exact failure mode being fixed. It also does a DB read per call, which is fine for one "can the user delete this?" check and wrong inside a directory walk. The new resolver uses `realpath` throughout and is resolved once; both functions carry docstrings pointing at each other so they don't drift.

## Verification

**3709 passed, 7 skipped** — full suite. Skips are the 6 known POSIX-only ones plus a new Windows-only symlink test.

14 new tests in `TestProtectedRoots`; the 8 existing `prune_empty_dirs` tests pass unmodified. Notable cases:

| Test | Guards against |
|---|---|
| `test_never_removes_watch_nested_inside_target` | the report |
| `test_watch_with_trailing_slash_is_still_protected` | the raw-string comparison |
| `test_hidden_named_watch_is_not_rmtree_as_junk` | the `_incoming` hole |
| `test_watch_under_hidden_ancestor_survives` | the same hole one level up |
| `test_watch_above_the_sweep_root_does_not_disable_the_sweep` | over-correcting into a no-op |
| `test_prunes_siblings_while_skipping_watch` | #423's behaviour still working |
| `test_refuses_to_sweep_a_library_root` | TARGET misconfigured to the collection |

## Two things for the reporter

**Confirm their WATCH value.** It is not established that `/downloads/processed/temp` *is* their WATCH. If it is, this fixes it outright. If it is instead an ordinary folder they wanted kept, this does not cover it — and the real gap is intent-vs-scope: #423 meant to remove wrapper folders left by a move, not to garbage-collect every empty folder in TARGET. Worth deciding separately whether the sweep should only remove folders it can attribute to a move.

**Check ownership on the recreated folder.** WATCH comes back via `api.py:112-118` on the next download, but that is a bare `os.makedirs` with no permission inheritance — on a NAS bind mount it can return owned such that the external download client can no longer write into it, and downloads then fail quietly. `entrypoint.sh:73-79` only recreates the default `/downloads/temp` and `/downloads/processed`, not a custom nested path.

## Known related issue, deliberately not fixed here

`app.py:778` walks TARGET collecting `.cbz/.cbr/.zip/.rar` without excluding WATCH. With WATCH nested inside TARGET, the wanted scan can pick up files still sitting in WATCH and move them into `/data`, bypassing the monitor's convert/rename/metadata pipeline. Separate data-loss path, separate fix — flagging it rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
