### PR TITLE
Add Apprise push notifications for downloads and wanted issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ gunicorn -w 1 --threads 8 -b 0.0.0.0:5577 --timeout 120 app:app
 | `core/metadata_scanner.py` | Background worker scanning ComicInfo.xml — priority queue, updates file_index with metadata |
 | `core/memory_utils.py` | Memory monitoring — tracks usage, triggers cleanup at thresholds, `memory_context()` manager |
 | `core/version.py` | Single `__version__` string |
+| `core/notifications.py` | Outbound push via Apprise - owner-global settings in `user_preferences`, event catalog (`EVENT_DEFS`), `notify_async()` used by every hook site. `apprise` is imported lazily and every path swallows its exceptions: a notification must never break the download it reports on |
 
 ### Other Root Modules
 | Module | Purpose |
@@ -93,6 +94,7 @@ gunicorn -w 1 --threads 8 -b 0.0.0.0:5577 --timeout 120 app:app
 | `routes/collection.py` | File browsing — directory listing, search, thumbnails, metadata browse |
 | `routes/metadata.py` | ComicInfo.xml management — provider search, batch processing, field updates |
 | `routes/series.py` | Releases/Wanted/Pull List — series sync, mapping, subscriptions |
+| `routes/notifications.py` | Notification settings - save, send-test, event catalog. Owner-only by path (`core/auth.py` gates all of `/api/config/`) |
 | `routes/api_v1.py` | External API access for publishers, files and download support. 
 
 !!! /api/v1/docs documents all token protected API routes. To keep the page in sync with the API, edit the ENDPOINTS list at
@@ -117,6 +119,35 @@ tests/
 - `collection_bp` (routes/collection.py): Collection browsing
 - `metadata_bp` (routes/metadata.py): Metadata management
 - `series_bp` (routes/series.py): Series and releases
+- `notifications_bp` (routes/notifications.py): Apprise notification settings
+
+### Notification Hook Sites
+
+Downloads settle in **three independent places** — there is no single choke
+point. A new download path needs its own hook:
+
+| Path | Terminal status set at |
+|------|------------------------|
+| In-process HTTP (GetComics/Pixeldrain/MEGA/ComicBookPlus) | `api.py` success in `process_download`; failure after the `is_cancel_requested` guard following `set_error_status` |
+| Usenet (SABnzbd/NZBGet) | `models/usenet.py` `_set_status` |
+| DC++ / AirDC++ | `models/dcpp.py` `_set_status` |
+
+Both pollers delegate to the shared `core.notifications.notify_download_terminal()`
+and must call it **outside** their `_jobs_lock`.
+
+Two rules that are easy to break:
+
+- **Cancellations must never notify.** Aborting a transfer is how a cancel
+  surfaces from most providers, so the failure path runs for cancels too.
+  `set_error_status` downgrades those to `cancelled`, and the notification sits
+  *after* the early return that follows it. Hooking inside `set_error_status`
+  would be wrong twice over — `download_getcomics` calls it a second time before
+  re-raising, so one failure would notify twice.
+- **Wanted issues send one digest per sweep.** The hook is in
+  `process_incoming_wanted_issues` inside the `if moved_count > 0` branch and
+  outside the per-match loop; a catch-up sweep can import dozens of issues, and
+  one push each is unusable. `tests/unit/test_wanted_digest_hook.py` asserts
+  this structurally, because app.py cannot be imported in tests.
 
 ### Data Flow
 1. Comics stored in `/data` (mounted volume)

--- a/api.py
+++ b/api.py
@@ -28,8 +28,12 @@ from urllib3.util.retry import Retry
 # Application logging and configuration (adjust these as needed)
 from models.getcomics import provider_label, is_unresolved_gc_redirect
 from core.app_logging import MONITOR_LOG
+from core.notifications import (
+    EVENT_DOWNLOAD_COMPLETE, EVENT_DOWNLOAD_FAILED, notify_async,
+)
 from helpers import is_hidden
 from core.config import config, load_config, load_flask_config
+from core.download_utils import download_notification_body
 
 # Load config and initialize Flask app.
 app = Flask(__name__)
@@ -458,6 +462,12 @@ def process_download(task):
             download_progress[download_id]['filename'] = file_path
             download_progress[download_id]['status']   = 'complete'
 
+            notify_async(
+                EVENT_DOWNLOAD_COMPLETE,
+                "Download complete",
+                download_notification_body(dest_filename, file_path, provider_name),
+            )
+
             # Update weekly pack status to 'completed' if applicable
             if weekly_pack_info:
                 try:
@@ -537,6 +547,17 @@ def process_download(task):
     set_error_status(download_id, last_error)
     if is_cancel_requested(download_id):
         return
+
+    # Past the cancel guard, so this is a genuine failure. Hooked here rather
+    # than inside set_error_status because download_getcomics calls that a
+    # second time before re-raising (see its own set_error_status call).
+    notify_async(
+        EVENT_DOWNLOAD_FAILED,
+        "Download failed",
+        download_notification_body(
+            dest_filename, None, None, error=last_error
+        ),
+    )
 
     # Update weekly pack status to 'failed' if applicable
     if weekly_pack_info:

--- a/app.py
+++ b/app.py
@@ -85,6 +85,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections import OrderedDict
 from core.version import __version__
 from core.download_utils import issue_number_to_int
+from core.notifications import (
+    EVENT_DEFS as NOTIFICATION_EVENT_DEFS,
+    get_settings as notification_settings,
+)
 import requests
 from packaging import version as pkg_version
 from core.database import (
@@ -352,6 +356,9 @@ app.register_blueprint(download_clients_bp)
 from routes.reading import reading_bp
 
 app.register_blueprint(reading_bp)
+from routes.notifications import notifications_bp
+
+app.register_blueprint(notifications_bp)
 
 # Start unified scheduler
 app_state.scheduler.start()
@@ -798,6 +805,7 @@ def process_incoming_wanted_issues():
 
     moved_count = 0
     affected_series = set()  # Track series that had files moved
+    moved_issues = []  # Human-readable list for the notification digest
     for match in matches:
         issue = match["issue"]
         actual_series_name = match["series_name"]
@@ -837,6 +845,7 @@ def process_incoming_wanted_issues():
             app_logger.info(f"Moved: {filename} -> {dest_dir}")
             moved_count += 1
             affected_series.add(issue["series_id"])
+            moved_issues.append(f"{actual_series_name} #{issue['number']}")
 
             # Index the file right away so later rename/metadata steps
             # can update the entry instead of warning "not found"
@@ -921,6 +930,20 @@ def process_incoming_wanted_issues():
 
         for series_id in affected_series:
             reconcile_wanted_for_series(series_id)
+
+        # One digest per sweep, not one message per issue: a catch-up sweep can
+        # import dozens of issues at once, and that many pushes is unusable.
+        # Sent after the reconcile above so it reflects settled state.
+        from core.notifications import (
+            EVENT_WANTED_ADDED, format_digest, notify_async,
+        )
+
+        plural = "issue" if moved_count == 1 else "issues"
+        notify_async(
+            EVENT_WANTED_ADDED,
+            f"{moved_count} wanted {plural} added",
+            format_digest("Added to your library:", moved_issues),
+        )
 
         # Files were just moved out of TARGET into series folders, which can leave
         # empty download wrapper folders behind (common with Usenet single-file
@@ -7226,6 +7249,8 @@ def config_page():
 
     from core.config import get_watch_dir, get_target_dir
 
+    notify_settings = notification_settings()
+
     return render_template(
         "config.html",
         watch=get_watch_dir() or "/downloads/temp",
@@ -7323,6 +7348,11 @@ def config_page():
         dashboard_order=site_default_dashboard_order(),
         dashboard_hidden=get_user_preference("dashboard_hidden", default=[]),
         dashboard_section_meta=dashboard_section_meta(),
+        # Notifications (Apprise). The URL list is rendered one-per-line into a
+        # textarea; parse_urls() reverses that on save.
+        notify_settings=notify_settings,
+        notify_urls_text="\n".join(notify_settings["urls"]),
+        notify_event_defs=NOTIFICATION_EVENT_DEFS,
     )
 
 

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -348,3 +348,24 @@ def watch_drain_timeout_seconds(reconcile_interval_minutes=5) -> int:
     except (TypeError, ValueError):
         minutes = 5
     return max(300, min(3600, minutes * 60 * 2 + 120))
+
+
+def download_notification_body(dest_filename, file_path=None, provider=None,
+                               error=None):
+    """Build the body of a download-complete/failed notification.
+
+    Lives here rather than in api.py so it can be tested without triggering
+    api.py's import-time side effects (worker threads, cloudscraper, DB).
+
+    ``dest_filename`` is absent for browser-extension grabs, so fall back to the
+    resolved path before giving up and calling it "Unknown file".
+    """
+    name = dest_filename
+    if not name and file_path:
+        name = os.path.basename(file_path)
+    lines = [name or "Unknown file"]
+    if provider:
+        lines.append(f"Source: {provider}")
+    if error:
+        lines.append(f"Error: {error}")
+    return "\n".join(lines)

--- a/core/notifications.py
+++ b/core/notifications.py
@@ -1,0 +1,300 @@
+"""Outbound push notifications via Apprise.
+
+CLU has no other outbound channel: ``core.app_state.add_notification`` is an
+in-app toast list that is process-local, expires after five minutes, and is lost
+on restart. This module is what tells a user something happened when they are
+not looking at the browser.
+
+Apprise (https://github.com/caronc/apprise) takes URL-style service definitions
+(``discord://...``, ``ntfy://...``, ``mailto://...``) and fans one message out to all
+of them, so CLU never implements a per-service integration.
+
+Design rules, all of which exist because a notification must never be able to
+break the thing it is reporting on:
+
+* ``import apprise`` is lazy. App import and the test suite must not depend on
+  the package being installed, and a broken install degrades to a logged error.
+* Every public function swallows its exceptions into ``app_logger``.
+* Callers use :func:`notify_async`. The hook sites are a download worker thread
+  and two single-threaded pollers that drive *every* tracked job - a hung
+  webhook on any of them would stall unrelated downloads.
+* Settings are read per call, so config changes take effect without a restart.
+"""
+
+import threading
+
+from core.app_logging import app_logger
+
+# Event ids. These are stored in user_preferences, so they are part of the
+# on-disk format - renaming one silently resets that event to its default.
+EVENT_DOWNLOAD_COMPLETE = "download_complete"
+EVENT_DOWNLOAD_FAILED = "download_failed"
+EVENT_WANTED_ADDED = "wanted_added"
+
+# Single source of truth for the config UI, payload validation and defaults.
+# The /config tab renders itself from this, so the two cannot drift.
+EVENT_DEFS = {
+    EVENT_DOWNLOAD_COMPLETE: {
+        "label": "Download completed",
+        "description": "A download finishes successfully.",
+        "notify_type": "success",
+        "default": True,
+    },
+    EVENT_DOWNLOAD_FAILED: {
+        "label": "Download failed",
+        "description": "A download fails after every mirror has been tried. "
+                       "Cancelled downloads are never reported.",
+        "notify_type": "failure",
+        "default": True,
+    },
+    EVENT_WANTED_ADDED: {
+        "label": "Wanted issues added",
+        "description": "Missing issues from your wanted list are matched and "
+                       "moved into the library. Sent as one digest per sweep.",
+        "notify_type": "success",
+        "default": True,
+    },
+}
+
+# Preference keys (category "notifications" in user_preferences).
+PREF_ENABLED = "notify_enabled"
+PREF_URLS = "notify_urls"
+PREF_EVENTS = "notify_events"
+
+# A digest naming every issue in a large catch-up sweep is unreadable on a phone
+# lock screen, so the body enumerates this many and then summarises the rest.
+MAX_DIGEST_LINES = 20
+
+
+def parse_urls(raw):
+    """Normalise Apprise URLs from a textarea (or an already-parsed list).
+
+    Accepts one URL per line. Blank lines and ``#`` comments are dropped so a
+    user can annotate or temporarily disable a target without deleting it.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = raw.splitlines()
+    if not isinstance(raw, (list, tuple)):
+        return []
+
+    urls = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        entry = entry.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        urls.append(entry)
+    return urls
+
+
+def sanitize_events(raw):
+    """Coerce an events payload to ``{known_event_id: bool}``.
+
+    Unknown ids are dropped and missing ones fall back to their default, so a
+    stale client cannot store junk or silently turn off an event it never knew
+    about.
+    """
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        event_id: bool(raw.get(event_id, defn["default"]))
+        for event_id, defn in EVENT_DEFS.items()
+    }
+
+
+def get_settings():
+    """Read the owner-global notification settings.
+
+    Returns ``{'enabled': bool, 'urls': [str], 'events': {id: bool}}``. On any
+    read failure this returns a disabled config rather than raising - a database
+    hiccup must not propagate into a download worker.
+    """
+    try:
+        from core.database import get_user_preference
+
+        return {
+            "enabled": bool(get_user_preference(PREF_ENABLED, default=False)),
+            "urls": parse_urls(get_user_preference(PREF_URLS, default=[])),
+            "events": sanitize_events(get_user_preference(PREF_EVENTS, default={})),
+        }
+    except Exception as e:
+        app_logger.error(f"Failed to read notification settings: {e}")
+        return {"enabled": False, "urls": [], "events": sanitize_events({})}
+
+
+def is_event_enabled(event, settings=None):
+    """True when ``event`` should be delivered right now.
+
+    Requires the master switch on, at least one target URL, and the event
+    itself ticked.
+    """
+    settings = settings if settings is not None else get_settings()
+    if not settings.get("enabled") or not settings.get("urls"):
+        return False
+    return bool(settings.get("events", {}).get(event))
+
+
+def _send(urls, title, body, notify_type):
+    """Deliver one message to ``urls``. Returns ``(ok, error_message)``."""
+    try:
+        import apprise
+    except Exception as e:
+        # Not installed, or installed broken. Nothing else in CLU imports
+        # apprise, so this is contained to notifications being unavailable.
+        msg = f"Apprise is not available: {e}"
+        app_logger.error(msg)
+        return False, msg
+
+    try:
+        client = apprise.Apprise()
+        rejected = [url for url in urls if not client.add(url)]
+        if rejected:
+            # add() rejects a malformed or unknown-scheme URL. Report it, but
+            # still deliver to whatever else parsed.
+            app_logger.error(
+                f"Apprise rejected {len(rejected)} notification URL(s): "
+                f"{', '.join(_redact(u) for u in rejected)}"
+            )
+        if not len(client):
+            return False, "No valid Apprise URLs configured"
+
+        ok = client.notify(title=title, body=body, notify_type=notify_type)
+        if not ok:
+            # notify() returns False when a service refused the message; the
+            # detail is on apprise's own logger.
+            return False, "Apprise reported a delivery failure"
+        return True, None
+    except Exception as e:
+        app_logger.error(f"Failed to send notification: {e}")
+        return False, str(e)
+
+
+def _redact(url):
+    """Strip credentials from an Apprise URL so it is safe to log."""
+    try:
+        scheme, _, rest = url.partition("://")
+        if not rest:
+            return url
+        host = rest.split("/", 1)[0]
+        if "@" in host:
+            host = "***@" + host.rsplit("@", 1)[1]
+        return f"{scheme}://{host}/..."
+    except Exception:
+        return "<unparseable url>"
+
+
+def notify(event, title, body):
+    """Send ``event`` synchronously. Returns True only if it was delivered.
+
+    Returns False (without raising) when notifications are off, the event is
+    unticked, no URLs are set, or delivery failed.
+    """
+    try:
+        if event not in EVENT_DEFS:
+            app_logger.error(f"Unknown notification event: {event}")
+            return False
+
+        settings = get_settings()
+        if not is_event_enabled(event, settings):
+            return False
+
+        ok, error = _send(
+            settings["urls"], title, body, EVENT_DEFS[event]["notify_type"]
+        )
+        if ok:
+            app_logger.info(f"Notification sent ({event}): {title}")
+        else:
+            app_logger.error(f"Notification failed ({event}): {error}")
+        return ok
+    except Exception as e:
+        app_logger.error(f"Notification dispatch failed ({event}): {e}")
+        return False
+
+
+def notify_async(event, title, body):
+    """Fire :func:`notify` on a daemon thread and return immediately.
+
+    Use this from every hook site. The callers are a download worker and two
+    pollers that advance every tracked job in one loop, so a slow endpoint must
+    not be able to hold them up.
+    """
+    try:
+        # Cheap gate on the calling thread: skip spawning a thread at all when
+        # notifications are off, which is the common case.
+        if not is_event_enabled(event):
+            return
+        threading.Thread(
+            target=notify,
+            args=(event, title, body),
+            daemon=True,
+        ).start()
+    except Exception as e:
+        app_logger.error(f"Failed to dispatch notification ({event}): {e}")
+
+
+def notify_download_terminal(status, filename, error=None, source=None):
+    """Notify for a terminal download status from a client-backed poller.
+
+    Shared by the Usenet and DC++ pollers (models/usenet.py, models/dcpp.py),
+    which each settle jobs through their own ``_set_status``. Call it outside
+    their job locks.
+
+    ``complete_no_move`` is a partial success: the client finished but CLU could
+    not reach its storage path, so the file still needs moving by hand. Say so
+    rather than reporting a clean completion.
+
+    Swallows everything. The Usenet poll loop has no per-round guard, so a raise
+    here would kill the poller and strand every tracked job.
+    """
+    try:
+        lines = [filename or "Unknown file"]
+        if source:
+            lines.append(f"Source: {source}")
+
+        if status in ("complete", "complete_no_move"):
+            if status == "complete_no_move":
+                lines.append(
+                    "Finished at the client, but CLU could not access the "
+                    "file - it has not been imported."
+                )
+            notify_async(
+                EVENT_DOWNLOAD_COMPLETE, "Download complete", "\n".join(lines)
+            )
+        elif status == "failed":
+            if error:
+                lines.append(f"Error: {error}")
+            notify_async(
+                EVENT_DOWNLOAD_FAILED, "Download failed", "\n".join(lines)
+            )
+    except Exception as e:
+        app_logger.error(f"Failed to notify for {source or 'download'}: {e}")
+
+
+def send_test(urls):
+    """Send a test message to ``urls``, bypassing the enable/event gates.
+
+    Used by the /config "Send Test Notification" button so an owner can verify a
+    target before saving it. Returns ``(ok, error_message)``.
+    """
+    urls = parse_urls(urls)
+    if not urls:
+        return False, "No notification URLs provided"
+    return _send(
+        urls,
+        "Comic Library Utilities",
+        "Test notification - your CLU notifications are working.",
+        "info",
+    )
+
+
+def format_digest(header, lines):
+    """Build a digest body, truncating a long list to a readable length."""
+    lines = [str(line) for line in (lines or [])]
+    shown = lines[:MAX_DIGEST_LINES]
+    body = "\n".join(shown)
+    remaining = len(lines) - len(shown)
+    if remaining > 0:
+        body += f"\n...and {remaining} more"
+    return f"{header}\n\n{body}" if body else header

--- a/models/dcpp.py
+++ b/models/dcpp.py
@@ -794,6 +794,7 @@ def _set_status(download_id, status, error=None, percent=None):
         if percent is not None:
             job["percent"] = percent
         current_percent = job["percent"]
+        filename = job.get("filename")
 
     # Retention: the ledger holds unresolved work only. A clean completion is
     # resolved — the file is in WATCH and monitor.py owns it from here. A
@@ -805,6 +806,21 @@ def _set_status(download_id, status, error=None, percent=None):
         _persist_update(
             download_id, status=status, error=error, percent=current_percent
         )
+
+    # Outside the lock, as with the persistence calls above. _set_status is only
+    # ever called with a terminal status, so this fires exactly once per job.
+    _notify_terminal_status(status, filename, error, "DC++")
+
+
+def _notify_terminal_status(status, filename, error, source):
+    """Thin wrapper over the shared notifier (see core.notifications).
+
+    Imported lazily so this module keeps no import-time dependency on the
+    notification stack.
+    """
+    from core.notifications import notify_download_terminal
+
+    notify_download_terminal(status, filename, error=error, source=source)
 
 
 def dismiss_dcpp_job(download_id: str) -> bool:

--- a/models/usenet.py
+++ b/models/usenet.py
@@ -494,6 +494,23 @@ def _set_status(download_id, status, error=None, percent=None):
             job["error"] = error
             if percent is not None:
                 job["percent"] = percent
+        filename = job.get("filename") if job is not None else None
+
+    # Outside the lock: a notification must never be sent while holding it.
+    # _set_status is only ever called with a terminal status, so this fires
+    # exactly once per job.
+    _notify_terminal_status(status, filename, error, "Usenet")
+
+
+def _notify_terminal_status(status, filename, error, source):
+    """Thin wrapper over the shared notifier (see core.notifications).
+
+    Imported lazily so this module keeps no import-time dependency on the
+    notification stack.
+    """
+    from core.notifications import notify_download_terminal
+
+    notify_download_terminal(status, filename, error=error, source=source)
 
 
 def _import_completed(storage_path, filename, source="Usenet") -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ anthropic>=0.2.1
 gunicorn>=21.0.0
 cloudscraper>=1.2.71
 defusedxml>=0.7.1
+apprise>=1.9.0

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,0 +1,106 @@
+"""Notification settings endpoints (Apprise).
+
+Owner-only by path: ``core.auth`` puts every ``/api/config/`` route behind the
+owner role (see ``_OWNER_PREFIXES``), so these need no decorator of their own.
+
+Lives in a blueprint rather than app.py so ``tests/routes`` can import it
+directly — routes defined in app.py have to be hand-mirrored in the test
+fixture, which duplicates the logic under test.
+"""
+
+from flask import Blueprint, jsonify, request
+
+from core.app_logging import app_logger
+from core.notifications import (
+    EVENT_DEFS,
+    PREF_ENABLED,
+    PREF_EVENTS,
+    PREF_URLS,
+    parse_urls,
+    sanitize_events,
+    send_test,
+)
+
+notifications_bp = Blueprint('notifications', __name__)
+
+
+@notifications_bp.route('/api/config/notifications', methods=['POST'])
+def save_notification_config():
+    """Persist the owner-global notification settings."""
+    from core.database import set_user_preference
+
+    try:
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"success": False, "error": "No data provided"}), 400
+
+        enabled = bool(data.get("enabled"))
+        urls = parse_urls(data.get("urls"))
+        events = sanitize_events(data.get("events"))
+
+        # Turning it on with nowhere to send is a silent no-op the user would
+        # only discover by not receiving anything — reject it instead.
+        if enabled and not urls:
+            return jsonify({
+                "success": False,
+                "error": "Add at least one notification URL, or turn "
+                         "notifications off.",
+            }), 400
+
+        set_user_preference(PREF_ENABLED, enabled, category="notifications")
+        set_user_preference(PREF_URLS, urls, category="notifications")
+        set_user_preference(PREF_EVENTS, events, category="notifications")
+
+        return jsonify({
+            "success": True,
+            "message": "Notification settings saved",
+            "urlCount": len(urls),
+        })
+    except Exception as e:
+        app_logger.error(f"Error saving notification config: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@notifications_bp.route('/api/config/notifications/test', methods=['POST'])
+def test_notification_config():
+    """Send a test notification to the URLs in the request body.
+
+    Deliberately uses the posted URLs rather than the saved ones, so an owner
+    can verify a target before committing it.
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        urls = parse_urls(data.get("urls"))
+        if not urls:
+            return jsonify({
+                "success": False,
+                "error": "Add at least one notification URL first.",
+            }), 400
+
+        ok, error = send_test(urls)
+        if ok:
+            return jsonify({
+                "success": True,
+                "message": f"Test notification sent to {len(urls)} target(s)",
+            })
+        return jsonify({"success": False, "error": error}), 502
+    except Exception as e:
+        app_logger.error(f"Error sending test notification: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@notifications_bp.route('/api/config/notifications/events', methods=['GET'])
+def list_notification_events():
+    """The catalog of notifiable events, for the settings UI."""
+    return jsonify({
+        "success": True,
+        "events": [
+            {
+                "id": event_id,
+                "label": defn["label"],
+                "description": defn["description"],
+                "default": defn["default"],
+            }
+            for event_id, defn in EVENT_DEFS.items()
+        ],
+    })

--- a/templates/config.html
+++ b/templates/config.html
@@ -64,6 +64,11 @@
                     type="button" role="tab" aria-controls="database" aria-selected="false">Database</button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="notifications-tab" data-bs-toggle="tab" data-bs-target="#notifications"
+                    type="button" role="tab" aria-controls="notifications"
+                    aria-selected="false">Notifications</button>
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="personalization-tab" data-bs-toggle="tab" data-bs-target="#personalization"
                     type="button" role="tab" aria-controls="personalization"
                     aria-selected="false">Personalization (Site Defaults)</button>
@@ -1477,6 +1482,74 @@
             <!-- TAB 4: Styling -->
             <!-- ========================================== -->
             <!-- ========================================== -->
+            <!-- TAB: Notifications -->
+            <!-- ========================================== -->
+            <div class="tab-pane fade" id="notifications" role="tabpanel" aria-labelledby="notifications-tab">
+
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <h4><i class="bi bi-bell me-2"></i>Push Notifications</h4>
+                    <p class="text-muted">
+                        Send a push when downloads finish and when missing issues land in your
+                        library. Powered by
+                        <a href="https://github.com/caronc/apprise" target="_blank" rel="noopener">Apprise</a>,
+                        which supports Discord, Telegram, ntfy, Gotify, Slack, email and
+                        <a href="https://github.com/caronc/apprise/wiki" target="_blank" rel="noopener">100+ other services</a>.
+                    </p>
+
+                    <div class="form-check form-switch mb-3">
+                        <input class="form-check-input" type="checkbox" id="notifyEnabled"
+                            {% if notify_settings.enabled %}checked{% endif %}>
+                        <label class="form-check-label" for="notifyEnabled">Enable notifications</label>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="notifyUrls" class="form-label">Notification URLs</label>
+                        <textarea class="form-control font-monospace" id="notifyUrls" rows="5"
+                            spellcheck="false"
+                            placeholder="ntfy://ntfy.sh/my-comics-topic&#10;discord://webhook_id/webhook_token">{{ notify_urls_text }}</textarea>
+                        <div class="form-text">
+                            One per line. Blank lines and lines starting with <code>#</code> are ignored,
+                            so you can annotate or temporarily disable a target.
+                            See the <a href="https://github.com/caronc/apprise/wiki" target="_blank"
+                                rel="noopener">Apprise wiki</a> for each service's URL format.
+                        </div>
+                    </div>
+
+                    <div class="alert alert-warning">
+                        <i class="bi bi-shield-lock me-1"></i>
+                        These URLs contain credentials (bot tokens, passwords). They are stored in
+                        plain text and are only visible on this owner-only page.
+                    </div>
+
+                    <h5 class="mt-4">Notify me when&hellip;</h5>
+                    <div id="notifyEventList">
+                        {% for event_id, defn in notify_event_defs.items() %}
+                        <div class="form-check mb-2">
+                            <input class="form-check-input notify-event-check" type="checkbox"
+                                id="notifyEvent_{{ event_id }}" data-event-id="{{ event_id }}"
+                                {% if notify_settings.events.get(event_id, defn.default) %}checked{% endif %}>
+                            <label class="form-check-label" for="notifyEvent_{{ event_id }}">
+                                <strong>{{ defn.label }}</strong>
+                                <div class="text-muted small">{{ defn.description }}</div>
+                            </label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="mb-3 text-center">
+                    <button type="button" class="btn btn-outline-secondary me-2" id="testNotificationBtn"
+                        onclick="sendTestNotification()">
+                        <i class="bi bi-send"></i> Send Test Notification
+                    </button>
+                    <button type="button" class="btn btn-primary" id="saveNotificationsBtn"
+                        onclick="saveNotificationSettings()">
+                        <i class="bi bi-floppy"></i> Save Notification Settings
+                    </button>
+                </div>
+            </div>
+
+            <!-- ========================================== -->
             <!-- TAB: Personalization -->
             <!-- ========================================== -->
             <div class="tab-pane fade" id="personalization" role="tabpanel" aria-labelledby="personalization-tab">
@@ -2070,6 +2143,79 @@
     // /account can reuse it. Rendered immediately (not on DOMContentLoaded) to
     // match where this script runs in the page.
     CLU.initDashboardEditor('dashboardSectionsList');
+
+    // ---------------------------------------------------------------
+    // Notifications (Apprise)
+    // ---------------------------------------------------------------
+
+    // Read the form once; both Save and Test need the same shape.
+    function readNotificationForm() {
+        const events = {};
+        document.querySelectorAll('.notify-event-check').forEach(cb => {
+            events[cb.dataset.eventId] = cb.checked;
+        });
+        return {
+            enabled: document.getElementById('notifyEnabled').checked,
+            urls: document.getElementById('notifyUrls').value,
+            events: events
+        };
+    }
+
+    async function saveNotificationSettings() {
+        const btn = document.getElementById('saveNotificationsBtn');
+        const originalHtml = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Saving...';
+
+        try {
+            const response = await fetch('/api/config/notifications', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(readNotificationForm())
+            });
+            const result = await response.json();
+
+            if (result.success) {
+                showToast(result.message || 'Notification settings saved', 'success');
+            } else {
+                showToast('Error: ' + (result.error || 'Failed to save'), 'error');
+            }
+        } catch (e) {
+            showToast('Error saving settings: ' + e.message, 'error');
+        } finally {
+            btn.disabled = false;
+            btn.innerHTML = originalHtml;
+        }
+    }
+
+    // Tests the URLs currently in the textarea, not the saved ones, so a target
+    // can be verified before it is committed.
+    async function sendTestNotification() {
+        const btn = document.getElementById('testNotificationBtn');
+        const originalHtml = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Sending...';
+
+        try {
+            const response = await fetch('/api/config/notifications/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ urls: document.getElementById('notifyUrls').value })
+            });
+            const result = await response.json();
+
+            if (result.success) {
+                showToast(result.message || 'Test notification sent', 'success');
+            } else {
+                showToast('Test failed: ' + (result.error || 'Unknown error'), 'error');
+            }
+        } catch (e) {
+            showToast('Error sending test: ' + e.message, 'error');
+        } finally {
+            btn.disabled = false;
+            btn.innerHTML = originalHtml;
+        }
+    }
 
     async function saveDashboardSettings() {
         const btn = document.getElementById('saveDashboardBtn');

--- a/tests/mocked/test_download_notifications.py
+++ b/tests/mocked/test_download_notifications.py
@@ -1,0 +1,143 @@
+"""Notification hooks on the Usenet and DC++ terminal-status choke points.
+
+Downloads settle in three independent places; these cover the two client-backed
+pollers. The in-process HTTP path is covered by tests/unit/test_api_notify.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import models.dcpp as dc
+import models.usenet as un
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Isolate module job dicts and keep DC++ ledger writes off a real DB."""
+    un.usenet_downloads.clear()
+    dc.dcpp_downloads.clear()
+    monkeypatch.setattr(dc, "_persist_new", MagicMock())
+    monkeypatch.setattr(dc, "_persist_update", MagicMock())
+    monkeypatch.setattr(dc, "_persist_delete", MagicMock(return_value=True))
+    yield
+    un.usenet_downloads.clear()
+    dc.dcpp_downloads.clear()
+
+
+@pytest.fixture
+def notify():
+    """Patch notify_async where the hooks import it: core.notifications."""
+    with patch("core.notifications.notify_async") as mock:
+        yield mock
+
+
+def _events(mock):
+    """(event_id, title) for each dispatched notification."""
+    return [(call.args[0], call.args[1]) for call in mock.call_args_list]
+
+
+class TestUsenetNotifications:
+
+    def test_complete_notifies_once(self, notify):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE
+
+        un.usenet_downloads["d1"] = {"filename": "Batman 001.cbz", "status": "downloading"}
+        un._set_status("d1", "complete", percent=100)
+
+        assert _events(notify) == [(EVENT_DOWNLOAD_COMPLETE, "Download complete")]
+        assert "Batman 001.cbz" in notify.call_args.args[2]
+        assert "Usenet" in notify.call_args.args[2]
+
+    def test_failed_notifies_with_the_error(self, notify):
+        from core.notifications import EVENT_DOWNLOAD_FAILED
+
+        un.usenet_downloads["d1"] = {"filename": "Batman 001.cbz", "status": "downloading"}
+        un._set_status("d1", "failed", error="Download failed at client")
+
+        assert _events(notify) == [(EVENT_DOWNLOAD_FAILED, "Download failed")]
+        assert "Download failed at client" in notify.call_args.args[2]
+
+    def test_complete_no_move_says_it_was_not_imported(self, notify):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE
+
+        un.usenet_downloads["d1"] = {"filename": "Batman 001.cbz", "status": "downloading"}
+        un._set_status("d1", "complete_no_move", percent=100)
+
+        assert _events(notify) == [(EVENT_DOWNLOAD_COMPLETE, "Download complete")]
+        assert "not been imported" in notify.call_args.args[2]
+
+    def test_untracked_job_still_notifies_without_a_filename(self, notify):
+        """A dropped job must not crash the poller mid-loop."""
+        un._set_status("gone", "complete", percent=100)
+
+        assert len(notify.call_args_list) == 1
+        assert "Unknown file" in notify.call_args.args[2]
+
+    def test_notification_failure_never_reaches_the_poller(self):
+        """_poll_loop has no per-round guard: a raise here kills the thread."""
+        with patch(
+            "core.notifications.notify_async", side_effect=RuntimeError("boom")
+        ):
+            un.usenet_downloads["d1"] = {"filename": "x.cbz", "status": "downloading"}
+            un._set_status("d1", "complete", percent=100)  # must not raise
+
+        assert un.usenet_downloads["d1"]["status"] == "complete"
+
+
+class TestDcppNotifications:
+
+    def test_complete_notifies_once(self, notify):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE
+
+        dc.dcpp_downloads["d1"] = {
+            "filename": "Batman 001.cbz", "status": "downloading", "percent": 50,
+        }
+        dc._set_status("d1", "complete", percent=100)
+
+        assert _events(notify) == [(EVENT_DOWNLOAD_COMPLETE, "Download complete")]
+        assert "Batman 001.cbz" in notify.call_args.args[2]
+        assert "DC++" in notify.call_args.args[2]
+
+    def test_failed_notifies_with_the_error(self, notify):
+        from core.notifications import EVENT_DOWNLOAD_FAILED
+
+        dc.dcpp_downloads["d1"] = {
+            "filename": "Batman 001.cbz", "status": "downloading", "percent": 50,
+        }
+        dc._set_status("d1", "failed", error="Download failed at client")
+
+        assert _events(notify) == [(EVENT_DOWNLOAD_FAILED, "Download failed")]
+        assert "Download failed at client" in notify.call_args.args[2]
+
+    def test_complete_no_move_says_it_was_not_imported(self, notify):
+        dc.dcpp_downloads["d1"] = {
+            "filename": "Batman 001.cbz", "status": "downloading", "percent": 50,
+        }
+        dc._set_status("d1", "complete_no_move", percent=100)
+
+        assert "not been imported" in notify.call_args.args[2]
+
+    def test_untracked_job_does_not_notify(self, notify):
+        """DC++ returns early for an unknown id, before the hook."""
+        dc._set_status("gone", "complete", percent=100)
+        notify.assert_not_called()
+
+    def test_notification_failure_never_reaches_the_poller(self):
+        with patch(
+            "core.notifications.notify_async", side_effect=RuntimeError("boom")
+        ):
+            dc.dcpp_downloads["d1"] = {
+                "filename": "x.cbz", "status": "downloading", "percent": 50,
+            }
+            dc._set_status("d1", "complete", percent=100)  # must not raise
+
+        assert dc.dcpp_downloads["d1"]["status"] == "complete"
+
+    def test_ledger_delete_still_runs_on_completion(self, notify):
+        dc.dcpp_downloads["d1"] = {
+            "filename": "Batman 001.cbz", "status": "downloading", "percent": 50,
+        }
+        dc._set_status("d1", "complete", percent=100)
+
+        dc._persist_delete.assert_called_once_with("d1")

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -177,6 +177,7 @@ def app(db_connection, tmp_path):
     from routes.api_v1_docs import api_docs_bp
     from routes.admin import admin_bp
     from routes.reading import reading_bp
+    from routes.notifications import notifications_bp
 
     test_app.register_blueprint(auth_bp)
     test_app.register_blueprint(favorites_bp)
@@ -194,6 +195,7 @@ def app(db_connection, tmp_path):
     test_app.register_blueprint(api_docs_bp)
     test_app.register_blueprint(admin_bp)
     test_app.register_blueprint(reading_bp)
+    test_app.register_blueprint(notifications_bp)
 
     # Stub routes that app.py defines but aren't in any blueprint.
     # Templates reference these via url_for().

--- a/tests/routes/test_notification_config.py
+++ b/tests/routes/test_notification_config.py
@@ -1,0 +1,164 @@
+"""Tests for routes/notifications.py (notification settings endpoints)."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestSaveNotificationConfig:
+    def test_persists_all_three_preferences(self, client):
+        from core.notifications import (
+            EVENT_DOWNLOAD_COMPLETE, EVENT_DOWNLOAD_FAILED, EVENT_WANTED_ADDED,
+            PREF_ENABLED, PREF_EVENTS, PREF_URLS,
+        )
+
+        with patch("core.database.set_user_preference") as save:
+            response = client.post("/api/config/notifications", json={
+                "enabled": True,
+                "urls": "ntfy://ntfy.sh/a\n\n# a note\nntfy://ntfy.sh/b",
+                "events": {
+                    EVENT_DOWNLOAD_COMPLETE: True,
+                    EVENT_DOWNLOAD_FAILED: False,
+                    EVENT_WANTED_ADDED: True,
+                },
+            })
+
+        assert response.status_code == 200
+        assert response.get_json()["success"] is True
+
+        stored = {call.args[0]: call.args[1] for call in save.call_args_list}
+        assert stored[PREF_ENABLED] is True
+        assert stored[PREF_URLS] == ["ntfy://ntfy.sh/a", "ntfy://ntfy.sh/b"]
+        assert stored[PREF_EVENTS][EVENT_DOWNLOAD_FAILED] is False
+        assert stored[PREF_EVENTS][EVENT_DOWNLOAD_COMPLETE] is True
+
+    def test_drops_unknown_event_ids(self, client):
+        from core.notifications import EVENT_DEFS, PREF_EVENTS
+
+        with patch("core.database.set_user_preference") as save:
+            client.post("/api/config/notifications", json={
+                "enabled": True,
+                "urls": "ntfy://ntfy.sh/a",
+                "events": {"bogus_event": True},
+            })
+
+        stored = {call.args[0]: call.args[1] for call in save.call_args_list}
+        assert set(stored[PREF_EVENTS]) == set(EVENT_DEFS)
+
+    def test_can_be_saved_disabled_with_no_urls(self, client):
+        from core.notifications import PREF_ENABLED, PREF_URLS
+
+        with patch("core.database.set_user_preference") as save:
+            response = client.post("/api/config/notifications", json={
+                "enabled": False,
+                "urls": "",
+                "events": {},
+            })
+
+        assert response.status_code == 200
+        stored = {call.args[0]: call.args[1] for call in save.call_args_list}
+        assert stored[PREF_ENABLED] is False
+        assert stored[PREF_URLS] == []
+
+    def test_rejects_enabled_with_no_urls(self, client):
+        """Enabling with nowhere to send is a silent no-op — reject it loudly."""
+        with patch("core.database.set_user_preference") as save:
+            response = client.post("/api/config/notifications", json={
+                "enabled": True,
+                "urls": "  \n# nothing\n",
+                "events": {},
+            })
+
+        assert response.status_code == 400
+        body = response.get_json()
+        assert body["success"] is False
+        assert "at least one notification URL" in body["error"]
+        save.assert_not_called()
+
+    def test_rejects_a_missing_body(self, client):
+        response = client.post(
+            "/api/config/notifications",
+            data="not json",
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert response.get_json()["success"] is False
+
+    def test_database_failure_returns_500(self, client):
+        with patch(
+            "core.database.set_user_preference", side_effect=RuntimeError("no db")
+        ):
+            response = client.post("/api/config/notifications", json={
+                "enabled": True,
+                "urls": "ntfy://ntfy.sh/a",
+                "events": {},
+            })
+
+        assert response.status_code == 500
+        assert response.get_json()["success"] is False
+
+
+class TestTestNotification:
+    def test_sends_to_the_posted_urls(self, client):
+        with patch(
+            "routes.notifications.send_test", return_value=(True, None)
+        ) as send:
+            response = client.post(
+                "/api/config/notifications/test",
+                json={"urls": "ntfy://ntfy.sh/a\nntfy://ntfy.sh/b"},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()["success"] is True
+        send.assert_called_once_with(["ntfy://ntfy.sh/a", "ntfy://ntfy.sh/b"])
+
+    def test_surfaces_the_delivery_error(self, client):
+        with patch(
+            "routes.notifications.send_test",
+            return_value=(False, "Apprise reported a delivery failure"),
+        ):
+            response = client.post(
+                "/api/config/notifications/test",
+                json={"urls": "ntfy://ntfy.sh/a"},
+            )
+
+        assert response.status_code == 502
+        body = response.get_json()
+        assert body["success"] is False
+        assert "delivery failure" in body["error"]
+
+    def test_requires_at_least_one_url(self, client):
+        with patch("routes.notifications.send_test") as send:
+            response = client.post(
+                "/api/config/notifications/test", json={"urls": ""}
+            )
+
+        assert response.status_code == 400
+        send.assert_not_called()
+
+    def test_unexpected_error_returns_500(self, client):
+        with patch(
+            "routes.notifications.send_test", side_effect=RuntimeError("boom")
+        ):
+            response = client.post(
+                "/api/config/notifications/test",
+                json={"urls": "ntfy://ntfy.sh/a"},
+            )
+
+        assert response.status_code == 500
+        assert response.get_json()["success"] is False
+
+
+class TestListNotificationEvents:
+    def test_returns_the_full_catalog(self, client):
+        from core.notifications import EVENT_DEFS
+
+        response = client.get("/api/config/notifications/events")
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["success"] is True
+        assert {e["id"] for e in body["events"]} == set(EVENT_DEFS)
+        for entry in body["events"]:
+            assert entry["label"]
+            assert entry["description"]

--- a/tests/unit/test_download_notify_hooks.py
+++ b/tests/unit/test_download_notify_hooks.py
@@ -1,0 +1,119 @@
+"""Notification hooks on the in-process download path (api.py).
+
+api.py cannot be imported in tests — it starts worker threads and builds a
+cloudscraper session at import time — so this covers the two halves that can be
+reached without it:
+
+* ``download_notification_body`` lives in core.download_utils for exactly that
+  reason, and is tested directly.
+* The ordering guarantee that a *cancelled* download never notifies is a
+  property of where the call sits in ``process_download``, so it is asserted
+  against the parsed AST rather than by running the function.
+"""
+
+import ast
+import os
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+API_PATH = os.path.join(PROJECT_ROOT, "api.py")
+
+
+class TestDownloadNotificationBody:
+    def test_uses_the_destination_filename(self):
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body("Batman 001.cbz")
+        assert body.startswith("Batman 001.cbz")
+
+    def test_includes_the_provider(self):
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body("Batman 001.cbz", provider="Pixeldrain")
+        assert "Source: Pixeldrain" in body
+
+    def test_includes_the_error(self):
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body("Batman 001.cbz", error="404 Not Found")
+        assert "Error: 404 Not Found" in body
+
+    def test_falls_back_to_the_resolved_path(self):
+        """Browser-extension grabs carry no dest_filename."""
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body(
+            None, file_path=os.path.join("downloads", "temp", "Batman 001.cbz")
+        )
+        assert body.startswith("Batman 001.cbz")
+
+    def test_falls_back_to_unknown_file(self):
+        from core.download_utils import download_notification_body
+
+        assert download_notification_body(None) == "Unknown file"
+
+    def test_one_field_per_line(self):
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body("a.cbz", provider="MEGA", error="boom")
+        assert body.splitlines() == ["a.cbz", "Source: MEGA", "Error: boom"]
+
+
+def _process_download_body():
+    """Top-level statements of api.process_download, without importing api."""
+    with open(API_PATH, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "process_download":
+            return node.body
+    pytest.fail("process_download not found in api.py")
+
+
+def _calls(node):
+    """Every called function name reachable under ``node``."""
+    names = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+            names.append(child.func.id)
+    return names
+
+
+class TestFailureNotifyIsBehindTheCancelGuard:
+    """A download the user cancelled must never report itself as failed.
+
+    Aborting a transfer is how a cancel surfaces from most providers, so the
+    failure path is reached for cancels too. ``set_error_status`` already
+    downgrades those to 'cancelled'; the notification has to sit *after* the
+    early return that follows it, or every cancel produces a "Download failed"
+    push.
+    """
+
+    def test_guard_precedes_the_notification(self):
+        body = _process_download_body()
+
+        guard_idx = notify_idx = None
+        for idx, stmt in enumerate(body):
+            if (
+                isinstance(stmt, ast.If)
+                and "is_cancel_requested" in _calls(stmt.test)
+                and any(isinstance(s, ast.Return) for s in stmt.body)
+            ):
+                guard_idx = idx
+            if guard_idx is not None and "notify_async" in _calls(stmt):
+                notify_idx = idx
+                break
+
+        assert guard_idx is not None, "cancel guard not found in process_download"
+        assert notify_idx is not None, "failure notification not found after the guard"
+        assert guard_idx < notify_idx
+
+    def test_the_failure_notification_is_the_failed_event(self):
+        body = _process_download_body()
+
+        for stmt in reversed(body):
+            if "notify_async" in _calls(stmt):
+                names = [n.id for n in ast.walk(stmt) if isinstance(n, ast.Name)]
+                assert "EVENT_DOWNLOAD_FAILED" in names
+                return
+        pytest.fail("no notify_async call at the top level of process_download")

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,0 +1,400 @@
+"""Tests for core/notifications.py (Apprise dispatch)."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def fake_apprise(monkeypatch):
+    """Install a stand-in ``apprise`` module and hand back its Apprise mock.
+
+    Mirrors how tests/conftest.py fakes apscheduler/cloudscraper/mokkari: the
+    real package must not be required for the suite to run.
+    """
+    client = MagicMock()
+    client.add.return_value = True
+    client.notify.return_value = True
+    client.__len__.return_value = 1
+
+    module = types.ModuleType("apprise")
+    module.Apprise = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "apprise", module)
+    return client
+
+
+def _settings(enabled=True, urls=None, events=None):
+    from core.notifications import EVENT_DEFS
+
+    return {
+        "enabled": enabled,
+        "urls": urls if urls is not None else ["ntfy://ntfy.sh/test"],
+        "events": events if events is not None else {k: True for k in EVENT_DEFS},
+    }
+
+
+class TestParseUrls:
+    def test_splits_lines_and_strips_whitespace(self):
+        from core.notifications import parse_urls
+
+        assert parse_urls("  a://one  \n b://two ") == ["a://one", "b://two"]
+
+    def test_drops_blank_lines_and_comments(self):
+        from core.notifications import parse_urls
+
+        raw = "a://one\n\n# disabled for now\nb://two\n   \n"
+        assert parse_urls(raw) == ["a://one", "b://two"]
+
+    def test_accepts_a_list(self):
+        from core.notifications import parse_urls
+
+        assert parse_urls(["a://one", "", "b://two"]) == ["a://one", "b://two"]
+
+    def test_tolerates_none_and_junk(self):
+        from core.notifications import parse_urls
+
+        assert parse_urls(None) == []
+        assert parse_urls(12345) == []
+        assert parse_urls([None, 7, "a://one"]) == ["a://one"]
+
+
+class TestSanitizeEvents:
+    def test_drops_unknown_ids(self):
+        from core.notifications import EVENT_DEFS, sanitize_events
+
+        result = sanitize_events({"bogus_event": True})
+        assert "bogus_event" not in result
+        assert set(result) == set(EVENT_DEFS)
+
+    def test_missing_ids_fall_back_to_default(self):
+        from core.notifications import EVENT_DEFS, sanitize_events
+
+        result = sanitize_events({})
+        for event_id, defn in EVENT_DEFS.items():
+            assert result[event_id] is defn["default"]
+
+    def test_explicit_false_is_kept(self):
+        from core.notifications import EVENT_DOWNLOAD_FAILED, sanitize_events
+
+        result = sanitize_events({EVENT_DOWNLOAD_FAILED: False})
+        assert result[EVENT_DOWNLOAD_FAILED] is False
+
+    def test_non_dict_input_is_all_defaults(self):
+        from core.notifications import sanitize_events
+
+        assert sanitize_events("nonsense") == sanitize_events({})
+
+
+class TestIsEventEnabled:
+    def test_requires_master_switch(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, is_event_enabled
+
+        assert not is_event_enabled(
+            EVENT_DOWNLOAD_COMPLETE, _settings(enabled=False)
+        )
+
+    def test_requires_at_least_one_url(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, is_event_enabled
+
+        assert not is_event_enabled(EVENT_DOWNLOAD_COMPLETE, _settings(urls=[]))
+
+    def test_requires_the_event_to_be_ticked(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, is_event_enabled
+
+        settings = _settings(events={EVENT_DOWNLOAD_COMPLETE: False})
+        assert not is_event_enabled(EVENT_DOWNLOAD_COMPLETE, settings)
+
+    def test_all_three_satisfied(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, is_event_enabled
+
+        assert is_event_enabled(EVENT_DOWNLOAD_COMPLETE, _settings())
+
+
+class TestNotify:
+    def test_sends_when_enabled(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        with patch("core.notifications.get_settings", return_value=_settings()):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is True
+
+        fake_apprise.add.assert_called_once_with("ntfy://ntfy.sh/test")
+        fake_apprise.notify.assert_called_once_with(
+            title="Title", body="Body", notify_type="success"
+        )
+
+    def test_failure_event_uses_failure_notify_type(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_FAILED, notify
+
+        with patch("core.notifications.get_settings", return_value=_settings()):
+            notify(EVENT_DOWNLOAD_FAILED, "Title", "Body")
+
+        assert fake_apprise.notify.call_args.kwargs["notify_type"] == "failure"
+
+    def test_disabled_does_not_send(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        with patch(
+            "core.notifications.get_settings", return_value=_settings(enabled=False)
+        ):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+
+        fake_apprise.notify.assert_not_called()
+
+    def test_no_urls_does_not_send(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        with patch(
+            "core.notifications.get_settings", return_value=_settings(urls=[])
+        ):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+
+        fake_apprise.notify.assert_not_called()
+
+    def test_unticked_event_does_not_send(self, fake_apprise):
+        from core.notifications import (
+            EVENT_DOWNLOAD_COMPLETE, EVENT_DOWNLOAD_FAILED, notify,
+        )
+
+        settings = _settings(
+            events={EVENT_DOWNLOAD_COMPLETE: False, EVENT_DOWNLOAD_FAILED: True}
+        )
+        with patch("core.notifications.get_settings", return_value=settings):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+
+        fake_apprise.notify.assert_not_called()
+
+    def test_unknown_event_is_rejected(self, fake_apprise):
+        from core.notifications import notify
+
+        assert notify("not_a_real_event", "Title", "Body") is False
+        fake_apprise.notify.assert_not_called()
+
+    def test_apprise_exception_is_swallowed(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        fake_apprise.notify.side_effect = RuntimeError("boom")
+        with patch("core.notifications.get_settings", return_value=_settings()):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+
+    def test_delivery_refusal_returns_false(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        fake_apprise.notify.return_value = False
+        with patch("core.notifications.get_settings", return_value=_settings()):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+
+    def test_missing_apprise_package_is_swallowed(self, monkeypatch):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        # Simulate the package not being installed at all.
+        monkeypatch.setitem(sys.modules, "apprise", None)
+        with patch("core.notifications.get_settings", return_value=_settings()):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+
+    def test_rejected_url_still_delivers_to_the_rest(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        fake_apprise.add.side_effect = [False, True]
+        settings = _settings(urls=["bogus://x", "ntfy://ntfy.sh/test"])
+        with patch("core.notifications.get_settings", return_value=settings):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is True
+
+    def test_all_urls_rejected_reports_failure(self, fake_apprise):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify
+
+        fake_apprise.add.return_value = False
+        fake_apprise.__len__.return_value = 0
+        with patch("core.notifications.get_settings", return_value=_settings()):
+            assert notify(EVENT_DOWNLOAD_COMPLETE, "Title", "Body") is False
+        fake_apprise.notify.assert_not_called()
+
+
+class TestNotifyAsync:
+    def test_skips_thread_when_disabled(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify_async
+
+        with patch(
+            "core.notifications.get_settings", return_value=_settings(enabled=False)
+        ), patch("core.notifications.threading.Thread") as thread:
+            notify_async(EVENT_DOWNLOAD_COMPLETE, "Title", "Body")
+
+        thread.assert_not_called()
+
+    def test_spawns_daemon_thread_when_enabled(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify, notify_async
+
+        with patch("core.notifications.get_settings", return_value=_settings()), \
+                patch("core.notifications.threading.Thread") as thread:
+            notify_async(EVENT_DOWNLOAD_COMPLETE, "Title", "Body")
+
+        thread.assert_called_once()
+        assert thread.call_args.kwargs["daemon"] is True
+        assert thread.call_args.kwargs["target"] is notify
+        assert thread.call_args.kwargs["args"] == (
+            EVENT_DOWNLOAD_COMPLETE, "Title", "Body",
+        )
+        thread.return_value.start.assert_called_once()
+
+    def test_never_raises(self):
+        from core.notifications import EVENT_DOWNLOAD_COMPLETE, notify_async
+
+        with patch(
+            "core.notifications.get_settings", side_effect=RuntimeError("boom")
+        ):
+            notify_async(EVENT_DOWNLOAD_COMPLETE, "Title", "Body")  # must not raise
+
+
+class TestSendTest:
+    def test_bypasses_the_enable_and_event_gates(self, fake_apprise):
+        from core.notifications import send_test
+
+        with patch(
+            "core.notifications.get_settings", return_value=_settings(enabled=False)
+        ):
+            ok, error = send_test("ntfy://ntfy.sh/test")
+
+        assert ok is True
+        assert error is None
+        fake_apprise.notify.assert_called_once()
+
+    def test_requires_at_least_one_url(self, fake_apprise):
+        from core.notifications import send_test
+
+        ok, error = send_test("   \n# nothing here\n")
+        assert ok is False
+        assert "No notification URLs" in error
+        fake_apprise.notify.assert_not_called()
+
+    def test_reports_the_error_string(self, fake_apprise):
+        from core.notifications import send_test
+
+        fake_apprise.notify.side_effect = RuntimeError("smtp refused")
+        ok, error = send_test("mailto://user:pass@example.com")
+        assert ok is False
+        assert "smtp refused" in error
+
+
+class TestGetSettings:
+    def test_database_failure_yields_a_disabled_config(self):
+        from core.notifications import get_settings
+
+        with patch(
+            "core.database.get_user_preference", side_effect=RuntimeError("no db")
+        ):
+            settings = get_settings()
+
+        assert settings["enabled"] is False
+        assert settings["urls"] == []
+
+    def test_reads_all_three_preferences(self):
+        from core.notifications import (
+            EVENT_DOWNLOAD_COMPLETE, PREF_ENABLED, PREF_EVENTS, PREF_URLS,
+            get_settings,
+        )
+
+        stored = {
+            PREF_ENABLED: True,
+            PREF_URLS: ["ntfy://ntfy.sh/a", "ntfy://ntfy.sh/b"],
+            PREF_EVENTS: {EVENT_DOWNLOAD_COMPLETE: False},
+        }
+        with patch(
+            "core.database.get_user_preference",
+            side_effect=lambda key, default=None: stored.get(key, default),
+        ):
+            settings = get_settings()
+
+        assert settings["enabled"] is True
+        assert settings["urls"] == ["ntfy://ntfy.sh/a", "ntfy://ntfy.sh/b"]
+        assert settings["events"][EVENT_DOWNLOAD_COMPLETE] is False
+
+
+class TestNotifyDownloadTerminal:
+    """The helper both client-backed pollers share."""
+
+    def test_complete_uses_the_complete_event(self):
+        from core.notifications import (
+            EVENT_DOWNLOAD_COMPLETE, notify_download_terminal,
+        )
+
+        with patch("core.notifications.notify_async") as notify:
+            notify_download_terminal("complete", "a.cbz", source="Usenet")
+
+        assert notify.call_args.args[0] == EVENT_DOWNLOAD_COMPLETE
+        assert "Source: Usenet" in notify.call_args.args[2]
+
+    def test_failed_uses_the_failed_event_and_carries_the_error(self):
+        from core.notifications import EVENT_DOWNLOAD_FAILED, notify_download_terminal
+
+        with patch("core.notifications.notify_async") as notify:
+            notify_download_terminal("failed", "a.cbz", error="429", source="DC++")
+
+        assert notify.call_args.args[0] == EVENT_DOWNLOAD_FAILED
+        assert "Error: 429" in notify.call_args.args[2]
+
+    def test_complete_no_move_flags_the_manual_step(self):
+        from core.notifications import notify_download_terminal
+
+        with patch("core.notifications.notify_async") as notify:
+            notify_download_terminal("complete_no_move", "a.cbz", source="DC++")
+
+        assert "not been imported" in notify.call_args.args[2]
+
+    def test_a_non_terminal_status_sends_nothing(self):
+        from core.notifications import notify_download_terminal
+
+        with patch("core.notifications.notify_async") as notify:
+            notify_download_terminal("downloading", "a.cbz", source="Usenet")
+
+        notify.assert_not_called()
+
+    def test_never_raises_into_the_poller(self):
+        from core.notifications import notify_download_terminal
+
+        with patch(
+            "core.notifications.notify_async", side_effect=RuntimeError("boom")
+        ):
+            notify_download_terminal("complete", "a.cbz", source="Usenet")
+
+
+class TestFormatDigest:
+    def test_lists_every_issue_when_short(self):
+        from core.notifications import format_digest
+
+        body = format_digest("Added:", ["Batman #1", "Batman #2"])
+        assert "Batman #1" in body
+        assert "Batman #2" in body
+        assert "more" not in body
+
+    def test_truncates_a_long_list(self):
+        from core.notifications import MAX_DIGEST_LINES, format_digest
+
+        items = [f"Batman #{n}" for n in range(MAX_DIGEST_LINES + 5)]
+        body = format_digest("Added:", items)
+
+        assert f"Batman #{MAX_DIGEST_LINES - 1}" in body
+        assert f"Batman #{MAX_DIGEST_LINES}" not in body
+        assert "...and 5 more" in body
+
+    def test_empty_list_is_just_the_header(self):
+        from core.notifications import format_digest
+
+        assert format_digest("Added:", []) == "Added:"
+
+
+class TestRedact:
+    def test_strips_credentials(self):
+        from core.notifications import _redact
+
+        assert "hunter2" not in _redact("mailto://bob:hunter2@smtp.example.com")
+
+    def test_keeps_the_scheme_for_diagnosis(self):
+        from core.notifications import _redact
+
+        assert _redact("discord://id/token").startswith("discord://")
+
+    def test_tolerates_garbage(self):
+        from core.notifications import _redact
+
+        assert _redact("not a url") == "not a url"

--- a/tests/unit/test_wanted_digest_hook.py
+++ b/tests/unit/test_wanted_digest_hook.py
@@ -1,0 +1,103 @@
+"""The wanted-issue digest hook in app.process_incoming_wanted_issues.
+
+A TARGET sweep can import dozens of issues in one run, so the notification is a
+single digest per sweep rather than one push per issue. That is a property of
+*where* the call sits — inside the ``if moved_count > 0`` branch and outside the
+per-match loop — so it is asserted against the parsed AST. app.py cannot be
+imported in tests (it starts the scheduler and spawns monitor.py at import).
+
+``format_digest`` itself, including its truncation, is covered in
+tests/unit/test_notifications.py.
+"""
+
+import ast
+import os
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+APP_PATH = os.path.join(PROJECT_ROOT, "app.py")
+
+FUNC = "process_incoming_wanted_issues"
+
+
+@pytest.fixture(scope="module")
+def func_node():
+    with open(APP_PATH, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC:
+            return node
+    pytest.fail(f"{FUNC} not found in app.py")
+
+
+def _notify_calls(node):
+    return [
+        child for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == "notify_async"
+    ]
+
+
+def _moved_count_guard(func_node):
+    """The ``if moved_count > 0:`` statement."""
+    for stmt in ast.walk(func_node):
+        if not isinstance(stmt, ast.If):
+            continue
+        test = stmt.test
+        if (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and test.left.id == "moved_count"
+            and isinstance(test.ops[0], ast.Gt)
+        ):
+            return stmt
+    pytest.fail("`if moved_count > 0:` not found")
+
+
+class TestWantedDigestHook:
+    def test_exactly_one_notification_in_the_function(self, func_node):
+        assert len(_notify_calls(func_node)) == 1
+
+    def test_it_is_the_wanted_added_event(self, func_node):
+        call = _notify_calls(func_node)[0]
+        names = [n.id for n in ast.walk(call) if isinstance(n, ast.Name)]
+        assert "EVENT_WANTED_ADDED" in names
+
+    def test_it_is_inside_the_moved_count_guard(self, func_node):
+        """No files moved means no push at all."""
+        guard = _moved_count_guard(func_node)
+        in_guard = sum(len(_notify_calls(stmt)) for stmt in guard.body)
+        assert in_guard == 1
+        # ...and not in the else branch, which is the "nothing matched" case.
+        assert sum(len(_notify_calls(stmt)) for stmt in guard.orelse) == 0
+
+    def test_it_is_not_inside_the_per_match_loop(self, func_node):
+        """One digest per sweep, not one push per issue."""
+        for stmt in ast.walk(func_node):
+            if isinstance(stmt, (ast.For, ast.AsyncFor)):
+                assert not _notify_calls(stmt), (
+                    "notify_async is inside a loop — that sends one push per "
+                    "issue instead of a single digest"
+                )
+
+    def test_it_uses_format_digest(self, func_node):
+        call = _notify_calls(func_node)[0]
+        called = [
+            c.func.id for c in ast.walk(call)
+            if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+        ]
+        assert "format_digest" in called
+
+    def test_moved_issues_is_collected_alongside_moved_count(self, func_node):
+        """The digest body needs the issue names, not just the count."""
+        appended = [
+            c for c in ast.walk(func_node)
+            if isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "append"
+            and isinstance(c.func.value, ast.Name)
+            and c.func.value.id == "moved_issues"
+        ]
+        assert appended, "moved_issues is never appended to"


### PR DESCRIPTION
Closes #505

## What

CLU has no outbound notification path today — the only feedback channel is the in-app toast list, which is process-local and expires after 300s. If you aren't looking at the browser, nothing tells you anything happened.

This adds [Apprise](https://github.com/caronc/apprise): one dependency, one URL scheme, 100+ services (`discord://`, `tgram://`, `ntfy://`, `mailto://`, …). An owner pastes one or more URLs into a new **Notifications** tab in `/config`, ticks the events they care about, and gets a push when:

- a download completes
- a download fails
- wanted issues land in the library

## Where the hooks are

Downloads settle in **three independent places** — there is no single choke point — so there are three hooks:

| Path | Terminal status set at |
|------|------------------------|
| In-process HTTP (GetComics/Pixeldrain/MEGA/ComicBookPlus) | `api.py` `process_download` |
| Usenet (SABnzbd/NZBGet) | `models/usenet.py` `_set_status` |
| DC++ / AirDC++ | `models/dcpp.py` `_set_status` |

Both pollers delegate to the shared `core.notifications.notify_download_terminal()` and call it **outside** their `_jobs_lock`. Their wrappers are deliberately defensive: `models/usenet.py:_poll_loop` has no per-round `try/except`, so a raise there would kill the poller thread and silently strand every tracked job.

The fourth hook is `process_incoming_wanted_issues` in `app.py`, which is the one function that imports matched wanted issues into series folders — so it covers every route by which a missing issue becomes owned.

## Two behaviours worth reviewing closely

- **Cancellations never notify.** Aborting a transfer is how a cancel surfaces from most providers, so the failure path runs for cancels too. `set_error_status` downgrades those to `cancelled`, and the notification sits *after* the early return that follows it. Hooking inside `set_error_status` would be wrong twice over — `download_getcomics` calls it a second time before re-raising, so one failure would notify twice.
- **Wanted issues send one digest per sweep.** The hook is inside the `if moved_count > 0` branch and outside the per-match loop. A catch-up sweep can import dozens of issues; one push each is unusable. `format_digest` caps the enumeration at 20 lines with an "and N more" tail.

## Design of `core/notifications.py`

All the logic lives here; nothing else imports apprise. Four rules:

1. `import apprise` is **lazy** — tests and app boot don't depend on it being installed, and a broken install degrades to a logged error rather than a failed boot.
2. Every public path swallows into `app_logger`. A notification must never break the download it reports on.
3. Callers use `notify_async` (daemon thread) — a hung Discord webhook must not block a download worker or a poller loop.
4. Settings are read fresh per call, so config changes take effect without a restart.

`EVENT_DEFS` is the single source of truth: it drives both payload validation and the config UI checkboxes, so the two can't drift.

## Storage and access

Owner-global in `user_preferences` (`notify_enabled`, `notify_urls`, `notify_events`) via the existing `get_user_preference`/`set_user_preference` helpers — **no schema change**.

`routes/notifications.py` is a blueprint rather than more routes in `app.py`, because `tests/routes/conftest.py` builds its app from blueprints and otherwise has to hand-mirror `app.py` routes. `/api/config/` is already owner-gated by `core/auth.py:_OWNER_PREFIXES`, so the endpoints need no extra decorator. These are not `/api/v1/*`, so `routes/api_v1_docs.py:ENDPOINTS` is unaffected (verified — `tests/routes/test_api_v1_docs.py` passes).

> ⚠️ Apprise URLs embed credentials (bot tokens, SMTP passwords). They are stored and rendered in plaintext exactly as `rec_api_key` already is, and `_redact()` strips them before anything is logged. Introducing encryption for one field would be inconsistent with the surrounding code and out of scope here — flagging it as a conscious decision, not an oversight.

## Testing

**3840 passed, 7 skipped** (baseline before this branch: 3761 passed, 7 skipped, 1 failed). 79 net-new tests, no regressions. The 7 skips are pre-existing POSIX chmod/symlink cases on Windows.

| File | Covers |
|------|--------|
| `tests/unit/test_notifications.py` | URL parsing, event gating, send/redaction, digest truncation, apprise missing/raising |
| `tests/routes/test_notification_config.py` | Save, send-test, event catalog |
| `tests/mocked/test_download_notifications.py` | Usenet + DC++ `_set_status` hooks, including "a raising hook must not reach the poller" |
| `tests/unit/test_download_notify_hooks.py` | `download_notification_body` + the cancel-guard ordering |
| `tests/unit/test_wanted_digest_hook.py` | One digest per sweep, inside the guard, outside the loop |

**Known gap:** `app.py` and `api.py` cannot be imported under pytest (import-time worker threads, cloudscraper session, scheduler start, `monitor.py` spawn). So the two *placement* guarantees — the cancel guard preceding the failure notify, and the digest sitting inside `if moved_count > 0` and outside the per-match loop — are asserted structurally against the parsed AST rather than by running the code. That's weaker than a behavioural test and it's the one thing I'd want a second pair of eyes on.

`download_notification_body` was moved into `core/download_utils.py` specifically so the body-formatting half *can* be tested for real.

## Manual verification

Done with apprise 1.13.0 actually installed:

- Real Apprise parses a valid scheme and rejects an unknown one with the expected messages.
- Full DB round-trip through the route (save → `get_settings` → gating): `download_failed: false` preserved, `#` comment lines dropped, master switch off silences everything.
- The Jinja notifications block renders with real context and checkbox state round-trips.

## Notes

- `core/notifications.py` is kept strictly ASCII. `core/app_logging.py` uses `logging.FileHandler` with no explicit encoding, so on Windows it writes cp1252 and a `…` or `—` in a log line raises `UnicodeEncodeError` *inside* logging.
- Apprise's transitive deps (certifi, click, markdown, PyYAML, requests, requests-oauthlib, tzdata) are all small and pure-Python; `click` and `requests` were already required. The Dockerfile installs from `requirements.txt`, so no Dockerfile change.
- `CLAUDE.md` gains a **Notification Hook Sites** section documenting the three-path table and the two easy-to-break rules above, so a future download path doesn't silently miss its hook.

## Out of scope (deliberately)

The "On the Stack" new-issue notice, notifications for newly-*discovered* wanted issues, and hooking `monitor.py` file imports — `monitor.py` runs as a separate OS process and would need its own config read and Apprise client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
