### PR TITLE
Let users turn off automatic metadata on move

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,7 +68,13 @@ from routes.favorites import favorites_bp
 from routes.opds import opds_bp
 from models import gcd
 from models import metron
-from core.config import config, load_flask_config, write_config, load_config
+from core.config import (
+    config,
+    load_flask_config,
+    write_config,
+    load_config,
+    is_auto_metadata_on_move_enabled,
+)
 from core.auth import enforce_path_access, current_user, filter_paths_for_user
 from cbz_ops.edit import (
     get_edit_modal,
@@ -4330,6 +4336,12 @@ def auto_fetch_comicvine_metadata(destination_path):
     Returns:
         The final file path (renamed path if file was renamed, original path otherwise)
     """
+    if not is_auto_metadata_on_move_enabled():
+        app_logger.debug(
+            "Automatic metadata on move is disabled, skipping ComicVine metadata"
+        )
+        return destination_path
+
     try:
         from models.comicvine import auto_fetch_metadata_for_folder
 
@@ -4405,6 +4417,12 @@ def auto_fetch_metron_metadata(destination_path):
     Returns:
         The final file path (renamed path if file was renamed, original path otherwise)
     """
+    if not is_auto_metadata_on_move_enabled():
+        app_logger.debug(
+            "Automatic metadata on move is disabled, skipping Metron metadata"
+        )
+        return destination_path
+
     try:
         from models.metron import (
             get_flask_api,
@@ -4586,6 +4604,12 @@ def auto_fetch_comicvine_sqlite_metadata(destination_path):
     Returns:
         The final file path (renamed path if file was renamed, original path otherwise)
     """
+    if not is_auto_metadata_on_move_enabled():
+        app_logger.debug(
+            "Automatic metadata on move is disabled, skipping local ComicVine metadata"
+        )
+        return destination_path
+
     try:
         from models import comicvine_sqlite
         from models.comicvine import (
@@ -6702,6 +6726,26 @@ def save_file_processing_config():
             bool(data.get("autoFolderThumbnails", True)),
             category="file_processing",
         )
+
+        # config.ini is deprecated for new settings; these live in user_preferences.
+        from core.config import PREF_AUTO_METADATA_ON_MOVE
+        set_user_preference(
+            PREF_AUTO_METADATA_ON_MOVE,
+            bool(data.get("autoMetadataOnMove", True)),
+            category="metadata",
+        )
+        from core.metadata_dates import PREF_MODE, PREF_TOLERANCE
+        _date_mode = str(data.get("dateCheckMode", "off")).strip().lower()
+        set_user_preference(
+            PREF_MODE,
+            _date_mode if _date_mode in ("off", "log", "enforce") else "off",
+            category="metadata",
+        )
+        try:
+            _tolerance = max(0, int(data.get("dateCheckToleranceYears", 2)))
+        except (TypeError, ValueError):
+            _tolerance = 2
+        set_user_preference(PREF_TOLERANCE, _tolerance, category="metadata")
         app.config["SMART_RENAME_PREVIEW_ENABLED"] = bool(
             data.get("smartRenamePreviewEnabled", True)
         )
@@ -6888,20 +6932,6 @@ def save_system_perf_config():
         config["SETTINGS"]["XML_YEAR"] = str(data.get("xmlYear", False))
         config["SETTINGS"]["XML_MARKDOWN"] = str(data.get("xmlMarkdown", False))
         config["SETTINGS"]["XML_LIST"] = str(data.get("xmlList", False))
-        # config.ini is deprecated for new settings; these live in user_preferences.
-        from core.metadata_dates import PREF_MODE, PREF_TOLERANCE
-        _date_mode = str(data.get("dateCheckMode", "off")).strip().lower()
-        set_user_preference(
-            PREF_MODE,
-            _date_mode if _date_mode in ("off", "log", "enforce") else "off",
-            category="metadata",
-        )
-        try:
-            _tolerance = max(0, int(data.get("dateCheckToleranceYears", 2)))
-        except (TypeError, ValueError):
-            _tolerance = 2
-        set_user_preference(PREF_TOLERANCE, _tolerance, category="metadata")
-
         write_config()
         load_flask_config(app)
 
@@ -7297,6 +7327,7 @@ def config_page():
         ),
         customHeaders=get_user_preference("custom_headers", ""),
         operationTimeout=settings.get("OPERATION_TIMEOUT", "3600"),
+        autoMetadataOnMove=is_auto_metadata_on_move_enabled(),
         dateCheckMode=get_user_preference("date_check_mode", default="off"),
         dateCheckToleranceYears=get_user_preference(
             "date_check_tolerance_years", default=2),

--- a/core/config.py
+++ b/core/config.py
@@ -214,6 +214,25 @@ def get_target_dir() -> str:
         return ""
 
 
+PREF_AUTO_METADATA_ON_MOVE = "auto_metadata_on_move"
+
+
+def is_auto_metadata_on_move_enabled() -> bool:
+    """True when files moved into a folder with a cvinfo should be auto-tagged.
+
+    Gates the post-move ``auto_fetch_*_metadata`` fetchers in app.py. Some
+    users curate their own ComicInfo.xml and do not want a move to trigger a
+    provider lookup, so this is a user-facing switch -- but it has always been
+    on, so the default stays True and an unreadable preference store fails
+    open rather than silently disabling the feature.
+    """
+    try:
+        from core.database import get_user_preference
+        return bool(get_user_preference(PREF_AUTO_METADATA_ON_MOVE, default=True))
+    except Exception:
+        return True
+
+
 def load_flask_config(app, logger=None):
     """
     Helper function to populate a Flask app's config with

--- a/templates/config.html
+++ b/templates/config.html
@@ -665,6 +665,65 @@
 
                 </div>
 
+                <!-- Automatic Metadata Configuration -->
+                <div class="container p-4 border rounded shadow-sm mb-4">
+                    <h4>Automatic Metadata</h4>
+                    <p class="text-muted">When a comic is moved into a folder that has a
+                        <code>cvinfo</code> file, CLU looks the issue up and writes
+                        <code>ComicInfo.xml</code> for it. Files that already carry metadata are
+                        never touched.</p>
+
+                    <div class="row mb-4">
+                        <div class="col-md-6">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch"
+                                    id="autoMetadataOnMove" name="autoMetadataOnMove"
+                                    {% if autoMetadataOnMove %}checked{% endif %}>
+                                <label class="form-check-label" for="autoMetadataOnMove">
+                                    Tag files automatically on move</label>
+                                <small class="form-text text-muted">
+                                    <br />Turn this off to keep moves purely as moves. Metadata can
+                                    still be fetched on demand from the Files page or a bulk
+                                    Fetch Metadata job.
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+
+                    <h4>Metadata Match Validation</h4>
+                    <p class="text-muted">Cross-check the date of a matched issue against the year in the
+                        filename, so a wrong series match is caught instead of being written into the file.
+                        Applies to automatic lookups only &mdash; a series you pick yourself is never
+                        second-guessed.</p>
+
+                    <div class="row mb-4">
+                        <div class="col-md-4">
+                            <label for="dateCheckMode" class="form-label">Date check</label>
+                            <select class="form-select" id="dateCheckMode" name="dateCheckMode">
+                                <option value="off" {% if dateCheckMode == 'off' %}selected{% endif %}>Off</option>
+                                <option value="log" {% if dateCheckMode == 'log' %}selected{% endif %}>Log only</option>
+                                <option value="enforce" {% if dateCheckMode == 'enforce' %}selected{% endif %}>Enforce</option>
+                            </select>
+                            <small class="form-text text-muted">
+                                <br /><strong>Log only</strong> reports conflicts without changing what is written &mdash;
+                                run this first to see what the check would do to your library.
+                                <strong>Enforce</strong> sends a conflicting match for review instead of tagging the file.
+                            </small>
+                        </div>
+
+                        <div class="col-md-4">
+                            <label for="dateCheckToleranceYears" class="form-label">Tolerance (years)</label>
+                            <input type="number" class="form-control" id="dateCheckToleranceYears"
+                                name="dateCheckToleranceYears" min="0" max="50"
+                                value="{{ dateCheckToleranceYears }}">
+                            <small class="form-text text-muted">
+                                <br />How far the dates may disagree before the match is treated as wrong. Cover
+                                dates, on-sale dates and reprints routinely differ by a year or two.
+                            </small>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Save Button for Tab 1 -->
                 <div class="mb-3 text-center">
                     <button type="button" class="btn btn-primary" onclick="saveFileProcessingSettings()">
@@ -1347,39 +1406,6 @@
 
                 <!-- ComicInfo XML editing Configuration -->
                 <div class="container p-4 border rounded shadow-sm mb-4">
-                    <h4>Metadata Match Validation</h4>
-                    <p class="text-muted">Cross-check the date of a matched issue against the year in the
-                        filename, so a wrong series match is caught instead of being written into the file.
-                        Applies to automatic lookups only &mdash; a series you pick yourself is never
-                        second-guessed.</p>
-
-                    <div class="row mb-4">
-                        <div class="col-md-4">
-                            <label for="dateCheckMode" class="form-label">Date check</label>
-                            <select class="form-select" id="dateCheckMode" name="dateCheckMode">
-                                <option value="off" {% if dateCheckMode == 'off' %}selected{% endif %}>Off</option>
-                                <option value="log" {% if dateCheckMode == 'log' %}selected{% endif %}>Log only</option>
-                                <option value="enforce" {% if dateCheckMode == 'enforce' %}selected{% endif %}>Enforce</option>
-                            </select>
-                            <small class="form-text text-muted">
-                                <br /><strong>Log only</strong> reports conflicts without changing what is written &mdash;
-                                run this first to see what the check would do to your library.
-                                <strong>Enforce</strong> sends a conflicting match for review instead of tagging the file.
-                            </small>
-                        </div>
-
-                        <div class="col-md-4">
-                            <label for="dateCheckToleranceYears" class="form-label">Tolerance (years)</label>
-                            <input type="number" class="form-control" id="dateCheckToleranceYears"
-                                name="dateCheckToleranceYears" min="0" max="50"
-                                value="{{ dateCheckToleranceYears }}">
-                            <small class="form-text text-muted">
-                                <br />How far the dates may disagree before the match is treated as wrong. Cover
-                                dates, on-sale dates and reprints routinely differ by a year or two.
-                            </small>
-                        </div>
-                    </div>
-
                     <h4>ComicInfo.XML Update Settings</h4>
                     <p class="text-muted">Enable/Disable features for updating or cleaning <code>ComicInfo.xml</code>
                         files. This proecess runs on a single directory, extracts the <code>ComicInfo.xml</code> file,
@@ -1925,7 +1951,10 @@
             trashDir: document.getElementById('trashDir')?.value || '',
             trashMaxSizeMb: document.getElementById('trashMaxSizeMb')?.value || '1024',
             hiddenDirectories: document.getElementById('hiddenDirectories')?.value || '@eaDir',
-            autoFolderThumbnails: document.getElementById('autoFolderThumbnails')?.checked ?? true
+            autoFolderThumbnails: document.getElementById('autoFolderThumbnails')?.checked ?? true,
+            autoMetadataOnMove: document.getElementById('autoMetadataOnMove')?.checked ?? true,
+            dateCheckMode: document.getElementById('dateCheckMode')?.value || 'off',
+            dateCheckToleranceYears: document.getElementById('dateCheckToleranceYears')?.value || '2'
         };
 
         try {
@@ -2083,9 +2112,7 @@
             enableDebugLogging: document.getElementById('enableDebugLogging')?.checked || false,
             xmlYear: document.getElementById('xmlYear')?.checked || false,
             xmlMarkdown: document.getElementById('xmlMarkdown')?.checked || false,
-            xmlList: document.getElementById('xmlList')?.checked || false,
-            dateCheckMode: document.getElementById('dateCheckMode')?.value || 'off',
-            dateCheckToleranceYears: document.getElementById('dateCheckToleranceYears')?.value || '2'
+            xmlList: document.getElementById('xmlList')?.checked || false
         };
 
         try {

--- a/tests/unit/test_auto_metadata_on_move_switch.py
+++ b/tests/unit/test_auto_metadata_on_move_switch.py
@@ -1,0 +1,195 @@
+"""The "tag files automatically on move" switch.
+
+Moving a comic into a folder that carries a ``cvinfo`` triggers a provider
+lookup and a ComicInfo.xml write. Users who curate their own metadata want
+moves to stay moves, so the behaviour is now switchable -- default ON, since
+that is what every existing install already does.
+
+The gate itself lives in ``core.config`` so it can be tested directly. Where
+it *sits* inside the three ``auto_fetch_*_metadata`` functions is the part that
+matters (a check placed after the provider call would still hit the API), and
+app.py cannot be imported in tests, so that half is asserted against the AST.
+"""
+import ast
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+FETCHERS = [
+    "auto_fetch_metron_metadata",
+    "auto_fetch_comicvine_metadata",
+    "auto_fetch_comicvine_sqlite_metadata",
+]
+
+
+@pytest.fixture(scope="module")
+def app_py():
+    return (ROOT / "app.py").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def app_tree(app_py):
+    return ast.parse(app_py)
+
+
+@pytest.fixture(scope="module")
+def save_handler(app_py):
+    """Source of the /api/config/file-processing handler, bounded by the next route."""
+    return app_py.split('@app.route("/api/config/file-processing"')[1].split("@app.route")[0]
+
+
+@pytest.fixture(scope="module")
+def config_html():
+    return (ROOT / "templates" / "config.html").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+class TestGate:
+    def test_defaults_to_enabled(self, monkeypatch):
+        import core.config as cfg
+
+        monkeypatch.setattr(
+            "core.database.get_user_preference",
+            lambda key, default=None: default,
+        )
+        assert cfg.is_auto_metadata_on_move_enabled() is True
+
+    def test_disabled_when_the_preference_is_false(self, monkeypatch):
+        import core.config as cfg
+
+        monkeypatch.setattr(
+            "core.database.get_user_preference",
+            lambda key, default=None: False,
+        )
+        assert cfg.is_auto_metadata_on_move_enabled() is False
+
+    def test_reads_the_shared_key(self, monkeypatch):
+        import core.config as cfg
+
+        seen = []
+        monkeypatch.setattr(
+            "core.database.get_user_preference",
+            lambda key, default=None: seen.append(key) or default,
+        )
+        cfg.is_auto_metadata_on_move_enabled()
+        assert seen == [cfg.PREF_AUTO_METADATA_ON_MOVE]
+
+    def test_fails_open_when_the_preference_store_is_unreadable(self, monkeypatch):
+        """A broken DB must not silently switch the feature off."""
+        import core.config as cfg
+
+        def boom(key, default=None):
+            raise RuntimeError("db gone")
+
+        monkeypatch.setattr("core.database.get_user_preference", boom)
+        assert cfg.is_auto_metadata_on_move_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Where the gate sits in app.py
+# ---------------------------------------------------------------------------
+
+
+def _function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in app.py")
+
+
+@pytest.mark.parametrize("name", FETCHERS)
+def test_fetcher_checks_the_gate_before_anything_else(app_tree, name):
+    """The gate must be the first statement after the docstring.
+
+    Anything before it -- a provider handshake, an os.listdir of the folder --
+    is work the user asked us not to do.
+    """
+    fn = _function(app_tree, name)
+    body = list(fn.body)
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+        body = body[1:]
+    first = body[0]
+    assert isinstance(first, ast.If), f"{name} does not open with the gate"
+    calls = [
+        n.func.id
+        for n in ast.walk(first.test)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    ]
+    assert "is_auto_metadata_on_move_enabled" in calls
+
+
+@pytest.mark.parametrize("name", FETCHERS)
+def test_disabled_fetcher_returns_the_path_untouched(app_tree, name):
+    """Callers chain the return value -- the gate must not drop the path."""
+    fn = _function(app_tree, name)
+    body = [
+        s for s in fn.body
+        if not (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant))
+    ]
+    gate = body[0]
+    returns = [n for n in ast.walk(gate) if isinstance(n, ast.Return)]
+    assert len(returns) == 1
+    assert isinstance(returns[0].value, ast.Name)
+    assert returns[0].value.id == fn.args.args[0].arg
+
+
+def test_gate_is_imported_not_redefined(app_py):
+    assert "is_auto_metadata_on_move_enabled," in app_py
+    assert "def is_auto_metadata_on_move_enabled" not in app_py
+
+
+# ---------------------------------------------------------------------------
+# Config page round trip
+# ---------------------------------------------------------------------------
+
+
+def test_switch_is_rendered(config_html):
+    assert 'id="autoMetadataOnMove"' in config_html
+    assert "{% if autoMetadataOnMove %}checked{% endif %}" in config_html
+
+
+def test_switch_is_collected_into_the_save_payload(config_html):
+    payload = config_html.split("async function saveFileProcessingSettings()")[1]
+    payload = payload.split("fetch(")[0]
+    assert "autoMetadataOnMove" in payload
+
+
+def test_switch_defaults_to_on_in_the_payload(config_html):
+    """A missing element must not read as "off" and disable the feature."""
+    payload = config_html.split("async function saveFileProcessingSettings()")[1]
+    payload = payload.split("fetch(")[0]
+    line = [ln for ln in payload.splitlines() if "autoMetadataOnMove" in ln][0]
+    assert "?? true" in line
+
+
+def test_endpoint_persists_the_preference(save_handler):
+    assert "autoMetadataOnMove" in save_handler
+    assert "PREF_AUTO_METADATA_ON_MOVE" in save_handler
+
+
+def test_endpoint_defaults_to_true(save_handler):
+    line = [ln for ln in save_handler.splitlines() if "autoMetadataOnMove" in ln][0]
+    assert "True" in line
+
+
+def test_switch_lives_on_the_file_processing_tab(config_html):
+    """The input must sit inside the tab whose Save button posts it."""
+    tab = config_html.split('id="file-processing" role="tabpanel"')[1]
+    tab = tab.split('role="tabpanel"')[0]
+    assert 'id="autoMetadataOnMove"' in tab
+
+
+def test_config_page_renders_the_current_value(app_py):
+    assert "autoMetadataOnMove=is_auto_metadata_on_move_enabled()" in app_py
+
+
+def test_setting_is_not_in_the_deprecated_config_ini():
+    """CLAUDE.md: new settings live in user_preferences, not config.ini."""
+    config_ini = (ROOT / "config.ini").read_text(encoding="utf-8")
+    assert "AUTO_METADATA_ON_MOVE" not in config_ini

--- a/tests/unit/test_date_check_settings_wiring.py
+++ b/tests/unit/test_date_check_settings_wiring.py
@@ -1,10 +1,14 @@
 """The date-check settings must survive the round trip from the Config page.
 
-The Config page does not post a form for these fields: the System & Performance
+The Config page does not post a form for these fields: the File Processing
 tab collects specific element ids into a JSON payload and posts it to
-/api/config/system-perf. A setting can therefore be rendered on the page, saved
-to config.ini by hand, and still be impossible to change from the UI -- which is
-what happened to these two before this test existed.
+/api/config/file-processing. A setting can therefore be rendered on the page,
+saved to config.ini by hand, and still be impossible to change from the UI --
+which is what happened to these two before this test existed.
+
+The tab is load-bearing here: the payload builder and the endpoint that reads
+it must be the *same* tab's pair, so moving a field between tabs without moving
+its save block leaves it silently unsaveable.
 
 These are source-level assertions on purpose. They pin the three places that
 must agree, without standing up a browser.
@@ -30,6 +34,12 @@ def app_py():
     return (ROOT / "app.py").read_text(encoding="utf-8")
 
 
+@pytest.fixture(scope="module")
+def save_handler(app_py):
+    """Source of the /api/config/file-processing handler, bounded by the next route."""
+    return app_py.split('@app.route("/api/config/file-processing"')[1].split("@app.route")[0]
+
+
 @pytest.mark.parametrize("field", FIELDS)
 def test_input_exists_on_the_page(config_html, field):
     assert f'id="{field}"' in config_html
@@ -38,15 +48,14 @@ def test_input_exists_on_the_page(config_html, field):
 @pytest.mark.parametrize("field", FIELDS)
 def test_field_is_collected_into_the_save_payload(config_html, field):
     """Rendering the input is not enough -- saveSystemPerfSettings must send it."""
-    payload = config_html.split("async function saveSystemPerfSettings()")[1]
+    payload = config_html.split("async function saveFileProcessingSettings()")[1]
     payload = payload.split("fetch(")[0]
     assert field in payload, f"{field} is rendered but never sent to the server"
 
 
 @pytest.mark.parametrize("field", FIELDS)
-def test_endpoint_reads_the_field(app_py, field):
-    handler = app_py.split('@app.route("/api/config/system-perf"')[1][:4000]
-    assert f'"{field}"' in handler, f"/api/config/system-perf ignores {field}"
+def test_endpoint_reads_the_field(save_handler, field):
+    assert f'"{field}"' in save_handler, f"/api/config/file-processing ignores {field}"
 
 
 @pytest.mark.parametrize("key", LEGACY_KEYS)
@@ -64,10 +73,9 @@ def test_setting_is_not_in_the_deprecated_config_ini(key):
 
 
 @pytest.mark.parametrize("pref", PREFS)
-def test_endpoint_persists_the_preference(app_py, pref):
-    handler = app_py.split('@app.route("/api/config/system-perf"')[1][:4000]
-    assert "set_user_preference" in handler
-    assert "PREF_MODE" in handler and "PREF_TOLERANCE" in handler
+def test_endpoint_persists_the_preference(save_handler, pref):
+    assert "set_user_preference" in save_handler
+    assert "PREF_MODE" in save_handler and "PREF_TOLERANCE" in save_handler
 
 
 @pytest.mark.parametrize("pref", PREFS)
@@ -77,13 +85,24 @@ def test_preference_key_is_defined_once(pref):
     assert f'"{pref}"' in md
 
 
-def test_mode_values_agree_between_ui_and_server(config_html, app_py):
+def test_mode_values_agree_between_ui_and_server(config_html, save_handler):
     """The select's options and the server's allow-list must not drift."""
     select = config_html.split('id="dateCheckMode"')[1].split("</select>")[0]
     ui_values = set(re.findall(r'value="([a-z]+)"', select))
     assert ui_values == {"off", "log", "enforce"}
 
-    handler = app_py.split('@app.route("/api/config/system-perf"')[1][:4000]
-    allowed = handler.split('_date_mode in (')[1].split(')')[0]
+    allowed = save_handler.split('_date_mode in (')[1].split(')')[0]
     server_values = set(re.findall(r'"([a-z]+)"', allowed))
     assert server_values == ui_values
+
+
+def test_fields_live_on_the_file_processing_tab(config_html):
+    """The inputs must sit inside the tab whose Save button posts them.
+
+    They started life on System & Performance; a field left behind on the old
+    tab still renders, but its Save button no longer sends it.
+    """
+    tab = config_html.split('id="file-processing" role="tabpanel"')[1]
+    tab = tab.split('role="tabpanel"')[0]
+    for field in FIELDS:
+        assert f'id="{field}"' in tab, f"{field} is not on the File Processing tab"


### PR DESCRIPTION
## What

Moving a comic into a folder that carries a `cvinfo` triggers a provider lookup and a `ComicInfo.xml` write. Users who curate their own metadata want a move to stay a move, so the behaviour is now switchable — **default ON**, since that is what every existing install already does.

## The gate

`core.config.is_auto_metadata_on_move_enabled()`, backed by the `auto_metadata_on_move` key in `user_preferences` (category `metadata`, per the config.ini deprecation in CLAUDE.md).

It **fails open**: if the preference store can't be read it returns `True`, so a DB hiccup can't silently disable a feature every install currently has.

## Where it's enforced

As the **first statement** in all three fetchers in `app.py` — `auto_fetch_metron_metadata`, `auto_fetch_comicvine_metadata`, `auto_fetch_comicvine_sqlite_metadata` — rather than at the call sites. Two reasons:

- It covers both callers at once: the file-move path (`routes/files.py:_do_move`, which dispatches through the destination library's provider order) and the wanted-issues import sweep (`app.py`).
- A check placed any later would still hit the provider API before bailing out.

Each returns `destination_path` untouched, because callers chain the return value through the providers in priority order.

On-demand tagging is unaffected — the Files page, bulk Fetch Metadata jobs and the review queue all still work with the switch off, which is what the help text tells the user.

## Config page

New "Automatic Metadata" switch. While adding it, the **Automatic Metadata** and **Metadata Match Validation** sections moved onto the **File Processing** tab; **ComicInfo.XML Update Settings** stays on System & Performance.

Each tab's Save button builds its own JSON payload and posts to its own endpoint, so the JS fields and the matching `set_user_preference` block had to move with the markup — a field left behind on the old tab renders fine but is silently unsaveable. Preference keys and categories are unchanged, so existing saved values carry over.

## Tests

`tests/unit/test_auto_metadata_on_move_switch.py` — 19 tests. The gate is unit-tested directly (default, off, key, fail-open). Because `app.py` can't be imported in tests, its *placement* is asserted against the AST: the check must be the first statement after the docstring, and must return the input path unchanged.

`tests/unit/test_date_check_settings_wiring.py` existed precisely because these two fields were once rendered but unsaveable — and it was pinned to the System & Performance pair, so it would have kept passing against the old tab while the UI silently broke. It now asserts the File Processing pair, and both wiring tests gained a check that each input sits inside the tab whose Save button posts it. The fixed-length `[:4000]` handler slices are replaced with a fixture bounded by the next `@app.route`; `save_file_processing_config` is long enough that the old slice would have missed the block entirely.

Full suite: **4173 passed, 7 skipped** (POSIX/symlink skips only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
