### PR TITLE
Maintain XML Data if it Doesn't Exist on a re-tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,46 @@ conn = get_db_connection()
 # Always use WAL mode - concurrent reads supported
 ```
 
+### ComicInfo.xml Writes
+
+`core/comicinfo.py` owns the **single** `generate_comicinfo_xml`.
+`routes/metadata.py` and `models/comicvine.py` only re-export it (callers and
+tests import the name from both). There used to be two near-duplicate copies
+that had drifted; a field added to one was silently dropped on the paths using
+the other. Do not add a third — extend the one in `core/`.
+
+It uses an explicit `add(tag, ...)` allowlist, so a field a provider maps but
+that has no line there is computed and then discarded. Adding a ComicInfo field
+means adding one `add()` call.
+
+> **The writer never invents a value it can't know.** It defaults only
+> `LanguageISO` (`en`) and `Manga` (`No`) — both safe, since every manga-aware
+> provider sets `Manga` itself. It deliberately has **no `Notes` fallback**: a
+> serializer cannot know a file's provenance, and `Notes` doubles as the
+> "already tagged, skip this file" sentinel read by `routes/metadata.py`,
+> `models/comicvine.py` and `app.py`, so a fabricated one would both mislabel
+> the source and make the file permanently un-retaggable. Every provider mapper
+> sets `Notes`; the two inline GCD-SQLite builders in `routes/metadata.py` set
+> theirs where the dict is assembled.
+
+Writing is a full rebuild of the archive, so `add_comicinfo_to_cbz`
+(`routes/metadata.py`) and `add_comicinfo_to_archive` (`models/comicvine.py`)
+**merge by default**: tags the archive already had that the new metadata does
+not supply are carried forward via `core.comicinfo.merge_comicinfo_bytes`.
+No provider covers every field — ComicVine has no genre data at all — so without
+this, re-tagging a GCD-sourced file with ComicVine wipes its `Genre`.
+
+> **A restore must pass `merge_existing=False`.** The bulk-metadata undo
+> (`routes/bulk_metadata.py`) re-applies snapshotted prior bytes; merging there
+> would carry tags forward from the very metadata being undone, leaving the file
+> in neither the old nor the new state.
+
+Credit roles from ComicVine arrive as ONE comma-joined string per creator
+("penciler, inker"). `models/comicvine.parse_creator_roles` splits it and
+buckets each token independently, so one person can hold several credits; the
+local-DB path (`models/comicvine_sqlite.py`) calls the same function so the two
+cannot drift.
+
 ### Image Processing
 Use `helpers.py` functions: `safe_image_open()`, `create_thumbnail_streaming()` for memory-safe PIL operations.
 

--- a/core/comicinfo.py
+++ b/core/comicinfo.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import re
+import io
 import zipfile
 import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as SafeET
@@ -322,6 +323,235 @@ def update_comicinfo_xml(xml_data: bytes, updates: dict) -> bytes:
     # Convert the updated XML back into bytes (with XML declaration)
     updated_xml_bytes = ET.tostring(root, encoding='utf-8', xml_declaration=True)
     return updated_xml_bytes
+
+
+def merge_comicinfo_bytes(new_xml: bytes, existing_xml=None) -> bytes:
+    """Carry forward ComicInfo tags that only the file's current XML has.
+
+    Provider metadata is written by rebuilding ComicInfo.xml from scratch, so any
+    tag the new provider did not supply used to be destroyed -- re-tagging a
+    GCD-sourced file with ComicVine wiped its Genre, because ComicVine has no
+    genre data at all.
+
+    Tags present in ``new_xml`` always win, including when their value differs.
+    Only tags that are absent there are copied over from ``existing_xml``.
+
+    This merges XML rather than the metadata dict on purpose: fields outside the
+    generate_comicinfo_xml allowlists (Format, Tags, GTIN, BlackAndWhite, Review
+    and the <Pages> bookmark block) survive re-tagging as well.
+
+    :param new_xml:      Freshly generated ComicInfo.xml bytes.
+    :param existing_xml: The archive's current ComicInfo.xml bytes, or None.
+    :return:             Merged XML bytes; ``new_xml`` unchanged on any problem.
+    """
+    if not existing_xml:
+        return new_xml
+
+    import copy
+
+    try:
+        new_root = SafeET.fromstring(new_xml)
+    except Exception as e:
+        app_logger.warning(f"merge_comicinfo_bytes: new XML unparseable, not merging: {e}")
+        return new_xml
+
+    try:
+        old_root = SafeET.fromstring(existing_xml)
+    except ET.ParseError:
+        try:
+            old_root = SafeET.fromstring(_sanitize_xml(existing_xml))
+        except Exception as e:
+            # A corrupt existing file must never block writing good metadata.
+            app_logger.warning(f"merge_comicinfo_bytes: existing XML unparseable, not merging: {e}")
+            return new_xml
+    except Exception as e:
+        app_logger.warning(f"merge_comicinfo_bytes: existing XML unreadable, not merging: {e}")
+        return new_xml
+
+    def _local(tag):
+        # ComicInfo.xml is written without namespaces on purpose (ComicRack
+        # chokes on them), so strip any the source file carried rather than
+        # re-serializing a carried tag as ns0:Genre.
+        return tag.rsplit('}', 1)[-1] if isinstance(tag, str) else tag
+
+    present = {_local(child.tag) for child in new_root}
+    carried = []
+    for child in old_root:
+        tag = _local(child.tag)
+        if tag in present:
+            continue
+        # Skip empty placeholders so a blank old tag can't shadow nothing useful.
+        if not (child.text or '').strip() and len(child) == 0:
+            continue
+        carried_child = copy.deepcopy(child)
+        carried_child.tag = tag
+        for sub in carried_child.iter():
+            sub.tag = _local(sub.tag)
+        new_root.append(carried_child)
+        present.add(tag)
+        carried.append(tag)
+
+    if not carried:
+        return new_xml
+
+    app_logger.info(f"merge_comicinfo_bytes: preserved existing tags {', '.join(carried)}")
+    ET.indent(new_root)
+    return ET.tostring(new_root, encoding='utf-8', xml_declaration=True)
+
+
+def _as_text(val):
+    """Normalize a metadata value to ComicInfo text, or None/'' if it has none.
+
+    Providers hand credits/characters through as either a pre-joined string or a
+    list; ComicInfo wants comma-separated text either way. Without this a list
+    would serialize as its Python repr, e.g. ``['Alan Moore', 'Dave Gibbons']``.
+    """
+    if val is None:
+        return None
+    if isinstance(val, (list, tuple, set)):
+        # ComicInfo expects comma-separated for multi-credits
+        return ", ".join(str(x) for x in val if x is not None and str(x).strip())
+    return str(val)
+
+
+def generate_comicinfo_xml(issue_data) -> bytes:
+    """Build a ComicInfo.xml that ComicRack will actually read.
+
+    - No XML namespaces
+    - UTF-8 bytes with an XML declaration
+    - Elements only written when there is a non-empty value
+    - Numeric fields emitted as integers-as-text
+
+    This is the single writer for every provider path. It used to be two
+    near-duplicates (routes/metadata.py and models/comicvine.py) that drifted,
+    so a field added to one was silently dropped by the other.
+
+    The tag list here is an explicit allowlist: a field a provider maps but that
+    has no ``add()`` line below is computed and then discarded. Anything the
+    caller does not supply is preserved from the file's current XML separately,
+    by :func:`merge_comicinfo_bytes`.
+
+    Every numeric coercion is guarded. Providers really do return values like a
+    Volume of "v2", and most callers have no try/except of their own.
+    """
+    root = ET.Element("ComicInfo")  # IMPORTANT: no xmlns/xsi attributes
+
+    def add(tag, value):
+        val = _as_text(value)
+        # An empty list normalizes to "" and a whitespace-only value to blank;
+        # neither should produce a tag.
+        if val and val.strip():
+            ET.SubElement(root, tag).text = val
+
+    # --- Identity -----------------------------------------------------------
+    add("Title", issue_data.get("Title"))
+    add("Series", issue_data.get("Series"))
+
+    # Number: whole numbers lose leading zeros, decimals keep their original
+    # formatting ("012.1" stays "012.1"), and a trailing .0 is dropped.
+    num = issue_data.get("Number")
+    if num is not None and str(num).strip():
+        num_str = str(num).strip()
+        try:
+            if num_str.replace(".", "", 1).isdigit():
+                if "." in num_str:
+                    num_val = float(num_str)
+                    add("Number", str(int(num_val)) if num_val == int(num_val) else num_str)
+                else:
+                    add("Number", str(int(num_str)))
+            else:
+                add("Number", num_str)
+        except (ValueError, TypeError):
+            # str.isdigit() is True for characters int()/float() reject ("²")
+            add("Number", num_str)
+
+    if issue_data.get("Count") not in (None, ""):
+        try:
+            add("Count", str(int(issue_data["Count"])))
+        except (ValueError, TypeError):
+            add("Count", issue_data["Count"])
+
+    vol = issue_data.get("Volume")
+    if vol is not None and str(vol).strip():
+        try:
+            add("Volume", str(int(vol)))
+        except (ValueError, TypeError):
+            add("Volume", vol)
+
+    add("Summary", issue_data.get("Summary"))
+
+    # --- Dates --------------------------------------------------------------
+    # Truthiness guards on purpose: a Year or Day of 0 carries no information.
+    if issue_data.get("Year"):
+        try:
+            add("Year", str(int(issue_data["Year"])))
+        except (ValueError, TypeError):
+            pass
+    if issue_data.get("Month"):
+        try:
+            m = int(issue_data["Month"])
+            if 1 <= m <= 12:
+                add("Month", str(m))
+        except (ValueError, TypeError):
+            pass
+    if issue_data.get("Day"):
+        try:
+            d = int(issue_data["Day"])
+            if 1 <= d <= 31:
+                add("Day", str(d))
+        except (ValueError, TypeError):
+            pass
+
+    # --- Credits ------------------------------------------------------------
+    add("Writer", issue_data.get("Writer"))
+    add("Penciller", issue_data.get("Penciller"))
+    add("Inker", issue_data.get("Inker"))
+    add("Colorist", issue_data.get("Colorist"))
+    add("Letterer", issue_data.get("Letterer"))
+    add("CoverArtist", issue_data.get("CoverArtist"))
+    add("Editor", issue_data.get("Editor"))
+    add("Translator", issue_data.get("Translator"))
+
+    add("Publisher", issue_data.get("Publisher"))
+
+    # --- Content ------------------------------------------------------------
+    add("Genre", issue_data.get("Genre"))
+    add("Characters", issue_data.get("Characters"))
+    add("Teams", issue_data.get("Teams"))
+    add("Locations", issue_data.get("Locations"))
+    add("StoryArc", issue_data.get("StoryArc"))
+    add("AlternateSeries", issue_data.get("AlternateSeries"))
+    add("AgeRating", issue_data.get("AgeRating"))
+
+    # ComicRack likes LanguageISO, e.g. 'en'
+    add("LanguageISO", issue_data.get("LanguageISO") or "en")
+
+    # via float() so a provider's "24.0" survives as 24 instead of being dropped
+    if issue_data.get("PageCount"):
+        try:
+            add("PageCount", str(int(float(issue_data["PageCount"]))))
+        except (ValueError, TypeError):
+            pass
+
+    # ComicRack expects "Yes", "No" or "YesAndRightToLeft". Every manga-aware
+    # provider sets this explicitly, so defaulting to "No" never mislabels.
+    add("Manga", issue_data.get("Manga") or "No")
+
+    add("Web", issue_data.get("Web"))
+    add("MetronId", issue_data.get("MetronId"))
+
+    # No fallback string here on purpose. A serializer cannot know a file's
+    # provenance, and Notes doubles as the "already tagged, skip this file"
+    # sentinel several callers read -- inventing one would both mislabel the
+    # source and make every file it touches permanently un-retaggable.
+    add("Notes", issue_data.get("Notes"))
+
+    # Pretty-print and serialize as UTF-8 BYTES (not a Python str)
+    ET.indent(root)  # Python 3.9+
+    tree = ET.ElementTree(root)
+    buf = io.BytesIO()
+    tree.write(buf, encoding="utf-8", xml_declaration=True)
+    return buf.getvalue()  # BYTES
 
 
 def update_comicinfo_in_zip(zip_path: str, updates: dict):

--- a/models/comicvine.py
+++ b/models/comicvine.py
@@ -723,6 +723,68 @@ def _extract_year_from_date(date_str: Optional[str]) -> Optional[int]:
             return None
 
 
+# ComicVine returns a creator's roles as ONE comma-joined string
+# (GenericCreator.roles, aliased from the API's "role") -- e.g. "penciler, inker"
+# or "writer, cover". Each token is matched independently so one creator can fill
+# several ComicInfo buckets; matching the whole string with a first-match-wins
+# chain silently dropped every credit but one.
+#
+# Order is significant: the first matcher a *token* hits wins for that token, so
+# "cover" and "color" must precede the penciller group, otherwise "cover artist"
+# and "color artist" would also land in Penciller.
+_CV_ROLE_MATCHERS = (
+    (("cover",), "cover_artists"),
+    (("editor",), "editors"),
+    (("translat",), "translators"),
+    (("letter",), "letterers"),
+    (("color", "colour"), "colorists"),
+    (("ink", "finish", "embellish"), "inkers"),
+    (("writer", "script", "plot", "story"), "writers"),
+    (("pencil", "illustrat", "artist", "painter", "breakdown", "layout"), "pencillers"),
+)
+
+# Bucket names, in matcher order. Callers build their issue dicts from these.
+CREDIT_BUCKETS = tuple(bucket for _, bucket in _CV_ROLE_MATCHERS)
+
+
+def parse_creator_roles(creators: Any) -> Dict[str, List[str]]:
+    """Bucket ComicVine person credits by ComicInfo role.
+
+    Accepts either Simyan ``GenericCreator`` objects (``.name`` / ``.roles``) or
+    plain dicts from the local SQLite dump (``{"name": ..., "role": ...}``), so
+    the API and local-DB paths share one implementation.
+
+    Names are de-duplicated per bucket and keep their original order. Role tokens
+    matching no bucket are dropped.
+    """
+    buckets: Dict[str, List[str]] = {bucket: [] for bucket in CREDIT_BUCKETS}
+
+    for credit in creators or []:
+        if isinstance(credit, dict):
+            name = credit.get('name')
+            roles = credit.get('role') or credit.get('roles') or ''
+        else:
+            name = getattr(credit, 'name', None)
+            if name is None:
+                name = str(credit)
+            roles = getattr(credit, 'roles', None) or ''
+
+        if not name:
+            continue
+
+        for token in str(roles).lower().split(','):
+            token = token.strip()
+            if not token:
+                continue
+            for needles, bucket in _CV_ROLE_MATCHERS:
+                if any(needle in token for needle in needles):
+                    if name not in buckets[bucket]:
+                        buckets[bucket].append(name)
+                    break
+
+    return buckets
+
+
 def _issue_to_dict(issue: Any) -> Dict[str, Any]:
     """
     Convert a Simyan Issue object to a dictionary.
@@ -784,32 +846,10 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
     cover_date_raw = _norm_date(getattr(issue, 'cover_date', None))
     store_date_raw = _norm_date(getattr(issue, 'store_date', None))
 
-    # Extract person credits (creators)
-    writers = []
-    pencillers = []
-    inkers = []
-    colorists = []
-    letterers = []
-    cover_artists = []
-
-    creators = getattr(issue, 'creators', None)
-    if creators:
-        for credit in creators:
-            name = credit.name if hasattr(credit, 'name') else str(credit)
-            role = credit.roles.lower() if hasattr(credit, 'roles') else ""
-
-            if "writer" in role or "script" in role:
-                writers.append(name)
-            elif "pencil" in role or "illustrat" in role:
-                pencillers.append(name)
-            elif "ink" in role:
-                inkers.append(name)
-            elif "color" in role:
-                colorists.append(name)
-            elif "letter" in role:
-                letterers.append(name)
-            elif "cover" in role:
-                cover_artists.append(name)
+    # Extract person credits (creators). A creator's roles arrive as one
+    # comma-joined string, so parse_creator_roles splits it and can place the
+    # same person in several buckets ("penciler, inker" -> Penciller AND Inker).
+    credits = parse_creator_roles(getattr(issue, 'creators', None))
 
     # Extract character names
     character_list = []
@@ -829,11 +869,14 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
     if locations:
         location_list = [loc.name if hasattr(loc, 'name') else str(loc) for loc in locations]
 
-    # Extract story arc
-    story_arc = None
-    story_arcs = getattr(issue, 'story_arcs', None)
-    if story_arcs and len(story_arcs) > 0:
-        story_arc = story_arcs[0].name if hasattr(story_arcs[0], 'name') else None
+    # Extract story arcs. ComicInfo's StoryArc is a comma-separated field, so
+    # keep every arc rather than only the first.
+    arc_names = []
+    for arc in getattr(issue, 'story_arcs', None) or []:
+        arc_name = arc.name if hasattr(arc, 'name') else None
+        if arc_name and arc_name not in arc_names:
+            arc_names.append(arc_name)
+    story_arc = ', '.join(arc_names) if arc_names else None
 
     # Get volume info
     volume = getattr(issue, 'volume', None)
@@ -862,16 +905,20 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
         "description": getattr(issue, 'description', None),  # BasicIssue.description -> Summary
         "image_url": image_url,
         "page_count": None,  # ComicVine doesn't always provide page count
-        "writers": writers,
-        "pencillers": pencillers,
-        "inkers": inkers,
-        "colorists": colorists,
-        "letterers": letterers,
-        "cover_artists": cover_artists,
+        "writers": credits["writers"],
+        "pencillers": credits["pencillers"],
+        "inkers": credits["inkers"],
+        "colorists": credits["colorists"],
+        "letterers": credits["letterers"],
+        "cover_artists": credits["cover_artists"],
+        "editors": credits["editors"],
+        "translators": credits["translators"],
         "characters": character_list,
         "teams": team_list,
         "locations": location_list,
         "story_arc": story_arc,
+        # site_detail_url -> ComicInfo Web
+        "site_url": str(issue.site_url) if getattr(issue, 'site_url', None) else None,
     }
 
 
@@ -913,6 +960,15 @@ def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str,
     if issue_data.get('cover_date') or issue_data.get('store_date'):
         notes += f' Cover/Store Date: {issue_data.get("cover_date") or issue_data.get("store_date")}.'
 
+    # Machine-readable issue identity, in the form comicbox/ComicTagger emit and
+    # parse. Without it no other tagger (or a later CLU re-tag) can tell which
+    # ComicVine issue a file was matched to -- the Volume ID above is not enough.
+    # 4000 is ComicVine's resource prefix for issues. Appended, so the
+    # "Volume ID:" prefix other code keys off stays byte-identical.
+    issue_id = issue_data.get('id')
+    if issue_id:
+        notes += f' [Issue ID 4000-{issue_id}] urn:comicvine:4000-{issue_id}'
+
     comicinfo = {
         'Series': series_name,
         'Number': issue_data.get('issue_number'),
@@ -934,10 +990,16 @@ def map_to_comicinfo(issue_data: Dict[str, Any], volume_data: Optional[Dict[str,
         'Colorist': ', '.join(issue_data.get('colorists', [])) if issue_data.get('colorists') else None,
         'Letterer': ', '.join(issue_data.get('letterers', [])) if issue_data.get('letterers') else None,
         'CoverArtist': ', '.join(issue_data.get('cover_artists', [])) if issue_data.get('cover_artists') else None,
+        'Editor': ', '.join(issue_data.get('editors', [])) if issue_data.get('editors') else None,
+        'Translator': ', '.join(issue_data.get('translators', [])) if issue_data.get('translators') else None,
         'Characters': ', '.join(issue_data.get('characters', [])) if issue_data.get('characters') else None,
         'Teams': ', '.join(issue_data.get('teams', [])) if issue_data.get('teams') else None,
         'Locations': ', '.join(issue_data.get('locations', [])) if issue_data.get('locations') else None,
         'StoryArc': issue_data.get('story_arc'),
+        # ComicVine's site_detail_url. Note ComicVine has no genre data at all,
+        # so Genre is deliberately absent here -- an existing Genre survives via
+        # the merge in core.comicinfo.merge_comicinfo_bytes.
+        'Web': issue_data.get('site_url'),
         'PageCount': issue_data.get('page_count'),
         'LanguageISO': 'en',  # ComicVine is primarily English content
         'Notes': notes,
@@ -1474,19 +1536,27 @@ def get_all_issues_for_volume(api_key: str, volume_id: int) -> List[Dict[str, An
 from models.providers.base import extract_issue_number  # noqa: F811
 
 
-def add_comicinfo_to_archive(file_path: str, xml_content) -> bool:
+def add_comicinfo_to_archive(file_path: str, xml_content, merge_existing: bool = True) -> bool:
     """
     Add or update ComicInfo.xml in a CBZ archive.
 
     Args:
         file_path: Path to the CBZ file
         xml_content: XML content to add (str or bytes)
+        merge_existing: Carry forward tags the archive already had that
+            xml_content does not supply (the default). No provider covers every
+            ComicInfo field, so a plain rebuild loses data on every re-tag.
 
     Returns:
         True on success, False on failure
     """
     import zipfile
     from helpers import open_zip_for_write
+    from core.comicinfo import merge_comicinfo_bytes
+
+    # Normalize up front so the merge below always has bytes to work with.
+    if isinstance(xml_content, str):
+        xml_content = xml_content.encode('utf-8')
 
     try:
         # open_zip_for_write assembles the new archive on a local volume and
@@ -1498,15 +1568,21 @@ def add_comicinfo_to_archive(file_path: str, xml_content) -> bool:
             with zipfile.ZipFile(file_path, 'r') as zin:
                 for item in zin.infolist():
                     # Skip existing ComicInfo.xml (any case, any nesting level)
+                    # -- but read it first so tags the new metadata omits survive.
                     if os.path.basename(item.filename).lower() == 'comicinfo.xml':
+                        if merge_existing:
+                            try:
+                                xml_content = merge_comicinfo_bytes(
+                                    xml_content, zin.read(item.filename)
+                                )
+                            except Exception as merge_error:
+                                app_logger.warning(
+                                    f"Could not merge existing ComicInfo.xml in {file_path}: {merge_error}"
+                                )
                         continue
                     zout.writestr(item, zin.read(item.filename))
 
-            # Add new ComicInfo.xml - handle both str and bytes
-            if isinstance(xml_content, bytes):
-                zout.writestr('ComicInfo.xml', xml_content)
-            else:
-                zout.writestr('ComicInfo.xml', xml_content.encode('utf-8'))
+            zout.writestr('ComicInfo.xml', xml_content)
 
         return True
 
@@ -1515,124 +1591,10 @@ def add_comicinfo_to_archive(file_path: str, xml_content) -> bool:
         return False
 
 
-def generate_comicinfo_xml(issue_data: Dict[str, Any]) -> bytes:
-    """
-    Generate ComicInfo.xml content from issue metadata.
-
-    Args:
-        issue_data: Dictionary with ComicInfo fields
-
-    Returns:
-        XML content as bytes
-    """
-    import xml.etree.ElementTree as ET
-    import io
-
-    root = ET.Element("ComicInfo")
-
-    def add(tag, value):
-        if value is not None and str(value).strip():
-            ET.SubElement(root, tag).text = str(value)
-
-    # Basic fields
-    add("Title", issue_data.get("Title"))
-    add("Series", issue_data.get("Series"))
-
-    # Number field
-    num = issue_data.get("Number")
-    if num is not None and str(num).strip():
-        try:
-            # Format as integer for whole numbers, preserve original string for decimals
-            num_str = str(num).strip()
-            if num_str.replace(".", "", 1).isdigit():
-                if "." in num_str:
-                    num_val = float(num_str)
-                    if num_val == int(num_val):
-                        add("Number", str(int(num_val)))
-                    else:
-                        add("Number", num_str)
-                else:
-                    add("Number", str(int(num_str)))
-            else:
-                add("Number", num_str)
-        except (ValueError, TypeError):
-            add("Number", str(num))
-
-    # Volume
-    vol = issue_data.get("Volume")
-    if vol is not None and str(vol).strip():
-        try:
-            add("Volume", str(int(vol)))
-        except (ValueError, TypeError):
-            add("Volume", str(vol))
-
-    add("Summary", issue_data.get("Summary"))
-
-    # Dates
-    if issue_data.get("Year"):
-        try:
-            add("Year", str(int(issue_data["Year"])))
-        except (ValueError, TypeError):
-            pass
-    if issue_data.get("Month"):
-        try:
-            m = int(issue_data["Month"])
-            if 1 <= m <= 12:
-                add("Month", str(m))
-        except (ValueError, TypeError):
-            pass
-    if issue_data.get("Day"):
-        try:
-            d = int(issue_data["Day"])
-            if 1 <= d <= 31:
-                add("Day", str(d))
-        except (ValueError, TypeError):
-            pass
-
-    # Credits
-    add("Writer", issue_data.get("Writer"))
-    add("Penciller", issue_data.get("Penciller"))
-    add("Inker", issue_data.get("Inker"))
-    add("Colorist", issue_data.get("Colorist"))
-    add("Letterer", issue_data.get("Letterer"))
-    add("CoverArtist", issue_data.get("CoverArtist"))
-
-    # Publisher
-    add("Publisher", issue_data.get("Publisher"))
-
-    # Characters/Teams/Locations
-    add("Characters", issue_data.get("Characters"))
-    add("Teams", issue_data.get("Teams"))
-    add("Locations", issue_data.get("Locations"))
-    add("StoryArc", issue_data.get("StoryArc"))
-    add("Genre", issue_data.get("Genre"))
-    add("AlternateSeries", issue_data.get("AlternateSeries"))
-
-    # Language
-    add("LanguageISO", issue_data.get("LanguageISO") or "en")
-    add("Manga", issue_data.get("Manga"))
-    add("Web", issue_data.get("Web"))
-    add("Count", issue_data.get("Count"))
-
-    # Page count
-    if issue_data.get("PageCount"):
-        try:
-            add("PageCount", str(int(issue_data["PageCount"])))
-        except (ValueError, TypeError):
-            pass
-
-    # Notes
-    add("Notes", issue_data.get("Notes"))
-
-    # Metron ID (for scrobble support)
-    add("MetronId", issue_data.get("MetronId"))
-
-    # Serialize as UTF-8 bytes
-    ET.indent(root)
-    tree = ET.ElementTree(root)
-    buf = io.BytesIO()
-    tree.write(buf, encoding="utf-8", xml_declaration=True)
-    return buf.getvalue()
+# The ComicInfo serializer lives in core.comicinfo. This module used to carry
+# a second, drifting copy of it; re-exported here because app.py imports the
+# name from models.comicvine alongside add_comicinfo_to_archive.
+from core.comicinfo import generate_comicinfo_xml  # noqa: F401
 
 
 def auto_fetch_metadata_for_folder(folder_path: str, api_key: str, target_file: str = None) -> Dict[str, Any]:

--- a/models/comicvine_sqlite.py
+++ b/models/comicvine_sqlite.py
@@ -5,7 +5,9 @@ Reads a user-provided SQLite export of ComicVine data (a file the user places on
 a mapped path and points to in Settings). It produces ComicInfo output identical
 to the ComicVine API provider by reusing ``models.comicvine.map_to_comicinfo`` —
 this module only builds the intermediate ``issue_data`` dict (same keys as
-``comicvine._issue_to_dict``) from the SQLite rows + JSON credit columns.
+``comicvine._issue_to_dict``) from the SQLite rows + JSON credit columns. Credit
+role bucketing is shared too, via ``models.comicvine.parse_creator_roles``, so
+the two paths cannot drift.
 
 Schema (user-provided dump):
 - cv_volume(id, name, aliases, start_year, publisher_id, count_of_issues,
@@ -26,7 +28,7 @@ from datetime import datetime
 from typing import Optional, Dict, Any, List
 
 from core.app_logging import app_logger
-from models.comicvine import map_to_comicinfo, _extract_year_from_date
+from models.comicvine import map_to_comicinfo, parse_creator_roles, _extract_year_from_date
 
 # Notes-field label so ComicInfo.xml written from the local DB is distinguishable
 # from the ComicVine API (which uses the default "ComicVine CVDB").
@@ -159,31 +161,15 @@ def _names_from(value) -> List[str]:
 def _parse_person_credits(value):
     """Map person_credits JSON into ComicInfo role buckets.
 
-    Replicates comicvine._issue_to_dict exactly: the role string is lowercased
-    and matched with a first-match-wins if/elif chain (NOT split on commas), so
-    each creator lands in exactly one bucket. Roles matching none are dropped.
+    Delegates to comicvine.parse_creator_roles so the local DB and the API agree
+    by construction: a role string is comma-separated ("penciler, inker"), each
+    token is bucketed independently, and tokens matching nothing are dropped.
+
+    Returns the same dict of role -> [names] that parse_creator_roles returns.
     """
-    writers, pencillers, inkers, colorists, letterers, cover_artists = [], [], [], [], [], []
-    for credit in _load_json_list(value):
-        if not isinstance(credit, dict):
-            continue
-        name = credit.get('name')
-        if not name:
-            continue
-        role = (credit.get('role') or '').lower()
-        if "writer" in role or "script" in role:
-            writers.append(name)
-        elif "pencil" in role or "illustrat" in role:
-            pencillers.append(name)
-        elif "ink" in role:
-            inkers.append(name)
-        elif "color" in role:
-            colorists.append(name)
-        elif "letter" in role:
-            letterers.append(name)
-        elif "cover" in role:
-            cover_artists.append(name)
-    return writers, pencillers, inkers, colorists, letterers, cover_artists
+    return parse_creator_roles(
+        [c for c in _load_json_list(value) if isinstance(c, dict)]
+    )
 
 
 # =============================================================================
@@ -319,7 +305,7 @@ def get_issue_by_number(volume_id: int, issue_number: str, year: Optional[int] =
         cursor = conn.cursor()
         cursor.execute(
             "SELECT i.id, i.volume_id, i.name, i.issue_number, i.cover_date,"
-            "       i.store_date, i.description, i.image_url,"
+            "       i.store_date, i.description, i.image_url, i.site_detail_url,"
             "       i.character_credits, i.person_credits, i.team_credits,"
             "       i.location_credits, i.story_arc_credits,"
             "       v.name AS volume_name, v.start_year AS volume_start_year,"
@@ -358,11 +344,11 @@ def _row_to_issue_data(row: Dict[str, Any]) -> Dict[str, Any]:
         except (ValueError, TypeError):
             pass
 
-    writers, pencillers, inkers, colorists, letterers, cover_artists = \
-        _parse_person_credits(row.get('person_credits'))
+    credits = _parse_person_credits(row.get('person_credits'))
 
+    # StoryArc is a comma-separated ComicInfo field -- keep every arc.
     story_arcs = _names_from(row.get('story_arc_credits'))
-    story_arc = story_arcs[0] if story_arcs else None
+    story_arc = ', '.join(dict.fromkeys(story_arcs)) if story_arcs else None
 
     return {
         "id": row.get('id'),
@@ -380,16 +366,19 @@ def _row_to_issue_data(row: Dict[str, Any]) -> Dict[str, Any]:
         "description": row.get('description'),
         "image_url": row.get('image_url'),
         "page_count": None,
-        "writers": writers,
-        "pencillers": pencillers,
-        "inkers": inkers,
-        "colorists": colorists,
-        "letterers": letterers,
-        "cover_artists": cover_artists,
+        "writers": credits["writers"],
+        "pencillers": credits["pencillers"],
+        "inkers": credits["inkers"],
+        "colorists": credits["colorists"],
+        "letterers": credits["letterers"],
+        "cover_artists": credits["cover_artists"],
+        "editors": credits["editors"],
+        "translators": credits["translators"],
         "characters": _names_from(row.get('character_credits')),
         "teams": _names_from(row.get('team_credits')),
         "locations": _names_from(row.get('location_credits')),
         "story_arc": story_arc,
+        "site_url": row.get('site_detail_url') or None,
     }
 
 

--- a/routes/bulk_metadata.py
+++ b/routes/bulk_metadata.py
@@ -921,9 +921,11 @@ def _revert_audit_row(audit_id):
     prior = row.get('prior_xml')
     try:
         if prior:
-            # Re-apply the prior XML (add_comicinfo_to_cbz overwrites by design).
+            # Restore the prior XML byte-for-byte. merge_existing=False is
+            # required: the default would carry tags forward from the metadata
+            # we are undoing, leaving the file in neither the old nor new state.
             from routes.metadata import add_comicinfo_to_cbz
-            add_comicinfo_to_cbz(file_path, bytes(prior))
+            add_comicinfo_to_cbz(file_path, bytes(prior), merge_existing=False)
         else:
             _strip_comicinfo_from_cbz(file_path)
     except Exception as e:

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -12,14 +12,12 @@ Provides routes for:
 
 import os
 import re
-import io
 import json
 import time
 import shutil
 import zipfile
 import threading
 import traceback
-import xml.etree.ElementTree as ET
 import sqlite3
 from datetime import datetime
 from flask import (Blueprint, request, jsonify, Response,
@@ -50,13 +48,10 @@ except (ValueError, TypeError):
 # Helper Functions (used by multiple routes)
 # =============================================================================
 
-def _as_text(val):
-    if val is None:
-        return None
-    if isinstance(val, (list, tuple, set)):
-        # ComicInfo expects comma-separated for multi-credits
-        return ", ".join(str(x) for x in val if x is not None and str(x).strip())
-    return str(val)
+# The ComicInfo serializer and its text normalizer live in core.comicinfo --
+# there used to be a second, drifting copy in models/comicvine.py. Re-exported
+# here because callers and tests import them from this module.
+from core.comicinfo import generate_comicinfo_xml, _as_text  # noqa: F401
 
 
 from core.metadata_dates import (
@@ -132,115 +127,21 @@ def extract_series_name_from_filename(filename):
     return s.strip()
 
 
-def generate_comicinfo_xml(issue_data, series_data=None):
-    """
-    Generate a ComicInfo.xml that ComicRack will actually read.
-    - No XML namespaces
-    - UTF-8 bytes with XML declaration
-    - Only write elements when we have non-empty values
-    - Ensure numeric fields are integers-as-text
-    """
-    root = ET.Element("ComicInfo")  # IMPORTANT: no xmlns/xsi attributes
-
-    def add(tag, value):
-        val = _as_text(value)
-        if val:
-            ET.SubElement(root, tag).text = val
-
-    # Basic
-    add("Title",   issue_data.get("Title"))
-    add("Series",  issue_data.get("Series"))
-    # Number/Count/Volume should be simple numerics-as-text
-    if issue_data.get("Number") not in (None, ""):
-        num_str = str(issue_data["Number"]).strip()
-        if num_str.replace(".", "", 1).isdigit():
-            if "." in num_str:
-                # Decimal issue: strip trailing .0, but preserve original formatting (e.g. "012.1")
-                num_val = float(num_str)
-                if num_val == int(num_val):
-                    add("Number", str(int(num_val)))
-                else:
-                    add("Number", num_str)
-            else:
-                # Whole number: convert to int to strip leading zeros
-                add("Number", str(int(num_str)))
-        else:
-            add("Number", num_str)
-    if issue_data.get("Count") not in (None, ""):
-        add("Count", str(int(issue_data["Count"])) )
-    if issue_data.get("Volume") not in (None, ""):
-        add("Volume", str(int(issue_data["Volume"])) )
-
-    add("Summary", issue_data.get("Summary"))
-
-    # Dates
-    if issue_data.get("Year") not in (None, ""):
-        add("Year", str(int(issue_data["Year"])))
-    if issue_data.get("Month") not in (None, ""):
-        m = int(issue_data["Month"])
-        if 1 <= m <= 12:
-            add("Month", str(m))
-
-    # Credits
-    add("Writer",      issue_data.get("Writer"))
-    add("Penciller",   issue_data.get("Penciller"))
-    add("Inker",       issue_data.get("Inker"))
-    add("Colorist",    issue_data.get("Colorist"))
-    add("Letterer",    issue_data.get("Letterer"))
-    add("CoverArtist", issue_data.get("CoverArtist"))
-
-    # Publisher/Imprint
-    add("Publisher", issue_data.get("Publisher"))
-
-    # Genre/Characters/Teams/Locations
-    add("Genre",      issue_data.get("Genre"))
-    add("Characters", issue_data.get("Characters"))
-    add("Teams",      issue_data.get("Teams"))
-    add("Locations",  issue_data.get("Locations"))
-    add("StoryArc",   issue_data.get("StoryArc"))
-    add("AlternateSeries", issue_data.get("AlternateSeries"))
-
-    # Language (ComicRack likes LanguageISO, e.g., 'en')
-    add("LanguageISO", issue_data.get("LanguageISO") or "en")
-
-    # Page count (integer)
-    if issue_data.get("PageCount") not in (None, ""):
-        add("PageCount", str(int(float(issue_data["PageCount"]))))
-
-    # Manga flag: ComicRack expects "Yes", "No", or "YesAndRightToLeft"
-    add("Manga", issue_data.get("Manga") or "No")
-
-    # Web link
-    add("Web", issue_data.get("Web"))
-
-    # Metron ID (for scrobble support)
-    add("MetronId", issue_data.get("MetronId"))
-
-    # Notes - use provided Notes if available (e.g., from ComicVine), otherwise generate GCD notes
-    if issue_data.get("Notes"):
-        add("Notes", issue_data.get("Notes"))
-    else:
-        # Default to GCD format for backward compatibility
-        notes = f"Metadata from Grand Comic Database (GCD). Issue ID: {issue_data.get('id', 'Unknown')} — retrieved {datetime.now():%Y-%m-%d}."
-        add("Notes", notes)
-
-    # Pretty-print and serialize as UTF-8 BYTES (not a Python str)
-    ET.indent(root)  # Python 3.9+
-    tree = ET.ElementTree(root)
-    buf = io.BytesIO()
-    tree.write(buf, encoding="utf-8", xml_declaration=True)
-    return buf.getvalue()  # BYTES
-
-
-def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
+def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes, merge_existing=True):
     """
     Writes ComicInfo.xml at the ROOT of the CBZ.
     - Removes any existing ComicInfo.xml (case-insensitive)
     - Uses UTF-8 bytes for content
     - Rebuilds the entire ZIP by extracting and recompressing (matches single_file.py approach)
     - Handles RAR files incorrectly named as CBZ
+
+    With merge_existing (the default), tags the archive already had that the new
+    metadata does not supply are carried forward instead of being destroyed --
+    no provider covers every ComicInfo field, so a plain rebuild loses data on
+    every re-tag. Pass merge_existing=False for a true replace.
     """
     from cbz_ops.single_file import convert_single_rar_file
+    from core.comicinfo import merge_comicinfo_bytes
 
     # Safety: ensure bytes
     if isinstance(comicinfo_xml_bytes, str):
@@ -263,8 +164,18 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
 
         with zipfile.ZipFile(file_path, 'r') as src:
             for filename in src.namelist():
-                # Skip any existing ComicInfo.xml
+                # Skip any existing ComicInfo.xml -- but read it first so the
+                # tags the new metadata omits can be carried forward.
                 if os.path.basename(filename).lower() == "comicinfo.xml":
+                    if merge_existing:
+                        try:
+                            comicinfo_xml_bytes = merge_comicinfo_bytes(
+                                comicinfo_xml_bytes, src.read(filename)
+                            )
+                        except Exception as merge_error:
+                            app_logger.warning(
+                                f"Could not merge existing ComicInfo.xml in {file_path}: {merge_error}"
+                            )
                     continue
                 try:
                     src.extract(filename, temp_extract_dir)
@@ -355,7 +266,7 @@ def add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes):
                 app_logger.info(f"Successfully converted RAR to CBZ. Now adding ComicInfo.xml...")
 
                 # Now recursively call this function to add ComicInfo.xml to the newly converted CBZ
-                add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes)
+                add_comicinfo_to_cbz(file_path, comicinfo_xml_bytes, merge_existing)
             else:
                 app_logger.error(f"Failed to convert {base_name}.rar to CBZ")
                 # Move the RAR file back to original CBZ name
@@ -1785,7 +1696,7 @@ def batch_metadata():
 
                     if metadata:
                         # Generate and add ComicInfo.xml
-                        xml_bytes = comicvine.generate_comicinfo_xml(metadata)
+                        xml_bytes = generate_comicinfo_xml(metadata)
                         add_comicinfo_to_cbz(file_path, xml_bytes)
 
                         # Auto-rename FIRST (before index update). Skipped in
@@ -2599,6 +2510,13 @@ def search_gcd_metadata():
                     'LanguageISO': issue_basic['language'],
                     'PageCount': page_count
                 }
+                # Provenance. Every other provider's mapper sets Notes itself;
+                # these two GCD-SQLite builders are the only dicts that don't, so
+                # the serializer has no fallback to invent one (it would mislabel
+                # other providers, and Notes doubles as the already-tagged flag).
+                issue_result['Notes'] = (
+                    f"Metadata from Grand Comic Database (GCD). Issue ID: {issue_result['id']} — retrieved {datetime.now():%Y-%m-%d}."
+                )
             else:
                 # If we still don't have issue_basic after all attempts, set issue_result to None
                 issue_result = None
@@ -2653,7 +2571,7 @@ def search_gcd_metadata():
                 # Generate ComicInfo.xml content
                 app_logger.debug(f"DEBUG: Generating ComicInfo.xml...")
                 try:
-                    comicinfo_xml = generate_comicinfo_xml(issue_result, best_series)
+                    comicinfo_xml = generate_comicinfo_xml(issue_result)
                     app_logger.debug(f"DEBUG: ComicInfo.xml generated successfully (length: {len(comicinfo_xml)} chars)")
                 except Exception as xml_error:
                     app_logger.debug(f"DEBUG: Error generating ComicInfo.xml: {str(xml_error)}")
@@ -3008,6 +2926,11 @@ def search_gcd_metadata_with_selection():
             if issue_result:
                 app_logger.debug(f"DEBUG: Issue result keys: {list(issue_result.keys())}")
                 app_logger.debug(f"DEBUG: Issue title: {issue_result.get('Title', 'N/A')}")
+                # Provenance -- see the sibling GCD builder above for why the
+                # serializer no longer invents this.
+                issue_result['Notes'] = (
+                    f"Metadata from Grand Comic Database (GCD). Issue ID: {issue_result['id']} — retrieved {datetime.now():%Y-%m-%d}."
+                )
 
             if issue_result:
                 # Check if ComicInfo.xml already exists and has Notes data
@@ -3032,7 +2955,7 @@ def search_gcd_metadata_with_selection():
                     app_logger.debug(f"DEBUG: Error checking existing ComicInfo.xml (will proceed with generation): {str(check_error)}")
 
                 # Generate ComicInfo.xml content
-                comicinfo_xml = generate_comicinfo_xml(issue_result, series_result)
+                comicinfo_xml = generate_comicinfo_xml(issue_result)
 
                 # Add ComicInfo.xml to the CBZ file
                 add_comicinfo_to_cbz(file_path, comicinfo_xml)
@@ -3335,8 +3258,9 @@ def _try_comicvine_single_impl(cvinfo_path, series_name, issue_number, year, nea
                     volume_data = {
                         'id': cv_volume_id,
                         'name': issue_data.get('volume_name', ''),
+                        # _issue_to_dict emits 'publisher', never 'publisher_name'
                         'start_year': issue_data.get('year'),
-                        'publisher_name': issue_data.get('publisher_name', '')
+                        'publisher_name': issue_data.get('publisher', '')
                     }
                     # Read start_year from cvinfo for Volume field
                     cvinfo_fields = comicvine.read_cvinfo_fields(cvinfo_path)
@@ -4397,12 +4321,19 @@ def search_comicvine_metadata():
                     volume_data = {
                         'id': cv_volume_id,
                         'name': issue_data.get('volume_name', ''),
+                        # _issue_to_dict emits 'publisher', never 'publisher_name'
                         'start_year': issue_data.get('year'),
-                        'publisher_name': issue_data.get('publisher_name', '')
+                        'publisher_name': issue_data.get('publisher', '')
                     }
 
+                    # Prefer the series start year from cvinfo for the Volume
+                    # field; issue_data['year'] is the issue's own cover year.
+                    cvinfo_start_year = comicvine.read_cvinfo_fields(cvinfo_path).get('start_year')
+
                     # Map to ComicInfo format
-                    comicinfo_data = comicvine.map_to_comicinfo(issue_data, volume_data)
+                    comicinfo_data = comicvine.map_to_comicinfo(
+                        issue_data, volume_data, start_year=cvinfo_start_year
+                    )
 
                     # Generate ComicInfo.xml
                     comicinfo_xml = generate_comicinfo_xml(comicinfo_data)

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -319,7 +319,7 @@ def make_mock_cv_volume(*, id=4050, name="Batman", start_year=2016,
 
 def make_mock_cv_issue(*, id=1001, issue_number="1", name="Rebirth",
                        cover_date="2020-01-15", store_date=None,
-                       publisher_name="DC Comics"):
+                       publisher_name="DC Comics", site_url=None):
     i = MagicMock()
     i.id = id
     i.issue_number = issue_number
@@ -327,6 +327,8 @@ def make_mock_cv_issue(*, id=1001, issue_number="1", name="Rebirth",
     i.cover_date = cover_date
     i.store_date = store_date
     i.description = "Batman returns"
+    # Simyan always populates site_url (site_detail_url) -> ComicInfo Web.
+    i.site_url = site_url or f"https://comicvine.gamespot.com/issue/4000-{id}/"
     img = MagicMock()
     img.small_url = "https://example.com/small.jpg"
     img.thumb_url = "https://example.com/thumb.jpg"
@@ -392,6 +394,7 @@ def build_comicvine_sqlite(path, *, extra_alias_volumes=False):
     person = json.dumps([
         {"id": 1, "name": "Bob Kane", "role": "writer, penciler"},
         {"id": 2, "name": "Jerry Robinson", "role": "penciler, cover"},
+        {"id": 3, "name": "Julius Schwartz", "role": "editor"},
     ])
     characters = json.dumps([{"id": 9, "name": "Batman"}, {"id": 10, "name": "Robin"}])
     teams = json.dumps([{"id": 5, "name": "Justice League"}])
@@ -399,11 +402,12 @@ def build_comicvine_sqlite(path, *, extra_alias_volumes=False):
     story_arcs = json.dumps([{"id": 3, "name": "Year One"}, {"id": 4, "name": "Second Arc"}])
     cur.executemany(
         "INSERT INTO cv_issue (id, volume_id, name, issue_number, cover_date, "
-        "store_date, description, image_url, character_credits, person_credits, "
-        "team_credits, location_credits, story_arc_credits) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "store_date, description, image_url, site_detail_url, character_credits, "
+        "person_credits, team_credits, location_credits, story_arc_credits) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         [(500, 4050, "The Beginning", "1", "2016-06-01", "2016-05-15",
           "An origin story.", "https://example.com/issue1.jpg",
+          "https://comicvine.gamespot.com/batman-1/4000-500/",
           characters, person, teams, locations, story_arcs)],
     )
 

--- a/tests/mocked/test_comicvine_model.py
+++ b/tests/mocked/test_comicvine_model.py
@@ -1,5 +1,7 @@
 """Tests for models/comicvine.py -- mocked Simyan library."""
 import threading
+import xml.etree.ElementTree as ET
+import zipfile
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -416,6 +418,61 @@ class TestGetIssueByNumber:
         assert get_issue_by_number("fake-key", 4050, "999") is None
 
 
+class TestIssueToDict:
+    """The API path's object -> dict step, including credit bucketing."""
+
+    def _issue(self, **over):
+        issue = make_mock_cv_issue(id=29348, issue_number="4", name="Race with the Devil")
+        issue.creators = []
+        issue.characters = []
+        issue.teams = []
+        issue.locations = []
+        issue.story_arcs = []
+        issue.site_url = "https://comicvine.gamespot.com/swords-of-texas-4/4000-29348/"
+        for k, v in over.items():
+            setattr(issue, k, v)
+        return issue
+
+    def test_multi_role_creator_fills_every_bucket(self):
+        from models.comicvine import _issue_to_dict
+
+        creator = MagicMock()
+        creator.name = "Ben Dunn"
+        creator.roles = "penciler, inker"
+        data = _issue_to_dict(self._issue(creators=[creator]))
+
+        assert data["pencillers"] == ["Ben Dunn"]
+        assert data["inkers"] == ["Ben Dunn"]
+
+    def test_editor_credit_captured(self):
+        from models.comicvine import _issue_to_dict
+
+        creator = MagicMock()
+        creator.name = "Tim Truman"
+        creator.roles = "editor"
+        data = _issue_to_dict(self._issue(creators=[creator]))
+        assert data["editors"] == ["Tim Truman"]
+
+    def test_site_url_captured_for_web(self):
+        from models.comicvine import _issue_to_dict
+
+        data = _issue_to_dict(self._issue())
+        assert data["site_url"] == "https://comicvine.gamespot.com/swords-of-texas-4/4000-29348/"
+
+    def test_missing_site_url(self):
+        from models.comicvine import _issue_to_dict
+
+        assert _issue_to_dict(self._issue(site_url=None))["site_url"] is None
+
+    def test_all_story_arcs_kept(self):
+        from models.comicvine import _issue_to_dict
+
+        first, second = MagicMock(), MagicMock()
+        first.name, second.name = "Year One", "Second Arc"
+        data = _issue_to_dict(self._issue(story_arcs=[first, second]))
+        assert data["story_arc"] == "Year One, Second Arc"
+
+
 class TestMapToComicinfo:
 
     def test_full_mapping(self):
@@ -457,6 +514,44 @@ class TestMapToComicinfo:
         assert "Batman" in result["Characters"]
         assert result["StoryArc"] == "City of Bane"
         assert "LanguageISO" in result
+
+    def test_maps_editor_translator_and_web(self):
+        from models.comicvine import map_to_comicinfo
+
+        issue_data = {
+            "id": 29348,
+            "issue_number": "4",
+            "volume_id": 3892,
+            "editors": ["Tim Truman"],
+            "translators": ["A. Translator"],
+            "site_url": "https://comicvine.gamespot.com/swords-of-texas-4/4000-29348/",
+        }
+        result = map_to_comicinfo(issue_data)
+        assert result["Editor"] == "Tim Truman"
+        assert result["Translator"] == "A. Translator"
+        assert result["Web"] == "https://comicvine.gamespot.com/swords-of-texas-4/4000-29348/"
+
+    def test_notes_carry_a_machine_readable_issue_id(self):
+        """Without it no tagger can tell which ComicVine issue was matched --
+        the Volume ID alone is not enough to identify the issue."""
+        from models.comicvine import map_to_comicinfo
+
+        result = map_to_comicinfo({"id": 29348, "issue_number": "4", "volume_id": 3892})
+        assert "Volume ID: 3892" in result["Notes"]
+        assert result["Notes"].endswith("[Issue ID 4000-29348] urn:comicvine:4000-29348")
+
+    def test_notes_omit_issue_markers_without_an_id(self):
+        from models.comicvine import map_to_comicinfo
+
+        result = map_to_comicinfo({"issue_number": "4", "volume_id": 3892})
+        assert "urn:comicvine" not in result["Notes"]
+
+    def test_genre_is_never_set(self):
+        """ComicVine has no genre data; an existing Genre survives instead via
+        core.comicinfo.merge_comicinfo_bytes."""
+        from models.comicvine import map_to_comicinfo
+
+        assert "Genre" not in map_to_comicinfo({"id": 1, "issue_number": "1"})
 
     def test_with_volume_data(self):
         from models.comicvine import map_to_comicinfo
@@ -642,53 +737,65 @@ class TestRankVolumesByYear:
         assert result[-1]["name"] == "C"  # None year goes last
 
 
-class TestGenerateComicInfoXml:
+class TestAddComicInfoToArchive:
+    """The batch/app.py write path. Like the routes writer, it rebuilds the
+    archive, so tags the new metadata omits must be carried forward."""
 
-    def test_generates_valid_xml(self):
-        from models.comicvine import generate_comicinfo_xml
+    def _cbz(self, tmp_path, existing=None):
+        cbz = tmp_path / "Book 001.cbz"
+        with zipfile.ZipFile(str(cbz), "w") as zf:
+            zf.writestr("001.jpg", b"fake image")
+            if existing is not None:
+                zf.writestr("ComicInfo.xml", existing)
+        return str(cbz)
 
-        data = {
-            "Series": "Batman",
-            "Number": "1",
-            "Title": "Rebirth",
-            "Year": 2020,
-            "Publisher": "DC Comics",
-        }
+    def _patch_cache_dir(self, cache_dir):
+        """Keep zip assembly (helpers._zip_assembly_dir) inside tmp_path."""
+        from core.config import config
 
-        xml_bytes = generate_comicinfo_xml(data)
-        assert isinstance(xml_bytes, bytes)
-        assert b"<Series>Batman</Series>" in xml_bytes
-        assert b"<Number>1</Number>" in xml_bytes
-        assert b"<Publisher>DC Comics</Publisher>" in xml_bytes
+        real_get = config.get
 
-    def test_decimal_issue_number_preserved(self):
-        """Decimal issue numbers like 12.1 should not be truncated to 12."""
-        from models.comicvine import generate_comicinfo_xml
+        def fake_get(section, option, *args, **kwargs):
+            if section == "SETTINGS" and option == "CACHE_DIR":
+                return str(cache_dir)
+            return real_get(section, option, *args, **kwargs)
 
-        data = {"Series": "Avengers", "Number": "12.1", "Year": 2011}
-        xml_bytes = generate_comicinfo_xml(data)
-        assert b"<Number>12.1</Number>" in xml_bytes
+        return patch.object(config, "get", side_effect=fake_get)
 
-    def test_decimal_issue_preserves_leading_zeros(self):
-        """012.1 should stay '012.1', not be stripped to '12.1' via float()."""
-        from models.comicvine import generate_comicinfo_xml
+    def test_preserves_tags_the_new_metadata_omits(self, tmp_path):
+        from models.comicvine import add_comicinfo_to_archive
 
-        data = {"Series": "Avengers", "Number": "012.1", "Year": 2011}
-        xml_bytes = generate_comicinfo_xml(data)
-        assert b"<Number>012.1</Number>" in xml_bytes
+        cbz = self._cbz(tmp_path, "<ComicInfo><Series>Old</Series><Genre>Humor</Genre></ComicInfo>")
+        with self._patch_cache_dir(tmp_path / "cache"),              patch("helpers.match_parent_permissions"):
+            assert add_comicinfo_to_archive(cbz, b"<ComicInfo><Series>New</Series></ComicInfo>")
 
-    def test_whole_number_drops_decimal(self):
-        """12.0 should be stored as '12', not '12.0'."""
-        from models.comicvine import generate_comicinfo_xml
+        with zipfile.ZipFile(cbz) as zf:
+            root = ET.fromstring(zf.read("ComicInfo.xml"))
+        assert root.find("Series").text == "New"
+        assert root.find("Genre").text == "Humor"
 
-        data = {"Series": "Batman", "Number": "12.0"}
-        xml_bytes = generate_comicinfo_xml(data)
-        assert b"<Number>12</Number>" in xml_bytes
+    def test_accepts_str_content(self, tmp_path):
+        from models.comicvine import add_comicinfo_to_archive
 
-    def test_omits_none_values(self):
-        from models.comicvine import generate_comicinfo_xml
+        cbz = self._cbz(tmp_path)
+        with self._patch_cache_dir(tmp_path / "cache"),              patch("helpers.match_parent_permissions"):
+            assert add_comicinfo_to_archive(cbz, "<ComicInfo><Series>S</Series></ComicInfo>")
 
-        data = {"Series": "Test", "Writer": None, "Publisher": None}
-        xml_bytes = generate_comicinfo_xml(data)
-        assert b"<Writer>" not in xml_bytes
-        assert b"<Publisher>" not in xml_bytes
+        with zipfile.ZipFile(cbz) as zf:
+            assert b"<Series>S</Series>" in zf.read("ComicInfo.xml")
+
+    def test_merge_can_be_disabled(self, tmp_path):
+        from models.comicvine import add_comicinfo_to_archive
+
+        cbz = self._cbz(tmp_path, "<ComicInfo><Genre>Humor</Genre></ComicInfo>")
+        new = b"<ComicInfo><Series>New</Series></ComicInfo>"
+        with self._patch_cache_dir(tmp_path / "cache"),              patch("helpers.match_parent_permissions"):
+            assert add_comicinfo_to_archive(cbz, new, merge_existing=False)
+
+        with zipfile.ZipFile(cbz) as zf:
+            assert zf.read("ComicInfo.xml") == new
+
+
+# generate_comicinfo_xml moved to core.comicinfo when the two drifting copies
+# were merged; its tests live in tests/unit/test_comicinfo_writer.py, which
+# also asserts the re-export here is the same object.

--- a/tests/mocked/test_comicvine_sqlite_model.py
+++ b/tests/mocked/test_comicvine_sqlite_model.py
@@ -100,19 +100,23 @@ class TestGetIssueByNumber:
         from models.comicvine_sqlite import get_issue_by_number
         data = get_issue_by_number(4050, "1")
         assert data is not None
-        # role "writer, penciler" -> Writer only (first-match-wins)
+        # A role string is comma-separated, so each token counts: "writer,
+        # penciler" fills BOTH Writer and Penciller.
         assert data['writers'] == ["Bob Kane"]
-        # role "penciler, cover" -> Penciller only
-        assert data['pencillers'] == ["Jerry Robinson"]
+        assert data['pencillers'] == ["Bob Kane", "Jerry Robinson"]
+        # "penciler, cover" also fills CoverArtist
+        assert data['cover_artists'] == ["Jerry Robinson"]
+        assert data['editors'] == ["Julius Schwartz"]
+        assert data['translators'] == []
         assert data['inkers'] == []
         assert data['colorists'] == []
         assert data['letterers'] == []
-        assert data['cover_artists'] == []
         assert data['characters'] == ["Batman", "Robin"]
         assert data['teams'] == ["Justice League"]
         assert data['locations'] == ["Gotham City"]
-        # Only the FIRST story arc
-        assert data['story_arc'] == "Year One"
+        # Every story arc, comma-joined (ComicInfo StoryArc is a list field)
+        assert data['story_arc'] == "Year One, Second Arc"
+        assert data['site_url'] == "https://comicvine.gamespot.com/batman-1/4000-500/"
         assert data['year'] == 2016
         assert data['month'] == 6
         assert data['day'] == 1
@@ -141,12 +145,16 @@ class TestGetIssueMetadata:
         assert meta['Title'] == "The Beginning"
         assert meta['Publisher'] == "DC Comics"
         assert meta['Writer'] == "Bob Kane"
-        assert meta['Penciller'] == "Jerry Robinson"
+        assert meta['Penciller'] == "Bob Kane, Jerry Robinson"
+        assert meta['CoverArtist'] == "Jerry Robinson"
+        assert meta['Editor'] == "Julius Schwartz"
         assert 'Inker' not in meta  # empty roles dropped
+        assert 'Translator' not in meta
         assert meta['Characters'] == "Batman, Robin"
         assert meta['Teams'] == "Justice League"
         assert meta['Locations'] == "Gotham City"
-        assert meta['StoryArc'] == "Year One"
+        assert meta['StoryArc'] == "Year One, Second Arc"
+        assert meta['Web'] == "https://comicvine.gamespot.com/batman-1/4000-500/"
         assert meta['Year'] == 2016
         assert meta['Month'] == 6
         assert meta['Day'] == 1
@@ -155,6 +163,8 @@ class TestGetIssueMetadata:
         assert "ComicVine (Local DB)" in meta['Notes']
         assert "ComicVine CVDB" not in meta['Notes']
         assert "Volume ID: 4050" in meta['Notes']
+        # Machine-readable issue identity so other taggers can round-trip it.
+        assert meta['Notes'].endswith("[Issue ID 4000-500] urn:comicvine:4000-500")
         assert meta['_image_url'] == "https://example.com/issue1.jpg"
 
     def test_not_found(self, comicvine_sqlite_configured):

--- a/tests/routes/test_bulk_metadata.py
+++ b/tests/routes/test_bulk_metadata.py
@@ -245,6 +245,13 @@ class TestRevert:
         restored = _read_xml_from_cbz(cbz)
         assert restored is not None
         assert b'<Series>Old</Series>' in restored
+        # A revert must restore the prior XML byte-for-byte. add_comicinfo_to_cbz
+        # now merges by default, which would leave tags from the metadata we are
+        # undoing behind -- the file would end up in neither the old nor the new
+        # state -- so the revert has to opt out of the merge.
+        assert b'<Number>' not in restored
+        assert b'<LanguageISO>' not in restored
+        assert b'<Manga>' not in restored
 
     def test_revert_strips_when_no_prior_xml(self, bulk_client, tmp_path):
         folder = tmp_path / 'Batman (2020)'

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -4,119 +4,15 @@ import json
 import os
 import re
 import zipfile
+import xml.etree.ElementTree as ET
 import pytest
 from unittest.mock import patch, MagicMock, call
 
 
-class TestGenerateComicInfoXml:
-
-    def test_generate_basic(self):
-        """Test the generate_comicinfo_xml helper function."""
-        from routes.metadata import generate_comicinfo_xml
-        import xml.etree.ElementTree as ET
-
-        issue_data = {
-            "Title": "The Origin",
-            "Series": "Batman",
-            "Number": "1",
-            "Volume": "2020",
-            "Summary": "The Dark Knight rises",
-            "Year": "2020",
-            "Month": "3",
-            "Writer": "Tom King",
-            "Penciller": "David Finch",
-            "Publisher": "DC Comics",
-        }
-        xml_bytes = generate_comicinfo_xml(issue_data)
-        assert xml_bytes is not None
-        assert b"<ComicInfo>" in xml_bytes or b"<ComicInfo" in xml_bytes
-
-        root = ET.fromstring(xml_bytes)
-        assert root.tag == "ComicInfo"
-        assert root.find("Series").text == "Batman"
-        assert root.find("Writer").text == "Tom King"
-
-    def test_decimal_issue_number_preserved(self):
-        """Decimal issue numbers like 12.1 should not be truncated to 12."""
-        from routes.metadata import generate_comicinfo_xml
-        import xml.etree.ElementTree as ET
-
-        issue_data = {"Series": "Avengers", "Number": "12.1", "Year": "2011"}
-        xml_bytes = generate_comicinfo_xml(issue_data)
-        root = ET.fromstring(xml_bytes)
-        assert root.find("Number").text == "12.1"
-
-    def test_decimal_issue_preserves_leading_zeros(self):
-        """012.1 should stay '012.1', not be stripped to '12.1' via float()."""
-        from routes.metadata import generate_comicinfo_xml
-        import xml.etree.ElementTree as ET
-
-        issue_data = {"Series": "Avengers", "Number": "012.1", "Year": "2011"}
-        xml_bytes = generate_comicinfo_xml(issue_data)
-        root = ET.fromstring(xml_bytes)
-        assert root.find("Number").text == "012.1"
-
-    def test_whole_number_as_float_drops_decimal(self):
-        """12.0 should be stored as '12', not '12.0'."""
-        from routes.metadata import generate_comicinfo_xml
-        import xml.etree.ElementTree as ET
-
-        issue_data = {"Series": "Batman", "Number": "12.0"}
-        xml_bytes = generate_comicinfo_xml(issue_data)
-        root = ET.fromstring(xml_bytes)
-        assert root.find("Number").text == "12"
-
-    def test_non_numeric_issue_number_preserved(self):
-        """Non-numeric issue numbers like '12.HU' should pass through unchanged."""
-        from routes.metadata import generate_comicinfo_xml
-        import xml.etree.ElementTree as ET
-
-        issue_data = {"Series": "Batman", "Number": "12.HU"}
-        xml_bytes = generate_comicinfo_xml(issue_data)
-        root = ET.fromstring(xml_bytes)
-        assert root.find("Number").text == "12.HU"
-
-    def test_generate_empty_data(self):
-        from routes.metadata import generate_comicinfo_xml
-        xml_bytes = generate_comicinfo_xml({})
-        assert xml_bytes is not None
-
-    def test_generate_list_credits(self):
-        from routes.metadata import generate_comicinfo_xml
-        import xml.etree.ElementTree as ET
-
-        issue_data = {
-            "Series": "X-Men",
-            "Writer": ["Chris Claremont", "Fabian Nicieza"],
-        }
-        xml_bytes = generate_comicinfo_xml(issue_data)
-        root = ET.fromstring(xml_bytes)
-        writer = root.find("Writer")
-        assert writer is not None
-        assert "Chris Claremont" in writer.text
-
-
-class TestAsText:
-
-    def test_none(self):
-        from routes.metadata import _as_text
-        assert _as_text(None) is None
-
-    def test_string(self):
-        from routes.metadata import _as_text
-        assert _as_text("hello") == "hello"
-
-    def test_list(self):
-        from routes.metadata import _as_text
-        assert _as_text(["a", "b", "c"]) == "a, b, c"
-
-    def test_list_with_none(self):
-        from routes.metadata import _as_text
-        assert _as_text(["a", None, "c"]) == "a, c"
-
-    def test_int(self):
-        from routes.metadata import _as_text
-        assert _as_text(42) == "42"
+# generate_comicinfo_xml and _as_text moved to core.comicinfo when the two
+# drifting copies were merged; their tests live in
+# tests/unit/test_comicinfo_writer.py, which also asserts the re-export here
+# is the same object.
 
 
 def _make_cbz(path, with_comicinfo=True):
@@ -189,6 +85,46 @@ class TestAddComicInfoToCbz:
 
         leftovers = [n for n in os.listdir(tmp_path) if n.startswith(".tmp")]
         assert leftovers == [], f"temp extraction dirs not cleaned up: {leftovers}"
+
+
+    def test_preserves_tags_the_new_metadata_omits(self, tmp_path):
+        """No provider covers every ComicInfo field -- ComicVine has no genre
+        data at all -- so a plain rebuild used to wipe Genre/Editor on re-tag."""
+        from routes.metadata import add_comicinfo_to_cbz
+
+        cbz_path = str(tmp_path / "Batman 004.cbz")
+        with zipfile.ZipFile(cbz_path, "w") as zf:
+            zf.writestr("page_001.png", b"fake image data")
+            zf.writestr(
+                "ComicInfo.xml",
+                "<ComicInfo><Series>Old</Series><Genre>Humor</Genre>"
+                "<Editor>Tim Truman</Editor></ComicInfo>",
+            )
+
+        xml = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        with self._patch_cache_dir(tmp_path / "cache"),              patch("helpers.match_parent_permissions"):
+            add_comicinfo_to_cbz(cbz_path, xml)
+
+        with zipfile.ZipFile(cbz_path, "r") as zf:
+            root = ET.fromstring(zf.read("ComicInfo.xml"))
+        assert root.find("Series").text == "Batman"   # new value wins
+        assert root.find("Genre").text == "Humor"     # carried forward
+        assert root.find("Editor").text == "Tim Truman"
+
+    def test_merge_can_be_disabled(self, tmp_path):
+        from routes.metadata import add_comicinfo_to_cbz
+
+        cbz_path = str(tmp_path / "Batman 005.cbz")
+        with zipfile.ZipFile(cbz_path, "w") as zf:
+            zf.writestr("page_001.png", b"fake image data")
+            zf.writestr("ComicInfo.xml", "<ComicInfo><Genre>Humor</Genre></ComicInfo>")
+
+        xml = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        with self._patch_cache_dir(tmp_path / "cache"),              patch("helpers.match_parent_permissions"):
+            add_comicinfo_to_cbz(cbz_path, xml, merge_existing=False)
+
+        with zipfile.ZipFile(cbz_path, "r") as zf:
+            assert zf.read("ComicInfo.xml") == xml
 
 
 class TestRemoveComicInfoHelper:
@@ -642,7 +578,6 @@ class TestBatchMetadataRenameUpdatesIndex:
         new_path = "/data/comics/Batman v2020 001.cbz"
         metadata = {"Series": "Batman", "Number": "1", "Volume": "2020"}
 
-        mock_cv.generate_comicinfo_xml.return_value = b"<ComicInfo/>"
         mock_rename.return_value = (new_path, True)
 
         # Simulate the batch flow logic inline (extracted from the generator)
@@ -650,7 +585,8 @@ class TestBatchMetadataRenameUpdatesIndex:
         filename = os.path.basename(old_path)
 
         # -- begin logic under test (mirrors routes/metadata.py ~line 1376) --
-        xml_bytes = mock_cv.generate_comicinfo_xml(metadata)
+        from routes.metadata import generate_comicinfo_xml
+        xml_bytes = generate_comicinfo_xml(metadata)
         mock_add_xml(file_path, xml_bytes)
 
         from cbz_ops.rename import rename_comic_from_metadata as _rename
@@ -690,12 +626,12 @@ class TestBatchMetadataRenameUpdatesIndex:
         file_path = "/data/comics/Batman 001 (2020).cbz"
         metadata = {"Series": "Batman", "Number": "1"}
 
-        mock_cv.generate_comicinfo_xml.return_value = b"<ComicInfo/>"
         mock_rename.return_value = (file_path, False)
 
         # Simulate batch flow
         filename = os.path.basename(file_path)
-        xml_bytes = mock_cv.generate_comicinfo_xml(metadata)
+        from routes.metadata import generate_comicinfo_xml
+        xml_bytes = generate_comicinfo_xml(metadata)
         mock_add_xml(file_path, xml_bytes)
 
         from cbz_ops.rename import rename_comic_from_metadata as _rename

--- a/tests/unit/test_comicinfo.py
+++ b/tests/unit/test_comicinfo.py
@@ -186,6 +186,96 @@ class TestUpdateComicinfoXml:
         assert isinstance(result, bytes)
 
 
+# ===== merge_comicinfo_bytes =====
+
+class TestMergeComicinfoBytes:
+    """Re-tagging rebuilds ComicInfo.xml from scratch, so anything the new
+    provider does not supply used to be destroyed. No provider covers every
+    field -- ComicVine has no genre data at all -- so tags only the old XML has
+    must be carried forward."""
+
+    def test_carries_forward_missing_tag(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b"<ComicInfo><Series>Old</Series><Genre>Humor</Genre></ComicInfo>"
+        root = ET.fromstring(merge_comicinfo_bytes(new, old))
+        assert root.find("Genre").text == "Humor"
+
+    def test_new_value_always_wins(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b"<ComicInfo><Series>Superman</Series></ComicInfo>"
+        root = ET.fromstring(merge_comicinfo_bytes(new, old))
+        assert root.find("Series").text == "Batman"
+        assert len(root.findall("Series")) == 1
+
+    def test_preserves_tags_outside_the_writer_allowlist(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = (b"<ComicInfo><Tags>read</Tags><GTIN>123</GTIN>"
+               b"<BlackAndWhite>Yes</BlackAndWhite></ComicInfo>")
+        root = ET.fromstring(merge_comicinfo_bytes(new, old))
+        assert root.find("Tags").text == "read"
+        assert root.find("GTIN").text == "123"
+        assert root.find("BlackAndWhite").text == "Yes"
+
+    def test_preserves_nested_pages_block(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b'<ComicInfo><Pages><Page Image="0" Type="FrontCover"/></Pages></ComicInfo>'
+        root = ET.fromstring(merge_comicinfo_bytes(new, old))
+        pages = root.find("Pages")
+        assert pages is not None
+        assert pages[0].get("Type") == "FrontCover"
+
+    def test_empty_old_tag_not_carried(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b"<ComicInfo><Genre>   </Genre></ComicInfo>"
+        root = ET.fromstring(merge_comicinfo_bytes(new, old))
+        assert root.find("Genre") is None
+
+    @pytest.mark.parametrize("existing", [None, b"", ""])
+    def test_no_existing_xml_is_a_noop(self, existing):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        assert merge_comicinfo_bytes(new, existing) == new
+
+    def test_nothing_to_carry_returns_new_unchanged(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        assert merge_comicinfo_bytes(new, new) == new
+
+    def test_corrupt_existing_xml_does_not_block_the_write(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        assert merge_comicinfo_bytes(new, b"<ComicInfo><brok") == new
+
+    def test_namespaces_stripped_from_carried_tags(self):
+        """ComicInfo.xml is written namespace-free on purpose (ComicRack chokes
+        on them), so a carried tag must not come back as ns0:Genre."""
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b'<ComicInfo xmlns="http://example.com/ci"><Genre>Humor</Genre></ComicInfo>'
+        merged = merge_comicinfo_bytes(new, old)
+        assert b"ns0:" not in merged
+        assert ET.fromstring(merged).find("Genre").text == "Humor"
+
+    def test_namespaced_duplicate_not_carried(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b'<ComicInfo xmlns="http://example.com/ci"><Series>Old</Series></ComicInfo>'
+        root = ET.fromstring(merge_comicinfo_bytes(new, old))
+        assert len(root.findall("Series")) == 1
+        assert root.find("Series").text == "Batman"
+
+    def test_returns_bytes(self):
+        from core.comicinfo import merge_comicinfo_bytes
+        new = b"<ComicInfo><Series>Batman</Series></ComicInfo>"
+        old = b"<ComicInfo><Genre>Humor</Genre></ComicInfo>"
+        assert isinstance(merge_comicinfo_bytes(new, old), bytes)
+
+
 # ===== read_comicinfo_from_zip =====
 
 class TestReadComicinfoFromZip:

--- a/tests/unit/test_comicinfo_writer.py
+++ b/tests/unit/test_comicinfo_writer.py
@@ -1,0 +1,226 @@
+"""Tests for the single ComicInfo.xml serializer, core.comicinfo.
+
+`generate_comicinfo_xml` used to be two near-duplicates -- one in
+routes/metadata.py and one in models/comicvine.py -- that had drifted apart, so
+a field added to one was silently discarded on the paths using the other. These
+tests are the union of both old suites, plus one per behaviour the merge had to
+reconcile.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from core.comicinfo import _as_text, generate_comicinfo_xml
+
+
+def gen(data):
+    return ET.fromstring(generate_comicinfo_xml(data))
+
+
+class TestAsText:
+    """Providers hand credits through as either a joined string or a list."""
+
+    def test_none(self):
+        assert _as_text(None) is None
+
+    def test_string(self):
+        assert _as_text("hello") == "hello"
+
+    def test_int(self):
+        assert _as_text(42) == "42"
+
+    def test_list_joined(self):
+        assert _as_text(["a", "b", "c"]) == "a, b, c"
+
+    def test_list_with_none_members(self):
+        assert _as_text(["a", None, "c"]) == "a, c"
+
+    def test_tuple_joined(self):
+        assert _as_text(("a", "b")) == "a, b"
+
+    def test_empty_list(self):
+        assert _as_text([]) == ""
+
+
+class TestBasics:
+
+    def test_generate_basic(self):
+        issue_data = {
+            "Title": "The Origin",
+            "Series": "Batman",
+            "Number": "1",
+            "Volume": "2020",
+            "Summary": "The Dark Knight rises",
+            "Year": "2020",
+            "Month": "3",
+            "Writer": "Tom King",
+            "Penciller": "David Finch",
+            "Publisher": "DC Comics",
+        }
+        xml_bytes = generate_comicinfo_xml(issue_data)
+        assert isinstance(xml_bytes, bytes)
+
+        root = ET.fromstring(xml_bytes)
+        assert root.tag == "ComicInfo"
+        assert root.attrib == {}, "ComicRack chokes on xmlns/xsi attributes"
+        assert root.find("Series").text == "Batman"
+        assert root.find("Writer").text == "Tom King"
+        assert root.find("Publisher").text == "DC Comics"
+
+    def test_generate_empty_data(self):
+        root = gen({})
+        # Only the two unconditional defaults
+        assert {c.tag for c in root} == {"LanguageISO", "Manga"}
+
+    def test_omits_none_values(self):
+        xml_bytes = generate_comicinfo_xml(
+            {"Series": "Test", "Writer": None, "Publisher": None}
+        )
+        assert b"<Writer>" not in xml_bytes
+        assert b"<Publisher>" not in xml_bytes
+
+
+class TestIssueNumbers:
+
+    def test_decimal_preserved(self):
+        """Decimal issue numbers like 12.1 should not be truncated to 12."""
+        assert gen({"Series": "Avengers", "Number": "12.1"}).find("Number").text == "12.1"
+
+    def test_decimal_preserves_leading_zeros(self):
+        """012.1 should stay '012.1', not be stripped to '12.1' via float()."""
+        assert gen({"Series": "Avengers", "Number": "012.1"}).find("Number").text == "012.1"
+
+    def test_whole_number_as_float_drops_decimal(self):
+        """12.0 should be stored as '12', not '12.0'."""
+        assert gen({"Series": "Batman", "Number": "12.0"}).find("Number").text == "12"
+
+    def test_whole_number_drops_leading_zeros(self):
+        assert gen({"Series": "Batman", "Number": "003"}).find("Number").text == "3"
+
+    def test_non_numeric_preserved(self):
+        """Non-numeric issue numbers like '12.HU' pass through unchanged."""
+        assert gen({"Series": "Batman", "Number": "12.HU"}).find("Number").text == "12.HU"
+
+    def test_exotic_digit_does_not_raise(self):
+        """str.isdigit() is True for characters int() rejects, e.g. superscript 2."""
+        sup2 = chr(0xB2)
+        assert gen({"Series": "Batman", "Number": sup2}).find("Number").text == sup2
+
+
+class TestCredits:
+
+    def test_list_credits_joined(self):
+        """The models/comicvine copy used str(value), writing a Python repr."""
+        root = gen({"Series": "X-Men",
+                    "Writer": ["Chris Claremont", "Fabian Nicieza"]})
+        assert root.find("Writer").text == "Chris Claremont, Fabian Nicieza"
+
+    def test_empty_list_credit_omitted(self):
+        assert gen({"Series": "X", "Writer": []}).find("Writer") is None
+
+    def test_writes_editor_translator_and_agerating(self):
+        """Mapped by the ComicVine and GCD providers but long dropped at
+        serialization because neither writer had an add() line."""
+        root = gen({
+            "Series": "Swords of Texas", "Number": "4",
+            "Editor": "Tim Truman", "Translator": "A. Translator",
+            "AgeRating": "Teen",
+        })
+        assert root.find("Editor").text == "Tim Truman"
+        assert root.find("Translator").text == "A. Translator"
+        assert root.find("AgeRating").text == "Teen"
+
+    def test_whitespace_only_value_omitted(self):
+        assert gen({"Series": "X", "Writer": "   "}).find("Writer") is None
+
+
+class TestDates:
+
+    def test_writes_year_month_day(self):
+        root = gen({"Series": "X", "Year": "1988", "Month": "3", "Day": "1"})
+        assert root.find("Year").text == "1988"
+        assert root.find("Month").text == "3"
+        assert root.find("Day").text == "1"
+
+    @pytest.mark.parametrize("tag,value", [
+        ("Day", "45"), ("Day", "0"), ("Month", "13"), ("Month", "0"),
+    ])
+    def test_out_of_range_dropped(self, tag, value):
+        assert gen({"Series": "X", tag: value}).find(tag) is None
+
+    def test_year_zero_omitted(self):
+        assert gen({"Series": "X", "Year": 0}).find("Year") is None
+
+
+class TestNumericRobustness:
+    """The routes copy used bare int() here, so a provider returning a Volume of
+    "v2" raised ValueError and 500'd the route. Five call sites had no
+    try/except of their own."""
+
+    @pytest.mark.parametrize("field,value", [
+        ("Volume", "v2"), ("Count", "12.5"), ("Count", "abc"),
+        ("Year", "n.d."), ("Month", "Spring"), ("Day", "??"),
+        ("PageCount", "n/a"), ("Number", "1"),
+    ])
+    def test_junk_never_raises(self, field, value):
+        assert gen({"Series": "X", field: value}).tag == "ComicInfo"
+
+    def test_unparseable_volume_passes_through(self):
+        assert gen({"Series": "X", "Volume": "v2"}).find("Volume").text == "v2"
+
+    def test_volume_coerced_to_int(self):
+        assert gen({"Series": "X", "Volume": 2016.0}).find("Volume").text == "2016"
+
+    def test_count_coerced_to_int(self):
+        """The models/comicvine copy did no coercion, so 12.0 wrote '12.0'."""
+        assert gen({"Series": "X", "Count": 12.0}).find("Count").text == "12"
+
+    def test_page_count_accepts_float_string(self):
+        """The models/comicvine copy used int("24.0"), which raised and dropped
+        the tag."""
+        assert gen({"Series": "X", "PageCount": "24.0"}).find("PageCount").text == "24"
+
+    def test_page_count_zero_omitted(self):
+        assert gen({"Series": "X", "PageCount": 0}).find("PageCount") is None
+
+
+class TestDefaults:
+
+    def test_language_and_manga_defaults(self):
+        root = gen({"Series": "X"})
+        assert root.find("LanguageISO").text == "en"
+        assert root.find("Manga").text == "No"
+
+    def test_explicit_values_win(self):
+        root = gen({"Series": "X", "Manga": "YesAndRightToLeft", "LanguageISO": "ja"})
+        assert root.find("Manga").text == "YesAndRightToLeft"
+        assert root.find("LanguageISO").text == "ja"
+
+    def test_no_notes_fallback(self):
+        """The routes copy invented a GCD-worded Notes for any dict without one.
+        That mislabels every other provider, and Notes doubles as the
+        already-tagged sentinel several callers read -- a file with a fabricated
+        Notes could never be re-tagged. The two GCD-SQLite builders now set
+        their own."""
+        xml_bytes = generate_comicinfo_xml({"Series": "X", "id": 44192})
+        assert b"<Notes>" not in xml_bytes
+        assert b"Grand Comic" not in xml_bytes
+
+    def test_notes_written_when_supplied(self):
+        assert gen({"Series": "X", "Notes": "From ComicVine"}).find("Notes").text == "From ComicVine"
+
+
+class TestSingleImplementation:
+    """Both former homes re-export the one writer, so existing imports and
+    mock.patch targets keep working."""
+
+    def test_routes_reexport_is_the_same_object(self):
+        import core.comicinfo
+        import routes.metadata
+        assert routes.metadata.generate_comicinfo_xml is core.comicinfo.generate_comicinfo_xml
+        assert routes.metadata._as_text is core.comicinfo._as_text
+
+    def test_comicvine_reexport_is_the_same_object(self):
+        import core.comicinfo
+        import models.comicvine
+        assert models.comicvine.generate_comicinfo_xml is core.comicinfo.generate_comicinfo_xml

--- a/tests/unit/test_comicvine_roles.py
+++ b/tests/unit/test_comicvine_roles.py
@@ -1,0 +1,138 @@
+"""Credit-role bucketing for ComicVine person credits.
+
+ComicVine returns a creator's roles as ONE comma-joined string, so the parser
+has to split it: matching the whole string with a first-match-wins chain
+assigned each creator to exactly one bucket and silently dropped every other
+credit they held (a "penciler, inker" lost the Inker credit outright).
+"""
+
+import pytest
+
+from models.comicvine import parse_creator_roles
+
+
+class _Creator:
+    """Stand-in for Simyan's GenericCreator (``.name`` / ``.roles``)."""
+
+    def __init__(self, name, roles):
+        self.name = name
+        self.roles = roles
+
+
+def buckets(*pairs):
+    return parse_creator_roles([_Creator(n, r) for n, r in pairs])
+
+
+class TestMultiRoleStrings:
+
+    def test_penciler_and_inker_fills_both(self):
+        b = buckets(("Ben Dunn", "penciler, inker"))
+        assert b['pencillers'] == ["Ben Dunn"]
+        assert b['inkers'] == ["Ben Dunn"]
+
+    def test_writer_and_cover_fills_both(self):
+        b = buckets(("Chuck Dixon", "writer, cover"))
+        assert b['writers'] == ["Chuck Dixon"]
+        assert b['cover_artists'] == ["Chuck Dixon"]
+
+    def test_three_roles(self):
+        b = buckets(("Flint Henry", "penciler, inker, colorist"))
+        assert b['pencillers'] == ["Flint Henry"]
+        assert b['inkers'] == ["Flint Henry"]
+        assert b['colorists'] == ["Flint Henry"]
+
+    def test_whitespace_and_empty_tokens_tolerated(self):
+        b = buckets(("Sam Parsons", "  colorist ,, "))
+        assert b['colorists'] == ["Sam Parsons"]
+
+
+class TestNewBuckets:
+
+    def test_editor(self):
+        assert buckets(("Tim Truman", "editor"))['editors'] == ["Tim Truman"]
+
+    def test_editor_variants(self):
+        b = buckets(("A", "assistant editor"), ("B", "editor-in-chief"))
+        assert b['editors'] == ["A", "B"]
+
+    def test_translator(self):
+        assert buckets(("T", "translator"))['translators'] == ["T"]
+
+    def test_bare_artist_is_a_penciller(self):
+        # ComicVine uses a bare "artist" role constantly; it previously matched
+        # neither "pencil" nor "illustrat" and produced nothing at all.
+        assert buckets(("A", "artist"))['pencillers'] == ["A"]
+
+    @pytest.mark.parametrize("role", ["painter", "breakdowns", "layouts"])
+    def test_other_art_roles_are_pencillers(self, role):
+        assert buckets(("A", role))['pencillers'] == ["A"]
+
+    @pytest.mark.parametrize("role", ["finishes", "embellisher"])
+    def test_finishing_roles_are_inkers(self, role):
+        assert buckets(("A", role))['inkers'] == ["A"]
+
+    @pytest.mark.parametrize("role", ["plot", "script", "story"])
+    def test_writing_roles(self, role):
+        assert buckets(("A", role))['writers'] == ["A"]
+
+    def test_british_spelling(self):
+        assert buckets(("A", "colourist"))['colorists'] == ["A"]
+
+
+class TestOrderingGuards:
+    """Matcher order stops compound roles landing in the wrong bucket."""
+
+    def test_cover_artist_is_not_a_penciller(self):
+        b = buckets(("A", "cover artist"))
+        assert b['cover_artists'] == ["A"]
+        assert b['pencillers'] == []
+
+    def test_color_artist_is_not_a_penciller(self):
+        b = buckets(("A", "color artist"))
+        assert b['colorists'] == ["A"]
+        assert b['pencillers'] == []
+
+    def test_inker_is_not_a_penciller(self):
+        b = buckets(("A", "inker"))
+        assert b['inkers'] == ["A"]
+        assert b['pencillers'] == []
+
+
+class TestHousekeeping:
+
+    def test_duplicates_deduped_within_a_bucket(self):
+        b = buckets(("A", "writer"), ("A", "writer, script"))
+        assert b['writers'] == ["A"]
+
+    def test_order_preserved(self):
+        b = buckets(("First", "writer"), ("Second", "writer"))
+        assert b['writers'] == ["First", "Second"]
+
+    def test_unknown_role_dropped(self):
+        b = buckets(("A", "journalist"))
+        assert all(v == [] for v in b.values())
+
+    def test_every_bucket_present_even_when_empty(self):
+        b = parse_creator_roles([])
+        assert set(b) == {
+            'writers', 'pencillers', 'inkers', 'colorists', 'letterers',
+            'cover_artists', 'editors', 'translators',
+        }
+        assert all(v == [] for v in b.values())
+
+    @pytest.mark.parametrize("creators", [None, [], ()])
+    def test_no_creators(self, creators):
+        assert all(v == [] for v in parse_creator_roles(creators).values())
+
+    def test_missing_or_none_roles_are_safe(self):
+        b = parse_creator_roles([_Creator("A", None), _Creator("B", "")])
+        assert all(v == [] for v in b.values())
+
+    def test_nameless_credit_skipped(self):
+        assert parse_creator_roles([{"role": "writer"}])['writers'] == []
+
+    def test_dict_credits_from_the_local_dump(self):
+        # The SQLite dump stores person_credits as JSON with a "role" key.
+        b = parse_creator_roles([{"name": "Bob Kane", "role": "writer, penciler"}])
+        assert b['writers'] == ["Bob Kane"]
+        assert b['pencillers'] == ["Bob Kane"]


### PR DESCRIPTION
## The report

Re-tagging a file through the ComicVine path produced far less than the file already carried. A downloaded *Swords of Texas #4* had been tagged by comicbox (ComicVine) and then re-tagged by ComicTagger (GCD):

```
Writer: Charles Dixon, Beau Smith    Colorist: Sam Parsons
Penciller: Ben Dunn, Flint Henry     Letterer: Tim Harkins
Inker: Mark McKenna, Flint Henry     Editor: Tim Truman
Genre: Humor, Science fiction        Web: https://comicvine.gamespot.com/...
```

Clearing it and re-applying our process gave back only `Penciller: Ben Dunn` and `Inker: Mark McKenna`.

## Root causes

Four independent defects, stacked:

1. **Roles were collapsed to one bucket per person.** ComicVine returns each creator's roles as *one comma-joined string* (`"penciler, inker"`), but the code matched the whole string with a first-match-wins `if/elif` chain — so a creator landed in exactly one bucket and every other credit they held was discarded. `models/comicvine_sqlite.py` deliberately replicated this "for parity".
2. **Several roles had no bucket at all** — `editor`, bare `artist`, `painter`, `plot`, `finishes`, `translator`. ComicVine's bare `artist` role is very common and produced nothing.
3. **`Web` was never mapped** (Simyan exposes `site_url`), and `Notes` recorded only the *volume* id — nothing could identify which issue was matched.
4. **Neither XML writer could emit `<Editor>`.** The GCD provider's editor credits were computed and then discarded at serialization. Same for Metron's `AgeRating`, and `Day` in the routes writer.

Compounding all of it: applying metadata **rebuilt ComicInfo.xml from scratch**, destroying every tag the new provider didn't supply. ComicVine has no genre data at all, so re-tagging a GCD-sourced file always lost its `Genre`.

## Changes

**Credit parsing** — new shared `models/comicvine.parse_creator_roles`, used by both the API and local-DB paths so they cannot drift again. Role strings are split on commas and each token bucketed independently, so one person can hold several credits. Adds `Editor` and `Translator`; matcher order stops `"cover artist"` and `"color artist"` landing in Penciller.

**Mapping** — `Editor`, `Translator`, `Web`, and every story arc rather than only the first. `Notes` gains a machine-readable `[Issue ID 4000-29348] urn:comicvine:4000-29348` so files round-trip with comicbox/ComicTagger.

**Preserve on re-tag** — new `core.comicinfo.merge_comicinfo_bytes`, wired into both archive writers: tags the new metadata omits are carried forward instead of destroyed. It merges XML rather than the metadata dict on purpose, so fields outside the writer's allowlist (`Tags`, `GTIN`, `BlackAndWhite`, the `<Pages>` bookmark block) survive too. The bulk-metadata **undo** opts out via `merge_existing=False` — merging there would carry tags forward from the very metadata being undone.

**One writer** — the two near-duplicate `generate_comicinfo_xml` copies are now a single implementation in `core/comicinfo.py`; `routes/metadata.py` and `models/comicvine.py` re-export it, so no import or `mock.patch` target moves. They were never a deliberate split (the second was written from scratch in `comicvine.py`; later refactors lifted them into separate modules), and each was correct about different things:

| | Before | Now |
|---|---|---|
| List credits | comicvine copy wrote `<Writer>['Alan Moore', 'Dave Gibbons']</Writer>` | joined properly |
| Junk numerics | routes copy used bare `int()` — a `Volume` of `"v2"` raised `ValueError` at **five unguarded call sites** | guarded, never raises |
| `PageCount: "24.0"` | comicvine copy dropped the tag silently | `24` |
| Whitespace-only value | routes copy wrote `<Tag>   </Tag>` | skipped |
| `Year: 0` | routes copy wrote `<Year>0</Year>` | omitted |

Also drops the dead `series_data` parameter (in the signature, never read).

### One thing deliberately not merged

The routes writer invented a Notes line — *"Metadata from Grand Comic Database (GCD)…"* — for any dict lacking one. Sharing that would have been actively harmful: `Notes` doubles as the **"already tagged, skip this file" sentinel** read by `routes/metadata.py`, `models/comicvine.py` and `app.py`, so every file the batch and auto-fetch paths touch would have become permanently un-retaggable, and ComicVine/Metron files would have been stamped with GCD provenance.

Verified safe to remove: all ten provider mappers set `Notes` themselves. The only dicts without it are the two inline GCD-SQLite builders, which now set theirs where the dict is assembled — confirmed character-for-character identical to the old output, em dash included.

## Verification

`pytest`: **4153 passed, 7 skipped** (skips are POSIX/symlink-only, unchanged from baseline).

New coverage: `tests/unit/test_comicvine_roles.py` (30 tests — multi-role strings, the new buckets, the ordering guards), `tests/unit/test_comicinfo_writer.py` (45 tests — the union of both old writer suites, one per reconciled difference, plus a check that both re-exports are the same object), and merge tests in `tests/unit/test_comicinfo.py`. The bulk-metadata revert test is tightened to catch a merging undo.

Against a realistic ComicVine payload the mapper now returns `Writer: Chuck Dixon, Beau Smith` / `Penciller: Ben Dunn, Flint Henry` / `Inker: Ben Dunn, Mark McKenna` / `Colorist: Sam Parsons` / `Letterer: Tim Harkins` / `Editor: Tim Truman`, plus the Web link and the urn-suffixed Notes.

## Note

I could not verify what ComicVine actually holds for that specific issue — the site returns 403 to automated fetches — so I can't say how much of the missing Writer/Colorist/Letterer was our mapping versus genuinely thin CV data for a 1988 Eclipse book. The `Editor` and `Genre` losses were definitely ours.

Found but left for separate issues: `ComicVineProvider.get_issue` calls `cv.issue(...)`, which Simyan doesn't have (always returns `None`, 502s the bulk manual-review apply); `get_issues` doesn't paginate; Metron drops Editor, Locations, StoryArc and every role outside its six exact-match lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
