### PR TITLE
Auto-retry failed downloads before reporting them as failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ point. A new download path needs its own hook:
 
 | Path | Terminal status set at |
 |------|------------------------|
-| In-process HTTP (GetComics/Pixeldrain/MEGA/ComicBookPlus) | `api.py` success in `process_download`; failure after the `is_cancel_requested` guard following `set_error_status` |
+| In-process HTTP (GetComics/Pixeldrain/MEGA/ComicBookPlus) | `api.py` success in `process_download`; failure after the `is_cancel_requested` guard *and* the `_schedule_auto_retry` gate that follows `set_error_status` |
 | Usenet (SABnzbd/NZBGet) | `models/usenet.py` `_set_status` |
 | DC++ / AirDC++ | `models/dcpp.py` `_set_status` |
 
@@ -143,6 +143,17 @@ Two rules that are easy to break:
   *after* the early return that follows it. Hooking inside `set_error_status`
   would be wrong twice over — `download_getcomics` calls it a second time before
   re-raising, so one failure would notify twice.
+- **A retryable failure must not notify either.** An in-process download that
+  fails on every mirror is parked in a backoff window and re-queued up to
+  `MAX_AUTO_RETRIES` times (`core/download_utils.py`), so the first failure is
+  usually transient. `_schedule_auto_retry` returns True in that case and
+  `process_download` returns early — no push, and no weekly-pack 'failed' write
+  either, or the scheduler would queue a second copy alongside the retry. The
+  ordering (cancel guard → auto-retry → notify) is asserted structurally in
+  `tests/unit/test_download_notify_hooks.py`. Auto-retry is deliberately skipped
+  when `manual_url` is set: that is the Cloudflare-challenge marker, and no
+  automated client passes those.
+
 - **Wanted issues send one digest per sweep.** The hook is in
   `process_incoming_wanted_issues` inside the `if moved_count > 0` branch and
   outside the per-match loop; a catch-up sweep can import dozens of issues, and

--- a/api.py
+++ b/api.py
@@ -63,11 +63,21 @@ from core.download_utils import (
     is_cancel_requested as _is_cancel_requested,
     mark_cancelled as _mark_cancelled,
     set_error_status as _set_error_status,
+    auto_retry_delay,
+    begin_retry_wait,
+    build_status_snapshot,
+    count_active_downloads,
+    reset_for_retry,
+    should_auto_retry,
+    CANCELLABLE_STATUSES,
+    RETRYABLE_STATUSES,
     monitor_enabled,
     post_download_action,
     watch_drain_timeout_seconds,
     DEFER_TO_MONITOR,
     FULL_POST_PROCESS,
+    MAX_AUTO_RETRIES,
+    RETRY_PENDING,
 )
 
 
@@ -84,6 +94,79 @@ def mark_cancelled(download_id, temp_paths=()):
 def set_error_status(download_id, error=None):
     """Set the error status unless the user already cancelled this download."""
     _set_error_status(download_progress, download_id, error)
+
+
+def _fire_retry(task):
+    """Put a backed-off task back on the queue. Runs on a Timer thread.
+
+    Re-checks the preconditions rather than trusting the ones that held when the
+    timer was armed: the wait is minutes long, and the user can cancel or
+    dismiss the download at any point during it.
+    """
+    download_id = task.get('download_id')
+    try:
+        entry = download_progress.get(download_id)
+        if not isinstance(entry, dict):
+            monitor_logger.info(
+                f"Auto-retry for {download_id} dropped: download no longer tracked"
+            )
+            return
+        if is_cancel_requested(download_id):
+            monitor_logger.info(
+                f"Auto-retry for {download_id} dropped: cancelled during backoff"
+            )
+            return
+        if entry.get('status') != RETRY_PENDING:
+            # Something else already moved this download on during the wait --
+            # a hand-driven /retry_download, most likely. Re-queueing now would
+            # download the same file twice.
+            monitor_logger.info(
+                f"Auto-retry for {download_id} dropped: status is "
+                f"'{entry.get('status')}', not a pending retry"
+            )
+            return
+        reset_for_retry(download_progress, download_id)
+        monitor_logger.info(
+            f"Auto-retry {task.get('retry_count')}/{MAX_AUTO_RETRIES} "
+            f"re-queued for {download_id}"
+        )
+        download_queue.put(task)
+    except Exception as e:
+        # Nothing joins these timer threads, so an escaping exception would be
+        # invisible and the download would sit at 'retry_pending' forever.
+        monitor_logger.error(
+            f"Failed to re-queue auto-retry for {download_id}: {e}", exc_info=True
+        )
+        set_error_status(download_id, e)
+
+
+def _schedule_auto_retry(task, last_error):
+    """Arm the next automatic retry for a failed download.
+
+    Returns True when a retry was scheduled, meaning the failure is not terminal
+    yet -- the caller must not send the failure notification or mark a weekly
+    pack failed. Returns False when the download is genuinely finished.
+
+    The wait happens on a daemon Timer, not on the worker: there are only three
+    workers, and the last backoff step is fifteen minutes.
+    """
+    download_id = task.get('download_id')
+    attempt = task.get('retry_count') or 0
+    if not should_auto_retry(download_progress, download_id, attempt):
+        return False
+
+    delay = auto_retry_delay(attempt)
+    begin_retry_wait(download_progress, download_id, attempt, delay, last_error)
+    task['retry_count'] = int(attempt) + 1
+
+    timer = threading.Timer(delay, _fire_retry, args=(task,))
+    timer.daemon = True
+    timer.start()
+    monitor_logger.warning(
+        f"Download {download_id} failed ({last_error}) - retry "
+        f"{task['retry_count']}/{MAX_AUTO_RETRIES} in {delay}s"
+    )
+    return True
 
 # Setup the download directory from config.
 watch = config.get("SETTINGS", "WATCH", fallback="watch")
@@ -548,6 +631,12 @@ def process_download(task):
     if is_cancel_requested(download_id):
         return
 
+    # Every mirror is spent, but the failure may still be transient. Park the
+    # download in a backoff window and put the same task back on the queue --
+    # only once those are exhausted is this a failure worth telling anyone about.
+    if _schedule_auto_retry(task, last_error):
+        return
+
     # Past the cancel guard, so this is a genuine failure. Hooked here rather
     # than inside set_error_status because download_getcomics calls that a
     # second time before re-raising (see its own set_error_status call).
@@ -555,7 +644,8 @@ def process_download(task):
         EVENT_DOWNLOAD_FAILED,
         "Download failed",
         download_notification_body(
-            dest_filename, None, None, error=last_error
+            dest_filename, None, None, error=last_error,
+            attempts=task.get('retry_count') or 0,
         ),
     )
 
@@ -1410,18 +1500,26 @@ def cancel_download(download_id):
     # connection and deletes the partial file. Setting it before touching
     # 'status' matters — the worker keys off the flag, not the label.
     details['cancelled'] = True
-    if details.get('status') in ('queued', 'in_progress'):
+    # 'retry_pending' is included so a cancel during the backoff window relabels
+    # the row immediately; the armed Timer still fires, but _fire_retry sees the
+    # flag and drops the task instead of re-queueing it.
+    if details.get('status') in CANCELLABLE_STATUSES:
         details['status'] = 'cancelled'
         monitor_logger.info(f"Cancel requested for download {download_id}")
     return jsonify({'message': 'Download cancelled', 'status': details.get('status')}), 200
 
 @app.route('/download_status_all', methods=['GET'])
 def download_status_all():
-    return jsonify(download_progress)
+    # build_status_snapshot decorates any download awaiting an auto-retry with
+    # the countdown /status renders. It lives in core.download_utils because
+    # api.py can't be imported by the test suite.
+    return jsonify(build_status_snapshot(download_progress))
 
 @app.route('/download_summary')
 def download_summary():
-    active = sum(1 for d in download_progress.values() if d.get("status") in ["queued", "in_progress"])
+    # Counts a download waiting out its backoff as active: it is still in
+    # flight as far as the user is concerned, and restarts on its own.
+    active = count_active_downloads(download_progress)
     return jsonify({"active": active})
 
 @app.route('/clear_downloads', methods=['POST'])
@@ -1449,22 +1547,21 @@ def retry_download(download_id):
     if download_id not in download_progress:
         return jsonify({'error': 'Download not found'}), 404
     details = download_progress[download_id]
-    if details.get('status') != 'error':
+    if details.get('status') not in RETRYABLE_STATUSES:
         return jsonify({'error': 'Only failed downloads can be retried'}), 400
 
     original_url = details.get('url')
     if not original_url:
         return jsonify({'error': 'No URL found for retry'}), 400
 
-    download_progress[download_id].update({
-        'progress': 0,
-        'bytes_total': 0,
-        'bytes_downloaded': 0,
-        'status': 'queued',
-        'error': None,
-        'cancelled': False,
-        'provider': None,
-    })
+    reset_for_retry(download_progress, download_id)
+    # A hand-driven retry is a fresh start: give the download its full automatic
+    # budget back rather than letting an earlier exhausted one veto every future
+    # auto-retry. Retrying a 'retry_pending' row also leaves an armed Timer
+    # behind, but reset_for_retry has already moved the status off
+    # 'retry_pending', which is exactly what _fire_retry checks before it
+    # re-queues -- so the stale timer expires into a no-op.
+    details['retry_count'] = 0
 
     task = {
         'download_id': download_id,

--- a/core/download_utils.py
+++ b/core/download_utils.py
@@ -8,6 +8,7 @@ module scope; the weekly-pack reconciler reaches for both lazily.
 
 import os
 import sys
+import time
 
 # Live api.download_progress status -> weekly_packs_history status. 'queued'
 # maps to itself and is filtered out before any write, so a genuinely queued
@@ -15,6 +16,11 @@ import sys
 _LIVE_TO_HISTORY_STATUS = {
     'queued': 'queued',
     'in_progress': 'downloading',
+    # A download waiting out its auto-retry backoff has not failed yet, and the
+    # same task is going back on the queue. Reporting it as 'failed' here would
+    # also make is_weekly_pack_downloaded() stop counting it, so the scheduler
+    # would queue a *second* download of the same pack alongside the retry.
+    'retry_pending': 'downloading',
     'complete': 'completed',
     'error': 'failed',
     'cancelled': 'cancelled',
@@ -139,6 +145,190 @@ def set_error_status(progress, download_id, error=None) -> None:
     entry['status'] = 'error'
     if error is not None:
         entry['error'] = str(error)
+
+
+# ---------------------------------------------------------------------------
+# Automatic retry
+#
+# Most download failures are transient -- an overloaded GetComics mirror, a
+# dropped connection, a 5xx. process_download already fails *over* between the
+# mirrors it was given, but once the last one raises there is nothing left, and
+# a user has to notice the red row on /status and click Retry by hand.
+#
+# So a failed download gets up to MAX_AUTO_RETRIES more goes, spaced out to give
+# an overloaded server time to recover. Two constraints shape the design:
+#
+# * The wait must not happen on a worker thread. There are only three of them
+#   (api.py), so sleeping in one for fifteen minutes would starve the queue --
+#   api.py schedules a daemon threading.Timer instead and releases the worker.
+# * The retry re-queues the *same task dict*, so fallback_urls, weekly_pack_info,
+#   page_url and internal all survive. Rebuilding a bare task (which is what
+#   /retry_download historically did) silently drops the fallback mirrors.
+#
+# The decision logic lives here rather than in api.py so it can be tested --
+# api.py starts worker threads and a cloudscraper session at import time and so
+# cannot be imported by the suite at all.
+# ---------------------------------------------------------------------------
+
+# Delay before each successive retry, in seconds. The length of this tuple is
+# the real bound on how many retries happen; MAX_AUTO_RETRIES mirrors it so
+# callers have a name to report ("gave up after N tries") without indexing.
+AUTO_RETRY_DELAYS = (60, 300, 900)
+MAX_AUTO_RETRIES = len(AUTO_RETRY_DELAYS)
+
+RETRY_PENDING = 'retry_pending'
+
+
+def auto_retry_delay(attempt) -> int:
+    """Seconds to wait before retry number ``attempt`` (0-indexed).
+
+    Clamps rather than raising, so shortening AUTO_RETRY_DELAYS can never turn
+    an out-of-range attempt into an IndexError on a download worker.
+    """
+    try:
+        attempt = int(attempt)
+    except (TypeError, ValueError):
+        attempt = 0
+    attempt = max(0, min(attempt, len(AUTO_RETRY_DELAYS) - 1))
+    return AUTO_RETRY_DELAYS[attempt]
+
+
+def should_auto_retry(progress, download_id, attempt) -> bool:
+    """Whether a just-failed download deserves another automatic attempt.
+
+    False when the budget is spent, when the entry has gone away (dismissed or
+    cleared while the download was still running), when the user cancelled, or
+    when the failure is one no automated client can get past.
+
+    That last case is Cloudflare: ``download_getcomics`` records ``manual_url``
+    on the progress entry when a mirror answers with a managed challenge, and
+    the flag persists across failover. Only a real, hand-driven browser passes
+    those, so three more attempts spread over twenty minutes would do nothing
+    but delay the manual link the user actually needs.
+    """
+    try:
+        attempt = int(attempt)
+    except (TypeError, ValueError):
+        return False
+    if attempt >= MAX_AUTO_RETRIES:
+        return False
+    entry = progress.get(download_id) if isinstance(progress, dict) else None
+    if not isinstance(entry, dict):
+        return False
+    if is_cancel_requested(progress, download_id):
+        return False
+    if entry.get('manual_url'):
+        return False
+    return True
+
+
+def begin_retry_wait(progress, download_id, attempt, delay, error=None) -> None:
+    """Park a failed download in the backoff window before retry ``attempt``.
+
+    ``retry_pending`` is deliberately its own status rather than a flag on
+    'error': "Clear Failed Downloads" must not delete a download that is about
+    to run again, and the row must not offer a Retry button for something that
+    is already retrying.
+
+    ``error`` is kept so the UI can still show what went wrong last time.
+    """
+    entry = progress.get(download_id) if isinstance(progress, dict) else None
+    if not isinstance(entry, dict):
+        return
+    entry['status'] = RETRY_PENDING
+    entry['retry_count'] = int(attempt) + 1
+    entry['retry_at'] = time.time() + delay
+    if error is not None:
+        entry['error'] = str(error)
+
+
+def reset_for_retry(progress, download_id) -> None:
+    """Clear per-attempt state so a download can be queued again.
+
+    Shared by the automatic retry timer and the manual /retry_download route so
+    the two cannot drift. ``manual_url`` is cleared as well: it is the Cloudflare
+    marker, and leaving a stale one behind would veto every future auto-retry of
+    this download.
+    """
+    entry = progress.get(download_id) if isinstance(progress, dict) else None
+    if not isinstance(entry, dict):
+        return
+    entry.update({
+        'progress': 0,
+        'bytes_total': 0,
+        'bytes_downloaded': 0,
+        'status': 'queued',
+        'error': None,
+        'cancelled': False,
+        'provider': None,
+        'manual_url': None,
+        'retry_at': None,
+    })
+
+
+def retry_seconds_remaining(entry, now=None) -> int:
+    """Whole seconds left in an entry's backoff window, never negative.
+
+    Computed server-side (see /download_status_all) so the countdown cannot be
+    thrown off by clock skew between the browser and the container.
+    """
+    if not isinstance(entry, dict):
+        return 0
+    try:
+        retry_at = float(entry.get('retry_at'))
+    except (TypeError, ValueError):
+        return 0
+    now = time.time() if now is None else now
+    return max(0, int(round(retry_at - now)))
+
+
+# Statuses that mean "this download is still going to happen". A pending retry
+# belongs here: nothing more is asked of the user, it restarts on its own.
+ACTIVE_STATUSES = frozenset({'queued', 'in_progress', RETRY_PENDING})
+
+# Statuses /retry_download will act on. RETRY_PENDING is included so a user who
+# doesn't want to sit through a fifteen-minute backoff can start it themselves.
+RETRYABLE_STATUSES = frozenset({'error', RETRY_PENDING})
+
+# Statuses /cancel_download relabels immediately. Cancellation is cooperative
+# everywhere else, but a download parked in a backoff window has no thread to
+# notice the flag, so the label has to be set here.
+CANCELLABLE_STATUSES = ACTIVE_STATUSES
+
+
+def count_active_downloads(progress) -> int:
+    """How many downloads are queued, running, or awaiting an auto-retry."""
+    if not isinstance(progress, dict):
+        return 0
+    return sum(
+        1 for entry in progress.values()
+        if isinstance(entry, dict) and entry.get('status') in ACTIVE_STATUSES
+    )
+
+
+def build_status_snapshot(progress, now=None) -> dict:
+    """Serialisable view of the progress dict for /download_status_all.
+
+    Decorates every download waiting out a backoff with ``retry_in`` (whole
+    seconds left) and ``retry_max``. Both are derived server-side: sending an
+    absolute ``retry_at`` instead would leave the countdown at the mercy of a
+    browser clock that disagrees with the container's, and hardcoding the
+    maximum in status.html would let it drift from AUTO_RETRY_DELAYS.
+
+    Entries are copied only when decorated, so the common case stays cheap --
+    /status polls this once a second.
+    """
+    if not isinstance(progress, dict):
+        return {}
+    now = time.time() if now is None else now
+    snapshot = {}
+    for download_id, entry in list(progress.items()):
+        if isinstance(entry, dict) and entry.get('status') == RETRY_PENDING:
+            entry = dict(entry)
+            entry['retry_in'] = retry_seconds_remaining(entry, now)
+            entry['retry_max'] = MAX_AUTO_RETRIES
+        snapshot[download_id] = entry
+    return snapshot
 
 
 def _live_download_progress():
@@ -351,7 +541,7 @@ def watch_drain_timeout_seconds(reconcile_interval_minutes=5) -> int:
 
 
 def download_notification_body(dest_filename, file_path=None, provider=None,
-                               error=None):
+                               error=None, attempts=0):
     """Build the body of a download-complete/failed notification.
 
     Lives here rather than in api.py so it can be tested without triggering
@@ -359,6 +549,11 @@ def download_notification_body(dest_filename, file_path=None, provider=None,
 
     ``dest_filename`` is absent for browser-extension grabs, so fall back to the
     resolved path before giving up and calling it "Unknown file".
+
+    ``attempts`` is the number of automatic retries already spent. Saying so
+    distinguishes "this mirror hiccuped once" from "CLU tried for twenty minutes
+    and this one is genuinely dead", which is the whole point of holding the
+    failure push back until the retries are exhausted.
     """
     name = dest_filename
     if not name and file_path:
@@ -368,4 +563,12 @@ def download_notification_body(dest_filename, file_path=None, provider=None,
         lines.append(f"Source: {provider}")
     if error:
         lines.append(f"Error: {error}")
+    try:
+        attempts = int(attempts)
+    except (TypeError, ValueError):
+        attempts = 0
+    if attempts == 1:
+        lines.append("Gave up after 1 automatic retry")
+    elif attempts > 1:
+        lines.append(f"Gave up after {attempts} automatic retries")
     return "\n".join(lines)

--- a/core/notifications.py
+++ b/core/notifications.py
@@ -42,8 +42,9 @@ EVENT_DEFS = {
     },
     EVENT_DOWNLOAD_FAILED: {
         "label": "Download failed",
-        "description": "A download fails after every mirror has been tried. "
-                       "Cancelled downloads are never reported.",
+        "description": "A download fails after every mirror and every automatic "
+                       "retry has been tried. Cancelled downloads are never "
+                       "reported.",
         "notify_type": "failure",
         "default": True,
     },

--- a/templates/status.html
+++ b/templates/status.html
@@ -65,6 +65,16 @@
 
     const mb = bytes => (bytes / (1024 * 1024)).toFixed(2);
 
+    // Countdown for a download waiting out its auto-retry backoff. The seconds
+    // come from the server (details.retry_in) so the figure can't drift with a
+    // browser clock that disagrees with the container's.
+    function formatCountdown(seconds) {
+      const total = Math.max(0, Math.round(seconds || 0));
+      const mins = Math.floor(total / 60);
+      const secs = total % 60;
+      return `${mins}m ${String(secs).padStart(2, '0')}s`;
+    }
+
     // Shared cell builders so direct and Usenet rows render identically.
     function providerCell(providerKey) {
       const td = document.createElement('td');
@@ -148,19 +158,29 @@
 
             // Status
             let statusClass = '';
+            let statusText = details.status;
             if (details.status === 'error') {
               statusClass = 'text-danger fw-bold';
             } else if (details.status === 'complete') {
               statusClass = 'text-success';
             } else if (details.status === 'cancelled') {
               statusClass = 'text-warning';
+            } else if (details.status === 'retry_pending') {
+              // Failed, but CLU is going to try again on its own. Show the wait
+              // and which attempt is coming; the last error stays on the hover
+              // title so it's still inspectable.
+              statusClass = 'text-warning';
+              statusText = `Retrying in ${formatCountdown(details.retry_in)}`
+                         + ` (${details.retry_count} of ${details.retry_max})`;
             }
-            tr.appendChild(statusCell(details.status, statusClass, details.error));
+            tr.appendChild(statusCell(statusText, statusClass, details.error));
 
             // Actions cell (Cancel/Retry buttons)
             const tdActions = document.createElement('td');
 
-            if (details.status === 'in_progress' || details.status === 'queued') {
+            // A pending retry is still in flight — offer Cancel, not Retry.
+            if (details.status === 'in_progress' || details.status === 'queued'
+                || details.status === 'retry_pending') {
               // Cancel button for in-progress downloads
               const cancelIcon = document.createElement('i');
               cancelIcon.className = "bi bi-x-circle text-danger action-icon";

--- a/tests/integration/test_weekly_pack_reconcile.py
+++ b/tests/integration/test_weekly_pack_reconcile.py
@@ -38,6 +38,11 @@ class TestLiveStatusMapping:
 
     @pytest.mark.parametrize("live_status,expected", [
         ("in_progress", "downloading"),
+        # A pack awaiting an auto-retry has not failed — the same task is going
+        # back on the queue. Mapping it to 'failed' would make
+        # is_weekly_pack_downloaded() stop counting the row, so the scheduler
+        # would queue a second download of the pack alongside the retry.
+        ("retry_pending", "downloading"),
         ("complete", "completed"),
         ("error", "failed"),
         ("cancelled", "cancelled"),

--- a/tests/unit/test_download_auto_retry.py
+++ b/tests/unit/test_download_auto_retry.py
@@ -1,0 +1,333 @@
+"""Automatic retry policy for failed downloads (core.download_utils).
+
+A download that fails on every mirror is usually the victim of something
+transient, so CLU parks it and puts the same task back on the queue up to
+``MAX_AUTO_RETRIES`` times before calling it dead. The decision logic lives in
+core.download_utils rather than api.py precisely so it can be tested here --
+api.py starts worker threads and a cloudscraper session at import time and
+cannot be imported by the suite at all. api.py keeps only the threading.Timer
+wiring on top of these functions.
+"""
+
+import ast
+import os
+
+import pytest
+
+from core.download_utils import (
+    ACTIVE_STATUSES,
+    AUTO_RETRY_DELAYS,
+    CANCELLABLE_STATUSES,
+    MAX_AUTO_RETRIES,
+    RETRYABLE_STATUSES,
+    RETRY_PENDING,
+    _LIVE_TO_HISTORY_STATUS,
+    auto_retry_delay,
+    begin_retry_wait,
+    build_status_snapshot,
+    count_active_downloads,
+    reset_for_retry,
+    retry_seconds_remaining,
+    should_auto_retry,
+)
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+API_PATH = os.path.join(PROJECT_ROOT, "api.py")
+
+
+@pytest.fixture
+def progress():
+    """A minimal stand-in for api.download_progress with one failed download."""
+    return {
+        "dl-1": {
+            "url": "https://example.test/comic.cbz",
+            "status": "error",
+            "progress": 63,
+            "bytes_total": 1000,
+            "bytes_downloaded": 630,
+            "error": "Connection reset",
+            "provider": "GetComics",
+        }
+    }
+
+
+class TestBackoffSchedule:
+    def test_three_retries_spaced_one_five_and_fifteen_minutes(self):
+        assert AUTO_RETRY_DELAYS == (60, 300, 900)
+
+    def test_max_retries_matches_the_schedule_length(self):
+        """The tuple is the real bound; the constant only names it."""
+        assert MAX_AUTO_RETRIES == len(AUTO_RETRY_DELAYS)
+
+    @pytest.mark.parametrize("attempt,expected", [(0, 60), (1, 300), (2, 900)])
+    def test_delay_for_each_attempt(self, attempt, expected):
+        assert auto_retry_delay(attempt) == expected
+
+    def test_out_of_range_attempt_clamps_instead_of_raising(self):
+        """Shortening the schedule must not IndexError on a download worker."""
+        assert auto_retry_delay(99) == AUTO_RETRY_DELAYS[-1]
+        assert auto_retry_delay(-3) == AUTO_RETRY_DELAYS[0]
+
+    def test_junk_attempt_falls_back_to_the_first_delay(self):
+        assert auto_retry_delay(None) == AUTO_RETRY_DELAYS[0]
+        assert auto_retry_delay("soon") == AUTO_RETRY_DELAYS[0]
+
+
+class TestShouldAutoRetry:
+    def test_a_fresh_failure_retries(self, progress):
+        assert should_auto_retry(progress, "dl-1", 0) is True
+
+    @pytest.mark.parametrize("attempt", range(MAX_AUTO_RETRIES))
+    def test_every_attempt_inside_the_budget_retries(self, progress, attempt):
+        assert should_auto_retry(progress, "dl-1", attempt) is True
+
+    def test_the_budget_is_capped(self, progress):
+        assert should_auto_retry(progress, "dl-1", MAX_AUTO_RETRIES) is False
+        assert should_auto_retry(progress, "dl-1", MAX_AUTO_RETRIES + 5) is False
+
+    def test_a_cancelled_download_never_retries(self, progress):
+        """Aborting the transfer is how a cancel surfaces from most providers,
+        so the failure path runs for cancels too."""
+        progress["dl-1"]["cancelled"] = True
+        assert should_auto_retry(progress, "dl-1", 0) is False
+
+    def test_a_dismissed_download_never_retries(self, progress):
+        """The entry can be cleared while the download is still running."""
+        assert should_auto_retry(progress, "dl-1", 0) is True
+        del progress["dl-1"]
+        assert should_auto_retry(progress, "dl-1", 0) is False
+
+    def test_a_cloudflare_failure_never_retries(self, progress):
+        """manual_url is only set on the Cloudflare-challenge branch. No
+        automated client passes those, so retrying only delays the manual link
+        the user actually needs by the full backoff window."""
+        progress["dl-1"]["manual_url"] = "https://getcomics.test/post"
+        assert should_auto_retry(progress, "dl-1", 0) is False
+
+    def test_tolerates_a_non_dict_progress(self):
+        assert should_auto_retry(None, "dl-1", 0) is False
+
+    def test_junk_attempt_does_not_raise(self, progress):
+        assert should_auto_retry(progress, "dl-1", "two") is False
+
+
+class TestBeginRetryWait:
+    def test_parks_the_download_in_its_own_status(self, progress):
+        begin_retry_wait(progress, "dl-1", 0, 60)
+        assert progress["dl-1"]["status"] == RETRY_PENDING
+
+    def test_the_pending_status_is_not_error(self, progress):
+        """'Clear Failed Downloads' filters on 'error' -- a download that is
+        about to run again must not be swept away by it."""
+        begin_retry_wait(progress, "dl-1", 0, 60)
+        assert progress["dl-1"]["status"] != "error"
+
+    def test_records_the_attempt_number_one_based(self, progress):
+        begin_retry_wait(progress, "dl-1", 1, 300)
+        assert progress["dl-1"]["retry_count"] == 2
+
+    def test_records_when_the_retry_is_due(self, progress):
+        begin_retry_wait(progress, "dl-1", 0, 60)
+        assert 55 <= retry_seconds_remaining(progress["dl-1"]) <= 60
+
+    def test_keeps_the_error_for_the_tooltip(self, progress):
+        begin_retry_wait(progress, "dl-1", 0, 60, error="HTTP 503")
+        assert progress["dl-1"]["error"] == "HTTP 503"
+
+    def test_leaves_the_existing_error_alone_when_none_is_given(self, progress):
+        begin_retry_wait(progress, "dl-1", 0, 60)
+        assert progress["dl-1"]["error"] == "Connection reset"
+
+    def test_a_missing_entry_is_a_no_op(self, progress):
+        begin_retry_wait(progress, "gone", 0, 60)
+        assert "gone" not in progress
+
+
+class TestResetForRetry:
+    def test_requeues_as_queued_with_counters_zeroed(self, progress):
+        reset_for_retry(progress, "dl-1")
+        entry = progress["dl-1"]
+        assert entry["status"] == "queued"
+        assert entry["progress"] == 0
+        assert entry["bytes_total"] == 0
+        assert entry["bytes_downloaded"] == 0
+        assert entry["error"] is None
+        assert entry["cancelled"] is False
+        assert entry["provider"] is None
+        assert entry["retry_at"] is None
+
+    def test_clears_the_cloudflare_marker(self, progress):
+        """A stale manual_url would veto every future auto-retry of this
+        download, because should_auto_retry treats it as unrecoverable."""
+        progress["dl-1"]["manual_url"] = "https://getcomics.test/post"
+        reset_for_retry(progress, "dl-1")
+        assert progress["dl-1"]["manual_url"] is None
+        assert should_auto_retry(progress, "dl-1", 0) is True
+
+    def test_keeps_the_url_so_the_download_can_run_again(self, progress):
+        reset_for_retry(progress, "dl-1")
+        assert progress["dl-1"]["url"] == "https://example.test/comic.cbz"
+
+    def test_a_missing_entry_is_a_no_op(self, progress):
+        reset_for_retry(progress, "gone")
+        assert "gone" not in progress
+
+
+class TestRetrySecondsRemaining:
+    def test_counts_down_to_the_due_time(self):
+        import time
+
+        assert retry_seconds_remaining({"retry_at": time.time() + 90}) == 90
+
+    def test_never_goes_negative(self):
+        import time
+
+        assert retry_seconds_remaining({"retry_at": time.time() - 500}) == 0
+
+    def test_accepts_an_explicit_now(self):
+        assert retry_seconds_remaining({"retry_at": 1_000_060}, now=1_000_000) == 60
+
+    def test_tolerates_a_missing_or_junk_due_time(self):
+        assert retry_seconds_remaining({}) == 0
+        assert retry_seconds_remaining({"retry_at": None}) == 0
+        assert retry_seconds_remaining({"retry_at": "soon"}) == 0
+        assert retry_seconds_remaining(None) == 0
+
+
+class TestWeeklyPackStatusMapping:
+    def test_a_pending_retry_still_reads_as_downloading(self):
+        """Mapping it to 'failed' would make is_weekly_pack_downloaded() stop
+        counting the row, so the scheduler would queue a second download of the
+        same pack alongside the pending retry."""
+        assert _LIVE_TO_HISTORY_STATUS[RETRY_PENDING] == "downloading"
+
+
+class TestStatusSets:
+    def test_a_pending_retry_counts_as_active(self):
+        """The nav badge must not go quiet while a download is still coming."""
+        assert RETRY_PENDING in ACTIVE_STATUSES
+
+    def test_a_pending_retry_can_be_retried_by_hand(self):
+        """Nobody should have to sit through a fifteen-minute backoff."""
+        assert RETRY_PENDING in RETRYABLE_STATUSES
+
+    def test_a_pending_retry_can_be_cancelled(self):
+        assert RETRY_PENDING in CANCELLABLE_STATUSES
+
+    def test_a_failed_download_is_retryable_but_not_active(self):
+        assert "error" in RETRYABLE_STATUSES
+        assert "error" not in ACTIVE_STATUSES
+
+    def test_settled_downloads_are_neither(self):
+        for status in ("complete", "cancelled"):
+            assert status not in ACTIVE_STATUSES
+            assert status not in RETRYABLE_STATUSES
+
+
+class TestCountActiveDownloads:
+    def test_counts_queued_running_and_pending_retries(self):
+        progress = {
+            "a": {"status": "queued"},
+            "b": {"status": "in_progress"},
+            "c": {"status": RETRY_PENDING},
+            "d": {"status": "complete"},
+            "e": {"status": "error"},
+            "f": {"status": "cancelled"},
+        }
+        assert count_active_downloads(progress) == 3
+
+    def test_empty_and_junk_inputs(self):
+        assert count_active_downloads({}) == 0
+        assert count_active_downloads(None) == 0
+        assert count_active_downloads({"a": "not a dict"}) == 0
+
+
+class TestBuildStatusSnapshot:
+    def test_decorates_a_pending_retry_with_a_countdown(self):
+        progress = {"dl-1": {"status": RETRY_PENDING, "retry_count": 2,
+                             "retry_at": 1_000_120}}
+
+        snapshot = build_status_snapshot(progress, now=1_000_000)
+
+        assert snapshot["dl-1"]["retry_in"] == 120
+        assert snapshot["dl-1"]["retry_max"] == MAX_AUTO_RETRIES
+
+    def test_the_countdown_does_not_leak_back_into_live_state(self):
+        """Only the response is decorated — the progress dict is the source of
+        truth for every other reader (weekly packs, the wanted sweep)."""
+        progress = {"dl-1": {"status": RETRY_PENDING, "retry_at": 1_000_120}}
+
+        build_status_snapshot(progress, now=1_000_000)
+
+        assert "retry_in" not in progress["dl-1"]
+        assert "retry_max" not in progress["dl-1"]
+
+    def test_other_downloads_pass_through_untouched(self):
+        entry = {"status": "in_progress", "progress": 42}
+        progress = {"dl-1": entry}
+
+        snapshot = build_status_snapshot(progress)
+
+        assert snapshot["dl-1"] is entry
+
+    def test_a_lapsed_countdown_reads_as_zero_not_negative(self):
+        progress = {"dl-1": {"status": RETRY_PENDING, "retry_at": 1_000_000}}
+
+        snapshot = build_status_snapshot(progress, now=1_000_090)
+
+        assert snapshot["dl-1"]["retry_in"] == 0
+
+    def test_empty_and_junk_inputs(self):
+        assert build_status_snapshot({}) == {}
+        assert build_status_snapshot(None) == {}
+
+
+def _api_function(name):
+    """Top-level statements of an api.py function, without importing api."""
+    with open(API_PATH, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    pytest.fail(f"{name} not found in api.py")
+
+
+def _names_used(node):
+    """Every identifier referenced anywhere under ``node``."""
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+
+
+class TestApiRoutesUseTheSharedPolicy:
+    """api.py's download routes must delegate, not reimplement.
+
+    api.py starts worker threads and a cloudscraper session at import time, so
+    the suite can never exercise these routes directly. Keeping the real logic
+    in core.download_utils (tested above) and asserting structurally that the
+    routes call it is what makes that coverage mean anything — a route that
+    inlines its own status list would silently drop 'retry_pending'.
+    """
+
+    def test_status_endpoint_delegates_to_build_status_snapshot(self):
+        assert "build_status_snapshot" in _names_used(
+            _api_function("download_status_all")
+        )
+
+    def test_summary_endpoint_delegates_to_count_active_downloads(self):
+        assert "count_active_downloads" in _names_used(
+            _api_function("download_summary")
+        )
+
+    def test_cancel_endpoint_uses_the_shared_status_set(self):
+        assert "CANCELLABLE_STATUSES" in _names_used(_api_function("cancel_download"))
+
+    def test_retry_endpoint_uses_the_shared_status_set(self):
+        assert "RETRYABLE_STATUSES" in _names_used(_api_function("retry_download"))
+
+    def test_retry_endpoint_restores_the_full_retry_budget(self):
+        """A hand-driven retry is a fresh start; an exhausted counter left in
+        place would veto every future automatic retry of this download."""
+        source = ast.unparse(_api_function("retry_download"))
+        assert "'retry_count'] = 0" in source
+
+    def test_retry_endpoint_shares_the_field_reset(self):
+        assert "reset_for_retry" in _names_used(_api_function("retry_download"))

--- a/tests/unit/test_download_notify_hooks.py
+++ b/tests/unit/test_download_notify_hooks.py
@@ -59,6 +59,32 @@ class TestDownloadNotificationBody:
         body = download_notification_body("a.cbz", provider="MEGA", error="boom")
         assert body.splitlines() == ["a.cbz", "Source: MEGA", "Error: boom"]
 
+    def test_reports_the_automatic_retries_that_were_spent(self):
+        """Distinguishes "a mirror hiccuped" from "CLU tried for twenty minutes
+        and this one is dead" — which is the point of holding the push back."""
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body("a.cbz", error="boom", attempts=3)
+        assert body.splitlines()[-1] == "Gave up after 3 automatic retries"
+
+    def test_a_single_retry_reads_naturally(self):
+        from core.download_utils import download_notification_body
+
+        body = download_notification_body("a.cbz", attempts=1)
+        assert body.splitlines()[-1] == "Gave up after 1 automatic retry"
+
+    def test_no_retry_line_when_none_were_spent(self):
+        """A Cloudflare failure is reported immediately, with no retries."""
+        from core.download_utils import download_notification_body
+
+        assert download_notification_body("a.cbz", attempts=0) == "a.cbz"
+        assert download_notification_body("a.cbz") == "a.cbz"
+
+    def test_a_junk_attempt_count_is_ignored(self):
+        from core.download_utils import download_notification_body
+
+        assert download_notification_body("a.cbz", attempts=None) == "a.cbz"
+
 
 def _process_download_body():
     """Top-level statements of api.process_download, without importing api."""
@@ -117,3 +143,76 @@ class TestFailureNotifyIsBehindTheCancelGuard:
                 assert "EVENT_DOWNLOAD_FAILED" in names
                 return
         pytest.fail("no notify_async call at the top level of process_download")
+
+
+def _top_level_index(body, predicate):
+    """Index of the first top-level statement matching ``predicate``."""
+    for idx, stmt in enumerate(body):
+        if predicate(stmt):
+            return idx
+    return None
+
+
+class TestAutoRetryDefersTheFailureNotification:
+    """A transient failure must not push, and a cancel must not auto-retry.
+
+    Both are properties of *where* ``_schedule_auto_retry`` sits in the terminal
+    failure block, so they are asserted against the parsed AST for the same
+    reason the cancel guard above is: api.py cannot be imported in tests.
+
+    The required order is cancel guard -> auto-retry -> notification. Move the
+    retry above the guard and every cancelled download gets re-queued; move it
+    below the notification and a user gets a "Download failed" push each time a
+    mirror hiccups, twenty minutes before CLU has actually given up.
+    """
+
+    def test_the_cancel_guard_precedes_the_auto_retry(self):
+        body = _process_download_body()
+
+        guard_idx = _top_level_index(
+            body,
+            lambda s: (
+                isinstance(s, ast.If)
+                and "is_cancel_requested" in _calls(s.test)
+                and any(isinstance(x, ast.Return) for x in s.body)
+            ),
+        )
+        retry_idx = _top_level_index(
+            body, lambda s: "_schedule_auto_retry" in _calls(s)
+        )
+
+        assert guard_idx is not None, "cancel guard not found in process_download"
+        assert retry_idx is not None, "_schedule_auto_retry not found in process_download"
+        assert guard_idx < retry_idx
+
+    def test_the_auto_retry_precedes_the_failure_notification(self):
+        body = _process_download_body()
+
+        retry_idx = _top_level_index(
+            body, lambda s: "_schedule_auto_retry" in _calls(s)
+        )
+        notify_idx = _top_level_index(
+            body,
+            lambda s: "notify_async" in _calls(s) and "EVENT_DOWNLOAD_FAILED" in [
+                n.id for n in ast.walk(s) if isinstance(n, ast.Name)
+            ],
+        )
+
+        assert retry_idx is not None, "_schedule_auto_retry not found in process_download"
+        assert notify_idx is not None, "failure notification not found"
+        assert retry_idx < notify_idx
+
+    def test_a_scheduled_retry_returns_before_notifying(self):
+        """Scheduling has to short-circuit the rest of the block, or the push
+        (and the weekly-pack 'failed' write) happen anyway."""
+        body = _process_download_body()
+
+        for stmt in body:
+            if "_schedule_auto_retry" not in _calls(stmt):
+                continue
+            assert isinstance(stmt, ast.If), (
+                "_schedule_auto_retry must gate an early return"
+            )
+            assert any(isinstance(x, ast.Return) for x in stmt.body)
+            return
+        pytest.fail("_schedule_auto_retry not found in process_download")


### PR DESCRIPTION
## Context

When an in-process download failed, CLU settled it as `error` immediately and the user had to notice the red row on `/status` and click Retry by hand. Most of those failures are transient — an overloaded GetComics mirror, a dropped connection, a 5xx — and would have succeeded on a second attempt minutes later.

The worker already fails *over* between mirrors (`fallback_urls`), but once the last one raised, that was the end of it.

Closes #503 

## What changed

A failed download is now parked in a backoff window and the same task put back on the queue, **up to 3 times, spaced 1 / 5 / 15 minutes apart**. The `download_failed` Apprise push from #508 is held back until those are spent, so a notification now means "this one is genuinely dead" rather than "the first mirror hiccuped" — and it says how many retries were burned.

`/status` shows the wait live:

> `Retrying in 4m 12s (2 of 3)` — in warning colour, with the last error on hover, offering **Cancel** instead of Retry.

## Design notes

**The wait cannot happen on a worker thread.** There are only three workers and the last backoff step is fifteen minutes, so sleeping in one would starve the queue. `api.py` arms a daemon `threading.Timer` and releases the worker.

**The retry re-queues the *same task dict***, so `fallback_urls`, `weekly_pack_info` and `page_url` all survive. `/retry_download` used to rebuild a bare task and silently drop the fallback mirrors — it now shares the same reset, so a hand-driven retry keeps them too.

**`retry_pending` is its own status, not a flag on `error`.** "Clear Failed Downloads" must not delete a download that is about to run again, and the row must not offer a Retry button for something already retrying. It maps to `downloading` for weekly packs — reporting a pending retry as failed would make `is_weekly_pack_downloaded()` stop counting the row, and the scheduler would queue a second copy alongside the retry.

**Cloudflare failures skip the retries entirely.** `manual_url` is only written on the challenge branch, and no automated client passes those, so three more attempts would do nothing but delay the manual link the user actually needs by twenty minutes.

**A manual retry during a backoff doesn't double-download.** `reset_for_retry` moves the status off `retry_pending`, and `_fire_retry` checks exactly that before re-queueing, so the stale timer expires into a no-op.

## Scope

Direct downloads only (GetComics / Pixeldrain / MEGA / ComicBookPlus). SABnzbd / NZBGet / AirDC++ rows are unchanged — those jobs live in the user's own client, and retrying belongs there.

Limits and delays are hardcoded constants (`AUTO_RETRY_DELAYS`), not settings.

## Files

| File | Change |
|---|---|
| `core/download_utils.py` | The whole policy layer: schedule, vetoes, field contracts, status sets, `build_status_snapshot` |
| `api.py` | `_schedule_auto_retry` / `_fire_retry` timer wiring; routes rewired to delegate |
| `templates/status.html` | `retry_pending` row rendering + countdown |
| `core/notifications.py` | `download_failed` description now mentions retries |
| `CLAUDE.md` | Notification Hook Sites contract updated — the documented failure hook was made incomplete by the new gate |

## Testing

`pytest` — **3899 passed, 7 skipped**, 100% pass rate.

- `tests/unit/test_download_auto_retry.py` (new, 51 tests) — the schedule, every veto (budget spent / cancelled / dismissed / Cloudflare), the field contracts, the snapshot decoration, and the status sets.
- `tests/unit/test_download_notify_hooks.py` — extends the existing AST technique to pin the order **cancel guard → auto-retry → notify**, plus the new "gave up after N retries" line.
- `tests/integration/test_weekly_pack_reconcile.py` — the `retry_pending → downloading` mapping.

`api.py` starts worker threads and a cloudscraper session at import time and cannot be imported by the suite, so the real logic lives in `core/download_utils.py` where it is tested directly, and the api.py routes' *delegation* to it is asserted structurally — a route that inlines its own status list and drops `retry_pending` fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)