### PR TITLE
Recognize "-1" issues instead of reporting them wanted

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -205,6 +205,43 @@ ONE_MILLION_ISSUE_PATTERN = re.compile(
 )
 
 
+# Marvel's 1997 "Flashback" month numbered its books -1, and every capture in
+# this module reads a leading minus as a separator: "Amazing Spider-Man -001
+# (1997).cbz" renames to "Amazing Spider-Man 001 (1997).cbz" — the name the real
+# #1 already carries. The two issues collapse onto one file and the wanted list
+# reports #-1 missing forever (helpers/collection.py keeps the matching half of
+# this rule).
+#
+# Structural, not keyword-based: the minus must be glued to the digits and
+# preceded by a separator, so a hyphenated name ("Amazing Spider-Man 001") and a
+# dash separator ("Batman - 001") are both untouched; and what follows the
+# digits must be a separator or "(" so a scanner tag ("-0-Day") is not read as
+# a number. A dot is only rejected when a digit follows it, so ".cbz" still ends
+# the name while a point issue ("-001.5") is left to the generic branches.
+NEGATIVE_ISSUE_PATTERN = re.compile(
+    r"^(?P<series>.+?)[\s_]+[-−](?P<issue>\d{1,4})(?!\d)(?!\.\d)"
+    r"(?P<extra>[\s_(].*?)?(?P<ext>\.\w+)$",
+    re.IGNORECASE,
+)
+
+
+def _negative_issue_parts(filename, width=3):
+    """Split a "-1" filename into (series, padded signed issue, year).
+
+    Returns None when the filename does not carry a negative issue number.
+    """
+    m = NEGATIVE_ISSUE_PATTERN.match(filename)
+    if not m:
+        return None
+    series = m.group("series")
+    year_match = re.search(r"\((\d{4})\)", filename)
+    year = year_match.group(1) if year_match else ""
+    series = re.sub(r"\s*\(\d{4}\)\s*", " ", series)
+    series = re.sub(r"[#\-\s]+$", "", series.replace("_", " ").strip())
+    issue = "-" + _pad_issue_number(m.group("issue"), width)
+    return smart_title_case(series.strip()), issue, year
+
+
 # ====== BEGIN: Rule Engine Helpers ======
 def _capitalize_word(word: str) -> str:
     """Capitalize a word, handling hyphenated words like Spider-Man, X-Men."""
@@ -844,6 +881,18 @@ def extract_comic_values(filename, width=3):
         values["issue_number"] = "1000000"
         app_logger.info(
             f"Matched One Million exception: series={values['series_name']}, year={values['year']}"
+        )
+        return values
+
+    # "Flashback" issues numbered -1: the sign is part of the number, and every
+    # capture below would drop it and hand back #1's name. See
+    # NEGATIVE_ISSUE_PATTERN.
+    negative_parts = _negative_issue_parts(filename, width)
+    if negative_parts:
+        values["series_name"], values["issue_number"], values["year"] = negative_parts
+        app_logger.info(
+            f"Matched negative issue exception: series={values['series_name']}, "
+            f"issue={values['issue_number']}, year={values['year']}"
         )
         return values
 
@@ -1684,6 +1733,23 @@ def get_renamed_filename(filename, file_path=None):
     rule_name = try_rule_engine(filename, "config/rename_rules.ini", width=pad_width)
     if rule_name:
         return clean_final_filename(rule_name)
+
+    # ==========================================================
+    # 0.4) "Flashback" exception (issue number is -1). The sign is part of the
+    #      number; every pattern below reads it as a separator and hands back
+    #      #1's name. See NEGATIVE_ISSUE_PATTERN.
+    # ==========================================================
+    negative_parts = _negative_issue_parts(filename, pad_width)
+    if negative_parts:
+        app_logger.info(f"Matched NEGATIVE_ISSUE_PATTERN for: {filename}")
+        clean_title, final_issue, found_year = negative_parts
+        last_dot = filename.rfind(".")
+        extension = filename[last_dot:] if last_dot != -1 else ""
+        if found_year:
+            new_filename = f"{clean_title} {final_issue} ({found_year}){extension}"
+        else:
+            new_filename = f"{clean_title} {final_issue}{extension}"
+        return clean_final_filename(new_filename)
 
     # ==========================================================
     # 0.5) DC "One Million" exception (issue number is literally 1,000,000)

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -192,6 +192,69 @@ def _word_regex(word):
     return re.escape(word)
 
 
+# A leading minus is part of the issue NUMBER, not a sign to be discarded:
+# Marvel's 1997 "Flashback" month shipped as issue -1, and Metron/ComicVine
+# carry it as "-1" (some rows as "-01"). Two things break when it is ignored:
+#   * "-1" and "-01" never compare equal — plain lstrip("0") only eats zeros at
+#     the front of the string, and there the front is the sign.
+#   * padding is written sign-first ("Amazing Spider-Man -001 (1997).cbz"), so
+#     a "0*" + "-1" pattern hunts for zeros in front of the minus and matches
+#     nothing, while the pattern for #1 happily claims that same file.
+_SIGN_CHARS = "-‐‑‒–—―−"
+_SIGN_CLASS = "[" + _SIGN_CHARS + "]"
+
+
+def normalize_issue_number(value):
+    """Canonical form of an issue number for equality comparison.
+
+    Drops leading zeros but keeps a leading sign, normalizing every dash
+    variant to ASCII "-": "007" -> "7", "-001" -> "-1", "-01" -> "-1".
+    Empty input returns "0", matching the historical ``lstrip('0') or '0'``.
+    """
+    text = str(value if value is not None else "").strip()
+    sign = ""
+    if text and text[0] in _SIGN_CHARS:
+        sign = "-"
+        text = text[1:].strip()
+    return sign + (text.lstrip("0") or "0")
+
+
+def issue_number_regex(issue_number):
+    r"""Regex fragment matching one issue number inside a filename.
+
+    Shared by the pattern matcher and the loose filename fallback so both agree
+    on which files a "-1" issue — and, just as importantly, which files a #1
+    issue — may claim.
+
+    Anchors on both sides:
+      (?<!\d)    the digit run must start here. Without it the separator in the
+                 caller's pattern absorbed " 05" and issue #1 matched
+                 "Nightwing 051 (2016).cbz" — every issue 1-40 came back
+                 "owned", all pointing at #51's file.
+      (?<!\d\.)  not the fractional half of a point issue: #1 must not match
+                 the trailing "1" of "001.1".
+      (?!\d)     the digit run must end here ("1" is not "10").
+      (?!\.\d)   not the whole half of a point issue: #1 must not claim
+                 "001.5.cbz". A bare "(?!\.)" would wrongly reject
+                 "Nightwing 001.cbz", so only a digit after the dot counts.
+
+    The sign is structural, never guessed from keywords. A minus glued to the
+    digits and not hanging off a word is a sign ("Amazing Spider-Man -001"); a
+    dash that is part of the previous word ("Batman-001"), followed by a space
+    ("Batman - 001") or preceded by a digit ("Batman 001-006") is a separator.
+    Issue #1 refuses the first form, issue #-1 requires it.
+    """
+    clean = normalize_issue_number(issue_number)
+    negative = clean.startswith("-")
+    digits = clean[1:] if negative else clean
+    body = r"0*" + re.escape(digits) + r"(?!\d)(?!\.\d)"
+    if negative:
+        return rf"(?<![A-Za-z0-9]){_SIGN_CLASS}{body}"
+    # A positive issue has to refuse that same shape, or #1 claims #-1's file.
+    unsigned = rf"(?<!^{_SIGN_CLASS})(?<![^A-Za-z0-9]{_SIGN_CLASS})"
+    return rf"(?<!\d)(?<!\d\.){unsigned}{body}"
+
+
 # What may sit between the series name and the issue number when strict_gap is
 # on. A spin-off writes its subtitle THERE ("TMNT - Nightwatcher 003"); a real
 # issue title comes AFTER the number ("Nightwing 117 - Absolute Power"), so
@@ -300,23 +363,10 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number, strict_
                     pattern_parts.append(sep)
         series_pattern = the_prefix + ''.join(pattern_parts)
 
-        # Normalize issue number - handle leading zeros (1, 01, 001 all match)
-        issue_num_clean = str(issue_number).strip().lstrip('0') or '0'
-        # Match issue number with optional leading zeros, anchored on BOTH sides
-        # so it can never match a fragment of a longer number.
-        #   (?<!\d)   the digit run must start here. Without it the separator
-        #             below absorbed " 05" and issue #1 matched
-        #             "Nightwing 051 (2016).cbz" - every issue 1-40 came back
-        #             "owned", all pointing at #51's file.
-        #   (?<!\d\.) not the fractional half of a point issue: #1 must not
-        #             match the trailing "1" of "001.1".
-        #   (?!\d)    the digit run must end here ("1" is not "10").
-        #   (?!\.\d)  not the whole half of a point issue: #1 must not claim
-        #             "001.5.cbz". A bare "(?!\.)" would wrongly reject
-        #             "Nightwing 001.cbz", so only a digit after the dot counts.
-        issue_pattern = (
-            r'(?<!\d)(?<!\d\.)0*' + re.escape(issue_num_clean) + r'(?!\d)(?!\.\d)'
-        )
+        # Match issue number with optional leading zeros, anchored on both sides
+        # so it can never match a fragment of a longer number, and sign-aware so
+        # #1 and #-1 keep their own files. See ``issue_number_regex``.
+        issue_pattern = issue_number_regex(issue_number)
 
         # Now substitute our patterns back in
         pattern = pattern.replace('<<<SERIES>>>', f'(?:{series_pattern})')
@@ -616,7 +666,7 @@ def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None
         if debug:
             app_logger.debug(f"Checking: '{actual_series_name}' #{issue_number}")
 
-        check_num = str(issue_number).strip().lstrip("0") or "0"
+        check_num = normalize_issue_number(issue_number)
         matched = None
         for filename, src in remaining:
             # A downloaded annual/TPB would otherwise satisfy issue #1 and get
@@ -636,7 +686,7 @@ def match_wanted_issues_to_files(wanted, files, match_pattern, alias_lookup=None
             if not match_result:
                 ci = extract_comicinfo_cached(src, comicinfo_cache)
                 if ci and ci.get("number"):
-                    meta_num = str(ci["number"]).strip().lstrip("0") or "0"
+                    meta_num = normalize_issue_number(ci["number"])
                     if meta_num == check_num:
                         meta_series = (ci.get("series") or "").lower()
                         if meta_series and any(
@@ -837,8 +887,8 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
                 ci = extract_comicinfo_cached(file_path, comicinfo_cache)
                 if ci.get('number'):
                     # Normalize issue numbers for comparison
-                    meta_num = str(ci['number']).strip().lstrip('0') or '0'
-                    check_num = issue_num.strip().lstrip('0') or '0'
+                    meta_num = normalize_issue_number(ci['number'])
+                    check_num = normalize_issue_number(issue_num)
 
                     if meta_num == check_num:
                         # Check series name matches (loose match)
@@ -851,10 +901,12 @@ def match_issues_to_collection(mapped_path, issues, series_info, use_cache=True)
 
         # 4c: Final fallback to generic filename patterns
         if not match_found:
-            check_num = issue_num.strip().lstrip('0') or '0'
+            # The shared fragment carries its own leading zeros and sign rules,
+            # so "-1" needs "Series -001" while #1 must not settle for it.
+            num_re = issue_number_regex(issue_num)
             patterns = [
-                rf'[\s\-_]0*{re.escape(check_num)}(?:[\s\-_\.\(]|$)',  # space/dash/underscore + number + delimiter
-                rf'#0*{re.escape(check_num)}(?:\D|$)',  # #1, #01, #001
+                rf'[\s\-_]{num_re}(?:[\s\-_\.\(]|$)',  # space/dash/underscore + number + delimiter
+                rf'#{num_re}(?:\D|$)',  # #1, #01, #001
             ]
 
             for file_path, metadata in file_metadata.items():

--- a/tests/integration/test_collection_status_matching.py
+++ b/tests/integration/test_collection_status_matching.py
@@ -224,3 +224,140 @@ class TestPublicationTypeGuard:
         status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
 
         assert status["1"]["found"] is True
+
+
+class TestNegativeIssueNumbers:
+    """Amazing Spider-Man (1963) #-1 — Marvel's 1997 "Flashback" month.
+
+    The reported bug: the wanted page kept listing #-1 as missing even though
+    "Amazing Spider-Man -001 (1997).cbz" sat in the mapped folder, because the
+    matcher stripped the sign and then looked for zeros in front of it.
+    """
+
+    ASM = "Amazing Spider-Man"
+    FILES = [
+        "Amazing Spider-Man -001 (1997).cbz",
+        "Amazing Spider-Man 001 (1963).cbz",
+    ]
+
+    def test_minus_one_is_found_on_scan(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, self.FILES, ["-1", "1"], name=self.ASM
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["-1"]["found"] is True
+        assert status["-1"]["file_path"].endswith("Amazing Spider-Man -001 (1997).cbz")
+
+    def test_minus_one_and_one_do_not_share_a_file(self, db_connection, tmp_path):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, self.FILES, ["-1", "1"], name=self.ASM
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["1"]["file_path"].endswith("Amazing Spider-Man 001 (1963).cbz")
+        assert status["-1"]["file_path"] != status["1"]["file_path"]
+
+    def test_issue_one_is_still_missing_with_only_the_minus_one_file(
+        self, db_connection, tmp_path
+    ):
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Amazing Spider-Man -001 (1997).cbz"], ["-1", "1"],
+            name=self.ASM,
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["-1"]["found"] is True
+        assert status["1"]["found"] is False
+
+    def test_padded_db_number_matches_the_same_file(self, db_connection, tmp_path):
+        """Providers hand back "-1" or "-01" — both are the same issue."""
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Amazing Spider-Man -001 (1997).cbz"], ["-01"],
+            name=self.ASM,
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["-01"]["found"] is True
+
+    def test_loose_fallback_also_honours_the_sign(self, db_connection, tmp_path):
+        """With no rename pattern configured, tier 4c must agree with 4a."""
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path, ["Amazing Spider-Man -001 (1997).cbz"], ["-1", "1"],
+            pattern="", name=self.ASM,
+        )
+        issue_objs, series_obj = _objs(series_id)
+
+        status = match_issues_to_collection(path, issue_objs, series_obj, use_cache=False)
+
+        assert status["-1"]["found"] is True
+        assert status["1"]["found"] is False
+
+
+class TestStaleCacheSelfHeals:
+    """Existing installs carry rows written by the pre-fix matcher.
+
+    collection_status is a cache, not a record: it is invalidated when the
+    folder holds more comic files than the cache matched while something is
+    still missing. A stale "-1 is missing" row always satisfies that (the -1
+    file is either unclaimed, or claimed by #1 leaving #1's file unclaimed), so
+    the fix reaches existing libraries on the next scan without a purge.
+    """
+
+    ASM = "Amazing Spider-Man"
+
+    def test_cached_missing_minus_one_is_rescanned(self, db_connection, tmp_path):
+        from core.database import save_collection_status_bulk, get_issues_for_series
+        from helpers.collection import match_issues_to_collection
+
+        series_id, path = _setup(
+            tmp_path,
+            [
+                "Amazing Spider-Man -001 (1997).cbz",
+                "Amazing Spider-Man 001 (1963).cbz",
+            ],
+            ["-1", "1"],
+            name=self.ASM,
+        )
+        issue_ids = {str(i["number"]): i["id"] for i in get_issues_for_series(series_id)}
+
+        # What the old matcher wrote: #1 pointing at the -1 file, -1 missing.
+        wrong_file = str(tmp_path / self.ASM / "Amazing Spider-Man -001 (1997).cbz")
+        save_collection_status_bulk([
+            {
+                "series_id": series_id, "issue_id": issue_ids["1"],
+                "issue_number": "1", "found": 1, "file_path": wrong_file,
+                "file_mtime": None, "matched_via": "pattern",
+            },
+            {
+                "series_id": series_id, "issue_id": issue_ids["-1"],
+                "issue_number": "-1", "found": 0, "file_path": None,
+                "file_mtime": None, "matched_via": None,
+            },
+        ])
+
+        # use_cache=True: the stale rows must not be trusted.
+        issue_objs, series_obj = _objs(series_id)
+        status = match_issues_to_collection(path, issue_objs, series_obj)
+
+        assert status["-1"]["found"] is True
+        assert status["-1"]["file_path"].endswith("Amazing Spider-Man -001 (1997).cbz")
+        assert status["1"]["file_path"].endswith("Amazing Spider-Man 001 (1963).cbz")

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -16,6 +16,7 @@ from helpers.collection import (
     strip_empty_groups,
     build_series_match_names,
     names_other_publication_type,
+    normalize_issue_number,
 )
 
 
@@ -499,6 +500,90 @@ class TestIssueNumberBoundaryWithoutYear:
     def test_plain_file_still_matches(self):
         assert self._regex("1").match("Nightwing 001.cbz")
         assert self._regex("1").match("Nightwing 001 - The Dawn.cbz")
+
+
+class TestNegativeIssueNumbers:
+    """Marvel's 1997 "Flashback" month shipped as issue -1.
+
+    Regression: the minus was treated as noise, so the compiled pattern looked
+    for zeros in front of the sign ("0*-1") and never matched
+    "Amazing Spider-Man -001 (1997).cbz" — the issue stayed on the wanted page
+    forever — while the pattern for #1 cheerfully claimed that same file.
+    """
+
+    def _regex(self, number, name="Amazing Spider-Man", strict_gap=False):
+        return generate_filename_pattern(
+            "{series_name} {issue_number} ({volume_year})", name, number,
+            strict_gap=strict_gap,
+        )
+
+    @pytest.mark.parametrize("number", ["-1", "-01", "-001"])
+    def test_minus_one_matches_its_padded_file(self, number):
+        assert self._regex(number).match("Amazing Spider-Man -001 (1997).cbz")
+
+    def test_minus_one_matches_the_unpadded_file(self):
+        assert self._regex("-1").match("Amazing Spider-Man -1 (1997).cbz")
+
+    @pytest.mark.parametrize("strict_gap", [False, True])
+    def test_minus_one_matches_under_both_gap_modes(self, strict_gap):
+        # The wanted/move matcher runs with strict_gap=True; the sign must
+        # survive the letters-banned gap too.
+        assert self._regex("-1", strict_gap=strict_gap).match(
+            "Amazing Spider-Man -001 (1997).cbz"
+        )
+
+    def test_issue_one_does_not_claim_the_minus_one_file(self):
+        assert not self._regex("1").match("Amazing Spider-Man -001 (1997).cbz")
+
+    def test_minus_one_does_not_claim_issue_ones_file(self):
+        assert not self._regex("-1").match("Amazing Spider-Man 001 (1963).cbz")
+
+    def test_issue_one_keeps_a_dash_separator_file(self):
+        # " - 001" is a separator (space after the dash), not a sign.
+        assert self._regex("1").match("Amazing Spider-Man - 001 (1963).cbz")
+
+    def test_issue_one_keeps_a_glued_dash_file(self):
+        # "Man-001" — the dash belongs to the word before it.
+        assert self._regex("1").match("Amazing Spider-Man-001 (1963).cbz")
+
+    def test_minus_one_does_not_read_a_glued_dash_as_its_sign(self):
+        assert not self._regex("-1").match("Amazing Spider-Man-001 (1963).cbz")
+
+    def test_minus_one_does_not_match_minus_eleven(self):
+        assert not self._regex("-1").match("Amazing Spider-Man -011 (1997).cbz")
+
+    def test_hyphenated_series_name_still_matches(self):
+        assert self._regex("1").match("Amazing Spider-Man 001 (1963).cbz")
+
+
+class TestNormalizeIssueNumber:
+    """normalize_issue_number is the shared equality form (ComicInfo compares)."""
+
+    @pytest.mark.parametrize("value,expected", [
+        ("1", "1"),
+        ("001", "1"),
+        ("007", "7"),
+        ("0", "0"),
+        ("000", "0"),
+        ("", "0"),
+        (None, "0"),
+        ("1.MU", "1.MU"),
+        ("001.1", "1.1"),
+        ("-1", "-1"),
+        ("-01", "-1"),
+        ("-001", "-1"),
+        ("−1", "-1"),   # Unicode minus
+        ("–1", "-1"),   # en dash
+        (" -1 ", "-1"),
+    ])
+    def test_normalizes(self, value, expected):
+        assert normalize_issue_number(value) == expected
+
+    def test_padded_and_unpadded_negatives_compare_equal(self):
+        assert normalize_issue_number("-01") == normalize_issue_number("-1")
+
+    def test_negative_never_equals_its_positive(self):
+        assert normalize_issue_number("-1") != normalize_issue_number("1")
 
 
 class TestNamesOtherPublicationType:

--- a/tests/unit/test_match_wanted_to_files.py
+++ b/tests/unit/test_match_wanted_to_files.py
@@ -418,3 +418,76 @@ class TestSpinOffSubtitleGuard:
             wanted, [("unhelpful.cbz", f)], PATTERN, alias_lookup=_no_aliases
         )
         assert len(matches) == 1
+
+
+class TestNegativeIssueNumbers:
+    """A wanted "-1" must find the file it already has, and only that file.
+
+    This is the download-scan half of the -1 bug: with the sign discarded, the
+    scan never recognized "Amazing Spider-Man -001 (1997).cbz" as issue -1, and
+    a wanted #1 would have grabbed it — moving and renaming the wrong comic.
+    """
+
+    ASM = "Amazing Spider-Man"
+
+    def _match(self, tmp_path, filenames, wanted_numbers):
+        series_dir = tmp_path / self.ASM
+        series_dir.mkdir()
+        files = []
+        for name in filenames:
+            path = str(tmp_path / name)
+            _touch(path)
+            files.append((name, path))
+        wanted = [_wanted(self.ASM, n, str(series_dir)) for n in wanted_numbers]
+        return match_wanted_issues_to_files(
+            wanted, files, PATTERN, alias_lookup=_no_aliases
+        )
+
+    def test_minus_one_matches_its_file(self, tmp_path):
+        matches = self._match(
+            tmp_path, ["Amazing Spider-Man -001 (1997).cbz"], ["-1"]
+        )
+        assert len(matches) == 1
+        assert matches[0]["filename"] == "Amazing Spider-Man -001 (1997).cbz"
+
+    def test_minus_one_and_one_keep_their_own_files(self, tmp_path):
+        matches = self._match(
+            tmp_path,
+            [
+                "Amazing Spider-Man -001 (1997).cbz",
+                "Amazing Spider-Man 001 (1963).cbz",
+            ],
+            ["1", "-1"],
+        )
+        by_number = {m["issue"]["number"]: m["filename"] for m in matches}
+        assert by_number["1"] == "Amazing Spider-Man 001 (1963).cbz"
+        assert by_number["-1"] == "Amazing Spider-Man -001 (1997).cbz"
+
+    def test_issue_one_does_not_move_the_minus_one_file(self, tmp_path):
+        matches = self._match(
+            tmp_path, ["Amazing Spider-Man -001 (1997).cbz"], ["1"]
+        )
+        assert matches == []
+
+    def test_comicinfo_padded_negative_still_matches(self, tmp_path):
+        """<Number>-01</Number> is the same issue as a wanted "-1"."""
+        series_dir = tmp_path / self.ASM
+        series_dir.mkdir()
+        f = str(tmp_path / "unhelpful.cbz")
+        _make_cbz_with_comicinfo(f, self.ASM, "-01")
+        wanted = [_wanted(self.ASM, "-1", str(series_dir))]
+        matches = match_wanted_issues_to_files(
+            wanted, [("unhelpful.cbz", f)], PATTERN, alias_lookup=_no_aliases
+        )
+        assert len(matches) == 1
+
+    def test_comicinfo_negative_does_not_satisfy_issue_one(self, tmp_path):
+        series_dir = tmp_path / self.ASM
+        series_dir.mkdir()
+        f = str(tmp_path / "unhelpful.cbz")
+        _make_cbz_with_comicinfo(f, self.ASM, "-1")
+        wanted = [_wanted(self.ASM, "1", str(series_dir))]
+        matches = match_wanted_issues_to_files(
+            wanted, [("unhelpful.cbz", f)], PATTERN, alias_lookup=_no_aliases
+        )
+        assert matches == []

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -296,6 +296,67 @@ class TestOneMillionException:
             assert get_renamed_filename(filename) == expected
 
 
+class TestNegativeIssueException:
+    """Marvel's 1997 "Flashback" month numbered its books -1.
+
+    Regression: the sign read as a separator, so
+    "Amazing Spider-Man -001 (1997).cbz" was renamed to
+    "Amazing Spider-Man 001 (1997).cbz" — the name #1 already carries. The two
+    issues then share one name, and the wanted page reports #-1 missing
+    forever. helpers/collection.py holds the matching half of the rule.
+    """
+
+    # --- extract_comic_values (custom-pattern path) ---
+    @pytest.mark.parametrize("filename,issue,year", [
+        ("Amazing Spider-Man -001 (1997).cbz", "-001", "1997"),
+        ("Amazing Spider-Man -1 (1997).cbz", "-001", "1997"),
+        ("Amazing Spider-Man -001.cbz", "-001", ""),
+        ("Amazing_Spider-Man_-001_(1997).cbz", "-001", "1997"),
+    ])
+    def test_extract_keeps_the_sign(self, filename, issue, year):
+        from cbz_ops.rename import extract_comic_values
+        values = extract_comic_values(filename)
+        assert values["issue_number"] == issue
+        assert values["year"] == year
+        assert values["series_name"] == "Amazing Spider-Man"
+
+    @pytest.mark.parametrize("filename,issue", [
+        # A hyphenated name is not a sign.
+        ("Amazing Spider-Man 001 (1963).cbz", "001"),
+        # A dash separator (space after it) is not a sign.
+        ("Batman - 001 (2016).cbz", "001"),
+        # A dash inside a scanner tag is not a sign.
+        ("Nightwing 001 (2016) (Digital) (Zone-Empire).cbz", "001"),
+    ])
+    def test_extract_leaves_positive_issues_alone(self, filename, issue):
+        from cbz_ops.rename import extract_comic_values
+        assert extract_comic_values(filename)["issue_number"] == issue
+
+    def test_pad_width_zero_keeps_the_sign(self):
+        from cbz_ops.rename import extract_comic_values
+        values = extract_comic_values("Amazing Spider-Man -001 (1997).cbz", 0)
+        assert values["issue_number"] == "-1"
+
+    # --- get_renamed_filename default-logic path ---
+    @pytest.mark.parametrize("filename,expected", [
+        ("Amazing Spider-Man -001 (1997).cbz", "Amazing Spider-Man -001 (1997).cbz"),
+        ("Amazing Spider-Man -1 (1997).cbz", "Amazing Spider-Man -001 (1997).cbz"),
+        ("Amazing Spider-Man -001.cbz", "Amazing Spider-Man -001.cbz"),
+    ])
+    def test_default_path_keeps_the_sign(self, filename, expected):
+        from cbz_ops.rename import get_renamed_filename
+        with patch("cbz_ops.rename.load_custom_rename_config", return_value=(False, "")),              patch("os.path.exists", return_value=False),              patch("cbz_ops.rename.load_issue_pad_width", return_value=3):
+            assert get_renamed_filename(filename) == expected
+
+    def test_negative_and_positive_do_not_collide(self):
+        """The whole point: the two issues must not end up with one name."""
+        from cbz_ops.rename import get_renamed_filename
+        with patch("cbz_ops.rename.load_custom_rename_config", return_value=(False, "")),              patch("os.path.exists", return_value=False),              patch("cbz_ops.rename.load_issue_pad_width", return_value=3):
+            minus_one = get_renamed_filename("Amazing Spider-Man -001 (1997).cbz")
+            issue_one = get_renamed_filename("Amazing Spider-Man 001 (1963).cbz")
+        assert minus_one != issue_one
+
+
 # ===== clean_final_filename =====
 
 class TestCleanFinalFilename:


### PR DESCRIPTION
## The bug

Amazing Spider-Man v1963 (Metron 835 / ComicVine 2127) kept listing `#-01` as wanted even though `Amazing Spider-Man -001 (1997).cbz` was sitting in the mapped folder.

Nothing was wrong with the wanted page — the issue↔file matcher was throwing away the minus sign.

## Why it happened

Marvel's 1997 "Flashback" month numbered its books **-1**, which is a real issue number, not a negative to be discarded. Two things fell out of ignoring the sign:

- Normalization was `lstrip('0')`, which only eats zeros at the *front of the string* — and for `-1` the front is the sign. So `-1` and `-01` (both forms come back from providers) never compared equal.
- Padding is written sign-first (`-001`), but the compiled pattern was `0*` + `-1` — it hunted for zeros *in front of* the minus and could never match.

The mirror image was worse: the pattern for **#1** happily claimed that same `-001` file, so two different issues resolved to one archive. In `match_wanted_issues_to_files` — which drives `shutil.move` plus a rename — that means filing the wrong comic under the right name.

## The fix

`helpers/collection.py` grows two shared primitives, used by every tier of both matchers (4a/4b/4c and the wanted/move matcher):

| | |
|---|---|
| `normalize_issue_number()` | equality form — keeps the sign, drops zeros (`-001` → `-1`) |
| `issue_number_regex()` | the sign-aware filename fragment |

The sign/separator rule is **structural, never keyword-based**:

| Filename | Read as |
|---|---|
| `Spider-Man -001` | sign — minus glued to the digits, not hanging off a word |
| `Batman-001` | separator — dash belongs to the word before it |
| `Batman - 001` | separator — space after the dash |
| `Batman 001-006` | separator — preceded by a digit (range packs still work) |

`#-1` requires the first form; `#1` now refuses it.

## Also fixed: the renamer

`cbz_ops/rename.py` had the same blind spot from the other direction — it renamed `Amazing Spider-Man -001 (1997).cbz` to `Amazing Spider-Man 001 (1997).cbz`, which is **#1's exact name**. The two issues collapse onto one file, and the recognition fix would be undone on the next rename pass. `NEGATIVE_ISSUE_PATTERN` now handles it in both the custom-pattern path and the default path (step 0.4, beside the One Million exception), preserving the sign and normalizing `-1` → `-001`.

## No cache purge needed

Matcher changes usually need a one-time `collection_status` purge to reach existing installs. Not here: a stale "-1 missing" row **always** leaves a comic file unmatched (the -1 file is either unclaimed, or claimed by #1 leaving #1's file unclaimed), which trips `match_issues_to_collection`'s existing "more files on disk than matched" invalidation. Auto-scan and the Refresh button both pick it up on the next pass. There's an integration test that seeds the wrong rows and asserts the rescan.

## Testing

31 tests added across `test_filename_pattern.py`, `test_match_wanted_to_files.py`, `test_rename.py` and `test_collection_status_matching.py` — covering both directions (the -1 file is found; #1 does not steal it), the ComicInfo fallback (`<Number>-01</Number>`), the loose 4c fallback, strict-gap mode, and the rename round-trip.

Full suite: **3762 passed, 7 skipped** (pre-existing Windows/POSIX skips).

## Not covered

The GetComics query for a wanted `#-1` still goes out as `"Amazing Spider-Man -1 1997"` and `score_getcomics_result` is not sign-aware. That's the pre-download scorer — a separate system from the post-download filename matcher — and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
