### PR TITLE
Apply the GCD language preference on the automatic metadata path

### DIFF
--- a/models/gcd.py
+++ b/models/gcd.py
@@ -425,6 +425,25 @@ def validate_issue(series_id: int, issue_number: str) -> Dict[str, Any]:
         }
 
 
+def get_configured_languages() -> List[str]:
+    """Language codes to filter GCD series by, from the user preference.
+
+    Reads the same ``gcd_metadata_languages`` preference the manual search
+    endpoint uses, so automatic and manual lookups agree. Falls back to
+    ``['en']`` when the preference is unset or unreadable, which was the
+    historical behaviour.
+    """
+    try:
+        from core.database import get_user_preference
+        raw = get_user_preference('gcd_metadata_languages', default='en')
+    except Exception as e:
+        app_logger.warning(f"Could not read gcd_metadata_languages preference: {e}")
+        return ['en']
+
+    codes = [code.strip().lower() for code in str(raw or '').split(',') if code.strip()]
+    return codes or ['en']
+
+
 def search_series(series_name: str, year: int = None, language_codes: List[str] = None) -> Optional[Dict[str, Any]]:
     """
     Search for a series in GCD and auto-select the best match.
@@ -432,13 +451,14 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
     Args:
         series_name: Name of the series to search for
         year: Optional year to filter/rank results
-        language_codes: Optional list of language codes (default: ['en'])
+        language_codes: Optional list of language codes. Defaults to the
+            configured ``gcd_metadata_languages`` preference.
 
     Returns:
         Best matching series dict with id, name, year_began, publisher_name, or None if not found
     """
     if language_codes is None:
-        language_codes = ['en']
+        language_codes = get_configured_languages()
 
     try:
         conn = get_connection()
@@ -503,6 +523,14 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
         cursor.close()
         conn.close()
 
+        if series_result is None:
+            # Logged because a language-filtered miss is otherwise invisible:
+            # the caller just sees "no match" with nothing to explain why.
+            app_logger.info(
+                f"GCD search_series: No match for '{series_name}' "
+                f"in languages {language_codes}"
+            )
+
         return series_result
 
     except Exception as e:
@@ -528,11 +556,14 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
 
         cursor = conn.cursor()
 
-        # Get series info first
+        # Get series info first. stddata_language is a core table (see
+        # GCD_CORE_TABLES), so the join is safe on any usable dump.
         series_query = """
-            SELECT s.id, s.name, s.year_began, p.name as publisher_name
+            SELECT s.id, s.name, s.year_began, p.name as publisher_name,
+                   l.code as language_code
             FROM gcd_series s
             LEFT JOIN gcd_publisher p ON s.publisher_id = p.id
+            LEFT JOIN stddata_language l ON s.language_id = l.id
             WHERE s.id = ?
         """
         cursor.execute(series_query, (series_id,))
@@ -698,7 +729,7 @@ def get_issue_metadata(series_id: int, issue_number: str) -> Optional[Dict[str, 
             'Colorist': ', '.join(colorists) if colorists else None,
             'Letterer': ', '.join(letterers) if letterers else None,
             'CoverArtist': ', '.join(cover_artists) if cover_artists else None,
-            'LanguageISO': 'en',
+            'LanguageISO': series['language_code'] or 'en',
             'Notes': f'Metadata from GCD (Grand Comics Database). Series ID: {series_id} — retrieved {current_date}.'
         }
 

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -2010,10 +2010,9 @@ def search_gcd_metadata():
             search_success_method = None
             app_logger.debug(f"DEBUG: Checkpoint 2 - Variables initialized")
 
-            # Language filter
-            from core.database import get_user_preference
-            gcd_langs = get_user_preference('gcd_metadata_languages', default='en')
-            languages = [language.strip().lower() for language in gcd_langs.split(",")]
+            # Language filter — shared with the automatic path so the two
+            # cannot drift apart again.
+            languages = gcd.get_configured_languages()
             app_logger.debug(f"DEBUG: Checkpoint 3 - languages set")
             app_logger.debug(f"DEBUG: Building IN clause for language filter with codes: {languages}")
             in_clause, in_params = build_in_clause(languages)

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -109,6 +109,10 @@ def build_gcd_sqlite(path, *, core_only=False):
     language, issues #1/#2/#10 (plus a bracketed variant), a story with a
     writer credit and a character. When `core_only` is True, only the core
     tables are created (to exercise missing-table handling).
+
+    Also contains an Italian series, Diabolik (id 201, Astorina, issue #1), so
+    the language filter can be exercised: it is invisible to an English-only
+    search and found when 'it' is configured.
     """
     import sqlite3
     conn = sqlite3.connect(str(path))
@@ -139,13 +143,14 @@ def build_gcd_sqlite(path, *, core_only=False):
     )
 
     cur.executemany("INSERT INTO stddata_language (id, code) VALUES (?, ?)",
-                    [(1, "en")])
+                    [(1, "en"), (2, "it")])
     cur.executemany("INSERT INTO gcd_publisher (id, name) VALUES (?, ?)",
-                    [(10, "DC Comics")])
+                    [(10, "DC Comics"), (11, "Astorina")])
     cur.executemany(
         "INSERT INTO gcd_series (id, name, year_began, year_ended, publisher_id, language_id) "
         "VALUES (?, ?, ?, ?, ?, ?)",
-        [(200, "Batman", 1940, None, 10, 1)],
+        [(200, "Batman", 1940, None, 10, 1),
+         (201, "Diabolik", 1962, None, 11, 2)],
     )
     cur.executemany(
         "INSERT INTO gcd_issue (id, number, volume, series_id, indicia_publisher_id, "
@@ -156,6 +161,7 @@ def build_gcd_sqlite(path, *, core_only=False):
             (502, "2", "1", 200, None, "1940-05-01", "1940-04-01", "", "", 64, 0, 0),
             (510, "10", "1", 200, None, "1941-01-01", "1940-12-01", "", "", 64, 0, 0),
             (511, "[nn]", "1", 200, None, "1941-02-01", "1941-01-01", "", "", 64, 0, 0),
+            (520, "1", "1", 201, None, "1962-11-01", "1962-11-01", "Il re del terrore", "", 128, 0, 0),
         ],
     )
     cur.executemany(

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -103,6 +103,65 @@ class TestSearchSeries:
         assert search_series("Batman") is None
 
 
+class TestConfiguredLanguages:
+    """The gcd_metadata_languages preference must reach every lookup path."""
+
+    def test_defaults_to_english(self, monkeypatch):
+        from models.gcd import get_configured_languages
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda key, default=None: default)
+        assert get_configured_languages() == ["en"]
+
+    def test_parses_and_normalises_the_preference(self, monkeypatch):
+        from models.gcd import get_configured_languages
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda key, default=None: " IT , en ")
+        assert get_configured_languages() == ["it", "en"]
+
+    def test_empty_preference_falls_back_to_english(self, monkeypatch):
+        from models.gcd import get_configured_languages
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda key, default=None: " , ")
+        assert get_configured_languages() == ["en"]
+
+    def test_unreadable_preference_falls_back_to_english(self, monkeypatch):
+        from models.gcd import get_configured_languages
+
+        def boom(key, default=None):
+            raise RuntimeError("no database")
+
+        monkeypatch.setattr("core.database.get_user_preference", boom)
+        assert get_configured_languages() == ["en"]
+
+
+class TestSearchSeriesLanguageFilter:
+    """Regression: the automatic path used to hardcode ['en'] (issue #510)."""
+
+    def test_non_english_series_hidden_from_english_only_search(self, gcd_configured):
+        from models.gcd import search_series
+        assert search_series("Diabolik", language_codes=["en"]) is None
+
+    def test_non_english_series_found_when_configured(self, gcd_configured, monkeypatch):
+        from models.gcd import search_series
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda key, default=None: "it,en")
+        result = search_series("Diabolik")
+        assert result is not None
+        assert result["name"] == "Diabolik"
+        assert result["publisher_name"] == "Astorina"
+
+    def test_default_honours_the_preference_not_english(self, gcd_configured, monkeypatch):
+        """No explicit language_codes: the preference decides, not a hardcoded 'en'."""
+        from models.gcd import search_series
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda key, default=None: "en")
+        assert search_series("Diabolik") is None
+
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda key, default=None: "it")
+        assert search_series("Diabolik") is not None
+
+
 class TestGetIssueMetadata:
 
     def test_returns_metadata(self, gcd_configured):
@@ -121,6 +180,15 @@ class TestGetIssueMetadata:
     def test_issue_not_found(self, gcd_configured):
         from models.gcd import get_issue_metadata
         assert get_issue_metadata(200, "999") is None
+
+    def test_language_iso_comes_from_the_series(self, gcd_configured):
+        """Regression: LanguageISO was hardcoded to 'en' (issue #510)."""
+        from models.gcd import get_issue_metadata
+        assert get_issue_metadata(200, "1")["LanguageISO"] == "en"
+        italian = get_issue_metadata(201, "1")
+        assert italian is not None
+        assert italian["Series"] == "Diabolik"
+        assert italian["LanguageISO"] == "it"
 
     def test_core_only_db_has_no_credits(self, gcd_core_only_db_path, monkeypatch):
         """A dump missing the credit tables still returns core fields."""
@@ -236,10 +304,11 @@ class TestGetDatabaseStats:
         from models.gcd import get_database_stats
         stats = get_database_stats()
         assert stats is not None
-        assert stats["series"] == 1
-        assert stats["issues"] == 4
+        # Batman (en) + Diabolik (it); Diabolik adds a fifth issue.
+        assert stats["series"] == 2
+        assert stats["issues"] == 5
         assert stats["stories"] == 1
-        assert stats["publishers"] == 1
+        assert stats["publishers"] == 2
         assert stats["creators"] == 1
         assert stats["core_ok"] is True
         assert stats["missing_tables"] == []

--- a/tests/mocked/test_gcd_stats.py
+++ b/tests/mocked/test_gcd_stats.py
@@ -15,10 +15,11 @@ class TestGetDatabaseStats:
         """Counts every mapped table via COUNT(*) against the test DB."""
         stats = get_database_stats()
         assert stats is not None
-        assert stats['series'] == 1
-        assert stats['issues'] == 4
+        # Batman (en) + Diabolik (it); Diabolik adds a fifth issue.
+        assert stats['series'] == 2
+        assert stats['issues'] == 5
         assert stats['stories'] == 1
-        assert stats['publishers'] == 1
+        assert stats['publishers'] == 2
         assert stats['creators'] == 1
         assert stats['table_count'] == len(EXPECTED_GCD_TABLES)
         assert stats['missing_tables'] == []
@@ -43,7 +44,7 @@ class TestGetDatabaseStats:
                             lambda: {"database_path": str(gcd_core_only_db_path)})
         stats = get_database_stats()
         assert stats is not None
-        assert stats['series'] == 1
+        assert stats['series'] == 2
         # gcd_creator absent → creators defaults to 0 (key still present)
         assert stats['creators'] == 0
         assert 'gcd_creator' in stats['missing_tables']


### PR DESCRIPTION
## 📝 Description
Closes #510

The `gcd_metadata_languages` preference was read only by `/search-gcd-metadata`. Every automatic
caller of `models.gcd.search_series` omitted `language_codes`, which defaulted to `['en']`, so
batch metadata, single-file auto lookups and the `BaseProvider` adapter searched only
English-language series regardless of the configured value.

`search_series` has no fallback when the filtered query returns nothing, and logged only on
success — so on a non-English library GCD contributed nothing without leaving any trace. Where
the English-only query returned a *wrong* result rather than none, that result was selected
(`GCD search_series: Found 'Diabolik' (1999)` for an Italian 2014 part-work).

This resolves the default from the preference instead of hardcoding `['en']`, so every caller
picks it up, and points the manual endpoint at the same helper so the two paths cannot drift
apart again.

It also fixes the related symptom in `get_issue_metadata`, which hardcoded `'LanguageISO': 'en'`
and so tagged non-English issues as English. The series language now comes from
`stddata_language`, as the manual path already does.

Both behaviours came in with #26 and 2df19138 and appear to have been lost when this code moved
into `models/gcd.py` — so this restores intended behaviour rather than proposing new behaviour.

## 🛠️ Changes Made
- [x] Added new feature logic — `models/gcd.py`: new `get_configured_languages()`, used as the
      `search_series` default and by `routes/metadata.py`; `get_issue_metadata` now reads the
      series language; a miss is logged with the languages searched
- [ ] Updated Docker/Config if necessary — not needed, no new setting is introduced
- [ ] Verified build locally (`docker build -t dev .`) — not run; no dependency or image change

## 📸 Screenshots / Logs

Before, with `gcd_metadata_languages = "it,en"` and GCD as the first provider, an Italian series
GCD does hold produced no match and no log line. The same queries `search_series` builds, run
against a comics.org dump:

```sql
-- what the automatic path ran: l.code IN ('en')
WHERE s.name LIKE '%Speciale Nathan Never%' AND l.code IN ('en')
-- 0 rows

-- with the configured 'it,en'
WHERE s.name LIKE '%Speciale Nathan Never%' AND l.code IN ('it','en')
--   39802 | Speciale Nathan Never | 1992 | it | Sergio Bonelli Editore
```

After, a miss is at least visible:

```
GCD search_series: No match for 'Speciale Nathan Never' in languages ['it', 'en']
```

## 🧪 Testing Performed
- [ ] Manual test in `dev` container — not run
- [x] Linting/Unit tests pass — full suite green: **3887 passed**

Test changes:
- `tests/mocked/conftest.py` — the fixture DB gains an Italian series (Diabolik, Astorina, one
  issue) alongside the English Batman, so the language filter has something to exclude.
- `tests/mocked/test_gcd_model.py` — new `TestConfiguredLanguages` (default, parsing/normalising,
  empty value, unreadable preference) and `TestSearchSeriesLanguageFilter` (non-English series
  hidden under `en`, found under the configured value, and the default following the preference
  rather than a hardcoded `en`); plus a regression test that `LanguageISO` follows the series.
- `tests/mocked/test_gcd_stats.py`, `test_gcd_model.py` — table-count assertions updated for the
  extra fixture rows.

Note: `tests/unit/test_monitor.py` fails on my machine with `PermissionError` on
`/private/var/folders/...`, identically on a clean checkout of `main`. It is unrelated to this
change and passes in CI.
